### PR TITLE
Add three runtime implementation specs to close design gaps

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -322,7 +322,7 @@ Most core tooling is done. Remaining items can be built incrementally.
 ## Open Design Questions
 
 ### Important (needed during Phase 5)
-- [ ] **Runtime simplification strategy** — Should initial compiler target full M:N scheduler with reactor (complex), or start with OS threads per spawn (simple) and upgrade later?
+- [x] **Runtime simplification strategy** — OS threads first (Phase A), M:N green tasks later (Phase B). See [runtime-strategy.md](specs/concurrency/runtime-strategy.md), [io-context.md](specs/concurrency/io-context.md), [hidden-params.md](specs/compiler/hidden-params.md)
 - [ ] `using` block expressions (`using ThreadPool(workers: 4) { ... }`) — parser dispatches `With` but examples use `using`
 
 ### Quality improvements (doesn't block, improves ergonomics)

--- a/specs/README.md
+++ b/specs/README.md
@@ -165,6 +165,7 @@ See [concurrency/README.md](concurrency/README.md) for the layered design.
 |------|-------------|
 | [generation-coalescing.md](compiler/generation-coalescing.md) | Redundant generation check elimination |
 | [semantic-hash-caching.md](compiler/semantic-hash-caching.md) | Incremental compilation, semantic hashing for generics |
+| [hidden-params.md](compiler/hidden-params.md) | Hidden parameter compiler pass for `using` clauses |
 
 ---
 

