### PR TITLE
Add concurrency primitives: threads, channels, and synchronization

### DIFF
--- a/compiler/runtime/Makefile
+++ b/compiler/runtime/Makefile
@@ -1,8 +1,9 @@
 CC ?= cc
-CFLAGS ?= -Wall -Wextra -Wpedantic -std=c11 -O2
+CFLAGS ?= -Wall -Wextra -Wpedantic -std=c11 -D_POSIX_C_SOURCE=200809L -O2
 AR ?= ar
 
-SRCS = runtime.c alloc.c vec.c string.c map.c pool.c args.c
+SRCS = runtime.c alloc.c vec.c string.c map.c pool.c args.c \
+       panic.c thread.c channel.c sync.c
 OBJS = $(SRCS:.c=.o)
 LIB  = librask_runtime.a
 

--- a/compiler/runtime/alloc.c
+++ b/compiler/runtime/alloc.c
@@ -1,39 +1,133 @@
 // SPDX-License-Identifier: (MIT OR Apache-2.0)
 
-// Heap allocator — thin wrappers around malloc/realloc/free.
-// Centralizes allocation so we can add tracking or swap allocators later.
+// Heap allocator with swappable backend and stats tracking.
+//
+// Default backend: malloc/realloc/free.
+// Call rask_allocator_set() before any allocations to swap in a custom
+// allocator (arena, pool, debug, etc.). Not thread-safe to swap — do it
+// once at startup.
+//
+// Stats are tracked with atomics so concurrent allocations don't lose counts.
+// Peak tracking uses a compare-and-swap loop.
 
 #include "rask_runtime.h"
+
 #include <stdlib.h>
 #include <stdio.h>
 #include <string.h>
+#include <stdatomic.h>
+
+// ─── Default allocator (malloc) ────────────────────────────
+
+static void *default_alloc(int64_t size, void *ctx) {
+    (void)ctx;
+    return malloc((size_t)size);
+}
+
+static void *default_realloc(void *ptr, int64_t old_size, int64_t new_size, void *ctx) {
+    (void)ctx;
+    (void)old_size;
+    return realloc(ptr, (size_t)new_size);
+}
+
+static void default_free(void *ptr, void *ctx) {
+    (void)ctx;
+    free(ptr);
+}
+
+// ─── Active allocator ──────────────────────────────────────
+
+static RaskAllocator active_allocator = {
+    .alloc   = default_alloc,
+    .realloc = default_realloc,
+    .free    = default_free,
+    .ctx     = NULL,
+};
+
+// ─── Stats (atomic for thread safety) ──────────────────────
+
+static atomic_int_least64_t stat_alloc_count;
+static atomic_int_least64_t stat_free_count;
+static atomic_int_least64_t stat_bytes_allocated;
+static atomic_int_least64_t stat_bytes_freed;
+static atomic_int_least64_t stat_current_bytes;
+static atomic_int_least64_t stat_peak_bytes;
+
+static void stats_track_alloc(int64_t size) {
+    atomic_fetch_add_explicit(&stat_alloc_count, 1, memory_order_relaxed);
+    atomic_fetch_add_explicit(&stat_bytes_allocated, size, memory_order_relaxed);
+    int64_t current = atomic_fetch_add_explicit(&stat_current_bytes, size,
+                                                 memory_order_relaxed) + size;
+    // CAS loop to update peak
+    int64_t peak = atomic_load_explicit(&stat_peak_bytes, memory_order_relaxed);
+    while (current > peak) {
+        if (atomic_compare_exchange_weak_explicit(&stat_peak_bytes, &peak, current,
+                                                   memory_order_relaxed,
+                                                   memory_order_relaxed)) {
+            break;
+        }
+    }
+}
+
+static void stats_track_free(int64_t size) {
+    atomic_fetch_add_explicit(&stat_free_count, 1, memory_order_relaxed);
+    atomic_fetch_add_explicit(&stat_bytes_freed, size, memory_order_relaxed);
+    atomic_fetch_sub_explicit(&stat_current_bytes, size, memory_order_relaxed);
+}
+
+// ─── Public API ────────────────────────────────────────────
+
+void rask_allocator_set(const RaskAllocator *a) {
+    active_allocator = *a;
+}
+
+void rask_alloc_stats(RaskAllocStats *out) {
+    out->alloc_count    = atomic_load_explicit(&stat_alloc_count, memory_order_relaxed);
+    out->free_count     = atomic_load_explicit(&stat_free_count, memory_order_relaxed);
+    out->bytes_allocated = atomic_load_explicit(&stat_bytes_allocated, memory_order_relaxed);
+    out->bytes_freed    = atomic_load_explicit(&stat_bytes_freed, memory_order_relaxed);
+    out->peak_bytes     = atomic_load_explicit(&stat_peak_bytes, memory_order_relaxed);
+}
 
 void *rask_alloc(int64_t size) {
     if (size <= 0) {
         return NULL;
     }
-    void *ptr = malloc((size_t)size);
+    void *ptr = active_allocator.alloc(size, active_allocator.ctx);
     if (!ptr) {
         fprintf(stderr, "rask: allocation failed (%lld bytes)\n", (long long)size);
         abort();
     }
+    stats_track_alloc(size);
     return ptr;
 }
 
 void *rask_realloc(void *ptr, int64_t old_size, int64_t new_size) {
-    (void)old_size;
     if (new_size <= 0) {
-        free(ptr);
+        if (ptr) {
+            active_allocator.free(ptr, active_allocator.ctx);
+            if (old_size > 0) stats_track_free(old_size);
+        }
         return NULL;
     }
-    void *new_ptr = realloc(ptr, (size_t)new_size);
+    void *new_ptr = active_allocator.realloc(ptr, old_size, new_size,
+                                              active_allocator.ctx);
     if (!new_ptr) {
         fprintf(stderr, "rask: reallocation failed (%lld bytes)\n", (long long)new_size);
         abort();
     }
+    // Track the delta
+    if (old_size > 0) stats_track_free(old_size);
+    stats_track_alloc(new_size);
     return new_ptr;
 }
 
 void rask_free(void *ptr) {
-    free(ptr);
+    if (ptr) {
+        active_allocator.free(ptr, active_allocator.ctx);
+        // Note: we don't know the size here, so free_count increments
+        // but bytes_freed doesn't. Use rask_realloc(ptr, old_size, 0)
+        // for accurate byte tracking when size is known.
+        atomic_fetch_add_explicit(&stat_free_count, 1, memory_order_relaxed);
+    }
 }

