### PR TITLE
Implement spawn/join/detach and channel concurrency primitives

### DIFF
--- a/compiler/crates/rask-codegen/src/dispatch.rs
+++ b/compiler/crates/rask-codegen/src/dispatch.rs
@@ -266,6 +266,88 @@ pub fn stdlib_entries() -> Vec<StdlibEntry> {
             params: &[types::I64],
             ret_ty: Some(types::I8),
         },
+
+        // ── Concurrency: spawn/join/detach ──────────────────────────
+        StdlibEntry {
+            mir_name: "spawn",
+            c_name: "rask_closure_spawn",
+            params: &[types::I64],
+            ret_ty: Some(types::I64),
+        },
+        StdlibEntry {
+            mir_name: "join",
+            c_name: "rask_task_join_simple",
+            params: &[types::I64],
+            ret_ty: Some(types::I64),
+        },
+        StdlibEntry {
+            mir_name: "detach",
+            c_name: "rask_task_detach",
+            params: &[types::I64],
+            ret_ty: None,
+        },
+        StdlibEntry {
+            mir_name: "rask_task_cancelled",
+            c_name: "rask_task_cancelled",
+            params: &[],
+            ret_ty: Some(types::I8),
+        },
+        StdlibEntry {
+            mir_name: "rask_sleep_ns",
+            c_name: "rask_sleep_ns",
+            params: &[types::I64],
+            ret_ty: None,
+        },
+
+        // ── Concurrency: channels ──────────────────────────────────
+        StdlibEntry {
+            mir_name: "Channel_new",
+            c_name: "rask_channel_new_i64",
+            params: &[types::I64],
+            ret_ty: Some(types::I64),
+        },
+        StdlibEntry {
+            mir_name: "channel_tx",
+            c_name: "rask_channel_get_tx",
+            params: &[types::I64],
+            ret_ty: Some(types::I64),
+        },
+        StdlibEntry {
+            mir_name: "channel_rx",
+            c_name: "rask_channel_get_rx",
+            params: &[types::I64],
+            ret_ty: Some(types::I64),
+        },
+        StdlibEntry {
+            mir_name: "send",
+            c_name: "rask_channel_send_i64",
+            params: &[types::I64, types::I64],
+            ret_ty: Some(types::I64),
+        },
+        StdlibEntry {
+            mir_name: "recv",
+            c_name: "rask_channel_recv_i64",
+            params: &[types::I64],
+            ret_ty: Some(types::I64),
+        },
+        StdlibEntry {
+            mir_name: "sender_clone",
+            c_name: "rask_sender_clone_i64",
+            params: &[types::I64],
+            ret_ty: Some(types::I64),
+        },
+        StdlibEntry {
+            mir_name: "sender_drop",
+            c_name: "rask_sender_drop_i64",
+            params: &[types::I64],
+            ret_ty: None,
+        },
+        StdlibEntry {
+            mir_name: "recver_drop",
+            c_name: "rask_recver_drop_i64",
+            params: &[types::I64],
+            ret_ty: None,
+        },
     ]
 }
 

