### PR TITLE
Implement C runtime library: allocator, Vec, String, Map, Pool, CLI args

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,10 @@ research/
 docs/build/
 docs/book/book/
 
+# C runtime build artifacts
+compiler/runtime/*.o
+compiler/runtime/*.a
+
 # Playground builds
 docs/playground/dist/
 docs/playground/node_modules/

--- a/compiler/runtime/Makefile
+++ b/compiler/runtime/Makefile
@@ -1,0 +1,20 @@
+CC ?= cc
+CFLAGS ?= -Wall -Wextra -Wpedantic -std=c11 -O2
+AR ?= ar
+
+SRCS = runtime.c alloc.c vec.c string.c map.c pool.c args.c
+OBJS = $(SRCS:.c=.o)
+LIB  = librask_runtime.a
+
+.PHONY: all clean
+
+all: $(LIB)
+
+$(LIB): $(OBJS)
+	$(AR) rcs $@ $^
+
+%.o: %.c rask_runtime.h
+	$(CC) $(CFLAGS) -c $< -o $@
+
+clean:
+	rm -f $(OBJS) $(LIB)

--- a/compiler/runtime/alloc.c
+++ b/compiler/runtime/alloc.c
@@ -1,0 +1,39 @@
+// SPDX-License-Identifier: (MIT OR Apache-2.0)
+
+// Heap allocator — thin wrappers around malloc/realloc/free.
+// Centralizes allocation so we can add tracking or swap allocators later.
+
+#include "rask_runtime.h"
+#include <stdlib.h>
+#include <stdio.h>
+#include <string.h>
+
+void *rask_alloc(int64_t size) {
+    if (size <= 0) {
+        return NULL;
+    }
+    void *ptr = malloc((size_t)size);
+    if (!ptr) {
+        fprintf(stderr, "rask: allocation failed (%lld bytes)\n", (long long)size);
+        abort();
+    }
+    return ptr;
+}
+
+void *rask_realloc(void *ptr, int64_t old_size, int64_t new_size) {
+    (void)old_size;
+    if (new_size <= 0) {
+        free(ptr);
+        return NULL;
+    }
+    void *new_ptr = realloc(ptr, (size_t)new_size);
+    if (!new_ptr) {
+        fprintf(stderr, "rask: reallocation failed (%lld bytes)\n", (long long)new_size);
+        abort();
+    }
+    return new_ptr;
+}
+
+void rask_free(void *ptr) {
+    free(ptr);
+}

--- a/compiler/runtime/args.c
+++ b/compiler/runtime/args.c
@@ -1,0 +1,22 @@
+// SPDX-License-Identifier: (MIT OR Apache-2.0)
+
+// CLI args — stores argc/argv from main() for access by Rask programs.
+
+#include "rask_runtime.h"
+
+static int    g_argc = 0;
+static char **g_argv = NULL;
+
+void rask_args_init(int argc, char **argv) {
+    g_argc = argc;
+    g_argv = argv;
+}
+
+int64_t rask_args_count(void) {
+    return (int64_t)g_argc;
+}
+
+const char *rask_args_get(int64_t index) {
+    if (index < 0 || index >= g_argc) return NULL;
+    return g_argv[index];
+}

--- a/compiler/runtime/map.c
+++ b/compiler/runtime/map.c
@@ -1,0 +1,199 @@
+// SPDX-License-Identifier: (MIT OR Apache-2.0)
+
+// Map — open-addressing hash map with linear probing.
+// Separate arrays for slot states, keys, and values.
+// Default hash: FNV-1a. Default equality: memcmp.
+
+#include "rask_runtime.h"
+#include <stdlib.h>
+#include <string.h>
+
+#define MAP_EMPTY     0
+#define MAP_OCCUPIED  1
+#define MAP_TOMBSTONE 2
+
+#define MAP_INITIAL_CAP 16
+#define MAP_LOAD_MAX_NUM 3  // load factor = 3/4 = 0.75
+#define MAP_LOAD_MAX_DEN 4
+
+struct RaskMap {
+    int64_t    key_size;
+    int64_t    val_size;
+    int64_t    cap;
+    int64_t    len;
+    uint8_t   *states;
+    char      *keys;
+    char      *vals;
+    RaskHashFn hash_fn;
+    RaskEqFn   eq_fn;
+};
+
+// ─── Built-in hash/eq ───────────────────────────────────────
+
+uint64_t rask_hash_bytes(const void *key, int64_t key_size) {
+    const uint8_t *p = (const uint8_t *)key;
+    uint64_t h = 0xcbf29ce484222325ULL;
+    for (int64_t i = 0; i < key_size; i++) {
+        h ^= p[i];
+        h *= 0x100000001b3ULL;
+    }
+    return h;
+}
+
+int rask_eq_bytes(const void *a, const void *b, int64_t key_size) {
+    return memcmp(a, b, (size_t)key_size) == 0;
+}
+
+// ─── Internal ───────────────────────────────────────────────
+
+static void map_alloc_tables(RaskMap *m, int64_t cap) {
+    m->cap = cap;
+    m->states = (uint8_t *)rask_alloc(cap);
+    memset(m->states, MAP_EMPTY, (size_t)cap);
+    m->keys = (char *)rask_alloc(cap * m->key_size);
+    m->vals = (char *)rask_alloc(cap * m->val_size);
+}
+
+static int64_t map_find_slot(const RaskMap *m, const void *key) {
+    uint64_t h = m->hash_fn(key, m->key_size);
+    int64_t idx = (int64_t)(h % (uint64_t)m->cap);
+    int64_t first_tombstone = -1;
+
+    for (int64_t i = 0; i < m->cap; i++) {
+        int64_t slot = (idx + i) % m->cap;
+        uint8_t state = m->states[slot];
+
+        if (state == MAP_EMPTY) {
+            return (first_tombstone >= 0) ? first_tombstone : slot;
+        }
+        if (state == MAP_TOMBSTONE) {
+            if (first_tombstone < 0) first_tombstone = slot;
+            continue;
+        }
+        // MAP_OCCUPIED — compare key
+        if (m->eq_fn(m->keys + slot * m->key_size, key, m->key_size)) {
+            return slot;
+        }
+    }
+    // Table is full (shouldn't happen with load factor < 1)
+    return (first_tombstone >= 0) ? first_tombstone : -1;
+}
+
+static void map_rehash(RaskMap *m) {
+    int64_t old_cap = m->cap;
+    uint8_t *old_states = m->states;
+    char *old_keys = m->keys;
+    char *old_vals = m->vals;
+
+    map_alloc_tables(m, old_cap * 2);
+    m->len = 0;
+
+    for (int64_t i = 0; i < old_cap; i++) {
+        if (old_states[i] == MAP_OCCUPIED) {
+            rask_map_insert(m, old_keys + i * m->key_size,
+                            old_vals + i * m->val_size);
+        }
+    }
+
+    rask_free(old_states);
+    rask_free(old_keys);
+    rask_free(old_vals);
+}
+
+// ─── Public API ─────────────────────────────────────────────
+
+RaskMap *rask_map_new(int64_t key_size, int64_t val_size) {
+    return rask_map_new_custom(key_size, val_size, rask_hash_bytes, rask_eq_bytes);
+}
+
+RaskMap *rask_map_new_custom(int64_t key_size, int64_t val_size,
+                             RaskHashFn hash, RaskEqFn eq) {
+    RaskMap *m = (RaskMap *)rask_alloc(sizeof(RaskMap));
+    m->key_size = key_size;
+    m->val_size = val_size;
+    m->len = 0;
+    m->hash_fn = hash;
+    m->eq_fn = eq;
+    map_alloc_tables(m, MAP_INITIAL_CAP);
+    return m;
+}
+
+void rask_map_free(RaskMap *m) {
+    if (!m) return;
+    rask_free(m->states);
+    rask_free(m->keys);
+    rask_free(m->vals);
+    rask_free(m);
+}
+
+int64_t rask_map_len(const RaskMap *m) {
+    return m ? m->len : 0;
+}
+
+// Returns 0 if inserted new, 1 if updated existing.
+int64_t rask_map_insert(RaskMap *m, const void *key, const void *val) {
+    if (!m) return -1;
+
+    // Rehash if load factor exceeded
+    if ((m->len + 1) * MAP_LOAD_MAX_DEN > m->cap * MAP_LOAD_MAX_NUM) {
+        map_rehash(m);
+    }
+
+    int64_t slot = map_find_slot(m, key);
+    if (slot < 0) {
+        // Shouldn't happen after rehash
+        map_rehash(m);
+        slot = map_find_slot(m, key);
+    }
+
+    int64_t was_occupied = (m->states[slot] == MAP_OCCUPIED);
+    memcpy(m->keys + slot * m->key_size, key, (size_t)m->key_size);
+    memcpy(m->vals + slot * m->val_size, val, (size_t)m->val_size);
+    m->states[slot] = MAP_OCCUPIED;
+    if (!was_occupied) m->len++;
+    return was_occupied ? 1 : 0;
+}
+
+void *rask_map_get(const RaskMap *m, const void *key) {
+    if (!m || m->len == 0) return NULL;
+
+    uint64_t h = m->hash_fn(key, m->key_size);
+    int64_t idx = (int64_t)(h % (uint64_t)m->cap);
+
+    for (int64_t i = 0; i < m->cap; i++) {
+        int64_t slot = (idx + i) % m->cap;
+        uint8_t state = m->states[slot];
+
+        if (state == MAP_EMPTY) return NULL;
+        if (state == MAP_TOMBSTONE) continue;
+        if (m->eq_fn(m->keys + slot * m->key_size, key, m->key_size)) {
+            return m->vals + slot * m->val_size;
+        }
+    }
+    return NULL;
+}
+
+int64_t rask_map_remove(RaskMap *m, const void *key) {
+    if (!m || m->len == 0) return -1;
+
+    uint64_t h = m->hash_fn(key, m->key_size);
+    int64_t idx = (int64_t)(h % (uint64_t)m->cap);
+
+    for (int64_t i = 0; i < m->cap; i++) {
+        int64_t slot = (idx + i) % m->cap;
+        uint8_t state = m->states[slot];
+
+        if (state == MAP_EMPTY) return -1;
+        if (state == MAP_TOMBSTONE) continue;
+        if (m->eq_fn(m->keys + slot * m->key_size, key, m->key_size)) {
+            m->states[slot] = MAP_TOMBSTONE;
+            m->len--;
+            return 0;
+        }
+    }
+    return -1;
+}
+
+int64_t rask_map_contains(const RaskMap *m, const void *key) {
+    return rask_map_get(m, key) != NULL;
+}

--- a/compiler/runtime/pool.c
+++ b/compiler/runtime/pool.c
@@ -1,0 +1,138 @@
+// SPDX-License-Identifier: (MIT OR Apache-2.0)
+
+// Pool — handle-based sparse storage with generation counters.
+// Each slot tracks a generation to detect stale handles at O(1).
+// Free slots form a singly-linked list through an index field.
+
+#include "rask_runtime.h"
+#include <stdlib.h>
+#include <string.h>
+
+// Per-slot metadata, stored separately from element data.
+typedef struct {
+    uint32_t generation;
+    int32_t  next_free; // -1 = occupied, >= 0 = next free slot index
+} PoolSlot;
+
+struct RaskPool {
+    uint32_t  pool_id;
+    int64_t   elem_size;
+    int64_t   cap;
+    int64_t   len;
+    PoolSlot *slots;
+    char     *data;
+    int32_t   free_head; // -1 = no free slots
+};
+
+static uint32_t g_next_pool_id = 1;
+
+static void pool_grow(RaskPool *p, int64_t new_cap) {
+    p->slots = (PoolSlot *)rask_realloc(p->slots,
+        (int64_t)(p->cap * sizeof(PoolSlot)),
+        (int64_t)(new_cap * sizeof(PoolSlot)));
+    p->data = (char *)rask_realloc(p->data,
+        p->cap * p->elem_size,
+        new_cap * p->elem_size);
+
+    // Initialize new slots as free, chained together
+    for (int64_t i = p->cap; i < new_cap; i++) {
+        p->slots[i].generation = 0;
+        p->slots[i].next_free = (i + 1 < new_cap) ? (int32_t)(i + 1) : p->free_head;
+    }
+    // New free list: old_cap -> old_cap+1 -> ... -> new_cap-1 -> old free_head
+    p->free_head = (int32_t)p->cap;
+    p->cap = new_cap;
+}
+
+RaskPool *rask_pool_new(int64_t elem_size) {
+    RaskPool *p = (RaskPool *)rask_alloc(sizeof(RaskPool));
+    p->pool_id = g_next_pool_id++;
+    p->elem_size = elem_size;
+    p->cap = 0;
+    p->len = 0;
+    p->slots = NULL;
+    p->data = NULL;
+    p->free_head = -1;
+    return p;
+}
+
+RaskPool *rask_pool_with_capacity(int64_t elem_size, int64_t cap) {
+    RaskPool *p = rask_pool_new(elem_size);
+    if (cap > 0) {
+        pool_grow(p, cap);
+    }
+    return p;
+}
+
+void rask_pool_free(RaskPool *p) {
+    if (!p) return;
+    rask_free(p->slots);
+    rask_free(p->data);
+    rask_free(p);
+}
+
+int64_t rask_pool_len(const RaskPool *p) {
+    return p ? p->len : 0;
+}
+
+RaskHandle rask_pool_insert(RaskPool *p, const void *elem) {
+    RaskHandle h = RASK_HANDLE_INVALID;
+    if (!p) return h;
+
+    // Grow if no free slots
+    if (p->free_head < 0) {
+        int64_t new_cap = p->cap ? p->cap * 2 : 4;
+        pool_grow(p, new_cap);
+    }
+
+    // Pop from free list
+    int32_t idx = p->free_head;
+    p->free_head = p->slots[idx].next_free;
+    p->slots[idx].next_free = -1; // mark occupied
+
+    // Write element data
+    memcpy(p->data + idx * p->elem_size, elem, (size_t)p->elem_size);
+    p->len++;
+
+    h.pool_id = p->pool_id;
+    h.index = (uint32_t)idx;
+    h.generation = p->slots[idx].generation;
+    return h;
+}
+
+static int pool_validate(const RaskPool *p, RaskHandle h) {
+    if (!p) return 0;
+    if (h.pool_id != p->pool_id) return 0;
+    if (h.index >= (uint32_t)p->cap) return 0;
+    if (p->slots[h.index].next_free >= 0) return 0; // slot is free
+    if (p->slots[h.index].generation != h.generation) return 0;
+    return 1;
+}
+
+void *rask_pool_get(const RaskPool *p, RaskHandle h) {
+    if (!pool_validate(p, h)) return NULL;
+    return (void *)(p->data + h.index * p->elem_size);
+}
+
+int64_t rask_pool_remove(RaskPool *p, RaskHandle h, void *out) {
+    if (!pool_validate(p, h)) return -1;
+
+    if (out) {
+        memcpy(out, p->data + h.index * p->elem_size, (size_t)p->elem_size);
+    }
+
+    // Bump generation (saturate at UINT32_MAX to permanently invalidate)
+    if (p->slots[h.index].generation < UINT32_MAX) {
+        p->slots[h.index].generation++;
+    }
+
+    // Push onto free list
+    p->slots[h.index].next_free = p->free_head;
+    p->free_head = (int32_t)h.index;
+    p->len--;
+    return 0;
+}
+
+int64_t rask_pool_is_valid(const RaskPool *p, RaskHandle h) {
+    return pool_validate(p, h);
+}

--- a/compiler/runtime/rask_runtime.h
+++ b/compiler/runtime/rask_runtime.h
@@ -1,0 +1,107 @@
+// SPDX-License-Identifier: (MIT OR Apache-2.0)
+
+// Rask C runtime — data structures and utilities for native-compiled programs.
+// Linked with object files produced by rask-codegen.
+
+#ifndef RASK_RUNTIME_H
+#define RASK_RUNTIME_H
+
+#include <stdint.h>
+#include <stddef.h>
+
+// ─── Allocator ──────────────────────────────────────────────
+
+void *rask_alloc(int64_t size);
+void *rask_realloc(void *ptr, int64_t old_size, int64_t new_size);
+void  rask_free(void *ptr);
+
+// ─── Vec ────────────────────────────────────────────────────
+// Growable array storing elements as raw bytes.
+
+typedef struct RaskVec RaskVec;
+
+RaskVec *rask_vec_new(int64_t elem_size);
+RaskVec *rask_vec_with_capacity(int64_t elem_size, int64_t cap);
+void     rask_vec_free(RaskVec *v);
+int64_t  rask_vec_len(const RaskVec *v);
+int64_t  rask_vec_capacity(const RaskVec *v);
+int64_t  rask_vec_push(RaskVec *v, const void *elem);
+void    *rask_vec_get(const RaskVec *v, int64_t index);
+void     rask_vec_set(RaskVec *v, int64_t index, const void *elem);
+int64_t  rask_vec_pop(RaskVec *v, void *out);
+int64_t  rask_vec_remove(RaskVec *v, int64_t index);
+void     rask_vec_clear(RaskVec *v);
+int64_t  rask_vec_reserve(RaskVec *v, int64_t additional);
+
+// ─── String ─────────────────────────────────────────────────
+// UTF-8 owned string, always null-terminated.
+
+typedef struct RaskString RaskString;
+
+RaskString *rask_string_new(void);
+RaskString *rask_string_from(const char *s);
+RaskString *rask_string_from_bytes(const char *data, int64_t len);
+void        rask_string_free(RaskString *s);
+int64_t     rask_string_len(const RaskString *s);
+const char *rask_string_ptr(const RaskString *s);
+int64_t     rask_string_push_byte(RaskString *s, uint8_t byte);
+int64_t     rask_string_push_char(RaskString *s, int32_t codepoint);
+int64_t     rask_string_append(RaskString *s, const RaskString *other);
+int64_t     rask_string_append_cstr(RaskString *s, const char *cstr);
+RaskString *rask_string_clone(const RaskString *s);
+int64_t     rask_string_eq(const RaskString *a, const RaskString *b);
+RaskString *rask_string_substr(const RaskString *s, int64_t start, int64_t end);
+
+// ─── Map ────────────────────────────────────────────────────
+// Open-addressing hash map with linear probing.
+// Keys and values stored as raw bytes. Uses FNV-1a hashing + memcmp by default.
+// For string-keyed maps, supply custom hash/eq via rask_map_new_custom.
+
+typedef struct RaskMap RaskMap;
+
+typedef uint64_t (*RaskHashFn)(const void *key, int64_t key_size);
+typedef int      (*RaskEqFn)(const void *a, const void *b, int64_t key_size);
+
+RaskMap *rask_map_new(int64_t key_size, int64_t val_size);
+RaskMap *rask_map_new_custom(int64_t key_size, int64_t val_size,
+                             RaskHashFn hash, RaskEqFn eq);
+void     rask_map_free(RaskMap *m);
+int64_t  rask_map_len(const RaskMap *m);
+int64_t  rask_map_insert(RaskMap *m, const void *key, const void *val);
+void    *rask_map_get(const RaskMap *m, const void *key);
+int64_t  rask_map_remove(RaskMap *m, const void *key);
+int64_t  rask_map_contains(const RaskMap *m, const void *key);
+
+// Built-in hash/eq functions
+uint64_t rask_hash_bytes(const void *key, int64_t key_size);
+int      rask_eq_bytes(const void *a, const void *b, int64_t key_size);
+
+// ─── Pool ───────────────────────────────────────────────────
+// Handle-based sparse storage with generation counters.
+
+typedef struct {
+    uint32_t pool_id;
+    uint32_t index;
+    uint32_t generation;
+} RaskHandle;
+
+typedef struct RaskPool RaskPool;
+
+RaskPool   *rask_pool_new(int64_t elem_size);
+RaskPool   *rask_pool_with_capacity(int64_t elem_size, int64_t cap);
+void        rask_pool_free(RaskPool *p);
+int64_t     rask_pool_len(const RaskPool *p);
+RaskHandle  rask_pool_insert(RaskPool *p, const void *elem);
+void       *rask_pool_get(const RaskPool *p, RaskHandle h);
+int64_t     rask_pool_remove(RaskPool *p, RaskHandle h, void *out);
+int64_t     rask_pool_is_valid(const RaskPool *p, RaskHandle h);
+
+#define RASK_HANDLE_INVALID ((RaskHandle){0, UINT32_MAX, 0})
+
+// ─── CLI args ───────────────────────────────────────────────
+
+void        rask_args_init(int argc, char **argv);
+int64_t     rask_args_count(void);
+const char *rask_args_get(int64_t index);
+
+#endif // RASK_RUNTIME_H

--- a/compiler/runtime/runtime.c
+++ b/compiler/runtime/runtime.c
@@ -10,6 +10,8 @@
 #include <fcntl.h>
 #include <string.h>
 
+#include "rask_runtime.h"
+
 // Forward declaration — user's main function, exported from the Rask module as rask_main
 extern void rask_main(void);
 
@@ -76,8 +78,7 @@ int64_t rask_io_write(int64_t fd, const void *buf, int64_t len) {
 // ─── Entry point ──────────────────────────────────────────────────
 
 int main(int argc, char **argv) {
-    (void)argc;
-    (void)argv;
+    rask_args_init(argc, argv);
     rask_main();
     return 0;
 }

--- a/compiler/runtime/string.c
+++ b/compiler/runtime/string.c
@@ -94,6 +94,8 @@ int64_t rask_string_push_char(RaskString *s, int32_t cp) {
         buf[1] = 0x80 | (uint8_t)(cp & 0x3F);
         n = 2;
     } else if (cp <= 0xFFFF) {
+        // Reject surrogates — not valid Unicode scalar values
+        if (cp >= 0xD800 && cp <= 0xDFFF) return -1;
         buf[0] = 0xE0 | (uint8_t)(cp >> 12);
         buf[1] = 0x80 | (uint8_t)((cp >> 6) & 0x3F);
         buf[2] = 0x80 | (uint8_t)(cp & 0x3F);

--- a/compiler/runtime/string.c
+++ b/compiler/runtime/string.c
@@ -1,0 +1,155 @@
+// SPDX-License-Identifier: (MIT OR Apache-2.0)
+
+// String — UTF-8 owned string, always null-terminated.
+// Internal buffer has room for the null byte beyond the reported length.
+
+#include "rask_runtime.h"
+#include <stdlib.h>
+#include <string.h>
+
+struct RaskString {
+    char   *data;
+    int64_t len;
+    int64_t cap; // capacity excluding null terminator
+};
+
+static void string_grow(RaskString *s, int64_t needed) {
+    if (needed <= s->cap) return;
+    int64_t new_cap = s->cap ? s->cap : 8;
+    while (new_cap < needed) {
+        new_cap *= 2;
+    }
+    // +1 for null terminator
+    s->data = (char *)rask_realloc(s->data, s->cap + 1, new_cap + 1);
+    s->cap = new_cap;
+}
+
+RaskString *rask_string_new(void) {
+    RaskString *s = (RaskString *)rask_alloc(sizeof(RaskString));
+    s->data = (char *)rask_alloc(1);
+    s->data[0] = '\0';
+    s->len = 0;
+    s->cap = 0;
+    return s;
+}
+
+RaskString *rask_string_from(const char *cstr) {
+    if (!cstr) return rask_string_new();
+    int64_t len = (int64_t)strlen(cstr);
+    RaskString *s = (RaskString *)rask_alloc(sizeof(RaskString));
+    s->data = (char *)rask_alloc(len + 1);
+    memcpy(s->data, cstr, (size_t)len + 1);
+    s->len = len;
+    s->cap = len;
+    return s;
+}
+
+RaskString *rask_string_from_bytes(const char *data, int64_t len) {
+    if (!data || len <= 0) return rask_string_new();
+    RaskString *s = (RaskString *)rask_alloc(sizeof(RaskString));
+    s->data = (char *)rask_alloc(len + 1);
+    memcpy(s->data, data, (size_t)len);
+    s->data[len] = '\0';
+    s->len = len;
+    s->cap = len;
+    return s;
+}
+
+void rask_string_free(RaskString *s) {
+    if (!s) return;
+    rask_free(s->data);
+    rask_free(s);
+}
+
+int64_t rask_string_len(const RaskString *s) {
+    return s ? s->len : 0;
+}
+
+const char *rask_string_ptr(const RaskString *s) {
+    if (!s) return "";
+    return s->data;
+}
+
+int64_t rask_string_push_byte(RaskString *s, uint8_t byte) {
+    if (!s) return -1;
+    string_grow(s, s->len + 1);
+    s->data[s->len] = (char)byte;
+    s->len++;
+    s->data[s->len] = '\0';
+    return 0;
+}
+
+// Encode a Unicode codepoint as UTF-8 and append it.
+int64_t rask_string_push_char(RaskString *s, int32_t cp) {
+    if (!s) return -1;
+    uint8_t buf[4];
+    int n;
+    if (cp < 0) {
+        return -1;
+    } else if (cp <= 0x7F) {
+        buf[0] = (uint8_t)cp;
+        n = 1;
+    } else if (cp <= 0x7FF) {
+        buf[0] = 0xC0 | (uint8_t)(cp >> 6);
+        buf[1] = 0x80 | (uint8_t)(cp & 0x3F);
+        n = 2;
+    } else if (cp <= 0xFFFF) {
+        buf[0] = 0xE0 | (uint8_t)(cp >> 12);
+        buf[1] = 0x80 | (uint8_t)((cp >> 6) & 0x3F);
+        buf[2] = 0x80 | (uint8_t)(cp & 0x3F);
+        n = 3;
+    } else if (cp <= 0x10FFFF) {
+        buf[0] = 0xF0 | (uint8_t)(cp >> 18);
+        buf[1] = 0x80 | (uint8_t)((cp >> 12) & 0x3F);
+        buf[2] = 0x80 | (uint8_t)((cp >> 6) & 0x3F);
+        buf[3] = 0x80 | (uint8_t)(cp & 0x3F);
+        n = 4;
+    } else {
+        return -1; // invalid codepoint
+    }
+    string_grow(s, s->len + n);
+    memcpy(s->data + s->len, buf, (size_t)n);
+    s->len += n;
+    s->data[s->len] = '\0';
+    return 0;
+}
+
+int64_t rask_string_append(RaskString *s, const RaskString *other) {
+    if (!s || !other || other->len == 0) return 0;
+    string_grow(s, s->len + other->len);
+    memcpy(s->data + s->len, other->data, (size_t)other->len);
+    s->len += other->len;
+    s->data[s->len] = '\0';
+    return 0;
+}
+
+int64_t rask_string_append_cstr(RaskString *s, const char *cstr) {
+    if (!s || !cstr) return 0;
+    int64_t clen = (int64_t)strlen(cstr);
+    if (clen == 0) return 0;
+    string_grow(s, s->len + clen);
+    memcpy(s->data + s->len, cstr, (size_t)clen);
+    s->len += clen;
+    s->data[s->len] = '\0';
+    return 0;
+}
+
+RaskString *rask_string_clone(const RaskString *s) {
+    if (!s) return rask_string_new();
+    return rask_string_from_bytes(s->data, s->len);
+}
+
+int64_t rask_string_eq(const RaskString *a, const RaskString *b) {
+    if (a == b) return 1;
+    if (!a || !b) return 0;
+    if (a->len != b->len) return 0;
+    return memcmp(a->data, b->data, (size_t)a->len) == 0;
+}
+
+RaskString *rask_string_substr(const RaskString *s, int64_t start, int64_t end) {
+    if (!s) return rask_string_new();
+    if (start < 0) start = 0;
+    if (end > s->len) end = s->len;
+    if (start >= end) return rask_string_new();
+    return rask_string_from_bytes(s->data + start, end - start);
+}

--- a/compiler/runtime/vec.c
+++ b/compiler/runtime/vec.c
@@ -1,0 +1,114 @@
+// SPDX-License-Identifier: (MIT OR Apache-2.0)
+
+// Vec — growable array storing elements as raw bytes.
+// Growth factor: 2x. Initial allocation deferred until first push.
+
+#include "rask_runtime.h"
+#include <stdlib.h>
+#include <string.h>
+
+struct RaskVec {
+    char   *data;
+    int64_t len;
+    int64_t cap;
+    int64_t elem_size;
+};
+
+RaskVec *rask_vec_new(int64_t elem_size) {
+    RaskVec *v = (RaskVec *)rask_alloc(sizeof(RaskVec));
+    v->data = NULL;
+    v->len = 0;
+    v->cap = 0;
+    v->elem_size = elem_size;
+    return v;
+}
+
+RaskVec *rask_vec_with_capacity(int64_t elem_size, int64_t cap) {
+    RaskVec *v = (RaskVec *)rask_alloc(sizeof(RaskVec));
+    v->len = 0;
+    v->elem_size = elem_size;
+    if (cap > 0) {
+        v->data = (char *)rask_alloc(elem_size * cap);
+        v->cap = cap;
+    } else {
+        v->data = NULL;
+        v->cap = 0;
+    }
+    return v;
+}
+
+void rask_vec_free(RaskVec *v) {
+    if (!v) return;
+    rask_free(v->data);
+    rask_free(v);
+}
+
+int64_t rask_vec_len(const RaskVec *v) {
+    return v ? v->len : 0;
+}
+
+int64_t rask_vec_capacity(const RaskVec *v) {
+    return v ? v->cap : 0;
+}
+
+static int vec_grow(RaskVec *v, int64_t needed) {
+    if (needed <= v->cap) return 0;
+    int64_t new_cap = v->cap ? v->cap : 4;
+    while (new_cap < needed) {
+        new_cap *= 2;
+    }
+    char *new_data = (char *)rask_realloc(v->data, v->cap * v->elem_size,
+                                          new_cap * v->elem_size);
+    v->data = new_data;
+    v->cap = new_cap;
+    return 0;
+}
+
+int64_t rask_vec_push(RaskVec *v, const void *elem) {
+    if (!v) return -1;
+    if (vec_grow(v, v->len + 1) != 0) return -1;
+    memcpy(v->data + v->len * v->elem_size, elem, (size_t)v->elem_size);
+    v->len++;
+    return 0;
+}
+
+void *rask_vec_get(const RaskVec *v, int64_t index) {
+    if (!v || index < 0 || index >= v->len) return NULL;
+    return v->data + index * v->elem_size;
+}
+
+void rask_vec_set(RaskVec *v, int64_t index, const void *elem) {
+    if (!v || index < 0 || index >= v->len) return;
+    memcpy(v->data + index * v->elem_size, elem, (size_t)v->elem_size);
+}
+
+int64_t rask_vec_pop(RaskVec *v, void *out) {
+    if (!v || v->len == 0) return -1;
+    v->len--;
+    if (out) {
+        memcpy(out, v->data + v->len * v->elem_size, (size_t)v->elem_size);
+    }
+    return 0;
+}
+
+int64_t rask_vec_remove(RaskVec *v, int64_t index) {
+    if (!v || index < 0 || index >= v->len) return -1;
+    // Shift elements left
+    int64_t remaining = v->len - index - 1;
+    if (remaining > 0) {
+        memmove(v->data + index * v->elem_size,
+                v->data + (index + 1) * v->elem_size,
+                (size_t)(remaining * v->elem_size));
+    }
+    v->len--;
+    return 0;
+}
+
+void rask_vec_clear(RaskVec *v) {
+    if (v) v->len = 0;
+}
+
+int64_t rask_vec_reserve(RaskVec *v, int64_t additional) {
+    if (!v) return -1;
+    return vec_grow(v, v->len + additional);
+}


### PR DESCRIPTION
Adds C-callable data structure implementations for native-compiled Rask
programs. Each type is a separate compilation unit linked into
librask_runtime.a.

- alloc.c: rask_alloc/realloc/free wrappers around malloc (centralized
  for future tracking/swap)
- vec.c: growable array with element-size-generic storage, 2x growth
- string.c: UTF-8 owned string with null termination, proper codepoint
  encoding (1-4 byte UTF-8)
- map.c: open-addressing hash map with FNV-1a hashing, linear probing,
  tombstone deletion, custom hash/eq function pointer support
- pool.c: handle-based sparse storage with generation counters for O(1)
  stale handle detection, free list slot reuse, unique pool IDs
- args.c: CLI argument access (argc/argv stored from main)
- runtime.c: wired up rask_args_init in main()
- Makefile: builds all sources into librask_runtime.a

All 49 tests pass (/tmp/test_runtime.c).

https://claude.ai/code/session_01KCm4Xu2eoG8bN2ZYtVyfyH