--- a/compiler/runtime/channel.c
+++ b/compiler/runtime/channel.c
@@ -1,0 +1,414 @@
+// SPDX-License-Identifier: (MIT OR Apache-2.0)
+
+// Channels — bounded ring buffer or rendezvous (unbuffered).
+//
+// Based on conc.async/CH1-CH4:
+//   - Sender/Receiver are non-linear (can be dropped without close)
+//   - Close-on-drop when refcount hits zero
+//   - Buffered: ring buffer with capacity N
+//   - Unbuffered (capacity=0): direct handoff (sender blocks until receiver)
+//
+// Both halves share a RaskChannel through refcounting. Senders and receivers
+// each have their own refcount. When all senders drop, receivers see CLOSED.
+// When all receivers drop, senders see CLOSED.
+
+#include "rask_runtime.h"
+
+#include <stdlib.h>
+#include <stdio.h>
+#include <string.h>
+#include <pthread.h>
+#include <stdatomic.h>
+
+// ─── Channel internals ─────────────────────────────────────
+
+struct RaskChannel {
+    // Shared state
+    pthread_mutex_t mutex;
+    pthread_cond_t  not_full;
+    pthread_cond_t  not_empty;
+
+    // Ring buffer
+    void   *buffer;          // NULL for unbuffered
+    int64_t elem_size;
+    int64_t capacity;        // 0 = unbuffered
+    int64_t head;            // next read position
+    int64_t tail;            // next write position
+    int64_t count;           // items in buffer
+
+    // Unbuffered handoff slot
+    const void *handoff_data;  // pointer to sender's data (unbuffered only)
+    int         handoff_ready; // sender has data waiting
+    int         handoff_taken; // receiver has copied data
+
+    // Lifecycle
+    atomic_int sender_count;
+    atomic_int recver_count;
+    int        closed;       // protected by mutex
+};
+
+struct RaskSender {
+    RaskChannel *chan;
+};
+
+struct RaskRecver {
+    RaskChannel *chan;
+};
+
+static RaskChannel *channel_alloc(int64_t elem_size, int64_t capacity) {
+    RaskChannel *ch = (RaskChannel *)calloc(1, sizeof(RaskChannel));
+    if (!ch) {
+        fprintf(stderr, "rask: channel alloc failed\n");
+        abort();
+    }
+
+    pthread_mutex_init(&ch->mutex, NULL);
+    pthread_cond_init(&ch->not_full, NULL);
+    pthread_cond_init(&ch->not_empty, NULL);
+
+    ch->elem_size = elem_size;
+    ch->capacity  = capacity;
+    ch->head = ch->tail = ch->count = 0;
+    ch->handoff_data  = NULL;
+    ch->handoff_ready = 0;
+    ch->handoff_taken = 0;
+
+    if (capacity > 0) {
+        ch->buffer = calloc((size_t)capacity, (size_t)elem_size);
+        if (!ch->buffer) {
+            fprintf(stderr, "rask: channel buffer alloc failed\n");
+            abort();
+        }
+    }
+
+    atomic_init(&ch->sender_count, 1);
+    atomic_init(&ch->recver_count, 1);
+    ch->closed = 0;
+
+    return ch;
+}
+
+static void channel_destroy(RaskChannel *ch) {
+    pthread_mutex_destroy(&ch->mutex);
+    pthread_cond_destroy(&ch->not_full);
+    pthread_cond_destroy(&ch->not_empty);
+    free(ch->buffer);
+    free(ch);
+}
+
+// Try to destroy if both sides are gone
+static void channel_maybe_destroy(RaskChannel *ch) {
+    int s = atomic_load_explicit(&ch->sender_count, memory_order_acquire);
+    int r = atomic_load_explicit(&ch->recver_count, memory_order_acquire);
+    if (s == 0 && r == 0) {
+        channel_destroy(ch);
+    }
+}
+
+// ─── Buffered operations ───────────────────────────────────
+
+static int64_t buffered_send(RaskChannel *ch, const void *data) {
+    pthread_mutex_lock(&ch->mutex);
+
+    while (ch->count >= ch->capacity && !ch->closed) {
+        // Check if all receivers are gone
+        if (atomic_load_explicit(&ch->recver_count, memory_order_acquire) == 0) {
+            ch->closed = 1;
+            break;
+        }
+        pthread_cond_wait(&ch->not_full, &ch->mutex);
+    }
+
+    if (ch->closed ||
+        atomic_load_explicit(&ch->recver_count, memory_order_acquire) == 0) {
+        pthread_mutex_unlock(&ch->mutex);
+        return RASK_CHAN_CLOSED;
+    }
+
+    char *slot = (char *)ch->buffer + ch->tail * ch->elem_size;
+    memcpy(slot, data, (size_t)ch->elem_size);
+    ch->tail = (ch->tail + 1) % ch->capacity;
+    ch->count++;
+
+    pthread_cond_signal(&ch->not_empty);
+    pthread_mutex_unlock(&ch->mutex);
+    return RASK_CHAN_OK;
+}
+
+static int64_t buffered_recv(RaskChannel *ch, void *data_out) {
+    pthread_mutex_lock(&ch->mutex);
+
+    while (ch->count == 0) {
+        // Empty — check if senders are gone
+        if (atomic_load_explicit(&ch->sender_count, memory_order_acquire) == 0) {
+            pthread_mutex_unlock(&ch->mutex);
+            return RASK_CHAN_CLOSED;
+        }
+        if (ch->closed) {
+            pthread_mutex_unlock(&ch->mutex);
+            return RASK_CHAN_CLOSED;
+        }
+        pthread_cond_wait(&ch->not_empty, &ch->mutex);
+    }
+
+    char *slot = (char *)ch->buffer + ch->head * ch->elem_size;
+    memcpy(data_out, slot, (size_t)ch->elem_size);
+    ch->head = (ch->head + 1) % ch->capacity;
+    ch->count--;
+
+    pthread_cond_signal(&ch->not_full);
+    pthread_mutex_unlock(&ch->mutex);
+    return RASK_CHAN_OK;
+}
+
+static int64_t buffered_try_send(RaskChannel *ch, const void *data) {
+    pthread_mutex_lock(&ch->mutex);
+
+    if (ch->closed ||
+        atomic_load_explicit(&ch->recver_count, memory_order_acquire) == 0) {
+        pthread_mutex_unlock(&ch->mutex);
+        return RASK_CHAN_CLOSED;
+    }
+
+    if (ch->count >= ch->capacity) {
+        pthread_mutex_unlock(&ch->mutex);
+        return RASK_CHAN_FULL;
+    }
+
+    char *slot = (char *)ch->buffer + ch->tail * ch->elem_size;
+    memcpy(slot, data, (size_t)ch->elem_size);
+    ch->tail = (ch->tail + 1) % ch->capacity;
+    ch->count++;
+
+    pthread_cond_signal(&ch->not_empty);
+    pthread_mutex_unlock(&ch->mutex);
+    return RASK_CHAN_OK;
+}
+
+static int64_t buffered_try_recv(RaskChannel *ch, void *data_out) {
+    pthread_mutex_lock(&ch->mutex);
+
+    if (ch->count == 0) {
+        int64_t result = RASK_CHAN_EMPTY;
+        if (atomic_load_explicit(&ch->sender_count, memory_order_acquire) == 0 ||
+            ch->closed) {
+            result = RASK_CHAN_CLOSED;
+        }
+        pthread_mutex_unlock(&ch->mutex);
+        return result;
+    }
+
+    char *slot = (char *)ch->buffer + ch->head * ch->elem_size;
+    memcpy(data_out, slot, (size_t)ch->elem_size);
+    ch->head = (ch->head + 1) % ch->capacity;
+    ch->count--;
+
+    pthread_cond_signal(&ch->not_full);
+    pthread_mutex_unlock(&ch->mutex);
+    return RASK_CHAN_OK;
+}
+
+// ─── Unbuffered (rendezvous) operations ────────────────────
+// Sender blocks until a receiver takes the value directly.
+
+static int64_t unbuffered_send(RaskChannel *ch, const void *data) {
+    pthread_mutex_lock(&ch->mutex);
+
+    // Wait for previous handoff to complete
+    while (ch->handoff_ready && !ch->closed) {
+        if (atomic_load_explicit(&ch->recver_count, memory_order_acquire) == 0) {
+            ch->closed = 1;
+            break;
+        }
+        pthread_cond_wait(&ch->not_full, &ch->mutex);
+    }
+
+    if (ch->closed ||
+        atomic_load_explicit(&ch->recver_count, memory_order_acquire) == 0) {
+        pthread_mutex_unlock(&ch->mutex);
+        return RASK_CHAN_CLOSED;
+    }
+
+    // Offer data to receiver
+    ch->handoff_data  = data;
+    ch->handoff_ready = 1;
+    ch->handoff_taken = 0;
+    pthread_cond_signal(&ch->not_empty);
+
+    // Wait until receiver copies the data
+    while (!ch->handoff_taken && !ch->closed) {
+        if (atomic_load_explicit(&ch->recver_count, memory_order_acquire) == 0) {
+            ch->closed = 1;
+            break;
+        }
+        pthread_cond_wait(&ch->not_full, &ch->mutex);
+    }
+
+    ch->handoff_ready = 0;
+    ch->handoff_data  = NULL;
+    ch->handoff_taken = 0;
+
+    int was_closed = ch->closed;
+    pthread_mutex_unlock(&ch->mutex);
+    return was_closed ? RASK_CHAN_CLOSED : RASK_CHAN_OK;
+}
+
+static int64_t unbuffered_recv(RaskChannel *ch, void *data_out) {
+    pthread_mutex_lock(&ch->mutex);
+
+    while (!ch->handoff_ready) {
+        if (atomic_load_explicit(&ch->sender_count, memory_order_acquire) == 0 ||
+            ch->closed) {
+            pthread_mutex_unlock(&ch->mutex);
+            return RASK_CHAN_CLOSED;
+        }
+        pthread_cond_wait(&ch->not_empty, &ch->mutex);
+    }
+
+    // Copy from sender's data
+    memcpy(data_out, ch->handoff_data, (size_t)ch->elem_size);
+
+    // Clear ready flag BEFORE signaling sender — prevents the receiver from
+    // re-entering recv and seeing the stale handoff_ready=1 before the sender
+    // has a chance to reset it.
+    ch->handoff_ready = 0;
+    ch->handoff_taken = 1;
+
+    // Wake sender to let it know we've taken the data
+    pthread_cond_signal(&ch->not_full);
+    pthread_mutex_unlock(&ch->mutex);
+    return RASK_CHAN_OK;
+}
+
+static int64_t unbuffered_try_send(RaskChannel *ch, const void *data) {
+    (void)data;
+    pthread_mutex_lock(&ch->mutex);
+
+    if (ch->closed ||
+        atomic_load_explicit(&ch->recver_count, memory_order_acquire) == 0) {
+        pthread_mutex_unlock(&ch->mutex);
+        return RASK_CHAN_CLOSED;
+    }
+
+    // Unbuffered try_send only succeeds if a receiver is already waiting.
+    // We can't guarantee that without a rendezvous, so always return FULL.
+    pthread_mutex_unlock(&ch->mutex);
+    return RASK_CHAN_FULL;
+}
+
+static int64_t unbuffered_try_recv(RaskChannel *ch, void *data_out) {
+    pthread_mutex_lock(&ch->mutex);
+
+    if (!ch->handoff_ready) {
+        int64_t result = RASK_CHAN_EMPTY;
+        if (atomic_load_explicit(&ch->sender_count, memory_order_acquire) == 0 ||
+            ch->closed) {
+            result = RASK_CHAN_CLOSED;
+        }
+        pthread_mutex_unlock(&ch->mutex);
+        return result;
+    }
+
+    memcpy(data_out, ch->handoff_data, (size_t)ch->elem_size);
+    ch->handoff_taken = 1;
+    pthread_cond_signal(&ch->not_full);
+    pthread_mutex_unlock(&ch->mutex);
+    return RASK_CHAN_OK;
+}
+
+// ─── Public API ────────────────────────────────────────────
+
+void rask_channel_new(int64_t elem_size, int64_t capacity,
+                      RaskSender **tx_out, RaskRecver **rx_out) {
+    if (elem_size <= 0) {
+        rask_panic("channel element size must be positive");
+    }
+    if (capacity < 0) {
+        rask_panic("channel capacity must be non-negative");
+    }
+
+    RaskChannel *ch = channel_alloc(elem_size, capacity);
+
+    RaskSender *tx = (RaskSender *)malloc(sizeof(RaskSender));
+    RaskRecver *rx = (RaskRecver *)malloc(sizeof(RaskRecver));
+    if (!tx || !rx) {
+        fprintf(stderr, "rask: channel sender/receiver alloc failed\n");
+        abort();
+    }
+    tx->chan = ch;
+    rx->chan = ch;
+
+    *tx_out = tx;
+    *rx_out = rx;
+}
+
+int64_t rask_channel_send(RaskSender *tx, const void *data) {
+    RaskChannel *ch = tx->chan;
+    if (ch->capacity > 0) {
+        return buffered_send(ch, data);
+    }
+    return unbuffered_send(ch, data);
+}
+
+int64_t rask_channel_recv(RaskRecver *rx, void *data_out) {
+    RaskChannel *ch = rx->chan;
+    if (ch->capacity > 0) {
+        return buffered_recv(ch, data_out);
+    }
+    return unbuffered_recv(ch, data_out);
+}
+
+int64_t rask_channel_try_send(RaskSender *tx, const void *data) {
+    RaskChannel *ch = tx->chan;
+    if (ch->capacity > 0) {
+        return buffered_try_send(ch, data);
+    }
+    return unbuffered_try_send(ch, data);
+}
+
+int64_t rask_channel_try_recv(RaskRecver *rx, void *data_out) {
+    RaskChannel *ch = rx->chan;
+    if (ch->capacity > 0) {
+        return buffered_try_recv(ch, data_out);
+    }
+    return unbuffered_try_recv(ch, data_out);
+}
+
+RaskSender *rask_sender_clone(RaskSender *tx) {
+    atomic_fetch_add_explicit(&tx->chan->sender_count, 1, memory_order_relaxed);
+    RaskSender *clone = (RaskSender *)malloc(sizeof(RaskSender));
+    if (!clone) {
+        fprintf(stderr, "rask: sender clone alloc failed\n");
+        abort();
+    }
+    clone->chan = tx->chan;
+    return clone;
+}
+
+void rask_sender_drop(RaskSender *tx) {
+    RaskChannel *ch = tx->chan;
+    free(tx);
+
+    if (atomic_fetch_sub_explicit(&ch->sender_count, 1, memory_order_acq_rel) == 1) {
+        // Last sender dropped — wake any blocked receivers
+        pthread_mutex_lock(&ch->mutex);
+        ch->closed = 1;
+        pthread_cond_broadcast(&ch->not_empty);
+        pthread_mutex_unlock(&ch->mutex);
+        channel_maybe_destroy(ch);
+    }
+}
+
+void rask_recver_drop(RaskRecver *rx) {
+    RaskChannel *ch = rx->chan;
+    free(rx);
+
+    if (atomic_fetch_sub_explicit(&ch->recver_count, 1, memory_order_acq_rel) == 1) {
+        // Last receiver dropped — wake any blocked senders
+        pthread_mutex_lock(&ch->mutex);
+        ch->closed = 1;
+        pthread_cond_broadcast(&ch->not_full);
+        pthread_mutex_unlock(&ch->mutex);
+        channel_maybe_destroy(ch);
+    }
+}