--- a/compiler/crates/rask-resolve/src/resolver.rs
+++ b/compiler/crates/rask-resolve/src/resolver.rs
@@ -55,6 +55,7 @@ impl Resolver {
             ("print", BuiltinFunctionKind::Print, None),
             ("panic", BuiltinFunctionKind::Panic, Some("!")),
             ("format", BuiltinFunctionKind::Format, None),
+            ("spawn", BuiltinFunctionKind::Spawn, None),
         ];
 
         for (name, builtin, ret_ty) in builtin_fns {

--- a/compiler/crates/rask-resolve/src/symbol.rs
+++ b/compiler/crates/rask-resolve/src/symbol.rs
@@ -114,6 +114,8 @@ pub enum BuiltinFunctionKind {
     Panic,
     /// format - string formatting
     Format,
+    /// spawn - spawn a concurrent task
+    Spawn,
 }
 
 /// Built-in module kinds (stdlib modules).

--- a/compiler/runtime/rask_runtime.h
+++ b/compiler/runtime/rask_runtime.h
@@ -171,6 +171,13 @@ int8_t rask_task_cancelled(void);
 // Sleep the current thread for the given number of nanoseconds.
 void rask_sleep_ns(int64_t ns);
 
+// Codegen wrapper: spawn a task from a closure pointer [func_ptr | captures...].
+// Extracts func/env, runs the task, and frees the closure allocation on completion.
+RaskTaskHandle *rask_closure_spawn(void *closure_ptr);
+
+// Simplified join: no panic message output. Returns 0 on success, -1 on panic.
+int64_t rask_task_join_simple(void *h);
+
 // ─── Channels ──────────────────────────────────────────────
 // Bounded ring buffer (capacity > 0) or rendezvous (capacity == 0).
 // Reference-counted sender/receiver halves. Close-on-drop.
@@ -208,6 +215,16 @@ RaskSender *rask_sender_clone(RaskSender *tx);
 // Drop sender/receiver. Closes the channel half when refcount hits zero.
 void rask_sender_drop(RaskSender *tx);
 void rask_recver_drop(RaskRecver *rx);
+
+// i64-based channel wrappers for codegen dispatch table.
+int64_t rask_channel_new_i64(int64_t capacity);
+int64_t rask_channel_get_tx(int64_t pair);
+int64_t rask_channel_get_rx(int64_t pair);
+int64_t rask_channel_send_i64(int64_t tx, int64_t value);
+int64_t rask_channel_recv_i64(int64_t rx);
+void    rask_sender_drop_i64(int64_t tx);
+void    rask_recver_drop_i64(int64_t rx);
+int64_t rask_sender_clone_i64(int64_t tx);
 
 // ─── Mutex ─────────────────────────────────────────────────
 // Exclusive access wrapper. Closure-based: data accessed only inside lock.


### PR DESCRIPTION
## Summary
This PR implements core concurrency support for the Rask language, including task spawning, joining, and channel-based communication. The implementation bridges the MIR compiler layer with a C runtime providing POSIX thread-based task execution and bounded ring buffer channels.

## Key Changes

### Compiler (MIR Lowering)
- **Spawn expression lowering** (`lower_spawn`): Synthesizes a closure function from the spawn body, collects free variables, generates environment layout with proper alignment, and emits `ClosureCreate` + `rask_closure_spawn` call
- **Free variable collection**: Implements `collect_free_vars_block` to identify variables captured by spawn bodies
- **Closure environment**: Properly handles variable capture with 8-byte alignment for environment offsets
- **Import additions**: Added `LocalId` to imports for closure capture tracking

### Codegen Dispatch Table
- **Concurrency functions**: Added stdlib entries for `spawn`, `join`, `detach`, and `rask_task_cancelled`
- **Sleep primitive**: Added `rask_sleep_ns` for nanosecond-precision delays
- **Channel operations**: Added 8 channel-related stdlib entries (`Channel_new`, `channel_tx`, `channel_rx`, `send`, `recv`, `sender_clone`, `sender_drop`, `recver_drop`)

### Runtime (C Implementation)
- **Closure spawn wrapper** (`rask_closure_spawn`): Extracts function pointer and environment from closure layout, spawns OS thread via `rask_task_spawn`, and frees closure allocation on task completion
- **Simplified join** (`rask_task_join_simple`): Wrapper returning status code instead of panic message
- **i64 channel wrappers**: Bridge between dispatch table's i64 calling convention and typed channel API:
  - `rask_channel_new_i64`: Creates channel and returns heap-allocated [tx, rx] pair
  - `rask_channel_get_tx/rx`: Extracts sender/receiver from pair
  - `rask_channel_send/recv_i64`: Type-agnostic send/recv for i64 values
  - `rask_sender/recver_drop_i64`: Reference counting cleanup
  - `rask_sender_clone_i64`: Sender duplication

### Symbol Resolution
- Added `Spawn` to `BuiltinFunctionKind` enum for resolver recognition

## Implementation Details
- Spawn bodies are lowered as separate synthesized functions with signature `fn(env_ptr: ptr) -> void`
- Free variables are captured into a heap-allocated environment with 8-byte alignment
- Closure layout: `[func_ptr(8) | captures...]` for codegen compatibility
- Channel implementation uses reference-counted sender/receiver halves with close-on-drop semantics
- All channel operations are i64-based to match the dispatch table's uniform calling convention

<html><body>
<!--StartFragment--><html><head></head><body><p>Not totally. Here's what's done and what's not.</p>
<p><strong>Working now (codegen → native):</strong></p>
<ul>
<li><code>spawn(|| { ... })</code> — creates a real OS thread, captures variables, frees closure on completion</li>
<li><code>.join()</code> — blocks until task finishes, returns status</li>
<li><code>.detach()</code> — fire-and-forget</li>
<li><code>Channel.new(cap)</code> — creates buffered channel, returns pair</li>
<li><code>.channel_tx()</code> / <code>.channel_rx()</code> — extract sender/receiver from pair</li>
<li><code>.send(val)</code> / <code>.recv()</code> — blocking i64 send/recv</li>
</ul>
<p><strong>Not wired yet:</strong></p>

Gap | What's missing
-- | --
Interpreter | rask run (without --native) doesn't know about spawn. Only codegen works.
Type checking | spawn returns an opaque i64. No TaskHandle type, no affine enforcement (must-join/detach).
Channel types | Channels are i64-only. No generic Channel<T> — structs, strings, floats won't work.
.cancel() | Dispatch entry missing (needs a rask_task_cancel_simple wrapper like join).
try_send / try_recv | No dispatch entries yet.
sender_drop / recver_drop | Wired in dispatch but never emitted — no automatic drop-on-scope-exit. Channels leak.
select { } | MIR has a stub for channel multiplexing but no codegen.
Mutex / Shared | C runtime is complete, no dispatch entries or MIR support.
Error propagation | join() returns 0/-1 but panic messages are discarded. No JoinError type.


<p>The biggest practical gaps are the lack of generic channel types (everything is i64), no automatic resource cleanup (channels/handles leak), and no interpreter support. The runtime primitives are solid — it's the compiler's type system and resource tracking that need to catch up.</p></body></html><!--EndFragment-->
</body>
</html>

https://claude.ai/code/session_01Pu6RNtX1d4mAM879Gsyxrj