--- a/specs/compiler/hidden-params.md
+++ b/specs/compiler/hidden-params.md
@@ -1,0 +1,485 @@
+<!-- id: comp.hidden-params -->
+<!-- status: decided -->
+<!-- summary: Compiler pass that inserts hidden context parameters for using clauses -->
+<!-- depends: memory/context-clauses.md, concurrency/io-context.md, concurrency/async.md -->
+
+# Hidden Parameter Compiler Pass
+
+Compiler pass that desugars `using` clauses into hidden function parameters. Runs after type checking, before MIR lowering. Handles both `Pool<T>` contexts (`mem.context`) and `RuntimeContext` (`conc.io-context`).
+
+## Pass Overview
+
+| Rule | Description |
+|------|-------------|
+| **HP1: Position in pipeline** | Runs after type checking, before monomorphization and MIR lowering |
+| **HP2: Two context families** | Pool contexts (`using Pool<T>`) and runtime contexts (`using Multitasking`) follow the same desugaring mechanism |
+| **HP3: Three operations** | The pass does three things: (1) rewrite function signatures, (2) rewrite call sites, (3) propagate through closures |
+| **HP4: Idempotent** | Running the pass twice produces the same output. No double-insertion of parameters |
+
+```
+Source → Lexer → Parser → AST
+  → Resolver → TypeChecker → [Hidden Param Pass] → Monomorphize → MIR → Codegen
+```
+
+## Pass Inputs and Outputs
+
+**Input:** Typed AST with:
+- Functions annotated with `using` clauses (CC1-CC3 from `mem.context`)
+- `using Multitasking { }` and `using ThreadPool { }` blocks (C1-C3 from `conc.async`)
+- Type information for all expressions (needed for context resolution)
+
+**Output:** Desugared AST where:
+- `using` clauses replaced with explicit hidden parameters
+- Call sites have hidden arguments inserted
+- `using` blocks replaced with context construction + teardown
+- Closures capture contexts appropriately
+
+## Step 1: Rewrite Function Signatures
+
+| Rule | Description |
+|------|-------------|
+| **SIG1: Pool context → parameter** | `func f() using Pool<T>` becomes `func f(__ctx_pool_T: &Pool<T>)` |
+| **SIG2: Named pool → parameter** | `func f() using players: Pool<T>` becomes `func f(__ctx_players: &Pool<T>)` with local alias |
+| **SIG3: Frozen pool → const ref** | `func f() using frozen Pool<T>` becomes `func f(__ctx_pool_T: &Pool<T>)` (read-only enforced by type checker) |
+| **SIG4: Runtime context → parameter** | Functions called inside `using Multitasking` gain `__ctx_runtime: RuntimeContext?` |
+| **SIG5: Multiple contexts** | Each `using` clause becomes one hidden parameter. Order: pools first, runtime last |
+| **SIG6: Hidden param naming** | `__ctx_` prefix marks hidden params. Debugger hides these by default (`conc.runtime/HP2.1`) |
+
+### Examples
+
+<!-- test: skip -->
+```rask
+// Before: pool context
+func damage(h: Handle<Player>, amount: i32) using Pool<Player> {
+    h.health -= amount
+}
+
+// After: hidden parameter
+func damage(h: Handle<Player>, amount: i32, __ctx_pool_Player: &Pool<Player>) {
+    __ctx_pool_Player[h].health -= amount
+}
+```
+
+<!-- test: skip -->
+```rask
+// Before: named pool context
+func award_bonus(h: Handle<Player>, amount: i32) using players: Pool<Player> {
+    h.score += amount
+    players.mark_dirty(h)
+}
+
+// After: hidden parameter with local alias
+func award_bonus(h: Handle<Player>, amount: i32, __ctx_players: &Pool<Player>) {
+    const players = __ctx_players  // Local alias for named context
+    __ctx_players[h].score += amount
+    players.mark_dirty(h)
+}
+```
+
+<!-- test: skip -->
+```rask
+// Before: runtime context (inside using Multitasking block)
+func process_file(path: string) -> Data or IoError {
+    const file = try File.open(path)
+    const data = try file.read_text()
+    return parse(data)
+}
+
+// After: hidden runtime parameter (if called from async context)
+func process_file(path: string, __ctx_runtime: RuntimeContext?) -> Data or IoError {
+    const file = try File.open(path, __ctx_runtime)
+    const data = try file.read_text(__ctx_runtime)
+    return parse(data)
+}
+```
+
+### Parameter optionality
+
+| Context type | Parameter type | Rationale |
+|-------------|---------------|-----------|
+| `using Pool<T>` | `&Pool<T>` (required) | Pool must exist — compile error if not available |
+| `using Multitasking` | `RuntimeContext?` (optional) | Function works in both sync and async contexts (`conc.io-context/IO1`) |
+
+Pool contexts are required because `Handle<T>` field access doesn't work without a pool. Runtime context is optional because the same function should work in both sync and async modes — sync just blocks.
+
+## Step 2: Rewrite Call Sites
+
+| Rule | Description |
+|------|-------------|
+| **CALL1: Resolve context source** | At each call to a function with hidden params, find the context value in scope |
+| **CALL2: Resolution order** | Search (in order): local variables → function parameters → fields of `self` → own `using` clause (same as `mem.context/CC4`) |
+| **CALL3: Insert hidden argument** | Append resolved context value as hidden argument at call site |
+| **CALL4: Propagation** | If the caller also has a `using` clause for the same type, its hidden parameter satisfies the callee's requirement (`mem.context/CC5`) |
+| **CALL5: Ambiguity is error** | Multiple pools of same type in scope → compile error (`mem.context/CC8`) |
+| **CALL6: Runtime context forwarding** | If caller has `__ctx_runtime`, forward to all callees that accept it |
+
+### Resolution algorithm
+
+```
+resolve_context(call_site, required_type) -> ContextSource:
+    // 1. Local variables in current scope
+    for var in current_scope.locals:
+        if var.type matches required_type:
+            return LocalVar(var)
+
+    // 2. Function parameters (explicit)
+    for param in current_function.params:
+        if param.type matches required_type:
+            return Param(param)
+
+    // 3. Fields of self (if in a method)
+    if current_function.has_self:
+        for field in self.type.fields:
+            if field.type matches required_type:
+                return SelfField(field)
+
+    // 4. Own hidden context parameter (propagation)
+    for hidden in current_function.hidden_params:
+        if hidden.type matches required_type:
+            return HiddenParam(hidden)
+
+    // 5. Not found
+    error("no context of type {required_type} available at {call_site}")
+```
+
+### Example: call site rewriting
+
+<!-- test: skip -->
+```rask
+// Before:
+func game_tick() {
+    const players = Pool.new()
+    const h = try players.insert(Player.new())
+    damage(h, 10)    // How does damage() get the pool?
+}
+
+// After:
+func game_tick() {
+    const players = Pool.new()
+    const h = try players.insert(Player.new())
+    damage(h, 10, &players)    // Resolved: local variable `players`
+}
+```
+
+<!-- test: skip -->
+```rask
+// Before: propagation through call chain
+func update_player(h: Handle<Player>) using Pool<Player> {
+    take_damage(h, 5)
+    check_death(h)
+}
+
+// After:
+func update_player(h: Handle<Player>, __ctx_pool_Player: &Pool<Player>) {
+    take_damage(h, 5, __ctx_pool_Player)    // Propagated from own hidden param
+    check_death(h, __ctx_pool_Player)       // Same
+}
+```
+
+## Step 3: Rewrite `using` Blocks
+
+| Rule | Description |
+|------|-------------|
+| **BLK1: Block creates context** | `using Multitasking { body }` desugars to context construction + body + teardown |
+| **BLK2: Body inherits context** | All calls inside the block have `__ctx_runtime` available for forwarding |
+| **BLK3: Block exit waits** | Teardown waits for all non-detached tasks (`conc.async/C4`) |
+| **BLK4: Nested blocks illegal** | Compile error for nested `using Multitasking` blocks |
+
+### Desugaring
+
+<!-- test: skip -->
+```rask
+// Before:
+func main() -> () or Error {
+    using Multitasking {
+        const h = spawn(|| { work() })
+        try h.join()
+    }
+}
+
+// After:
+func main() -> () or Error {
+    const __ctx_runtime = RuntimeContext.__new(ContextMode.ThreadBacked)
+    {
+        const h = spawn(|| { work() }, __ctx_runtime)
+        try h.join(__ctx_runtime)
+    }
+    __ctx_runtime.__shutdown()  // Waits for tasks, releases resources
+}
+```
+
+<!-- test: skip -->
+```rask
+// Before: with configuration
+using Multitasking(workers: 4) {
+    // ...
+}
+
+// After:
+const __ctx_runtime = RuntimeContext.__new_with(
+    ContextMode.ThreadBacked,
+    RuntimeConfig { workers: 4 }
+)
+{
+    // ...
+}
+__ctx_runtime.__shutdown()
+```
+
+## Step 4: Closure Context Capture
+
+| Rule | Description |
+|------|-------------|
+| **CL1: Immediate closures inherit** | Expression-scoped closures (iterator callbacks, immediate callbacks) capture context by reference (`mem.context/CC9`) |
+| **CL2: Spawn closures capture** | `spawn(|| { })` closures capture `__ctx_runtime` (needed for I/O inside spawned tasks) |
+| **CL3: Storable closures exclude** | Storable closures cannot capture context implicitly (`mem.context/CC10`) |
+| **CL4: Pool context in spawn** | Spawn closures can capture pool contexts if the pool is `Send + Sync` |
+
+### Spawn closure desugaring
+
+<!-- test: skip -->
+```rask
+// Before:
+using Multitasking {
+    spawn(|| {
+        const data = try File.read("input.txt")
+        process(data)
+    }).detach()
+}
+
+// After:
+const __ctx_runtime = RuntimeContext.__new(ContextMode.ThreadBacked)
+{
+    spawn(|| {
+        // __ctx_runtime captured by the closure
+        const data = try File.read("input.txt", __ctx_runtime)
+        process(data)
+    }, __ctx_runtime).detach(__ctx_runtime)
+}
+__ctx_runtime.__shutdown()
+```
+
+### Iterator closure desugaring
+
+<!-- test: skip -->
+```rask
+// Before:
+func process_all(handles: Vec<Handle<Player>>) using Pool<Player> {
+    handles.iter().for_each(|h| {
+        h.score += 10
+    })
+}
+
+// After:
+func process_all(handles: Vec<Handle<Player>>, __ctx_pool_Player: &Pool<Player>) {
+    handles.iter().for_each(|h| {
+        // __ctx_pool_Player captured by reference (expression-scoped)
+        __ctx_pool_Player[h].score += 10
+    })
+}
+```
+
+## Implementation Notes
+
+### Pass structure (Rust pseudocode)
+
+```rust
+struct HiddenParamPass {
+    // Track which functions need which hidden params
+    function_contexts: HashMap<FuncId, Vec<HiddenParam>>,
+}
+
+struct HiddenParam {
+    name: String,          // __ctx_pool_Player, __ctx_runtime
+    param_type: Type,      // &Pool<Player>, RuntimeContext?
+    source: ContextSource, // Where it comes from at call sites
+}
+
+impl HiddenParamPass {
+    fn run(ast: &mut TypedProgram) {
+        // Phase 1: Collect — scan all functions for `using` clauses
+        self.collect_contexts(ast);
+
+        // Phase 2: Propagate — functions that call context-needing functions
+        //          also need the context (transitive)
+        self.propagate_contexts(ast);
+
+        // Phase 3: Rewrite signatures — add hidden params
+        self.rewrite_signatures(ast);
+
+        // Phase 4: Rewrite call sites — insert hidden arguments
+        self.rewrite_calls(ast);
+
+        // Phase 5: Rewrite using blocks — construct/teardown
+        self.rewrite_blocks(ast);
+
+        // Phase 6: Rewrite closures — capture rules
+        self.rewrite_closures(ast);
+    }
+}
+```
+
+### Propagation algorithm
+
+The critical subtlety: functions that don't declare `using` clauses but call functions that require context must also receive the hidden parameter.
+
+```
+propagate_contexts(call_graph):
+    changed = true
+    while changed:
+        changed = false
+        for func in all_functions:
+            for callee in func.callees:
+                for ctx in callee.required_contexts:
+                    if ctx not in func.required_contexts:
+                        if func can resolve ctx from locals/self/params:
+                            // Context available locally, no propagation needed
+                            continue
+                        else:
+                            // Must propagate: add hidden param to func
+                            func.required_contexts.add(ctx)
+                            changed = true
+```
+
+**Fixed-point iteration:** Keep propagating until no new contexts added. Typically converges in 2-3 iterations (call chains are shallow).
+
+**Cycle handling:** Recursive functions that need context propagate it in one iteration (function already has it from the recursive call requirement).
+
+### Public function constraint
+
+| Rule | Description |
+|------|-------------|
+| **PUB1: Public functions declare contexts** | Public functions must have explicit `using` clauses (`mem.context/CC6`). The pass does not add hidden params to public functions that don't declare them |
+| **PUB2: Private functions may infer** | Private functions can have contexts inferred by propagation (`mem.context/CC7`) |
+
+This prevents context propagation from changing public API surfaces. If a private helper needs a pool, propagation adds it silently. If a public function needs a pool, the programmer must declare it.
+
+## Interaction with Monomorphization
+
+| Rule | Description |
+|------|-------------|
+| **MONO1: Before monomorphization** | Hidden param pass runs before monomorphization. Generic functions get generic hidden params |
+| **MONO2: Specialized contexts** | `func f<T>() using Pool<T>` becomes `func f<T>(__ctx_pool_T: &Pool<T>)`. Monomorphization then specializes both `T` and the hidden param type |
+
+<!-- test: skip -->
+```rask
+// Before:
+func process_all<T>(handles: Vec<Handle<T>>) using Pool<T>
+    where T: Processable
+{
+    for h in handles { h.process() }
+}
+
+// After hidden param pass:
+func process_all<T>(handles: Vec<Handle<T>>, __ctx_pool_T: &Pool<T>)
+    where T: Processable
+{
+    for h in handles { __ctx_pool_T[h].process() }
+}
+
+// After monomorphization (for T = Player):
+func process_all_Player(handles: Vec<Handle<Player>>, __ctx_pool_Player: &Pool<Player>) {
+    for h in handles { __ctx_pool_Player[h].process() }
+}
+```
+
+## Error Messages
+
+```
+ERROR [comp.hidden-params/CALL5]: ambiguous context
+   |
+10 |  const pool_a = Pool::<Player>.new()
+11 |  const pool_b = Pool::<Player>.new()
+13 |  damage(h, 10)
+   |  ^^^^^^^^^^^ multiple Pool<Player> in scope
+   |
+WHY: The compiler can't determine which pool to pass as hidden context.
+
+FIX: Pass the pool explicitly:
+  damage_explicit(pool_a, h, 10)
+```
+
+```
+ERROR [comp.hidden-params/PUB1]: public function needs explicit context
+   |
+1  |  public func damage(h: Handle<Player>, amount: i32) {
+   |                      ^^^^^^^^^^^^^^^^ uses Handle<Player> but no context declared
+   |
+WHY: Public functions must declare context dependencies in their signature.
+
+FIX: Add using clause:
+  public func damage(h: Handle<Player>, amount: i32) using Pool<Player> {
+```
+
+```
+ERROR [comp.hidden-params/CL3]: storable closure cannot capture context
+   |
+5  |  const callback: |Handle<Player>| = |h| {
+6  |      h.health -= 10
+   |      ^ no Pool<Player> context
+   |
+WHY: Storable closures may execute where context isn't available.
+
+FIX: Pass the pool as an explicit parameter.
+```
+
+## Edge Cases
+
+| Case | Behavior | Rule |
+|------|----------|------|
+| Function with `using Pool<T>` called outside any pool scope | Compile error | CALL1 |
+| Public function without `using` calls private function with context | Compile error on public function | PUB1 |
+| Recursive function with `using` clause | Self-propagation, one hidden param | Propagation |
+| `comptime` function with `using Pool<T>` | Compile error (no pools at comptime) | `ctrl.comptime/CT20` |
+| Generic function with `using Pool<T>` | Hidden param is generic, specialized at monomorphization | MONO2 |
+| Closure captures two different pool contexts | Two hidden captures, ordered same as enclosing function | CL1, SIG5 |
+| `using Multitasking` in non-main function | Works — any function can create a runtime context | BLK1 |
+
+---
+
+## Appendix (non-normative)
+
+### Rationale
+
+**HP1 (after type checking):** The pass needs type information to resolve contexts (know which variables are `Pool<Player>` vs `Pool<Enemy>`). Running before monomorphization means we handle generics once, not per-instantiation.
+
+**HP2 (unified mechanism):** Pool contexts and runtime contexts follow the same pattern: declare in signature, thread as hidden param, resolve at call sites. Having one pass handle both prevents divergence. If we add other context types later (allocator contexts, logger contexts), the same pass extends naturally.
+
+**PUB1 (public functions declare):** Without this rule, adding a private helper that needs a pool could silently change a public function's ABI. Requiring explicit declaration on public functions means ABI changes are intentional and visible in diffs.
+
+### Debugging the pass
+
+`rask check --explicit-context` shows the desugared signatures:
+
+```
+$ rask check --explicit-context game.rk
+
+func damage(h: Handle<Player>, amount: i32)
+  + hidden: __ctx_pool_Player: &Pool<Player>
+  resolved from: local variable 'players' at game.rk:5
+
+func process_file(path: string)
+  + hidden: __ctx_runtime: RuntimeContext?
+  resolved from: using Multitasking block at game.rk:20
+```
+
+This helps programmers understand context flow when debugging unexpected behavior.
+
+### Alternative: thread-local contexts
+
+I considered using thread-local storage instead of hidden parameters. Thread-locals are simpler (no compiler pass needed) but have problems:
+
+1. **Not composable** — can't have two runtimes in one thread
+2. **Not explicit** — dependency on global state is invisible
+3. **Inconsistent** — pool contexts already use hidden params (`mem.context`); using a different mechanism for runtime contexts would be confusing
+4. **Migration-hostile** — green tasks can migrate between threads; thread-local context would be lost after migration
+
+Hidden parameters are more work but produce a cleaner, more predictable system.
+
+### See Also
+
+- `mem.context/CC1-CC10` — Using clause semantics (programmer-facing)
+- `conc.io-context` — How I/O functions use the runtime context
+- `conc.runtime/HP1-HP3` — Debuggability requirements for hidden parameters
+- `conc.strategy` — Phase A vs Phase B runtime (affects context mode)
+- `comp.codegen/P1` — MIR pipeline position