--- a/compiler/runtime/panic.c
+++ b/compiler/runtime/panic.c
@@ -1,0 +1,103 @@
+// SPDX-License-Identifier: (MIT OR Apache-2.0)
+
+// Structured panic handler.
+//
+// Main thread: panics print message + optional backtrace, then abort.
+// Spawned tasks: panics longjmp back to the task entry point, storing the
+// message for propagation as JoinError::Panicked(msg) on join.
+//
+// Thread-local storage holds the per-task panic context (jmp_buf + message).
+
+#include "rask_runtime.h"
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <stdarg.h>
+#include <setjmp.h>
+
+#ifdef __linux__
+#include <execinfo.h>
+#define RASK_HAS_BACKTRACE 1
+#else
+#define RASK_HAS_BACKTRACE 0
+#endif
+
+// ─── Per-thread panic context ──────────────────────────────
+
+struct RaskPanicCtx {
+    jmp_buf buf;
+    int     active;       // handler installed?
+    char   *message;      // heap-allocated on panic
+};
+
+static __thread struct RaskPanicCtx panic_ctx;
+
+RaskPanicCtx *rask_panic_install(void) {
+    panic_ctx.active  = 0;
+    panic_ctx.message = NULL;
+    return &panic_ctx;
+}
+
+void rask_panic_remove(void) {
+    if (panic_ctx.message) {
+        free(panic_ctx.message);
+        panic_ctx.message = NULL;
+    }
+    panic_ctx.active = 0;
+}
+
+// Called by thread.c task entry — returns the stored jmp_buf for setjmp.
+jmp_buf *rask_panic_jmpbuf(void) {
+    return &panic_ctx.buf;
+}
+
+// Mark the handler as active (called after setjmp returns 0).
+void rask_panic_activate(void) {
+    panic_ctx.active = 1;
+}
+
+// Retrieve the panic message after longjmp. Transfers ownership to caller.
+char *rask_panic_take_message(void) {
+    char *msg = panic_ctx.message;
+    panic_ctx.message = NULL;
+    return msg;
+}
+
+// ─── Backtrace ─────────────────────────────────────────────
+
+static void print_backtrace(void) {
+#if RASK_HAS_BACKTRACE
+    void *frames[64];
+    int n = backtrace(frames, 64);
+    if (n > 0) {
+        fprintf(stderr, "backtrace:\n");
+        backtrace_symbols_fd(frames, n, 2); // fd 2 = stderr
+    }
+#endif
+}
+
+// ─── Panic entry points ────────────────────────────────────
+
+_Noreturn void rask_panic(const char *msg) {
+    if (panic_ctx.active) {
+        // Spawned task — store message and longjmp back to task entry
+        panic_ctx.message = msg ? strdup(msg) : strdup("(unknown panic)");
+        panic_ctx.active = 0;
+        longjmp(panic_ctx.buf, 1);
+    }
+
+    // Main thread or no handler — print and abort
+    fprintf(stderr, "panic: %s\n", msg ? msg : "(unknown panic)");
+    print_backtrace();
+    abort();
+}
+
+_Noreturn void rask_panic_fmt(const char *fmt, ...) {
+    char buf[RASK_PANIC_MSG_MAX];
+    va_list args;
+    va_start(args, fmt);
+    vsnprintf(buf, sizeof(buf), fmt, args);
+    va_end(args);
+    rask_panic(buf);
+}

