### PR TITLE
Add string interpolation, enum variants(), and stdlib I/O functions

### DIFF
--- a/compiler/Cargo.lock
+++ b/compiler/Cargo.lock
@@ -896,6 +896,8 @@ name = "rask-desugar"
 version = "0.1.0"
 dependencies = [
  "rask-ast",
+ "rask-lexer",
+ "rask-parser",
 ]
 
 [[package]]

--- a/compiler/crates/rask-codegen/src/dispatch.rs
+++ b/compiler/crates/rask-codegen/src/dispatch.rs
@@ -121,6 +121,20 @@ pub fn stdlib_entries() -> Vec<StdlibEntry> {
             ret_ty: Some(types::I64),
         },
 
+        // ── Conversion to string ──────────────────────────────
+        StdlibEntry {
+            mir_name: "i64_to_string",
+            c_name: "rask_i64_to_string",
+            params: &[types::I64],
+            ret_ty: Some(types::I64),
+        },
+        StdlibEntry {
+            mir_name: "bool_to_string",
+            c_name: "rask_bool_to_string",
+            params: &[types::I64],
+            ret_ty: Some(types::I64),
+        },
+
         // ── Map operations ─────────────────────────────────────
         StdlibEntry {
             mir_name: "Map_new",
@@ -222,6 +236,34 @@ pub fn stdlib_entries() -> Vec<StdlibEntry> {
             mir_name: "contains",
             c_name: "rask_string_contains",
             params: &[types::I64, types::I64],
+            ret_ty: Some(types::I8),
+        },
+
+        // ── IO module ───────────────────────────────────────────
+        StdlibEntry {
+            mir_name: "io_read_line",
+            c_name: "rask_io_read_line",
+            params: &[],
+            ret_ty: Some(types::I64),
+        },
+
+        // ── More FS module ──────────────────────────────────────
+        StdlibEntry {
+            mir_name: "fs_read_file",
+            c_name: "rask_fs_read_file",
+            params: &[types::I64],
+            ret_ty: Some(types::I64),
+        },
+        StdlibEntry {
+            mir_name: "fs_write_file",
+            c_name: "rask_fs_write_file",
+            params: &[types::I64, types::I64],
+            ret_ty: None,
+        },
+        StdlibEntry {
+            mir_name: "fs_exists",
+            c_name: "rask_fs_exists",
+            params: &[types::I64],
             ret_ty: Some(types::I8),
         },
     ]

--- a/compiler/crates/rask-desugar/Cargo.toml
+++ b/compiler/crates/rask-desugar/Cargo.toml
@@ -6,3 +6,5 @@ edition.workspace = true
 
 [dependencies]
 rask-ast = { path = "../rask-ast" }
+rask-lexer = { path = "../rask-lexer" }
+rask-parser = { path = "../rask-parser" }

