### PR TITLE
Implement enum variant construction and pattern matching

### DIFF
--- a/compiler/crates/rask-codegen/src/builder.rs
+++ b/compiler/crates/rask-codegen/src/builder.rs
@@ -646,14 +646,11 @@ impl<'a> FunctionBuilder<'a> {
                             0
                         }
                     }
-                    // No layout available — derive stride from the field's load type.
-                    // This covers Option/Result/Tuple which MIR lowers to Ptr.
-                    _ => {
-                        let stride = expected_ty
-                            .map(|t| t.bytes() as i32)
-                            .unwrap_or(8);
-                        (*field_index as i32) * stride
-                    }
+                    // No layout available (Option/Result/Tuple lowered to MirType::Ptr).
+                    // Currently only field_index 0 reaches here (enum payload extraction).
+                    // Higher indices would need full layout info to account for alignment
+                    // padding between heterogeneous fields.
+                    _ => 0
                 };
 
                 let flags = MemFlags::new();

--- a/compiler/crates/rask-codegen/src/tests.rs
+++ b/compiler/crates/rask-codegen/src/tests.rs
@@ -1129,7 +1129,7 @@ mod tests {
             locals: vec![],
             blocks: vec![
                 block(0, vec![], MirTerminator::CleanupReturn {
-                    value: i32_const(42),
+                    value: Some(i32_const(42)),
                     cleanup_chain: vec![],
                 }),
             ],
@@ -1155,7 +1155,7 @@ mod tests {
             locals: vec![],
             blocks: vec![
                 block(0, vec![], MirTerminator::CleanupReturn {
-                    value: i32_const(99),
+                    value: Some(i32_const(99)),
                     cleanup_chain: vec![BlockId(1)],
                 }),
                 block(1, vec![

--- a/compiler/crates/rask-mir/src/display.rs
+++ b/compiler/crates/rask-mir/src/display.rs
@@ -139,7 +139,7 @@ impl fmt::Display for MirStmt {
                 write!(f, "_{} = resource_register({}, depth={})", dst.0, type_name, scope_depth)
             }
             MirStmt::ResourceConsume { resource_id } => {
-                write!(f, "resource_consume(_{}", resource_id.0)
+                write!(f, "resource_consume(_{})", resource_id.0)
             }
             MirStmt::ResourceScopeCheck { scope_depth } => {
                 write!(f, "resource_scope_check(depth={})", scope_depth)
@@ -198,7 +198,11 @@ impl fmt::Display for MirTerminator {
             }
             MirTerminator::Unreachable => write!(f, "unreachable"),
             MirTerminator::CleanupReturn { value, cleanup_chain } => {
-                write!(f, "cleanup_return {} [", value)?;
+                if let Some(v) = value {
+                    write!(f, "cleanup_return {} [", v)?;
+                } else {
+                    write!(f, "cleanup_return [",)?;
+                }
                 for (i, b) in cleanup_chain.iter().enumerate() {
                     if i > 0 { write!(f, ", ")?; }
                     write!(f, "bb{}", b.0)?;

--- a/compiler/crates/rask-mir/src/stmt.rs
+++ b/compiler/crates/rask-mir/src/stmt.rs
@@ -95,7 +95,7 @@ pub enum MirTerminator {
     },
     Unreachable,
     CleanupReturn {
-        value: MirOperand,
+        value: Option<MirOperand>,
         cleanup_chain: Vec<BlockId>,
     },
 }

--- a/compiler/crates/rask-mono/src/lib.rs
+++ b/compiler/crates/rask-mono/src/lib.rs
@@ -13,8 +13,8 @@ mod reachability;
 
 pub use instantiate::instantiate_function;
 pub use layout::{
-    compute_enum_layout, compute_struct_layout, EnumLayout, FieldLayout, StructLayout,
-    VariantLayout,
+    compute_enum_layout, compute_struct_layout, type_size_align, EnumLayout, FieldLayout,
+    StructLayout, VariantLayout,
 };
 pub use reachability::Monomorphizer;
 

--- a/compiler/crates/rask-mono/src/lib.rs
+++ b/compiler/crates/rask-mono/src/lib.rs
@@ -55,15 +55,17 @@ pub fn monomorphize(
 
     mono.run();
 
-    // Compute layouts for all referenced struct/enum types
+    // Compute layouts for concrete (non-generic) struct/enum types.
+    // Generic types need concrete type_args for correct field sizes;
+    // their layouts are computed per-instantiation, not here.
     let mut struct_layouts = Vec::new();
     let mut enum_layouts = Vec::new();
     for decl in decls {
         match &decl.kind {
-            DeclKind::Struct(_) => {
+            DeclKind::Struct(s) if s.type_params.is_empty() => {
                 struct_layouts.push(compute_struct_layout(decl, &[]));
             }
-            DeclKind::Enum(_) => {
+            DeclKind::Enum(e) if e.type_params.is_empty() => {
                 enum_layouts.push(compute_enum_layout(decl, &[]));
             }
             _ => {}

--- a/compiler/crates/rask-types/src/checker/check_pattern.rs
+++ b/compiler/crates/rask-types/src/checker/check_pattern.rs
@@ -200,7 +200,10 @@ impl TypeChecker {
             }
             "None" => {
                 if fields.is_empty() {
-                    if !matches!(&resolved_scrutinee, Type::Option(_) | Type::Var(_)) {
+                    // Constrain scrutinee to Option unless already known to be one.
+                    // Var types need the constraint too — otherwise a standalone
+                    // None arm won't propagate the Option requirement.
+                    if !matches!(&resolved_scrutinee, Type::Option(_)) {
                         let inner_ty = self.ctx.fresh_var();
                         self.ctx.add_constraint(TypeConstraint::Equal(
                             scrutinee_ty.clone(),

--- a/compiler/crates/rask-types/src/checker/check_pattern.rs
+++ b/compiler/crates/rask-types/src/checker/check_pattern.rs
@@ -105,9 +105,33 @@ impl TypeChecker {
             Pattern::Or(alternatives) => {
                 if let Some(first) = alternatives.first() {
                     let bindings = self.check_pattern(first, scrutinee_ty, span);
+                    let expected_names: Vec<&str> = bindings.iter()
+                        .map(|(n, _)| n.as_str())
+                        .collect();
                     for alt in &alternatives[1..] {
-                        let _alt_bindings = self.check_pattern(alt, scrutinee_ty, span);
-                        // TODO: verify same names and compatible types
+                        let alt_bindings = self.check_pattern(alt, scrutinee_ty, span);
+                        // Verify all alternatives bind the same names
+                        let alt_names: Vec<&str> = alt_bindings.iter()
+                            .map(|(n, _)| n.as_str())
+                            .collect();
+                        if alt_names != expected_names {
+                            self.errors.push(TypeError::GenericError(
+                                format!(
+                                    "or-pattern alternatives must bind the same variables \
+                                     (first binds {:?}, alternative binds {:?})",
+                                    expected_names, alt_names,
+                                ),
+                                span,
+                            ));
+                        }
+                        // Unify binding types across alternatives
+                        for ((_, first_ty), (_, alt_ty)) in bindings.iter().zip(alt_bindings.iter()) {
+                            self.ctx.add_constraint(TypeConstraint::Equal(
+                                first_ty.clone(),
+                                alt_ty.clone(),
+                                span,
+                            ));
+                        }
                     }
                     bindings
                 } else {

--- a/compiler/crates/rask-types/src/checker/declarations.rs
+++ b/compiler/crates/rask-types/src/checker/declarations.rs
@@ -20,6 +20,12 @@ impl TypeChecker {
                 DeclKind::Struct(s) => self.register_struct(s),
                 DeclKind::Enum(e) => self.register_enum(e),
                 DeclKind::Trait(t) => self.register_trait(t),
+                DeclKind::Fn(f) if !f.type_params.is_empty() => {
+                    let params: Vec<String> = f.type_params.iter()
+                        .map(|p| p.name.clone())
+                        .collect();
+                    self.fn_type_params.insert(f.name.clone(), params);
+                }
                 _ => {}
             }
         }

--- a/compiler/crates/rask-types/src/checker/mod.rs
+++ b/compiler/crates/rask-types/src/checker/mod.rs
@@ -60,8 +60,10 @@ pub struct TypeChecker {
     /// Pending generic call sites: (call NodeId, fresh type vars for type params).
     /// Resolved after constraint solving to populate TypedProgram.call_type_args.
     pub(super) pending_call_type_args: Vec<(NodeId, Vec<Type>)>,
-    /// Function name → type param names (populated during declaration collection).
-    pub(super) fn_type_params: HashMap<String, Vec<String>>,
+    /// SymbolId → type param names for generic functions.
+    /// Keyed by SymbolId (not name) to avoid collisions between
+    /// same-named functions in different scopes.
+    pub(super) fn_type_params: HashMap<SymbolId, Vec<String>>,
 }
 
 impl TypeChecker {


### PR DESCRIPTION
## Summary

This PR implements proper enum variant construction and pattern matching in the MIR lowering phase. Previously, enum variants were treated as regular function calls. Now they are lowered to direct memory operations (tag + payload stores), and pattern matching expressions properly extract and compare enum discriminants.

## Key Changes

### Enum Variant Construction
- **Type constructor detection**: Added `is_type_constructor_name()` to distinguish type names from variable identifiers
- **Variant lowering**: When lowering method calls on type names (e.g., `Shape.Circle(5.0)`), intercept before value lowering and emit direct `Store` statements for the discriminant tag and payload fields
- **Layout integration**: Use `EnumLayout` data to determine tag offset, tag value, and field offsets for correct memory layout

### Pattern Matching
- **Tag extraction**: Implemented `pattern_tag()` to resolve pattern names to their discriminant values (e.g., "Some" → 0, "None" → 1)
- **Payload binding**: Added `bind_pattern_payload()` to extract enum payload fields and bind them as named locals after a successful tag match
- **Type-aware extraction**: Implemented `extract_payload_type()` and `extract_err_type()` using raw type information to correctly determine payload types for Option/Result patterns

### Expression Lowering Updates
- **If-let**: Now properly extracts enum tag, compares against expected variant, and binds payload variables in the then-branch
- **Guard patterns**: Implements tag matching with payload extraction and binding
- **Is-pattern**: Evaluates to a boolean by comparing enum tags
- **While-let**: Extracts tag and compares in loop condition, binds payload in loop body
- **Static method calls**: Distinguish between enum variant construction and static methods on types (e.g., `Vec.new()`, `string.new()`)

### Type System Improvements
- **Generic substitution**: Added `build_subst()` and `resolve_field_type()` in layout computation to properly substitute type parameters with concrete types in struct/enum fields
- **Generic function calls**: Track fresh type variables for generic function type parameters and populate `call_type_args` for monomorphization
- **Or-pattern validation**: Verify that all alternatives in or-patterns bind the same variable names with compatible types

### Code Generation Fixes
- **Logical NOT**: Fixed `UnaryOp::Not` to use XOR with 1 instead of bitwise NOT (which was flipping all bits instead of just the boolean bit)
- **Enum tag type handling**: Properly derive Cranelift type from enum layout's tag type size
- **Return type handling**: Changed `CleanupReturn.value` to `Option<MirOperand>` to support void returns

### Testing
- Added comprehensive tests for enum variant construction with various payload configurations (no payload, single field, multiple fields)
- Added tests for static method calls on types vs. methods on values
- Tests verify correct number of store operations and proper function call generation

## Implementation Details

The enum variant construction uses a two-phase approach:
1. **Detection phase**: Check if the method call object is a type name (not in locals) and if a matching enum variant exists
2. **Lowering phase**: Allocate a temporary for the enum value, store the discriminant tag at the correct offset, then store each payload field at its layout-determined offset

Pattern matching leverages the existing `MirRValue::EnumTag` operation to extract the discriminant, then compares it against the expected tag value before binding payload variables.

https://claude.ai/code/session_01ASaSxfcjABbYKawZ8n7Xu6