--- a/compiler/runtime/sync.c
+++ b/compiler/runtime/sync.c
@@ -1,0 +1,137 @@
+// SPDX-License-Identifier: (MIT OR Apache-2.0)
+
+// Synchronization primitives (conc.sync/SY1-SY4).
+//
+// Mutex<T>:   exclusive access via closure (conc.sync/MX1-MX2)
+// Shared<T>:  multiple-reader / exclusive-writer via closure (conc.sync/R1-R3)
+//
+// Both use closure-based access (conc.sync/CB1-CB2): the protected data
+// is only reachable inside the callback, preventing reference escapes.
+
+#include "rask_runtime.h"
+
+#include <stdlib.h>
+#include <stdio.h>
+#include <string.h>
+#include <pthread.h>
+
+// ─── Mutex ─────────────────────────────────────────────────
+
+struct RaskMutex {
+    pthread_mutex_t lock;
+    void           *data;
+    int64_t         data_size;
+};
+
+RaskMutex *rask_mutex_new(const void *initial_data, int64_t data_size) {
+    if (data_size <= 0) {
+        rask_panic("Mutex data size must be positive");
+    }
+
+    RaskMutex *m = (RaskMutex *)malloc(sizeof(RaskMutex));
+    if (!m) {
+        fprintf(stderr, "rask: mutex alloc failed\n");
+        abort();
+    }
+
+    pthread_mutex_init(&m->lock, NULL);
+    m->data_size = data_size;
+    m->data = malloc((size_t)data_size);
+    if (!m->data) {
+        fprintf(stderr, "rask: mutex data alloc failed\n");
+        abort();
+    }
+
+    memcpy(m->data, initial_data, (size_t)data_size);
+    return m;
+}
+
+void rask_mutex_free(RaskMutex *m) {
+    if (!m) return;
+    pthread_mutex_destroy(&m->lock);
+    free(m->data);
+    free(m);
+}
+
+void rask_mutex_lock(RaskMutex *m, RaskAccessFn f, void *ctx) {
+    pthread_mutex_lock(&m->lock);
+    f(m->data, ctx);
+    pthread_mutex_unlock(&m->lock);
+}
+
+int64_t rask_mutex_try_lock(RaskMutex *m, RaskAccessFn f, void *ctx) {
+    if (pthread_mutex_trylock(&m->lock) == 0) {
+        f(m->data, ctx);
+        pthread_mutex_unlock(&m->lock);
+        return 1;
+    }
+    return 0;
+}
+
+// ─── Shared (RwLock) ───────────────────────────────────────
+
+struct RaskShared {
+    pthread_rwlock_t lock;
+    void            *data;
+    int64_t          data_size;
+};
+
+RaskShared *rask_shared_new(const void *initial_data, int64_t data_size) {
+    if (data_size <= 0) {
+        rask_panic("Shared data size must be positive");
+    }
+
+    RaskShared *s = (RaskShared *)malloc(sizeof(RaskShared));
+    if (!s) {
+        fprintf(stderr, "rask: shared alloc failed\n");
+        abort();
+    }
+
+    pthread_rwlock_init(&s->lock, NULL);
+    s->data_size = data_size;
+    s->data = malloc((size_t)data_size);
+    if (!s->data) {
+        fprintf(stderr, "rask: shared data alloc failed\n");
+        abort();
+    }
+
+    memcpy(s->data, initial_data, (size_t)data_size);
+    return s;
+}
+
+void rask_shared_free(RaskShared *s) {
+    if (!s) return;
+    pthread_rwlock_destroy(&s->lock);
+    free(s->data);
+    free(s);
+}
+
+void rask_shared_read(RaskShared *s, RaskAccessFn f, void *ctx) {
+    pthread_rwlock_rdlock(&s->lock);
+    f(s->data, ctx);
+    pthread_rwlock_unlock(&s->lock);
+}
+
+void rask_shared_write(RaskShared *s, RaskAccessFn f, void *ctx) {
+    pthread_rwlock_wrlock(&s->lock);
+    f(s->data, ctx);
+    pthread_rwlock_unlock(&s->lock);
+}
+
+int64_t rask_shared_try_read(RaskShared *s, RaskAccessFn f, void *ctx) {
+    if (pthread_rwlock_tryrdlock(&s->lock) == 0) {
+        f(s->data, ctx);
+        pthread_rwlock_unlock(&s->lock);
+        return 1;
+    }
+    return 0;
+}
+
+int64_t rask_shared_try_write(RaskShared *s, RaskAccessFn f, void *ctx) {
+    if (pthread_rwlock_trywrlock(&s->lock) == 0) {
+        f(s->data, ctx);
+        pthread_rwlock_unlock(&s->lock);
+        return 1;
+    }
+    return 0;
+}