--- a/specs/concurrency/README.md
+++ b/specs/concurrency/README.md
@@ -22,10 +22,12 @@ Concurrency model for Rask.
 |------|--------|---------|
 | [async.md](async.md) | Draft | **Execution model**: Multitasking, ThreadPool, spawn, handles |
 | [runtime.md](runtime.md) | Draft | **Runtime implementation**: M:N scheduler, reactor, task state machines |
+| [runtime-strategy.md](runtime-strategy.md) | Draft | **Implementation strategy**: OS threads first, M:N later |
+| [io-context.md](io-context.md) | Draft | **I/O dispatch**: How stdlib detects async context, sync/async code paths |
 | [sync.md](sync.md) | Draft | **Shared state**: Shared<T>, Mutex<T> for cross-task access |
 | [select.md](select.md) | Draft | Select statement, multiplexing |
 
-**Start here:** [async.md](async.md) for the execution model overview.
+**Start here:** [async.md](async.md) for the execution model overview, then [runtime-strategy.md](runtime-strategy.md) for implementation plan.
 
 ## Quick Reference
 

--- a/specs/concurrency/io-context.md
+++ b/specs/concurrency/io-context.md
@@ -1,0 +1,315 @@
+<!-- id: conc.io-context -->
+<!-- status: decided -->
+<!-- summary: How stdlib I/O functions detect async context and dispatch between sync/async paths -->
+<!-- depends: concurrency/async.md, concurrency/runtime-strategy.md, stdlib/io.md, memory/context-clauses.md -->
+
+# I/O Context Integration
+
+Stdlib I/O functions accept a hidden `RuntimeContext` parameter. When present, I/O is non-blocking (task parks). When absent, I/O blocks the thread. Same function, two code paths, no function coloring.
+
+## RuntimeContext Type
+
+| Rule | Description |
+|------|-------------|
+| **CTX1: Opaque handle** | `RuntimeContext` is an opaque type — programmers never construct or inspect it |
+| **CTX2: Provided by `using`** | `using Multitasking { }` creates a `RuntimeContext` and threads it through all calls in the block |
+| **CTX3: Optional parameter** | Stdlib I/O functions accept `__ctx?: RuntimeContext` — present in async context, absent in sync |
+| **CTX4: Not a trait** | `RuntimeContext` is a concrete type, not a trait. No dynamic dispatch on context detection |
+
+<!-- test: skip -->
+```rask
+// What the programmer writes:
+using Multitasking {
+    const file = try File.open("data.txt")
+    const data = try file.read_text()
+}
+
+// What the compiler generates (conceptual):
+const __ctx = RuntimeContext.__new()
+const file = try File.open("data.txt", __ctx)
+const data = try file.read_text(__ctx)
+__ctx.__shutdown()
+```
+
+## Context Structure
+
+### Phase A (OS threads, `conc.strategy/A1`)
+
+<!-- test: skip -->
+```rask
+// Minimal marker — enough to thread through call chains
+struct RuntimeContext {
+    mode: ContextMode
+}
+
+enum ContextMode {
+    ThreadBacked    // Phase A: OS threads, blocking I/O
+}
+```
+
+In Phase A, `RuntimeContext` is a marker. I/O functions receive it but ignore it — all I/O blocks the calling thread regardless. The value of threading it now is validating the desugaring pass (`conc.strategy/A5`).
+
+### Phase B (M:N green tasks, `conc.runtime`)
+
+<!-- test: skip -->
+```rask
+struct RuntimeContext {
+    mode: ContextMode
+    scheduler: Scheduler      // Work-stealing scheduler handle
+    reactor: Reactor          // I/O event loop handle
+    current_task: Task        // Currently executing task
+}
+
+enum ContextMode {
+    ThreadBacked    // Fallback
+    GreenTask       // Phase B: non-blocking I/O, task parking
+}
+```
+
+## I/O Function Pattern
+
+| Rule | Description |
+|------|-------------|
+| **IO1: Dual-path implementation** | Every I/O function has a blocking path and an async path, selected by `__ctx` presence |
+| **IO2: Blocking is default** | Without context, I/O functions call blocking syscalls directly |
+| **IO3: Async registers with reactor** | With context (Phase B), non-blocking syscall → EAGAIN → register FD with reactor → park task |
+| **IO4: Phase A ignores context** | With context but in Phase A (`ThreadBacked`), I/O blocks the thread (same as no context) |
+
+### Concrete implementation pattern
+
+Every I/O function in `rask-rt` follows this template:
+
+```rust
+// rask-rt implementation (Rust)
+pub fn rask_file_read(
+    file: &File,
+    buf: &mut [u8],
+    ctx: Option<&RuntimeContext>,
+) -> Result<usize, IoError> {
+    match ctx {
+        None => {
+            // Sync path: blocking read
+            blocking_read(file.fd(), buf)
+        }
+        Some(ctx) if ctx.mode == ContextMode::ThreadBacked => {
+            // Phase A: still blocking, context is just a marker
+            blocking_read(file.fd(), buf)
+        }
+        Some(ctx) => {
+            // Phase B: non-blocking + reactor
+            match nonblocking_read(file.fd(), buf) {
+                Ok(n) => Ok(n),
+                Err(EAGAIN) => {
+                    ctx.reactor.register(file.fd(), Interest::Readable, ctx.current_task.waker());
+                    ctx.current_task.park();  // Yield to scheduler
+                    // Re-polled when I/O ready
+                    nonblocking_read(file.fd(), buf)
+                }
+                Err(e) => Err(e),
+            }
+        }
+    }
+}
+```
+
+### Which functions need context
+
+| Module | Functions | Context needed? |
+|--------|-----------|----------------|
+| `fs` | `File.open`, `File.read`, `File.write`, `File.close` | Yes — file I/O blocks |
+| `fs` | `fs.read_file`, `fs.write_file`, `fs.exists` | Yes — convenience functions do I/O |
+| `net` | `TcpListener.accept`, `TcpConnection.read/write` | Yes — network I/O blocks |
+| `io` | `Stdin.read`, `Stdout.write`, `Stderr.write` | Yes — stream I/O blocks |
+| `io` | `Buffer.read`, `Buffer.write` | No — in-memory, never blocks |
+| `async` | `sleep`, `timeout` | Yes — needs timer/scheduler |
+| `async` | `spawn`, `Channel.send/recv` | Yes — needs scheduler/reactor |
+| collections | `Vec`, `Map`, `Pool` | No — pure memory operations |
+| `json` | `json.encode`, `json.decode` | No — pure computation |
+| `fmt` | `format` | No — pure computation |
+| `math` | All functions | No — pure computation |
+
+**Rule of thumb:** If the function touches file descriptors, the network, or sleeps, it takes `__ctx`. If it's pure computation or in-memory, it doesn't.
+
+## Cancellation Integration
+
+| Rule | Description |
+|------|-------------|
+| **IO5: Cancel check before I/O** | I/O functions check `cancel_flag` before initiating syscalls (`conc.async/CN3`) |
+| **IO6: Cancel returns error** | If cancelled, return `Err(IoError.Cancelled)` before the syscall happens |
+
+<!-- test: skip -->
+```rask
+// Cancellation check woven into I/O
+func File.read(self, buf: []u8) -> usize or IoError {
+    // Check cancel before doing work
+    if __ctx is Some(ctx) {
+        if ctx.current_task.cancel_flag.load() {
+            return Err(IoError.Cancelled)
+        }
+    }
+
+    // Proceed with actual I/O...
+}
+```
+
+## Reader/Writer Trait Integration
+
+| Rule | Description |
+|------|-------------|
+| **IO7: Traits don't mention context** | `Reader` and `Writer` trait signatures stay clean — no `__ctx` parameter |
+| **IO8: Implementors receive context** | Concrete implementations (File, TcpConnection) receive `__ctx` via compiler desugaring |
+| **IO9: Generic I/O propagates** | `io.copy(reader, writer)` threads `__ctx` to both `reader.read()` and `writer.write()` calls |
+
+<!-- test: skip -->
+```rask
+// Trait signature — no context visible
+trait Reader {
+    func read(self, buf: []u8) -> usize or IoError
+}
+
+// File implements Reader — compiler adds __ctx
+extend File with Reader {
+    func read(self, buf: []u8) -> usize or IoError {
+        // Compiler desugars to: read(self, buf, __ctx?)
+        // __ctx available if caller is in async context
+    }
+}
+
+// Generic function — context threads through
+func io.copy(reader: any Reader, writer: any Writer) -> usize or IoError {
+    // Compiler desugars to: io.copy(reader, writer, __ctx?)
+    const buf = [0u8; 8192]
+    let total = 0
+    loop {
+        const n = try reader.read(buf)   // __ctx forwarded
+        if n == 0 { break }
+        try writer.write_all(buf[..n])    // __ctx forwarded
+        total += n
+    }
+    return total
+}
+```
+
+The key insight: trait dispatch and context threading are orthogonal. The compiler inserts `__ctx` at every call site that has one available. Trait implementations receive it like any other function.
+
+## Error Types
+
+| Rule | Description |
+|------|-------------|
+| **IO10: IoError.Cancelled** | New variant for cancellation during I/O |
+| **IO11: No RuntimePoisoned in Phase A** | Phase A doesn't have a reactor that can poison. Phase B adds `IoError.RuntimePoisoned` |
+
+<!-- test: skip -->
+```rask
+// Extended IoError (additions from this spec)
+enum IoError {
+    // ... existing variants from std.io/E1 ...
+    Cancelled           // Task was cancelled before I/O completed (IO6)
+    RuntimePoisoned     // Reactor thread panicked (Phase B only, conc.runtime/E7)
+}
+```
+
+## Error Messages
+
+```
+ERROR [conc.io-context/CTX2]: I/O outside async context
+   |
+5  |  spawn(|| { File.open("x.txt") })
+   |              ^^^^^^^^^ spawn() requires 'using Multitasking'
+   |
+WHY: spawn() needs a runtime context to manage the spawned task.
+
+FIX: Wrap in using Multitasking { spawn(|| { ... }) }
+```
+
+```
+ERROR [conc.io-context/IO7]: trait method cannot declare context parameter
+   |
+3  |  trait Reader {
+4  |      func read(self, buf: []u8, ctx: RuntimeContext) -> usize or IoError
+   |                                 ^^^^^^^^^^^^^^^^^^^^ context is implicit
+   |
+WHY: Trait signatures must not include RuntimeContext. The compiler threads
+     context automatically through implementations.
+
+FIX: Remove the context parameter from the trait signature.
+```
+
+## Edge Cases
+
+| Case | Behavior | Rule |
+|------|----------|------|
+| I/O in `comptime` block | Compile error (comptime can't do I/O) | `ctrl.comptime/CT33` |
+| I/O without `using Multitasking` | Blocks calling thread (sync path) | IO2 |
+| `Buffer.read` in async context | No parking (in-memory, never blocks) | IO1 |
+| Cancelled task does I/O | `IoError.Cancelled` before syscall | IO5, IO6 |
+| Nested `using Multitasking` | Compile error | `conc.async/C1` |
+| I/O in `ThreadPool.spawn` closure | Blocks pool thread (no reactor in pool) | IO2 |
+| `io.copy` in async context | Both read and write can park | IO9 |
+
+---
+
+## Appendix (non-normative)
+
+### Rationale
+
+**CTX4 (not a trait):** I considered making `RuntimeContext` a trait so Phase A and Phase B could be different implementations behind dynamic dispatch. But that adds vtable overhead on every I/O call, and the context type is known at compile time. Concrete type with a `mode` discriminant is simpler and zero-cost once the branch is predictable.
+
+**IO7 (traits don't mention context):** Putting `__ctx` in `Reader` would infect every generic function that uses `Reader`. The whole point of hidden parameters is that they're hidden. Traits define the programmer-visible contract; context is a compiler implementation detail.
+
+**IO4 (Phase A ignores context):** This means Phase A programs behave identically whether `using Multitasking` is present or not — I/O always blocks. That's correct: Phase A's `using Multitasking` creates real threads per spawn, and each thread can block independently. The scaling limit (~10k) comes from OS thread count, not from blocking I/O.
+
+### I/O in ThreadPool context
+
+`ThreadPool.spawn` closures don't get async I/O even in Phase B. Thread pool workers are OS threads that run jobs to completion — no parking, no reactor. I/O in a thread pool closure blocks the pool thread.
+
+This is by design: `ThreadPool` is for CPU-bound work. If you need I/O, use `spawn()` (green tasks) instead.
+
+<!-- test: skip -->
+```rask
+using Multitasking, ThreadPool {
+    // Good: I/O in green task
+    spawn(|| {
+        const data = try File.read("big.csv")  // Parks task
+        const result = try ThreadPool.spawn(|| {
+            parse_csv(data)  // CPU-bound, no I/O
+        }).join()
+        try File.write("output.json", result)   // Parks task
+    }).detach()
+
+    // Bad: I/O in thread pool (blocks pool thread)
+    ThreadPool.spawn(|| {
+        const data = try File.read("big.csv")  // Blocks pool thread!
+        parse_csv(data)
+    }).detach()
+}
+```
+
+Linter rule `conc.runtime/HP2.4` warns about I/O inside `ThreadPool.spawn`.
+
+### Pause point visibility
+
+IDE ghost annotations show where I/O can park a task:
+
+<!-- test: skip -->
+```rask
+using Multitasking {
+    const file = try File.open("data.txt")    // ⟨pauses⟩
+    const data = try file.read_text()          // ⟨pauses⟩
+    const parsed = json.decode<Config>(data)   // (no annotation)
+    try file.close()                           // ⟨pauses⟩
+}
+```
+
+The annotation appears on any call where `__ctx` is threaded to an I/O function. Pure computation calls (json, math, collections) never show the annotation.
+
+### See Also
+
+- `conc.async/IO1-IO2` — Transparent pausing and sync fallback semantics
+- `conc.runtime/IO1-IO3` — Async I/O flow, reactor registration protocol
+- `conc.strategy` — Phase A vs Phase B runtime implementation
+- `conc.hidden-params` — Compiler pass that inserts `__ctx` parameters
+- `std.io` — Reader/Writer traits, IoError
+- `std.fs` — File type and convenience functions
+- `std.net` — TcpListener, TcpConnection
+- `mem.context` — `using` clause mechanism for Pool contexts

--- a/specs/concurrency/runtime-strategy.md
+++ b/specs/concurrency/runtime-strategy.md
@@ -1,0 +1,190 @@
+<!-- id: conc.strategy -->
+<!-- status: decided -->
+<!-- summary: Phased runtime implementation — OS threads first, M:N scheduler later -->
+<!-- depends: concurrency/async.md, concurrency/runtime.md, compiler/codegen.md -->
+
+# Runtime Implementation Strategy
+
+OS threads first. Full M:N scheduler later. Same programmer-facing semantics either way.
+
+## Decision
+
+| Rule | Description |
+|------|-------------|
+| **RS1: Two-phase approach** | Phase A targets OS threads (1:1). Phase B upgrades to M:N green tasks. Both implement `conc.async` semantics identically |
+| **RS2: Semantic parity** | `spawn`, `join`, `detach`, `cancel`, channels, `select` — all work in both phases. Programs don't change |
+| **RS3: Performance boundary** | Phase A handles ~10k concurrent tasks. Phase B targets 100k+ (per `conc.runtime/P3`) |
+| **RS4: No feature gating** | Phase A implements everything in `conc.async` — no deferred features. Only implementation strategy differs |
+
+**Why not jump straight to M:N?** The Cranelift backend doesn't have control flow working yet. Building a closure-to-state-machine compiler transform, work-stealing scheduler, and reactor simultaneously with a half-working backend is a recipe for debugging three things at once. OS threads let us validate the full concurrency API with a backend that's a thin wrapper around Rust's stdlib.
+
+## Phase A: OS Threads (1:1)
+
+| Rule | Description |
+|------|-------------|
+| **A1: Thread per spawn** | `spawn(|| {})` creates an OS thread via Rust's `std::thread::spawn` |
+| **A2: Blocking I/O** | All I/O blocks the calling thread. No reactor, no parking |
+| **A3: Real channels** | Channels use `std::sync::mpsc` or crossbeam. Blocking send/recv |
+| **A4: Affine handles** | `TaskHandle` wraps `JoinHandle`. Runtime panic on drop (same as interpreter) |
+| **A5: Context parameter threaded** | `using Multitasking` still desugars to hidden `__ctx` parameter — but context is a marker, not a scheduler handle |
+| **A6: ThreadPool real** | `ThreadPool` uses a real bounded thread pool (already correct in interpreter) |
+
+### What `using Multitasking` does in Phase A
+
+```rask
+using Multitasking {
+    const h = spawn(|| { work() })
+    try h.join()
+}
+```
+
+Desugars to:
+
+```rust
+// Compiler output (pseudocode)
+let __ctx = RuntimeContext::ThreadBacked;
+
+let handle = std::thread::spawn(move || {
+    work()
+});
+
+let result = handle.join().map_err(|e| JoinError::Panicked(format!("{:?}", e)))?;
+```
+
+No scheduler. No reactor. Thread blocks on `join()`. Same semantics, simpler implementation.
+
+### Phase A runtime library (`rask-rt`)
+
+| Component | Implementation | Lines (est.) |
+|-----------|---------------|-------------|
+| `rask_spawn` | `std::thread::spawn` wrapper | ~30 |
+| `rask_join` | `JoinHandle::join` + error mapping | ~20 |
+| `rask_detach` | Drop handle, track via `Arc` for block exit | ~20 |
+| `rask_cancel` | `AtomicBool` flag + join | ~30 |
+| `rask_channel_*` | Wrap `crossbeam::bounded` / `crossbeam::unbounded` | ~80 |
+| `rask_select` | `crossbeam::select!` macro wrapper | ~60 |
+| `rask_sleep` | `std::thread::sleep` | ~5 |
+| `rask_timeout` | Thread + channel race (per `conc.runtime/TM5`) | ~40 |
+| `rask_mutex` | `std::sync::Mutex` wrapper | ~30 |
+| `rask_shared` | `std::sync::RwLock` wrapper | ~30 |
+| Context plumbing | Marker type, threaded as hidden param | ~20 |
+| **Total** | | **~365** |
+
+### What this validates
+
+- Full `conc.async` API surface (S1-S4, H1-H4, C1-C4, CH1-CH4, CN1-CN3)
+- Hidden parameter desugaring (`conc.strategy/A5`)
+- Affine handle enforcement (runtime)
+- Channel semantics (buffered, unbuffered, close-on-drop)
+- `select` statement compilation
+- `ensure` hooks on cancellation
+- Error propagation through task boundaries
+
+### What this defers
+
+- Green tasks / stackless state machines (runtime.md/T1-T3)
+- Work-stealing scheduler (runtime.md/S1-S4)
+- Reactor / epoll / kqueue (runtime.md/R1-R3)
+- Transparent I/O pausing (tasks block their OS thread instead)
+- Timer wheel (uses `std::thread::sleep`)
+- 100k+ concurrent task scalability
+
+## Phase B: M:N Green Tasks
+
+| Rule | Description |
+|------|-------------|
+| **B1: Full runtime.md** | Implements everything in `conc.runtime` — scheduler, reactor, state machines |
+| **B2: State machine transform** | Compiler pass converts closures to stackless state machines at pause points |
+| **B3: Swap rask-rt internals** | `rask_spawn` switches from `std::thread::spawn` to scheduler queue push. API unchanged |
+| **B4: Trigger** | Upgrade when: (a) Cranelift backend handles full control flow, and (b) real programs hit the ~10k thread ceiling |
+
+### Migration path
+
+No source changes. The `rask-rt` library swaps internals:
+
+| Function | Phase A | Phase B |
+|----------|---------|---------|
+| `rask_spawn` | `std::thread::spawn` | Allocate `Task`, push to worker queue |
+| `rask_join` | `JoinHandle::join` | Park task or block thread (J1) |
+| I/O calls | Blocking syscall | Non-blocking + reactor registration |
+| `rask_channel_send` | `crossbeam::send` | Lock ring buffer + waker (runtime.md/CH2) |
+| `rask_sleep` | `std::thread::sleep` | Timer wheel registration (runtime.md/TM3) |
+
+### New compiler requirements for Phase B
+
+| Requirement | Description | Spec reference |
+|-------------|-------------|---------------|
+| State machine transform | Closure → enum with `poll()` method | `conc.runtime/T3` |
+| Pause point detection | Identify I/O calls, channel ops, sleep | `conc.io-context` (new spec) |
+| Context parameter insertion | Already done in Phase A | `conc.strategy/A5` |
+
+## What doesn't change between phases
+
+| Aspect | Stays the same |
+|--------|---------------|
+| Programmer syntax | `spawn(|| {})`, `.join()`, `.detach()`, channels, `select` |
+| Error types | `JoinError`, `SendError`, `RecvError`, `TimedOut` |
+| Affine handle rules | Must consume via join/detach/cancel |
+| `using` block scoping | Block exit waits for non-detached tasks |
+| Channel semantics | Buffered/unbuffered, close-on-drop, backpressure |
+| Context clauses | `using Multitasking`, `using ThreadPool` |
+
+## Error Messages
+
+```
+ERROR [conc.strategy/RS3]: too many concurrent tasks
+   |
+   | 10,247 OS threads active (Phase A limit: ~10,000)
+   |
+WHY: Phase A uses OS threads. Each spawn() creates a real thread.
+
+FIX: Reduce concurrent tasks, or wait for Phase B (green tasks).
+```
+
+## Edge Cases
+
+| Case | Phase A | Phase B |
+|------|---------|---------|
+| 100k concurrent spawns | OS thread limit (~10k), panics | Works (120 bytes/task) |
+| I/O in tight loop | Blocks thread (acceptable for <10k tasks) | Parks task, runs others |
+| `join()` in async context | Blocks calling thread | Parks calling task |
+| Nested `using Multitasking` | Compile error (same in both) | Compile error |
+| `cancelled()` check | Works (AtomicBool) | Works (same mechanism) |
+
+---
+
+## Appendix (non-normative)
+
+### Rationale
+
+**RS1 (two-phase):** The interpreter already proves OS threads work for semantics validation. The compiled version needs a working backend before it can do state machine transforms. Building them in sequence avoids coupling backend bugs with runtime bugs.
+
+**RS4 (no feature gating):** Deferring features creates two languages. If Phase A skips `select` or channels, programs written against Phase A won't exercise the full API. Then Phase B ships with untested surface area.
+
+**A5 (hidden parameter even in Phase A):** Threading `__ctx` even when it's just a marker validates the desugaring pass. If we skip it in Phase A and add it in Phase B, we're debugging desugaring and runtime simultaneously.
+
+### Implementation order within Phase A
+
+1. `rask_spawn` + `rask_join` + `rask_detach` (minimal concurrency)
+2. `rask_channel_*` (producer-consumer patterns)
+3. `rask_cancel` + ensure hooks (resource safety)
+4. `rask_select` (multiplexing)
+5. `rask_sleep` + `rask_timeout` (timers)
+6. `rask_mutex` + `rask_shared` (shared state)
+
+Each step is independently testable. Step 1 alone enables `spawn(|| {}).detach()` and `try h.join()`.
+
+### Risk: Phase A "good enough" trap
+
+If Phase A handles most real programs, there's temptation to never build Phase B. Guard against this by:
+- Documenting the ~10k thread limit prominently
+- Including a validation program that requires >10k concurrent connections (HTTP server benchmark)
+- Tracking Phase B as a blocking requirement for v1.0
+
+### See Also
+
+- `conc.async` — Programmer-facing concurrency semantics
+- `conc.runtime` — Full M:N runtime specification (Phase B target)
+- `conc.io-context` — I/O context detection and async/sync dispatch
+- `conc.hidden-params` — Hidden parameter compiler pass
+- `comp.codegen/RT1-RT3` — Runtime library requirements


### PR DESCRIPTION
- runtime-strategy.md: Decides OS threads first (Phase A), M:N green
  tasks later (Phase B). Resolves the open question in TODO.md.
- io-context.md: Specifies how stdlib I/O functions detect async context
  and dispatch between blocking and non-blocking code paths.
- hidden-params.md: Formalizes the compiler pass that desugars `using`
  clauses into hidden function parameters.

Updates concurrency README, specs README, and TODO.md.

https://claude.ai/code/session_014uHJaLrHuTPbEoAUndRpN7