--- a/compiler/crates/rask-interp/src/builtins/primitives.rs
+++ b/compiler/crates/rask-interp/src/builtins/primitives.rs
@@ -184,6 +184,7 @@ impl Interpreter {
     ) -> Result<Value, RuntimeError> {
         match method {
             "eq" => { let b = self.expect_bool(args, 0)?; Ok(Value::Bool(a == b)) }
+            "to_string" => Ok(Value::String(Arc::new(Mutex::new(if a { "true" } else { "false" }.to_string())))),
             _ => Err(RuntimeError::NoSuchMethod {
                 ty: "bool".to_string(),
                 method: method.to_string(),

--- a/compiler/crates/rask-interp/src/builtins/strings.rs
+++ b/compiler/crates/rask-interp/src/builtins/strings.rs
@@ -52,6 +52,12 @@ impl Interpreter {
                 Ok(Value::String(Arc::new(Mutex::new(s.lock().unwrap().trim_end().to_string()))))
             }
             "to_string" => Ok(Value::String(Arc::clone(s))),
+            "concat" => {
+                let other = self.expect_string(&args, 0)?;
+                let mut result = s.lock().unwrap().clone();
+                result.push_str(&other);
+                Ok(Value::String(Arc::new(Mutex::new(result))))
+            }
             "to_owned" => {
                 Ok(Value::String(Arc::new(Mutex::new(s.lock().unwrap().clone()))))
             }

--- a/compiler/crates/rask-resolve/src/resolver.rs
+++ b/compiler/crates/rask-resolve/src/resolver.rs
@@ -100,6 +100,8 @@ impl Resolver {
         let builtin_modules = [
             ("io", BuiltinModuleKind::Io),
             ("fs", BuiltinModuleKind::Fs),
+            ("cli", BuiltinModuleKind::Cli),
+            ("std", BuiltinModuleKind::Std),
             ("json", BuiltinModuleKind::Json),
             ("random", BuiltinModuleKind::Random),
             ("time", BuiltinModuleKind::Time),

--- a/compiler/crates/rask-types/src/checker/resolve.rs
+++ b/compiler/crates/rask-types/src/checker/resolve.rs
@@ -178,6 +178,11 @@ impl TypeChecker {
             return self.unify(&ty, &ret, span);
         }
 
+        // to_string() on any type returns string
+        if method == "to_string" && args.is_empty() {
+            return self.unify(&ret, &Type::String, span);
+        }
+
         match &ty {
             Type::Var(_) => {
                 self.ctx.add_constraint(TypeConstraint::HasMethod {
@@ -470,6 +475,10 @@ impl TypeChecker {
                 self.unify(ret, &Type::Bool, span)
             }
             "push" | "push_str" => self.unify(ret, &Type::Unit, span),
+            "concat" if args.len() == 1 => {
+                self.unify(&args[0], &Type::String, span)?;
+                self.unify(ret, &Type::String, span)
+            }
             _ => Ok(false),
         }
     }


### PR DESCRIPTION
## Summary
This PR adds three major features to the Rask compiler:
1. **String interpolation** with automatic desugaring to `.concat()` and `.to_string()` calls
2. **Enum variant iteration** via `.variants()` method on fieldless enums
3. **Standard library I/O and file operations** with runtime support

## Key Changes

### String Interpolation (Desugaring)
- Added `desugar_string_interpolation()` in `rask-desugar` to parse `{expr}` segments in string literals
- Transforms `"hello {name}"` → `"hello ".concat(name.to_string()).concat(...)`
- Parses interpolated expressions using the real lexer/parser for full expression support
- Includes segment parsing with nested brace depth tracking

### Enum Variant Iteration
- Added `.variants()` method for fieldless enums that returns `Vec` of all variant values
- Type checker validates that enum has no payloads (E7-E8 rules in spec)
- MIR lowering generates `Vec_new()` + `push()` calls for each variant's tag value
- Interpreter support for `.variants()` with runtime validation

### Enum Field Access & Pattern Matching Improvements
- Added field access syntax for enum variants: `Color.Red` (no parens for fieldless variants)
- Enhanced match expression lowering to support:
  - Value matches (switch on scrutinee directly, not just enum tags)
  - Pattern-based case resolution via `resolve_pattern_tag()`
  - Enum payload binding in match arms
  - Wildcard and identifier patterns as defaults

### String Conversion Methods
- Implemented `to_string()` method on all types (String, I64, Bool, etc.)
- Added `concat()` method for string concatenation
- Type checker unifies `to_string()` return type to `String`
- Runtime functions: `rask_i64_to_string()`, `rask_bool_to_string()`

### For-In Loop Desugaring
- Rewrote generic iterator protocol to index-based iteration:
  - `for item in collection` → `_i = 0; while _i < len { item = get(_i); ... }`
  - Generates explicit `len()` and `get()` calls instead of `next()` protocol
  - Added `collection_elem_types` tracking for element type propagation post-mono

### Standard Library Functions
- **I/O module**: `io_read_line()` for stdin input
- **FS module**: `fs_read_file()`, `fs_write_file()`, `fs_exists()`
- Added dispatch entries and C runtime implementations
- Proper string allocation and null-termination handling

### Codegen Improvements
- Fixed void function call handling (define dest as zero to maintain SSA validity)
- Added `assert()` builtin with trap on failure
- Fixed switch statement value type extension (u8 enum tags → i64)
- Improved call result handling for functions with no return value

### Type Checking & Resolution
- Added `to_string()` method resolution for all types
- Enum `.variants()` validation (fieldless constraint)
- Module resolution for `cli` and `std` builtins

## Notable Implementation Details
- String interpolation uses segment-based parsing with proper brace nesting
- Enum variant tags are resolved at compile time from layout information
- For-in loops now generate explicit index-based iteration (more predictable codegen)
- Match expressions support both enum discriminant switching and value-based switching
- All string operations properly allocate and manage memory in C runtime

https://claude.ai/code/session_01Jo32snS62L4bLjazpVyjzy