--- a/compiler/runtime/thread.c
+++ b/compiler/runtime/thread.c
@@ -1,0 +1,202 @@
+// SPDX-License-Identifier: (MIT OR Apache-2.0)
+
+// Phase A thread primitives (conc.strategy/A1).
+//
+// One OS thread per spawn. Panics in spawned tasks are caught via
+// setjmp/longjmp and propagated as JoinError on join.
+//
+// TaskHandle lifecycle:
+//   spawn → [running] → join/detach/cancel → [consumed]
+//
+// The shared TaskState is refcounted: one ref for the handle, one for
+// the running thread. Last one to drop frees it.
+
+#include "rask_runtime.h"
+
+#include <stdlib.h>
+#include <stdio.h>
+#include <string.h>
+#include <time.h>
+#include <pthread.h>
+#include <stdatomic.h>
+#include <setjmp.h>
+
+// ─── Internal declarations from panic.c ────────────────────
+
+extern jmp_buf *rask_panic_jmpbuf(void);
+extern void     rask_panic_activate(void);
+extern char    *rask_panic_take_message(void);
+
+// ─── Task state (shared between handle and thread) ─────────
+
+#define RASK_TASK_RUNNING   0
+#define RASK_TASK_OK        1
+#define RASK_TASK_PANICKED  2
+#define RASK_TASK_CANCELLED 3
+
+typedef struct {
+    atomic_int   refcount;
+    atomic_int   status;
+    atomic_int   cancel_flag;
+    char        *panic_msg;     // set on panic, owned by state
+    pthread_t    thread;
+} RaskTaskState;
+
+struct RaskTaskHandle {
+    RaskTaskState *state;
+};
+
+// Per-thread cancel flag pointer (points into the task's state).
+static __thread atomic_int *current_cancel_flag;
+
+static RaskTaskState *state_new(void) {
+    RaskTaskState *s = (RaskTaskState *)malloc(sizeof(RaskTaskState));
+    if (!s) {
+        fprintf(stderr, "rask: task state alloc failed\n");
+        abort();
+    }
+    atomic_init(&s->refcount, 2);  // handle + thread
+    atomic_init(&s->status, RASK_TASK_RUNNING);
+    atomic_init(&s->cancel_flag, 0);
+    s->panic_msg = NULL;
+    return s;
+}
+
+static void state_release(RaskTaskState *s) {
+    if (atomic_fetch_sub_explicit(&s->refcount, 1, memory_order_acq_rel) == 1) {
+        if (s->panic_msg) free(s->panic_msg);
+        free(s);
+    }
+}
+
+// ─── Thread entry point ────────────────────────────────────
+
+typedef struct {
+    RaskTaskFn     func;
+    void          *env;
+    RaskTaskState *state;
+} TaskEntry;
+
+static void *task_thread_entry(void *arg) {
+    TaskEntry *entry = (TaskEntry *)arg;
+    RaskTaskState *state = entry->state;
+    RaskTaskFn func = entry->func;
+    void *env = entry->env;
+    free(entry);
+
+    // Set up cancel flag for this thread
+    current_cancel_flag = &state->cancel_flag;
+
+    // Install panic handler
+    rask_panic_install();
+    jmp_buf *jb = rask_panic_jmpbuf();
+
+    if (setjmp(*jb) == 0) {
+        rask_panic_activate();
+        func(env);
+        atomic_store_explicit(&state->status, RASK_TASK_OK, memory_order_release);
+    } else {
+        // Returned via longjmp from rask_panic
+        state->panic_msg = rask_panic_take_message();
+        atomic_store_explicit(&state->status, RASK_TASK_PANICKED,
+                              memory_order_release);
+    }
+
+    rask_panic_remove();
+    current_cancel_flag = NULL;
+    state_release(state);
+    return NULL;
+}
+
+// ─── Public API ────────────────────────────────────────────
+
+RaskTaskHandle *rask_task_spawn(RaskTaskFn func, void *env) {
+    RaskTaskState *state = state_new();
+
+    TaskEntry *entry = (TaskEntry *)malloc(sizeof(TaskEntry));
+    if (!entry) {
+        fprintf(stderr, "rask: task entry alloc failed\n");
+        abort();
+    }
+    entry->func  = func;
+    entry->env   = env;
+    entry->state = state;
+
+    int err = pthread_create(&state->thread, NULL, task_thread_entry, entry);
+    if (err != 0) {
+        free(entry);
+        state_release(state);
+        state_release(state); // drop both refs
+        rask_panic_fmt("spawn failed: pthread_create returned %d", err);
+    }
+
+    RaskTaskHandle *h = (RaskTaskHandle *)malloc(sizeof(RaskTaskHandle));
+    if (!h) {
+        fprintf(stderr, "rask: task handle alloc failed\n");
+        abort();
+    }
+    h->state = state;
+    return h;
+}
+
+int64_t rask_task_join(RaskTaskHandle *h, char **msg_out) {
+    if (!h || !h->state) {
+        rask_panic("join on consumed TaskHandle");
+    }
+
+    RaskTaskState *state = h->state;
+    pthread_join(state->thread, NULL);
+
+    int status = atomic_load_explicit(&state->status, memory_order_acquire);
+    int64_t result = 0;
+
+    if (status == RASK_TASK_PANICKED) {
+        if (msg_out) {
+            *msg_out = state->panic_msg;
+            state->panic_msg = NULL; // transfer ownership
+        }
+        result = -1;
+    } else if (msg_out) {
+        *msg_out = NULL;
+    }
+
+    state_release(state);
+    free(h);
+    return result;
+}
+
+void rask_task_detach(RaskTaskHandle *h) {
+    if (!h || !h->state) {
+        rask_panic("detach on consumed TaskHandle");
+    }
+
+    RaskTaskState *state = h->state;
+    pthread_detach(state->thread);
+    state_release(state);
+    free(h);
+}
+
+int64_t rask_task_cancel(RaskTaskHandle *h, char **msg_out) {
+    if (!h || !h->state) {
+        rask_panic("cancel on consumed TaskHandle");
+    }
+
+    // Set cancel flag — task checks via rask_task_cancelled()
+    atomic_store_explicit(&h->state->cancel_flag, 1, memory_order_release);
+
+    // Wait for completion
+    return rask_task_join(h, msg_out);
+}
+
+int8_t rask_task_cancelled(void) {
+    if (!current_cancel_flag) return 0;
+    return atomic_load_explicit(current_cancel_flag, memory_order_acquire) ? 1 : 0;
+}
+
+void rask_sleep_ns(int64_t ns) {
+    if (ns <= 0) return;
+    struct timespec ts;
+    ts.tv_sec  = ns / 1000000000LL;
+    ts.tv_nsec = ns % 1000000000LL;
+    nanosleep(&ts, NULL);
+}


