### PR TITLE
Implement struct/enum field access, pointers, and string literals in codegen

### DIFF
--- a/compiler/Cargo.lock
+++ b/compiler/Cargo.lock
@@ -868,6 +868,7 @@ dependencies = [
  "object",
  "rask-mir",
  "rask-mono",
+ "rask-types",
  "target-lexicon",
 ]
 

--- a/compiler/crates/rask-cli/src/commands/build.rs
+++ b/compiler/crates/rask-cli/src/commands/build.rs
@@ -112,6 +112,14 @@ pub fn cmd_build(path: &str) {
                                                             }
                                                         }
 
+                                                        // Register string constants before codegen
+                                                        if total_errors == 0 {
+                                                            if let Err(e) = codegen.register_strings(&mir_functions) {
+                                                                eprintln!("codegen error: {}", e);
+                                                                total_errors += 1;
+                                                            }
+                                                        }
+
                                                         // Generate each function
                                                         if total_errors == 0 {
                                                             for mir_fn in &mir_functions {

--- a/compiler/crates/rask-codegen/Cargo.toml
+++ b/compiler/crates/rask-codegen/Cargo.toml
@@ -16,3 +16,6 @@ cranelift-frontend = "0.114"
 
 target-lexicon = "0.12"
 object = "0.36"
+
+[dev-dependencies]
+rask-types = { path = "../rask-types" }

--- a/compiler/crates/rask-mir/src/lib.rs
+++ b/compiler/crates/rask-mir/src/lib.rs
@@ -18,4 +18,4 @@ pub use builder::BlockBuilder;
 pub use function::{BlockId, MirBlock, MirFunction, MirLocal};
 pub use operand::{BinOp, FunctionRef, LocalId, MirConst, MirOperand, MirRValue, UnaryOp};
 pub use stmt::{MirStmt, MirTerminator};
-pub use types::MirType;
+pub use types::{MirType, StructLayoutId, EnumLayoutId};

--- a/compiler/runtime/runtime.c
+++ b/compiler/runtime/runtime.c
@@ -6,6 +6,9 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <stdint.h>
+#include <unistd.h>
+#include <fcntl.h>
+#include <string.h>
 
 // Forward declaration — user's main function, exported from the Rask module as rask_main
 extern void rask_main(void);
@@ -18,6 +21,16 @@ void rask_print_i64(int64_t val) {
 
 void rask_print_bool(int8_t val) {
     printf("%s", val ? "true" : "false");
+}
+
+void rask_print_f64(double val) {
+    printf("%g", val);
+}
+
+void rask_print_string(const char *ptr) {
+    if (ptr) {
+        fputs(ptr, stdout);
+    }
 }
 
 void rask_print_newline(void) {
@@ -38,6 +51,26 @@ void rask_panic_unwrap(void) {
 void rask_assert_fail(void) {
     fprintf(stderr, "panic: assertion failed\n");
     abort();
+}
+
+// ─── I/O primitives ──────────────────────────────────────────────
+// Thin wrappers around POSIX syscalls. Return values match POSIX
+// conventions: bytes transferred on success, -1 on error.
+
+int64_t rask_io_open(const char *path, int64_t flags, int64_t mode) {
+    return (int64_t)open(path, (int)flags, (mode_t)mode);
+}
+
+int64_t rask_io_close(int64_t fd) {
+    return (int64_t)close((int)fd);
+}
+
+int64_t rask_io_read(int64_t fd, void *buf, int64_t len) {
+    return (int64_t)read((int)fd, buf, (size_t)len);
+}
+
+int64_t rask_io_write(int64_t fd, const void *buf, int64_t len) {
+    return (int64_t)write((int)fd, buf, (size_t)len);
 }
 
 // ─── Entry point ──────────────────────────────────────────────────


### PR DESCRIPTION
## Summary
This PR implements comprehensive support for aggregate type operations and string handling in the Cranelift code generator. It adds field access for structs and enums, pointer operations (ref/deref), stack allocation for aggregates, string literal data sections, and I/O runtime functions.

## Key Changes

### Aggregate Type Support
- **Struct field access**: Implement `MirRValue::Field` to load fields from struct pointers with proper offset calculation
- **Enum tag extraction**: Implement `MirRValue::EnumTag` to extract discriminant values from enum instances
- **Enum field access**: Support extracting payloads from enum variants after tag checks
- **Stack allocation**: Pre-allocate stack slots for non-parameter struct and enum locals, storing their addresses in variables

### Pointer Operations
- **Reference (`Ref`)**: Create pointers to aggregates (returns stack address) or spill scalars to stack and return address
- **Dereference (`Deref`)**: Load values from pointers with proper type handling

### String Literal Support
- **Data section registration**: Scan MIR for string constants and create null-terminated data objects in the object module
- **String deduplication**: Reuse data objects for identical string literals
- **String operand lowering**: Convert string constants to global data addresses during code generation

### Runtime Functions
- **I/O primitives**: Declare and implement `rask_io_open`, `rask_io_close`, `rask_io_read`, `rask_io_write` as thin wrappers around POSIX syscalls
- **String printing**: Add `rask_print_string` and `rask_print_f64` runtime functions
- **C runtime**: Implement all I/O functions in `runtime.c` with proper error handling

### Code Generator Infrastructure
- Pass struct/enum layouts and string globals through the builder pipeline
- Extend `FunctionBuilder` to accept layout information and string data mappings
- Add helper methods for MIR type lookup and string constant collection

### Testing
- Add 13 comprehensive tests covering:
  - Struct field access and construction
  - Enum tag extraction and variant unwrapping
  - Reference and dereference operations
  - String constant handling and deduplication
  - Stack allocation for aggregates
  - I/O function declarations

## Implementation Details
- Aggregate locals are represented as i64 pointers to stack-allocated storage
- Field offsets are computed from monomorphized layout information
- String data is registered in a separate pass before function code generation
- Stack slots are created before the function builder processes blocks to avoid borrow conflicts

https://claude.ai/code/session_01GM3Xg3RUaYt9jKgfe42rwb