### PR DESCRIPTION
## Summary

This PR implements Phase A concurrency support for the Rask runtime, adding thread spawning, channels (both buffered and unbuffered), and synchronization primitives (Mutex and RwLock). These are based on the conc.async and conc.sync specifications.

## Key Changes

- **Thread support** (`thread.c`): One OS thread per spawn with panic handling via setjmp/longjmp. TaskHandle is affine and must be joined, detached, or cancelled. Panics in spawned tasks are caught and propagated as JoinError on join.

- **Channels** (`channel.c`): Bounded ring buffer (capacity > 0) or rendezvous/unbuffered (capacity == 0) channels with reference-counted sender/receiver halves. Close-on-drop semantics when refcount hits zero. Supports both blocking and non-blocking operations.

- **Synchronization primitives** (`sync.c`): 
  - `Mutex<T>`: Exclusive access via closure-based API to prevent reference escapes
  - `Shared<T>`: Multiple-reader / exclusive-writer (RwLock) with closure-based access

- **Panic handling** (`panic.c`): Structured panic system that aborts in the main thread but is catchable in spawned tasks via setjmp/longjmp, storing panic messages for propagation.

- **Enhanced allocator** (`alloc.c`): Swappable allocator backend with optional stats tracking (alloc/free counts, bytes allocated/freed, peak memory). Default uses malloc/realloc/free.

- **Runtime header updates** (`rask_runtime.h`): Added public API declarations for all new concurrency primitives and allocator functions.

- **Build system updates**: Updated linker configuration to compile all new runtime sources and link with `-lpthread`.

## Implementation Details

- Channels use pthread_mutex and pthread_cond for synchronization, with separate refcounts for senders and receivers
- Unbuffered channels implement direct handoff via a shared pointer and handoff flags
- Thread cancellation is cooperative via atomic flag checking
- Panic context is thread-local, allowing per-task panic handling
- Allocator stats use atomic operations for thread-safe concurrent tracking
- All synchronization primitives use closure-based access patterns to prevent data reference escapes

https://claude.ai/code/session_013UnWzHvrHnBdfSXp1Tisrr