### PR TITLE
Implement state machine transform for green task spawn closures

### DIFF
--- a/compiler/crates/rask-codegen/src/builder.rs
+++ b/compiler/crates/rask-codegen/src/builder.rs
@@ -74,7 +74,7 @@ impl<'a> FunctionBuilder<'a> {
                 let size = match &l.ty {
                     MirType::Struct(id) => self.struct_layouts.get(id.0 as usize).map(|sl| sl.size),
                     MirType::Enum(id) => self.enum_layouts.get(id.0 as usize).map(|el| el.size),
-                    MirType::Array { elem, len } => Some(crate::types::mir_type_size(elem) * len),
+                    MirType::Array { elem, len } => Some(elem.size() * len),
                     _ => None,
                 };
                 size.filter(|&s| s > 0).map(|s| (l.id, s))

--- a/compiler/crates/rask-codegen/src/dispatch.rs
+++ b/compiler/crates/rask-codegen/src/dispatch.rs
@@ -620,7 +620,7 @@ pub fn stdlib_entries() -> Vec<StdlibEntry> {
         },
         StdlibEntry {
             mir_name: "rask_sleep_ns",
-            c_name: "rask_sleep_ns",
+            c_name: "rask_green_sleep_ns",
             params: &[types::I64],
             ret_ty: None,
         },

--- a/compiler/crates/rask-codegen/src/dispatch.rs
+++ b/compiler/crates/rask-codegen/src/dispatch.rs
@@ -587,36 +587,160 @@ pub fn stdlib_entries() -> Vec<StdlibEntry> {
             ret_ty: Some(types::I64),
         },
 
-        // ── Concurrency: spawn/join/detach ──────────────────────────
+        // ── Concurrency: spawn/join/detach (green scheduler) ────────
         StdlibEntry {
             mir_name: "spawn",
-            c_name: "rask_closure_spawn",
+            c_name: "rask_green_closure_spawn",
             params: &[types::I64],
             ret_ty: Some(types::I64),
         },
         StdlibEntry {
             mir_name: "join",
-            c_name: "rask_task_join_simple",
+            c_name: "rask_green_join",
             params: &[types::I64],
             ret_ty: Some(types::I64),
         },
         StdlibEntry {
             mir_name: "detach",
-            c_name: "rask_task_detach",
+            c_name: "rask_green_detach",
             params: &[types::I64],
             ret_ty: None,
         },
         StdlibEntry {
+            mir_name: "cancel",
+            c_name: "rask_green_cancel",
+            params: &[types::I64],
+            ret_ty: Some(types::I64),
+        },
+        StdlibEntry {
             mir_name: "rask_task_cancelled",
-            c_name: "rask_task_cancelled",
+            c_name: "rask_green_task_is_cancelled",
             params: &[],
-            ret_ty: Some(types::I8),
+            ret_ty: Some(types::I32),
         },
         StdlibEntry {
             mir_name: "rask_sleep_ns",
             c_name: "rask_sleep_ns",
             params: &[types::I64],
             ret_ty: None,
+        },
+
+        // ── Concurrency: runtime init/shutdown ───────────────────────
+        StdlibEntry {
+            mir_name: "rask_runtime_init",
+            c_name: "rask_runtime_init",
+            params: &[types::I64],
+            ret_ty: None,
+        },
+        StdlibEntry {
+            mir_name: "rask_runtime_shutdown",
+            c_name: "rask_runtime_shutdown",
+            params: &[],
+            ret_ty: None,
+        },
+
+        // ── Concurrency: green spawn (poll-based state machine) ──────
+        StdlibEntry {
+            mir_name: "rask_green_spawn",
+            c_name: "rask_green_spawn",
+            params: &[types::I64, types::I64, types::I64],
+            ret_ty: Some(types::I64),
+        },
+
+        // ── Concurrency: yield helpers ───────────────────────────────
+        StdlibEntry {
+            mir_name: "rask_yield",
+            c_name: "rask_yield",
+            params: &[],
+            ret_ty: None,
+        },
+        StdlibEntry {
+            mir_name: "rask_yield_timeout",
+            c_name: "rask_yield_timeout",
+            params: &[types::I64],
+            ret_ty: None,
+        },
+        StdlibEntry {
+            mir_name: "rask_yield_read",
+            c_name: "rask_yield_read",
+            params: &[types::I32, types::I64, types::I64],
+            ret_ty: None,
+        },
+        StdlibEntry {
+            mir_name: "rask_yield_write",
+            c_name: "rask_yield_write",
+            params: &[types::I32, types::I64, types::I64],
+            ret_ty: None,
+        },
+        StdlibEntry {
+            mir_name: "rask_yield_accept",
+            c_name: "rask_yield_accept",
+            params: &[types::I32],
+            ret_ty: None,
+        },
+
+        // ── Async I/O (dual-path: green task or blocking) ─────────────
+        StdlibEntry {
+            mir_name: "rask_async_read",
+            c_name: "rask_async_read",
+            params: &[types::I32, types::I64, types::I64],
+            ret_ty: Some(types::I64),
+        },
+        StdlibEntry {
+            mir_name: "rask_async_write",
+            c_name: "rask_async_write",
+            params: &[types::I32, types::I64, types::I64],
+            ret_ty: Some(types::I64),
+        },
+        StdlibEntry {
+            mir_name: "rask_async_accept",
+            c_name: "rask_async_accept",
+            params: &[types::I32],
+            ret_ty: Some(types::I64),
+        },
+
+        // ── Async channels (yield-based) ─────────────────────────────
+        StdlibEntry {
+            mir_name: "rask_channel_send_async",
+            c_name: "rask_channel_send_async",
+            params: &[types::I64, types::I64],
+            ret_ty: Some(types::I64),
+        },
+        StdlibEntry {
+            mir_name: "rask_channel_recv_async",
+            c_name: "rask_channel_recv_async",
+            params: &[types::I64],
+            ret_ty: Some(types::I64),
+        },
+
+        // ── Green-aware sleep ────────────────────────────────────────
+        StdlibEntry {
+            mir_name: "rask_green_sleep_ns",
+            c_name: "rask_green_sleep_ns",
+            params: &[types::I64],
+            ret_ty: None,
+        },
+
+        // ── Ensure hooks (LIFO cleanup) ──────────────────────────────
+        StdlibEntry {
+            mir_name: "rask_ensure_push",
+            c_name: "rask_ensure_push",
+            params: &[types::I64, types::I64],
+            ret_ty: None,
+        },
+        StdlibEntry {
+            mir_name: "rask_ensure_pop",
+            c_name: "rask_ensure_pop",
+            params: &[],
+            ret_ty: None,
+        },
+
+        // ── Memory allocation ─────────────────────────────────────────
+        StdlibEntry {
+            mir_name: "rask_alloc",
+            c_name: "rask_alloc",
+            params: &[types::I64],
+            ret_ty: Some(types::I64),
         },
 
         // ── Concurrency: channels ──────────────────────────────────

--- a/compiler/crates/rask-codegen/src/types.rs
+++ b/compiler/crates/rask-codegen/src/types.rs
@@ -34,32 +34,3 @@ pub fn mir_to_cranelift_type(ty: &MirType) -> CodegenResult<Type> {
     }
 }
 
-/// Get the size in bytes of a MirType.
-/// Used for stack slot allocation.
-pub fn mir_type_size(ty: &MirType) -> u32 {
-    match ty {
-        MirType::Void => 0,
-        MirType::Bool | MirType::I8 | MirType::U8 => 1,
-        MirType::I16 | MirType::U16 => 2,
-        MirType::I32 | MirType::U32 | MirType::F32 | MirType::Char => 4,
-        MirType::I64 | MirType::U64 | MirType::F64 | MirType::Ptr | MirType::FuncPtr(_) => 8,
-        MirType::String => 16, // ptr + len
-        MirType::Struct(_) => 8, // Pointer for now (should use layout)
-        MirType::Enum(_) => 8,   // Pointer for now
-        MirType::Array { elem, len } => mir_type_size(elem) * len,
-    }
-}
-
-/// Get the alignment of a MirType.
-pub fn mir_type_alignment(ty: &MirType) -> u32 {
-    match ty {
-        MirType::Void => 1,
-        MirType::Bool | MirType::I8 | MirType::U8 => 1,
-        MirType::I16 | MirType::U16 => 2,
-        MirType::I32 | MirType::U32 | MirType::F32 | MirType::Char => 4,
-        MirType::I64 | MirType::U64 | MirType::F64 | MirType::Ptr | MirType::String | MirType::FuncPtr(_) => 8,
-        MirType::Struct(_) => 8, // Should use layout
-        MirType::Enum(_) => 8,
-        MirType::Array { elem, .. } => mir_type_alignment(elem),
-    }
-}

--- a/compiler/crates/rask-mir/src/lib.rs
+++ b/compiler/crates/rask-mir/src/lib.rs
@@ -11,6 +11,7 @@ mod display;
 mod function;
 mod operand;
 mod stmt;
+pub mod transform;
 mod types;
 
 pub mod lower;

--- a/compiler/crates/rask-mir/src/lower/expr.rs
+++ b/compiler/crates/rask-mir/src/lower/expr.rs
@@ -4,7 +4,7 @@
 
 use super::{
     binop_result_type, is_type_constructor_name, is_variant_name, lower_binop, lower_unaryop,
-    mir_type_size, operator_method_to_binop, operator_method_to_unaryop, LoweringError,
+    operator_method_to_binop, operator_method_to_unaryop, LoweringError,
     MirLowerer, TypedOperand,
 };
 use crate::{
@@ -527,7 +527,7 @@ impl<'a> MirLowerer<'a> {
                     }
                     lowered.push(elem_op);
                 }
-                let elem_size = mir_type_size(&elem_ty);
+                let elem_size = elem_ty.size();
                 let array_ty = MirType::Array {
                     elem: Box::new(elem_ty),
                     len: elems.len() as u32,
@@ -549,7 +549,7 @@ impl<'a> MirLowerer<'a> {
                 let mut offset = 0u32;
                 for elem in elems.iter() {
                     let (elem_op, elem_ty) = self.lower_expr(elem)?;
-                    let elem_size = mir_type_size(&elem_ty);
+                    let elem_size = elem_ty.size();
                     let elem_align = elem_size.max(1);
                     // Align offset for this element
                     offset = (offset + elem_align - 1) & !(elem_align - 1);
@@ -1387,7 +1387,7 @@ impl<'a> MirLowerer<'a> {
         let mut captures = Vec::new();
         let mut env_offset = 0u32;
         for (_name, local_id, ty) in &free_vars {
-            let size = mir_type_size(ty);
+            let size = ty.size();
             // 8-byte alignment
             let aligned_offset = (env_offset + 7) & !7;
             captures.push(ClosureCapture {
@@ -1496,7 +1496,7 @@ impl<'a> MirLowerer<'a> {
         let mut captures = Vec::new();
         let mut env_offset = 0u32;
         for (_name, local_id, ty) in &free_vars {
-            let size = mir_type_size(ty);
+            let size = ty.size();
             let aligned_offset = (env_offset + 7) & !7;
             captures.push(ClosureCapture {
                 local_id: *local_id,

--- a/compiler/crates/rask-mir/src/lower/mod.rs
+++ b/compiler/crates/rask-mir/src/lower/mod.rs
@@ -701,31 +701,6 @@ fn collect_pattern_names(
     }
 }
 
-// =================================================================
-// MIR type size (for computing offsets in aggregates)
-// =================================================================
-
-/// Return byte size for a MirType. Used for array/tuple/struct store offsets.
-fn mir_type_size(ty: &MirType) -> u32 {
-    match ty {
-        MirType::Void => 0,
-        MirType::Bool | MirType::I8 | MirType::U8 => 1,
-        MirType::I16 | MirType::U16 => 2,
-        MirType::I32 | MirType::U32 | MirType::F32 | MirType::Char => 4,
-        MirType::I64 | MirType::U64 | MirType::F64 | MirType::Ptr | MirType::FuncPtr(_) => 8,
-        MirType::String => 16,
-        MirType::Struct(id) => {
-            // Can't look up the layout without context — fallback to pointer size
-            let _ = id;
-            8
-        }
-        MirType::Enum(id) => {
-            let _ = id;
-            8
-        }
-        MirType::Array { elem, len } => mir_type_size(elem) * len,
-    }
-}
 
 // =================================================================
 // Operator mappings

--- a/compiler/crates/rask-mir/src/transform/mod.rs
+++ b/compiler/crates/rask-mir/src/transform/mod.rs
@@ -1,0 +1,5 @@
+// SPDX-License-Identifier: (MIT OR Apache-2.0)
+
+//! MIR transform passes.
+
+pub mod state_machine;

--- a/compiler/crates/rask-mir/src/transform/state_machine.rs
+++ b/compiler/crates/rask-mir/src/transform/state_machine.rs
@@ -1,0 +1,894 @@
+// SPDX-License-Identifier: (MIT OR Apache-2.0)
+
+//! State machine transform for spawn closures.
+//!
+//! Converts spawn closure functions containing yield points into poll-based
+//! state machines. A yield point is a call to a function that suspends the
+//! green task (sleep, channel ops, async I/O).
+//!
+//! Without yield points, the closure runs to completion via the closure bridge
+//! (`rask_green_closure_spawn`). With yield points, we generate a poll function
+//! that can be suspended and resumed by the scheduler.
+//!
+//! The transform operates on an already-lowered MIR function (the synthesized
+//! spawn closure). It produces a new MIR function with poll semantics plus a
+//! state struct layout.
+
+use std::collections::{HashMap, HashSet};
+
+use crate::{
+    BlockBuilder, BlockId, FunctionRef, LocalId, MirBlock, MirFunction, MirLocal, MirOperand,
+    MirRValue, MirStmt, MirTerminator, MirType,
+};
+use crate::operand::MirConst;
+
+// ── Yield point registry ────────────────────────────────────────────
+
+/// Known functions that act as yield points in green tasks.
+/// When the state machine hits one, it saves state and returns PENDING.
+const YIELD_POINT_FUNCTIONS: &[&str] = &[
+    // Core yield primitives
+    "rask_sleep_ns",
+    "rask_green_sleep_ns",
+    "rask_yield_timeout",
+    "rask_yield_read",
+    "rask_yield_write",
+    "rask_yield_accept",
+    "rask_yield",
+    // Dual-path async I/O
+    "rask_async_read",
+    "rask_async_write",
+    "rask_async_accept",
+    // Async channel ops
+    "rask_channel_send_async",
+    "rask_channel_recv_async",
+];
+
+/// Check if a function name is a yield point.
+pub fn is_yield_point(name: &str) -> bool {
+    YIELD_POINT_FUNCTIONS.contains(&name)
+}
+
+// ── Public API ──────────────────────────────────────────────────────
+
+/// Result of the state machine transform.
+pub struct StateMachineResult {
+    /// The poll function: `fn poll(state_ptr: Ptr, task_ctx: Ptr) -> I32`
+    pub poll_fn: MirFunction,
+    /// Layout of the state struct (field offsets and types).
+    /// The first field is always `state_tag: I32`.
+    pub state_fields: Vec<StateField>,
+    /// Total size of the state struct in bytes.
+    pub state_size: u32,
+}
+
+/// A field in the generated state struct.
+#[derive(Debug, Clone)]
+pub struct StateField {
+    /// Which local variable this saves (None for state_tag)
+    pub local_id: Option<LocalId>,
+    pub name: String,
+    pub ty: MirType,
+    pub offset: u32,
+    pub size: u32,
+}
+
+/// Check if a spawn function contains yield points. If not, the closure
+/// bridge can handle it without transformation.
+pub fn has_yield_points(func: &MirFunction) -> bool {
+    func.blocks.iter().any(|block| {
+        block.statements.iter().any(|stmt| {
+            if let MirStmt::Call { func: fref, .. } = stmt {
+                is_yield_point(&fref.name)
+            } else {
+                false
+            }
+        })
+    })
+}
+
+/// Transform a spawn closure function into a poll-based state machine.
+///
+/// The input function has signature `fn name(env_ptr: Ptr) -> Void`.
+/// The output poll function has signature `fn name_poll(state_ptr: Ptr, task_ctx: Ptr) -> I32`.
+///
+/// Returns None if no yield points are found (use closure bridge instead).
+pub fn transform(func: &MirFunction) -> Option<StateMachineResult> {
+    if !has_yield_points(func) {
+        return None;
+    }
+
+    // Flatten all statements from all blocks into a linear sequence.
+    // Spawn closures are straight-line code (no branches from user code),
+    // so we can safely linearize. If we encounter branches, we fall back
+    // to the simple approach of treating the whole body as segment 0.
+    let linear = linearize(func);
+
+    // Find yield point indices in the linear sequence
+    let yield_indices = find_yield_indices(&linear);
+    if yield_indices.is_empty() {
+        return None;
+    }
+
+    // Segment the linear body at yield points
+    let segments = segment(&linear, &yield_indices);
+
+    // Compute liveness: which locals are defined before a yield and used after
+    let live_across = compute_liveness(&segments, func);
+
+    // Build state struct layout
+    let (state_fields, state_size) = build_state_layout(&live_across, func);
+
+    // Generate the poll function
+    let poll_fn = generate_poll_fn(func, &segments, &yield_indices, &state_fields, state_size, &live_across);
+
+    Some(StateMachineResult {
+        poll_fn,
+        state_fields,
+        state_size,
+    })
+}
+
+// ── Linearization ───────────────────────────────────────────────────
+
+/// A linear statement with its source block info.
+#[derive(Debug, Clone)]
+struct LinearStmt {
+    stmt: MirStmt,
+}
+
+/// Flatten a function's blocks into a linear statement sequence.
+/// For spawn closures this is straightforward since they're mostly linear.
+fn linearize(func: &MirFunction) -> Vec<LinearStmt> {
+    let mut result = Vec::new();
+
+    // Walk blocks in order. Spawn closures have a simple linear structure.
+    // We follow Goto chains but stop at branches/switches.
+    let mut visited = HashSet::new();
+    let mut current = Some(func.entry_block);
+
+    while let Some(block_id) = current {
+        if !visited.insert(block_id) {
+            break; // avoid cycles
+        }
+
+        let block = &func.blocks[block_id.0 as usize];
+        for stmt in &block.statements {
+            result.push(LinearStmt { stmt: stmt.clone() });
+        }
+
+        current = match &block.terminator {
+            MirTerminator::Goto { target } => Some(*target),
+            MirTerminator::Return { .. } => None,
+            _ => None, // branches/switches end linearization
+        };
+    }
+
+    result
+}
+
+/// Find indices of yield point calls in the linear sequence.
+fn find_yield_indices(stmts: &[LinearStmt]) -> Vec<usize> {
+    stmts
+        .iter()
+        .enumerate()
+        .filter_map(|(i, ls)| {
+            if let MirStmt::Call { func, .. } = &ls.stmt {
+                if is_yield_point(&func.name) {
+                    return Some(i);
+                }
+            }
+            None
+        })
+        .collect()
+}
+
+// ── Segmentation ────────────────────────────────────────────────────
+
+/// A segment is a slice of statements between yield points.
+/// Segment 0: [start .. first yield]
+/// Segment 1: [first yield+1 .. second yield]
+/// ...
+/// Segment N: [last yield+1 .. end]
+struct Segment {
+    stmts: Vec<MirStmt>,
+}
+
+fn segment(linear: &[LinearStmt], yield_indices: &[usize]) -> Vec<Segment> {
+    let mut segments = Vec::new();
+    let mut start = 0;
+
+    for &yi in yield_indices {
+        // Include the yield call itself in the segment (it's the last stmt)
+        let end = yi + 1;
+        segments.push(Segment {
+            stmts: linear[start..end].iter().map(|ls| ls.stmt.clone()).collect(),
+        });
+        start = end;
+    }
+
+    // Final segment: everything after the last yield
+    segments.push(Segment {
+        stmts: linear[start..].iter().map(|ls| ls.stmt.clone()).collect(),
+    });
+
+    segments
+}
+
+// ── Liveness analysis ───────────────────────────────────────────────
+
+/// Collect LocalIds that are defined (written) by a statement.
+fn stmt_defs(stmt: &MirStmt) -> Vec<LocalId> {
+    match stmt {
+        MirStmt::Assign { dst, .. } => vec![*dst],
+        MirStmt::Store { .. } => vec![],
+        MirStmt::Call { dst: Some(d), .. } => vec![*d],
+        MirStmt::Call { dst: None, .. } => vec![],
+        MirStmt::ClosureCreate { dst, .. } => vec![*dst],
+        MirStmt::ClosureCall { dst: Some(d), .. } => vec![*d],
+        MirStmt::ClosureCall { dst: None, .. } => vec![],
+        MirStmt::LoadCapture { dst, .. } => vec![*dst],
+        MirStmt::ResourceRegister { dst, .. } => vec![*dst],
+        MirStmt::PoolCheckedAccess { dst, .. } => vec![*dst],
+        _ => vec![],
+    }
+}
+
+/// Collect LocalIds that are used (read) by a statement.
+fn stmt_uses(stmt: &MirStmt) -> Vec<LocalId> {
+    let mut uses = Vec::new();
+    match stmt {
+        MirStmt::Assign { rvalue, .. } => rvalue_uses(rvalue, &mut uses),
+        MirStmt::Store { addr, value, .. } => {
+            uses.push(*addr);
+            operand_uses(value, &mut uses);
+        }
+        MirStmt::Call { args, .. } => {
+            for arg in args {
+                operand_uses(arg, &mut uses);
+            }
+        }
+        MirStmt::ClosureCreate { captures, .. } => {
+            for cap in captures {
+                uses.push(cap.local_id);
+            }
+        }
+        MirStmt::ClosureCall { closure, args, .. } => {
+            uses.push(*closure);
+            for arg in args {
+                operand_uses(arg, &mut uses);
+            }
+        }
+        MirStmt::LoadCapture { env_ptr, .. } => {
+            uses.push(*env_ptr);
+        }
+        MirStmt::ClosureDrop { closure } => {
+            uses.push(*closure);
+        }
+        MirStmt::ResourceConsume { resource_id } => {
+            uses.push(*resource_id);
+        }
+        MirStmt::PoolCheckedAccess { pool, handle, .. } => {
+            uses.push(*pool);
+            uses.push(*handle);
+        }
+        _ => {}
+    }
+    uses
+}
+
+fn operand_uses(op: &MirOperand, uses: &mut Vec<LocalId>) {
+    if let MirOperand::Local(id) = op {
+        uses.push(*id);
+    }
+}
+
+fn rvalue_uses(rv: &MirRValue, uses: &mut Vec<LocalId>) {
+    match rv {
+        MirRValue::Use(op) => operand_uses(op, uses),
+        MirRValue::Ref(id) => uses.push(*id),
+        MirRValue::Deref(op) => operand_uses(op, uses),
+        MirRValue::BinaryOp { left, right, .. } => {
+            operand_uses(left, uses);
+            operand_uses(right, uses);
+        }
+        MirRValue::UnaryOp { operand, .. } => operand_uses(operand, uses),
+        MirRValue::Cast { value, .. } => operand_uses(value, uses),
+        MirRValue::Field { base, .. } => operand_uses(base, uses),
+        MirRValue::EnumTag { value } => operand_uses(value, uses),
+    }
+}
+
+/// Compute the set of locals that are live across yield boundaries.
+/// A local is "live across" if it's defined in segment i (or earlier)
+/// and used in segment j where j > i.
+fn compute_liveness(segments: &[Segment], _func: &MirFunction) -> HashSet<LocalId> {
+    // Collect defs and uses per segment
+    let mut defs_before: HashSet<LocalId> = HashSet::new();
+    let mut uses_after: HashSet<LocalId> = HashSet::new();
+
+    // For each yield boundary, accumulate defs from segments 0..i
+    // and uses from segments i+1..N
+    let n = segments.len();
+
+    // Collect all defs per segment
+    let seg_defs: Vec<HashSet<LocalId>> = segments
+        .iter()
+        .map(|seg| {
+            let mut defs = HashSet::new();
+            for stmt in &seg.stmts {
+                for d in stmt_defs(stmt) {
+                    defs.insert(d);
+                }
+            }
+            defs
+        })
+        .collect();
+
+    // Collect all uses per segment
+    let seg_uses: Vec<HashSet<LocalId>> = segments
+        .iter()
+        .map(|seg| {
+            let mut uses_set = HashSet::new();
+            for stmt in &seg.stmts {
+                for u in stmt_uses(stmt) {
+                    uses_set.insert(u);
+                }
+            }
+            uses_set
+        })
+        .collect();
+
+    // For each yield boundary (between segment i and i+1):
+    // Live = (union of defs in 0..=i) ∩ (union of uses in i+1..N)
+    let mut live = HashSet::new();
+    for boundary in 0..n.saturating_sub(1) {
+        defs_before.extend(&seg_defs[boundary]);
+        uses_after.clear();
+        for j in (boundary + 1)..n {
+            uses_after.extend(&seg_uses[j]);
+        }
+        for id in defs_before.intersection(&uses_after) {
+            live.insert(*id);
+        }
+    }
+
+    live
+}
+
+// ── State struct layout ─────────────────────────────────────────────
+
+fn mir_type_size(ty: &MirType) -> u32 {
+    match ty {
+        MirType::Void => 0,
+        MirType::Bool | MirType::I8 | MirType::U8 => 1,
+        MirType::I16 | MirType::U16 => 2,
+        MirType::I32 | MirType::U32 | MirType::F32 | MirType::Char => 4,
+        MirType::I64 | MirType::U64 | MirType::F64 | MirType::Ptr | MirType::FuncPtr(_) => 8,
+        MirType::String => 16,
+        MirType::Struct(_) | MirType::Enum(_) => 8,
+        MirType::Array { elem, len } => mir_type_size(elem) * len,
+    }
+}
+
+fn mir_type_align(ty: &MirType) -> u32 {
+    match ty {
+        MirType::Void => 1,
+        MirType::Bool | MirType::I8 | MirType::U8 => 1,
+        MirType::I16 | MirType::U16 => 2,
+        MirType::I32 | MirType::U32 | MirType::F32 | MirType::Char => 4,
+        _ => 8,
+    }
+}
+
+fn align_up(offset: u32, align: u32) -> u32 {
+    (offset + align - 1) & !(align - 1)
+}
+
+/// Build the state struct layout from the set of live-across locals.
+fn build_state_layout(
+    live_across: &HashSet<LocalId>,
+    func: &MirFunction,
+) -> (Vec<StateField>, u32) {
+    let mut fields = Vec::new();
+
+    // Field 0: state_tag (I32) — always at offset 0
+    fields.push(StateField {
+        local_id: None,
+        name: "state_tag".to_string(),
+        ty: MirType::I32,
+        offset: 0,
+        size: 4,
+    });
+
+    let mut offset: u32 = 4;
+
+    // Add fields for each live-across local, sorted by LocalId for determinism
+    let mut live_locals: Vec<LocalId> = live_across.iter().copied().collect();
+    live_locals.sort_by_key(|id| id.0);
+
+    for local_id in live_locals {
+        // Look up the local's type
+        let ty = func
+            .locals
+            .iter()
+            .find(|l| l.id == local_id)
+            .map(|l| l.ty.clone())
+            .unwrap_or(MirType::I64);
+
+        let size = mir_type_size(&ty);
+        let align = mir_type_align(&ty);
+        offset = align_up(offset, align);
+
+        let name = func
+            .locals
+            .iter()
+            .find(|l| l.id == local_id)
+            .and_then(|l| l.name.clone())
+            .unwrap_or_else(|| format!("_t{}", local_id.0));
+
+        fields.push(StateField {
+            local_id: Some(local_id),
+            name,
+            ty,
+            offset,
+            size,
+        });
+
+        offset += size;
+    }
+
+    // Final alignment to 8 bytes
+    let total = align_up(offset, 8);
+    (fields, total)
+}
+
+// ── Poll function generation ────────────────────────────────────────
+
+/// Generate the poll function from segments.
+///
+/// Structure:
+/// ```text
+/// fn poll(state_ptr: Ptr, task_ctx: Ptr) -> I32 {
+///   tag = load state_ptr[0] as I32
+///   switch tag {
+///     0 => { segment_0; save; tag=1; return PENDING }
+///     1 => { restore; segment_1; save; tag=2; return PENDING }
+///     ...
+///     N => { restore; segment_N; return READY }
+///   }
+/// }
+/// ```
+fn generate_poll_fn(
+    orig: &MirFunction,
+    segments: &[Segment],
+    _yield_indices: &[usize],
+    state_fields: &[StateField],
+    _state_size: u32,
+    live_across: &HashSet<LocalId>,
+) -> MirFunction {
+    let poll_name = format!("{}_poll", orig.name);
+    let mut builder = BlockBuilder::new(poll_name, MirType::I32);
+
+    // Parameters: state_ptr and task_ctx
+    let state_ptr = builder.add_param("__state_ptr".to_string(), MirType::Ptr);
+    let _task_ctx = builder.add_param("__task_ctx".to_string(), MirType::Ptr);
+
+    // Re-create all locals from the original function (except the env_ptr param)
+    let mut local_map: HashMap<LocalId, LocalId> = HashMap::new();
+    for local in &orig.locals {
+        if local.is_param {
+            continue; // skip env_ptr — we use state_ptr instead
+        }
+        let new_id = if let Some(ref name) = local.name {
+            builder.alloc_local(name.clone(), local.ty.clone())
+        } else {
+            builder.alloc_temp(local.ty.clone())
+        };
+        local_map.insert(local.id, new_id);
+    }
+
+    // Build local-to-field mapping for save/restore
+    let field_map: HashMap<LocalId, &StateField> = state_fields
+        .iter()
+        .filter_map(|f| f.local_id.map(|id| (id, f)))
+        .collect();
+
+    let n_segments = segments.len();
+
+    // Load the state tag
+    let tag_local = builder.alloc_temp(MirType::I32);
+    builder.push_stmt(MirStmt::Assign {
+        dst: tag_local,
+        rvalue: MirRValue::Field {
+            base: MirOperand::Local(state_ptr),
+            field_index: 0, // state_tag is field 0
+        },
+    });
+
+    // Create blocks for each segment
+    let segment_blocks: Vec<BlockId> = (0..n_segments).map(|_| builder.create_block()).collect();
+    let default_block = builder.create_block();
+
+    // Switch on tag
+    let cases: Vec<(u64, BlockId)> = segment_blocks
+        .iter()
+        .enumerate()
+        .map(|(i, &block)| (i as u64, block))
+        .collect();
+
+    builder.terminate(MirTerminator::Switch {
+        value: MirOperand::Local(tag_local),
+        cases,
+        default: default_block,
+    });
+
+    // Default block: return READY (shouldn't happen, but safe fallback)
+    builder.switch_to_block(default_block);
+    builder.terminate(MirTerminator::Return {
+        value: Some(MirOperand::Constant(MirConst::Int(0))), // READY
+    });
+
+    // Generate each segment block
+    for (seg_idx, segment) in segments.iter().enumerate() {
+        builder.switch_to_block(segment_blocks[seg_idx]);
+        let is_last = seg_idx == n_segments - 1;
+
+        // Restore live locals from state (except for segment 0)
+        if seg_idx > 0 {
+            for (&orig_id, field) in &field_map {
+                if let Some(&new_id) = local_map.get(&orig_id) {
+                    builder.push_stmt(MirStmt::LoadCapture {
+                        dst: new_id,
+                        env_ptr: state_ptr,
+                        offset: field.offset,
+                    });
+                }
+            }
+        }
+
+        // Emit segment statements, remapping locals
+        for stmt in &segment.stmts {
+            let remapped = remap_stmt(stmt, &local_map);
+            // Skip the yield call itself — it was just a marker
+            if let MirStmt::Call { func: ref fref, .. } = remapped {
+                if is_yield_point(&fref.name) {
+                    // Emit the yield call (it submits I/O or timer)
+                    builder.push_stmt(remapped);
+                    continue;
+                }
+            }
+            builder.push_stmt(remapped);
+        }
+
+        if is_last {
+            // Final segment: return READY
+            builder.terminate(MirTerminator::Return {
+                value: Some(MirOperand::Constant(MirConst::Int(0))), // READY
+            });
+        } else {
+            // Save live locals to state
+            for (&orig_id, field) in &field_map {
+                if live_across.contains(&orig_id) {
+                    if let Some(&new_id) = local_map.get(&orig_id) {
+                        builder.push_stmt(MirStmt::Store {
+                            addr: state_ptr,
+                            offset: field.offset,
+                            value: MirOperand::Local(new_id),
+                        });
+                    }
+                }
+            }
+
+            // Update state_tag to next segment
+            let next_tag = (seg_idx + 1) as i64;
+            builder.push_stmt(MirStmt::Store {
+                addr: state_ptr,
+                offset: 0, // state_tag offset
+                value: MirOperand::Constant(MirConst::Int(next_tag)),
+            });
+
+            // Return PENDING
+            builder.terminate(MirTerminator::Return {
+                value: Some(MirOperand::Constant(MirConst::Int(1))), // PENDING
+            });
+        }
+    }
+
+    builder.finish()
+}
+
+/// Remap LocalIds in a statement using the local_map.
+fn remap_stmt(stmt: &MirStmt, map: &HashMap<LocalId, LocalId>) -> MirStmt {
+    match stmt {
+        MirStmt::Assign { dst, rvalue } => MirStmt::Assign {
+            dst: remap_id(*dst, map),
+            rvalue: remap_rvalue(rvalue, map),
+        },
+        MirStmt::Store { addr, offset, value } => MirStmt::Store {
+            addr: remap_id(*addr, map),
+            offset: *offset,
+            value: remap_operand(value, map),
+        },
+        MirStmt::Call { dst, func, args } => MirStmt::Call {
+            dst: dst.map(|d| remap_id(d, map)),
+            func: func.clone(),
+            args: args.iter().map(|a| remap_operand(a, map)).collect(),
+        },
+        MirStmt::ClosureCreate { dst, func_name, captures, heap } => MirStmt::ClosureCreate {
+            dst: remap_id(*dst, map),
+            func_name: func_name.clone(),
+            captures: captures
+                .iter()
+                .map(|c| crate::ClosureCapture {
+                    local_id: remap_id(c.local_id, map),
+                    offset: c.offset,
+                    size: c.size,
+                })
+                .collect(),
+            heap: *heap,
+        },
+        MirStmt::ClosureCall { dst, closure, args } => MirStmt::ClosureCall {
+            dst: dst.map(|d| remap_id(d, map)),
+            closure: remap_id(*closure, map),
+            args: args.iter().map(|a| remap_operand(a, map)).collect(),
+        },
+        MirStmt::LoadCapture { dst, env_ptr, offset } => MirStmt::LoadCapture {
+            dst: remap_id(*dst, map),
+            env_ptr: remap_id(*env_ptr, map),
+            offset: *offset,
+        },
+        MirStmt::ClosureDrop { closure } => MirStmt::ClosureDrop {
+            closure: remap_id(*closure, map),
+        },
+        MirStmt::ResourceRegister { dst, type_name, scope_depth } => {
+            MirStmt::ResourceRegister {
+                dst: remap_id(*dst, map),
+                type_name: type_name.clone(),
+                scope_depth: *scope_depth,
+            }
+        }
+        MirStmt::ResourceConsume { resource_id } => MirStmt::ResourceConsume {
+            resource_id: remap_id(*resource_id, map),
+        },
+        MirStmt::PoolCheckedAccess { dst, pool, handle } => MirStmt::PoolCheckedAccess {
+            dst: remap_id(*dst, map),
+            pool: remap_id(*pool, map),
+            handle: remap_id(*handle, map),
+        },
+        // Pass through unchanged
+        other => other.clone(),
+    }
+}
+
+fn remap_id(id: LocalId, map: &HashMap<LocalId, LocalId>) -> LocalId {
+    map.get(&id).copied().unwrap_or(id)
+}
+
+fn remap_operand(op: &MirOperand, map: &HashMap<LocalId, LocalId>) -> MirOperand {
+    match op {
+        MirOperand::Local(id) => MirOperand::Local(remap_id(*id, map)),
+        MirOperand::Constant(c) => MirOperand::Constant(c.clone()),
+    }
+}
+
+fn remap_rvalue(rv: &MirRValue, map: &HashMap<LocalId, LocalId>) -> MirRValue {
+    match rv {
+        MirRValue::Use(op) => MirRValue::Use(remap_operand(op, map)),
+        MirRValue::Ref(id) => MirRValue::Ref(remap_id(*id, map)),
+        MirRValue::Deref(op) => MirRValue::Deref(remap_operand(op, map)),
+        MirRValue::BinaryOp { op, left, right } => MirRValue::BinaryOp {
+            op: *op,
+            left: remap_operand(left, map),
+            right: remap_operand(right, map),
+        },
+        MirRValue::UnaryOp { op, operand } => MirRValue::UnaryOp {
+            op: *op,
+            operand: remap_operand(operand, map),
+        },
+        MirRValue::Cast { value, target_ty } => MirRValue::Cast {
+            value: remap_operand(value, map),
+            target_ty: target_ty.clone(),
+        },
+        MirRValue::Field { base, field_index } => MirRValue::Field {
+            base: remap_operand(base, map),
+            field_index: *field_index,
+        },
+        MirRValue::EnumTag { value } => MirRValue::EnumTag {
+            value: remap_operand(value, map),
+        },
+    }
+}
+
+// ── Tests ───────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn make_test_spawn_fn(stmts: Vec<MirStmt>) -> MirFunction {
+        let mut builder = BlockBuilder::new("test__spawn_0".to_string(), MirType::Void);
+        let _env = builder.add_param("__env".to_string(), MirType::Ptr);
+
+        for stmt in stmts {
+            builder.push_stmt(stmt);
+        }
+
+        builder.terminate(MirTerminator::Return { value: None });
+        builder.finish()
+    }
+
+    #[test]
+    fn no_yield_points_returns_none() {
+        let func = make_test_spawn_fn(vec![MirStmt::Call {
+            dst: None,
+            func: FunctionRef { name: "work".to_string() },
+            args: vec![],
+        }]);
+
+        assert!(!has_yield_points(&func));
+        assert!(transform(&func).is_none());
+    }
+
+    #[test]
+    fn detects_sleep_as_yield_point() {
+        let func = make_test_spawn_fn(vec![MirStmt::Call {
+            dst: None,
+            func: FunctionRef { name: "rask_sleep_ns".to_string() },
+            args: vec![MirOperand::Constant(MirConst::Int(1_000_000))],
+        }]);
+
+        assert!(has_yield_points(&func));
+    }
+
+    #[test]
+    fn transform_produces_poll_fn() {
+        let mut builder = BlockBuilder::new("test__spawn_0".to_string(), MirType::Void);
+        let _env = builder.add_param("__env".to_string(), MirType::Ptr);
+
+        let x = builder.alloc_local("x".to_string(), MirType::I64);
+        builder.push_stmt(MirStmt::Assign {
+            dst: x,
+            rvalue: MirRValue::Use(MirOperand::Constant(MirConst::Int(42))),
+        });
+
+        builder.push_stmt(MirStmt::Call {
+            dst: None,
+            func: FunctionRef { name: "rask_sleep_ns".to_string() },
+            args: vec![MirOperand::Constant(MirConst::Int(1_000_000))],
+        });
+
+        // Use x after the yield
+        builder.push_stmt(MirStmt::Call {
+            dst: None,
+            func: FunctionRef { name: "print_i64".to_string() },
+            args: vec![MirOperand::Local(x)],
+        });
+
+        builder.terminate(MirTerminator::Return { value: None });
+        let func = builder.finish();
+
+        let result = transform(&func).expect("should transform");
+
+        // Poll function should have state_ptr and task_ctx params
+        assert_eq!(result.poll_fn.params.len(), 2);
+        assert_eq!(result.poll_fn.ret_ty, MirType::I32);
+
+        // State struct should have state_tag + x
+        assert!(result.state_fields.len() >= 2);
+        assert_eq!(result.state_fields[0].name, "state_tag");
+
+        // State size should be reasonable (tag + one i64)
+        assert!(result.state_size >= 12);
+
+        // Should have at least 3 blocks: entry + 2 segments + default
+        assert!(result.poll_fn.blocks.len() >= 3);
+    }
+
+    #[test]
+    fn liveness_tracks_cross_yield_locals() {
+        let mut builder = BlockBuilder::new("test__spawn_0".to_string(), MirType::Void);
+        let _env = builder.add_param("__env".to_string(), MirType::Ptr);
+
+        let x = builder.alloc_local("x".to_string(), MirType::I64);
+        let y = builder.alloc_local("y".to_string(), MirType::I64);
+
+        // x = 1 (used after yield)
+        builder.push_stmt(MirStmt::Assign {
+            dst: x,
+            rvalue: MirRValue::Use(MirOperand::Constant(MirConst::Int(1))),
+        });
+
+        // y = 2 (NOT used after yield)
+        builder.push_stmt(MirStmt::Assign {
+            dst: y,
+            rvalue: MirRValue::Use(MirOperand::Constant(MirConst::Int(2))),
+        });
+
+        // yield
+        builder.push_stmt(MirStmt::Call {
+            dst: None,
+            func: FunctionRef { name: "rask_sleep_ns".to_string() },
+            args: vec![MirOperand::Constant(MirConst::Int(1000))],
+        });
+
+        // use x (cross-yield)
+        builder.push_stmt(MirStmt::Call {
+            dst: None,
+            func: FunctionRef { name: "print_i64".to_string() },
+            args: vec![MirOperand::Local(x)],
+        });
+
+        builder.terminate(MirTerminator::Return { value: None });
+        let func = builder.finish();
+
+        let result = transform(&func).expect("should transform");
+
+        // x should be in state struct, y should not
+        let has_x = result
+            .state_fields
+            .iter()
+            .any(|f| f.local_id == Some(x) && f.name == "x");
+        let has_y = result
+            .state_fields
+            .iter()
+            .any(|f| f.local_id == Some(y));
+
+        assert!(has_x, "x should be in state struct (live across yield)");
+        assert!(!has_y, "y should NOT be in state struct (dead after yield)");
+    }
+
+    #[test]
+    fn multiple_yield_points_create_multiple_segments() {
+        let mut builder = BlockBuilder::new("test__spawn_0".to_string(), MirType::Void);
+        let _env = builder.add_param("__env".to_string(), MirType::Ptr);
+
+        // work1
+        builder.push_stmt(MirStmt::Call {
+            dst: None,
+            func: FunctionRef { name: "work1".to_string() },
+            args: vec![],
+        });
+
+        // yield 1
+        builder.push_stmt(MirStmt::Call {
+            dst: None,
+            func: FunctionRef { name: "rask_sleep_ns".to_string() },
+            args: vec![MirOperand::Constant(MirConst::Int(1000))],
+        });
+
+        // work2
+        builder.push_stmt(MirStmt::Call {
+            dst: None,
+            func: FunctionRef { name: "work2".to_string() },
+            args: vec![],
+        });
+
+        // yield 2
+        builder.push_stmt(MirStmt::Call {
+            dst: None,
+            func: FunctionRef { name: "rask_yield".to_string() },
+            args: vec![],
+        });
+
+        // work3
+        builder.push_stmt(MirStmt::Call {
+            dst: None,
+            func: FunctionRef { name: "work3".to_string() },
+            args: vec![],
+        });
+
+        builder.terminate(MirTerminator::Return { value: None });
+        let func = builder.finish();
+
+        let result = transform(&func).expect("should transform");
+
+        // 3 segments: [work1+yield1], [work2+yield2], [work3]
+        // Poll function should have entry block + 3 segment blocks + default
+        assert!(
+            result.poll_fn.blocks.len() >= 4,
+            "expected >=4 blocks for 3 segments, got {}",
+            result.poll_fn.blocks.len()
+        );
+    }
+}

--- a/compiler/crates/rask-mir/src/transform/state_machine.rs
+++ b/compiler/crates/rask-mir/src/transform/state_machine.rs
@@ -4,7 +4,7 @@
 //!
 //! Converts spawn closure functions containing yield points into poll-based
 //! state machines. A yield point is a call to a function that suspends the
-//! green task (sleep, channel ops, async I/O).
+//! green task (sleep, I/O yield helpers).
 //!
 //! Without yield points, the closure runs to completion via the closure bridge
 //! (`rask_green_closure_spawn`). With yield points, we generate a poll function
@@ -17,7 +17,7 @@
 use std::collections::{HashMap, HashSet};
 
 use crate::{
-    BlockBuilder, BlockId, FunctionRef, LocalId, MirBlock, MirFunction, MirLocal, MirOperand,
+    BlockBuilder, LocalId, MirFunction, MirOperand,
     MirRValue, MirStmt, MirTerminator, MirType,
 };
 use crate::operand::MirConst;
@@ -25,26 +25,20 @@ use crate::operand::MirConst;
 // ── Yield point registry ────────────────────────────────────────────
 
 /// Known functions that act as yield points in green tasks.
-/// When the state machine hits one, it saves state and returns PENDING.
+/// Each of these submits work to the scheduler/I/O engine and expects the
+/// poll function to return PENDING afterward.
+///
+/// NOT included: `rask_channel_send_async`/`recv_async` — they handle
+/// yielding internally via retry loops and complete before returning.
 const YIELD_POINT_FUNCTIONS: &[&str] = &[
-    // Core yield primitives
-    "rask_sleep_ns",
     "rask_green_sleep_ns",
     "rask_yield_timeout",
     "rask_yield_read",
     "rask_yield_write",
     "rask_yield_accept",
     "rask_yield",
-    // Dual-path async I/O
-    "rask_async_read",
-    "rask_async_write",
-    "rask_async_accept",
-    // Async channel ops
-    "rask_channel_send_async",
-    "rask_channel_recv_async",
 ];
 
-/// Check if a function name is a yield point.
 pub fn is_yield_point(name: &str) -> bool {
     YIELD_POINT_FUNCTIONS.contains(&name)
 }
@@ -56,16 +50,18 @@ pub struct StateMachineResult {
     /// The poll function: `fn poll(state_ptr: Ptr, task_ctx: Ptr) -> I32`
     pub poll_fn: MirFunction,
     /// Layout of the state struct (field offsets and types).
-    /// The first field is always `state_tag: I32`.
     pub state_fields: Vec<StateField>,
     /// Total size of the state struct in bytes.
     pub state_size: u32,
+    /// Captures the parent must store into the state struct at spawn time.
+    /// Each entry: (env_offset in original closure, offset in state struct).
+    pub capture_stores: Vec<(u32, u32)>,
 }
 
 /// A field in the generated state struct.
 #[derive(Debug, Clone)]
 pub struct StateField {
-    /// Which local variable this saves (None for state_tag)
+    /// Which local variable this saves (None for state_tag).
     pub local_id: Option<LocalId>,
     pub name: String,
     pub ty: MirType,
@@ -73,143 +69,158 @@ pub struct StateField {
     pub size: u32,
 }
 
-/// Check if a spawn function contains yield points. If not, the closure
-/// bridge can handle it without transformation.
+/// Check if a spawn function contains yield points.
 pub fn has_yield_points(func: &MirFunction) -> bool {
     func.blocks.iter().any(|block| {
-        block.statements.iter().any(|stmt| {
-            if let MirStmt::Call { func: fref, .. } = stmt {
-                is_yield_point(&fref.name)
-            } else {
-                false
-            }
-        })
+        block.statements.iter().any(|stmt| matches!(
+            stmt,
+            MirStmt::Call { func: fref, .. } if is_yield_point(&fref.name)
+        ))
     })
 }
 
 /// Transform a spawn closure function into a poll-based state machine.
 ///
-/// The input function has signature `fn name(env_ptr: Ptr) -> Void`.
-/// The output poll function has signature `fn name_poll(state_ptr: Ptr, task_ctx: Ptr) -> I32`.
+/// Input: `fn name(env_ptr: Ptr) -> Void`
+/// Output: `fn name_poll(state_ptr: Ptr, task_ctx: Ptr) -> I32`
 ///
-/// Returns None if no yield points are found (use closure bridge instead).
+/// Returns None if no yield points found.
 pub fn transform(func: &MirFunction) -> Option<StateMachineResult> {
     if !has_yield_points(func) {
         return None;
     }
 
-    // Flatten all statements from all blocks into a linear sequence.
-    // Spawn closures are straight-line code (no branches from user code),
-    // so we can safely linearize. If we encounter branches, we fall back
-    // to the simple approach of treating the whole body as segment 0.
     let linear = linearize(func);
 
-    // Find yield point indices in the linear sequence
     let yield_indices = find_yield_indices(&linear);
     if yield_indices.is_empty() {
         return None;
     }
 
-    // Segment the linear body at yield points
     let segments = segment(&linear, &yield_indices);
 
-    // Compute liveness: which locals are defined before a yield and used after
-    let live_across = compute_liveness(&segments, func);
+    // Extract capture info from LoadCapture instructions
+    let captures = extract_captures(&linear, func);
 
-    // Build state struct layout
-    let (state_fields, state_size) = build_state_layout(&live_across, func);
+    // Locals live across yield boundaries
+    let live_across = compute_liveness(&segments);
 
-    // Generate the poll function
-    let poll_fn = generate_poll_fn(func, &segments, &yield_indices, &state_fields, state_size, &live_across);
+    // Build state struct: tag + captures + live-across locals
+    let (state_fields, state_size, capture_stores) =
+        build_state_layout(&captures, &live_across, func);
+
+    // Build capture offset remap: env_offset → state_struct_offset
+    let capture_remap: HashMap<u32, u32> = capture_stores
+        .iter()
+        .map(|&(env_off, state_off)| (env_off, state_off))
+        .collect();
+
+    let poll_fn = generate_poll_fn(
+        func, &segments, &state_fields, &live_across, &capture_remap,
+    );
 
     Some(StateMachineResult {
         poll_fn,
         state_fields,
         state_size,
+        capture_stores,
     })
 }
 
 // ── Linearization ───────────────────────────────────────────────────
 
-/// A linear statement with its source block info.
-#[derive(Debug, Clone)]
-struct LinearStmt {
-    stmt: MirStmt,
-}
-
 /// Flatten a function's blocks into a linear statement sequence.
-/// For spawn closures this is straightforward since they're mostly linear.
-fn linearize(func: &MirFunction) -> Vec<LinearStmt> {
+/// Spawn closures have simple linear structure — follow Goto chains,
+/// stop at branches.
+fn linearize(func: &MirFunction) -> Vec<MirStmt> {
     let mut result = Vec::new();
-
-    // Walk blocks in order. Spawn closures have a simple linear structure.
-    // We follow Goto chains but stop at branches/switches.
     let mut visited = HashSet::new();
     let mut current = Some(func.entry_block);
 
     while let Some(block_id) = current {
         if !visited.insert(block_id) {
-            break; // avoid cycles
+            break;
         }
 
         let block = &func.blocks[block_id.0 as usize];
         for stmt in &block.statements {
-            result.push(LinearStmt { stmt: stmt.clone() });
+            result.push(stmt.clone());
         }
 
         current = match &block.terminator {
             MirTerminator::Goto { target } => Some(*target),
-            MirTerminator::Return { .. } => None,
-            _ => None, // branches/switches end linearization
+            _ => None,
         };
     }
 
     result
 }
 
-/// Find indices of yield point calls in the linear sequence.
-fn find_yield_indices(stmts: &[LinearStmt]) -> Vec<usize> {
+fn find_yield_indices(stmts: &[MirStmt]) -> Vec<usize> {
     stmts
         .iter()
         .enumerate()
-        .filter_map(|(i, ls)| {
-            if let MirStmt::Call { func, .. } = &ls.stmt {
-                if is_yield_point(&func.name) {
-                    return Some(i);
-                }
+        .filter_map(|(i, stmt)| match stmt {
+            MirStmt::Call { func, .. } if is_yield_point(&func.name) => Some(i),
+            _ => None,
+        })
+        .collect()
+}
+
+// ── Capture extraction ──────────────────────────────────────────────
+
+/// A captured variable loaded via LoadCapture in the spawn body.
+struct CaptureInfo {
+    /// Local in the spawn function that receives this capture.
+    dst_local: LocalId,
+    /// Offset in the original closure environment.
+    env_offset: u32,
+    ty: MirType,
+}
+
+/// Find all LoadCapture instructions to identify captured variables.
+fn extract_captures(stmts: &[MirStmt], func: &MirFunction) -> Vec<CaptureInfo> {
+    stmts
+        .iter()
+        .filter_map(|stmt| match stmt {
+            MirStmt::LoadCapture { dst, offset, .. } => {
+                let ty = func.locals.iter()
+                    .find(|l| l.id == *dst)
+                    .map(|l| l.ty.clone())
+                    .unwrap_or(MirType::I64);
+                Some(CaptureInfo {
+                    dst_local: *dst,
+                    env_offset: *offset,
+                    ty,
+                })
             }
-            None
+            _ => None,
         })
         .collect()
 }
 
 // ── Segmentation ────────────────────────────────────────────────────
 
-/// A segment is a slice of statements between yield points.
-/// Segment 0: [start .. first yield]
-/// Segment 1: [first yield+1 .. second yield]
-/// ...
-/// Segment N: [last yield+1 .. end]
+/// A slice of statements between yield points.
 struct Segment {
     stmts: Vec<MirStmt>,
 }
 
-fn segment(linear: &[LinearStmt], yield_indices: &[usize]) -> Vec<Segment> {
+fn segment(linear: &[MirStmt], yield_indices: &[usize]) -> Vec<Segment> {
     let mut segments = Vec::new();
     let mut start = 0;
 
     for &yi in yield_indices {
-        // Include the yield call itself in the segment (it's the last stmt)
-        let end = yi + 1;
+        // Include the yield call in this segment (last stmt before suspension)
         segments.push(Segment {
-            stmts: linear[start..end].iter().map(|ls| ls.stmt.clone()).collect(),
+            stmts: linear[start..=yi].to_vec(),
         });
-        start = end;
+        start = yi + 1;
     }
 
     // Final segment: everything after the last yield
     segments.push(Segment {
-        stmts: linear[start..].iter().map(|ls| ls.stmt.clone()).collect(),
+        stmts: linear[start..].to_vec(),
     });
 
     segments
@@ -217,24 +228,21 @@ fn segment(linear: &[LinearStmt], yield_indices: &[usize]) -> Vec<Segment> {
 
 // ── Liveness analysis ───────────────────────────────────────────────
 
-/// Collect LocalIds that are defined (written) by a statement.
+/// Collect locals defined by a statement.
 fn stmt_defs(stmt: &MirStmt) -> Vec<LocalId> {
     match stmt {
-        MirStmt::Assign { dst, .. } => vec![*dst],
-        MirStmt::Store { .. } => vec![],
-        MirStmt::Call { dst: Some(d), .. } => vec![*d],
-        MirStmt::Call { dst: None, .. } => vec![],
-        MirStmt::ClosureCreate { dst, .. } => vec![*dst],
-        MirStmt::ClosureCall { dst: Some(d), .. } => vec![*d],
-        MirStmt::ClosureCall { dst: None, .. } => vec![],
-        MirStmt::LoadCapture { dst, .. } => vec![*dst],
-        MirStmt::ResourceRegister { dst, .. } => vec![*dst],
-        MirStmt::PoolCheckedAccess { dst, .. } => vec![*dst],
+        MirStmt::Assign { dst, .. }
+        | MirStmt::ClosureCreate { dst, .. }
+        | MirStmt::LoadCapture { dst, .. }
+        | MirStmt::ResourceRegister { dst, .. }
+        | MirStmt::PoolCheckedAccess { dst, .. } => vec![*dst],
+        MirStmt::Call { dst: Some(d), .. }
+        | MirStmt::ClosureCall { dst: Some(d), .. } => vec![*d],
         _ => vec![],
     }
 }
 
-/// Collect LocalIds that are used (read) by a statement.
+/// Collect locals used by a statement.
 fn stmt_uses(stmt: &MirStmt) -> Vec<LocalId> {
     let mut uses = Vec::new();
     match stmt {
@@ -259,15 +267,9 @@ fn stmt_uses(stmt: &MirStmt) -> Vec<LocalId> {
                 operand_uses(arg, &mut uses);
             }
         }
-        MirStmt::LoadCapture { env_ptr, .. } => {
-            uses.push(*env_ptr);
-        }
-        MirStmt::ClosureDrop { closure } => {
-            uses.push(*closure);
-        }
-        MirStmt::ResourceConsume { resource_id } => {
-            uses.push(*resource_id);
-        }
+        MirStmt::LoadCapture { env_ptr, .. } => uses.push(*env_ptr),
+        MirStmt::ClosureDrop { closure } => uses.push(*closure),
+        MirStmt::ResourceConsume { resource_id } => uses.push(*resource_id),
         MirStmt::PoolCheckedAccess { pool, handle, .. } => {
             uses.push(*pool);
             uses.push(*handle);
@@ -285,9 +287,8 @@ fn operand_uses(op: &MirOperand, uses: &mut Vec<LocalId>) {
 
 fn rvalue_uses(rv: &MirRValue, uses: &mut Vec<LocalId>) {
     match rv {
-        MirRValue::Use(op) => operand_uses(op, uses),
+        MirRValue::Use(op) | MirRValue::Deref(op) => operand_uses(op, uses),
         MirRValue::Ref(id) => uses.push(*id),
-        MirRValue::Deref(op) => operand_uses(op, uses),
         MirRValue::BinaryOp { left, right, .. } => {
             operand_uses(left, uses);
             operand_uses(right, uses);
@@ -299,61 +300,38 @@ fn rvalue_uses(rv: &MirRValue, uses: &mut Vec<LocalId>) {
     }
 }
 
-/// Compute the set of locals that are live across yield boundaries.
-/// A local is "live across" if it's defined in segment i (or earlier)
-/// and used in segment j where j > i.
-fn compute_liveness(segments: &[Segment], _func: &MirFunction) -> HashSet<LocalId> {
-    // Collect defs and uses per segment
-    let mut defs_before: HashSet<LocalId> = HashSet::new();
-    let mut uses_after: HashSet<LocalId> = HashSet::new();
+/// Compute locals live across at least one yield boundary.
+///
+/// A local is live-across if it's defined in segments 0..=i and used in
+/// segments i+1..N for any boundary i. Since we only need the flat set
+/// (not per-boundary), this simplifies to:
+///   defs_in(0..N-1) ∩ uses_in(1..N)
+fn compute_liveness(segments: &[Segment]) -> HashSet<LocalId> {
+    if segments.len() < 2 {
+        return HashSet::new();
+    }
 
-    // For each yield boundary, accumulate defs from segments 0..i
-    // and uses from segments i+1..N
-    let n = segments.len();
-
-    // Collect all defs per segment
-    let seg_defs: Vec<HashSet<LocalId>> = segments
-        .iter()
-        .map(|seg| {
-            let mut defs = HashSet::new();
-            for stmt in &seg.stmts {
-                for d in stmt_defs(stmt) {
-                    defs.insert(d);
-                }
+    // Defs in all segments except the last
+    let mut defs_before_last: HashSet<LocalId> = HashSet::new();
+    for seg in &segments[..segments.len() - 1] {
+        for stmt in &seg.stmts {
+            for d in stmt_defs(stmt) {
+                defs_before_last.insert(d);
             }
-            defs
-        })
-        .collect();
-
-    // Collect all uses per segment
-    let seg_uses: Vec<HashSet<LocalId>> = segments
-        .iter()
-        .map(|seg| {
-            let mut uses_set = HashSet::new();
-            for stmt in &seg.stmts {
-                for u in stmt_uses(stmt) {
-                    uses_set.insert(u);
-                }
-            }
-            uses_set
-        })
-        .collect();
-
-    // For each yield boundary (between segment i and i+1):
-    // Live = (union of defs in 0..=i) ∩ (union of uses in i+1..N)
-    let mut live = HashSet::new();
-    for boundary in 0..n.saturating_sub(1) {
-        defs_before.extend(&seg_defs[boundary]);
-        uses_after.clear();
-        for j in (boundary + 1)..n {
-            uses_after.extend(&seg_uses[j]);
-        }
-        for id in defs_before.intersection(&uses_after) {
-            live.insert(*id);
         }
     }
 
-    live
+    // Uses in all segments except the first
+    let mut uses_after_first: HashSet<LocalId> = HashSet::new();
+    for seg in &segments[1..] {
+        for stmt in &seg.stmts {
+            for u in stmt_uses(stmt) {
+                uses_after_first.insert(u);
+            }
+        }
+    }
+
+    defs_before_last.intersection(&uses_after_first).copied().collect()
 }
 
 // ── State struct layout ─────────────────────────────────────────────
@@ -373,8 +351,7 @@ fn mir_type_size(ty: &MirType) -> u32 {
 
 fn mir_type_align(ty: &MirType) -> u32 {
     match ty {
-        MirType::Void => 1,
-        MirType::Bool | MirType::I8 | MirType::U8 => 1,
+        MirType::Bool | MirType::I8 | MirType::U8 | MirType::Void => 1,
         MirType::I16 | MirType::U16 => 2,
         MirType::I32 | MirType::U32 | MirType::F32 | MirType::Char => 4,
         _ => 8,
@@ -385,14 +362,21 @@ fn align_up(offset: u32, align: u32) -> u32 {
     (offset + align - 1) & !(align - 1)
 }
 
-/// Build the state struct layout from the set of live-across locals.
+/// Build the state struct layout.
+///
+/// Layout: [state_tag: I32] [captures...] [live-across locals...]
+///
+/// Returns: (fields, total_size, capture_stores)
+/// capture_stores: Vec<(env_offset, state_offset)> — what the parent must init.
 fn build_state_layout(
+    captures: &[CaptureInfo],
     live_across: &HashSet<LocalId>,
     func: &MirFunction,
-) -> (Vec<StateField>, u32) {
+) -> (Vec<StateField>, u32, Vec<(u32, u32)>) {
     let mut fields = Vec::new();
+    let mut capture_stores = Vec::new();
 
-    // Field 0: state_tag (I32) — always at offset 0
+    // Field 0: state_tag (I32) at offset 0
     fields.push(StateField {
         local_id: None,
         name: "state_tag".to_string(),
@@ -400,30 +384,50 @@ fn build_state_layout(
         offset: 0,
         size: 4,
     });
-
     let mut offset: u32 = 4;
 
-    // Add fields for each live-across local, sorted by LocalId for determinism
-    let mut live_locals: Vec<LocalId> = live_across.iter().copied().collect();
+    // Track which locals are already covered by captures
+    let mut captured_locals: HashSet<LocalId> = HashSet::new();
+
+    // Captures — always included (needed by segment 0)
+    for cap in captures {
+        let size = mir_type_size(&cap.ty);
+        let align = mir_type_align(&cap.ty);
+        offset = align_up(offset, align);
+
+        let name = func.locals.iter()
+            .find(|l| l.id == cap.dst_local)
+            .and_then(|l| l.name.clone())
+            .unwrap_or_else(|| format!("_cap{}", cap.dst_local.0));
+
+        capture_stores.push((cap.env_offset, offset));
+        captured_locals.insert(cap.dst_local);
+
+        fields.push(StateField {
+            local_id: Some(cap.dst_local),
+            name,
+            ty: cap.ty.clone(),
+            offset,
+            size,
+        });
+        offset += size;
+    }
+
+    // Live-across locals (excluding those already added as captures)
+    let mut live_locals: Vec<LocalId> = live_across.iter()
+        .filter(|id| !captured_locals.contains(id))
+        .copied()
+        .collect();
     live_locals.sort_by_key(|id| id.0);
 
     for local_id in live_locals {
-        // Look up the local's type
-        let ty = func
-            .locals
-            .iter()
-            .find(|l| l.id == local_id)
-            .map(|l| l.ty.clone())
-            .unwrap_or(MirType::I64);
-
+        let local = func.locals.iter().find(|l| l.id == local_id);
+        let ty = local.map(|l| l.ty.clone()).unwrap_or(MirType::I64);
         let size = mir_type_size(&ty);
         let align = mir_type_align(&ty);
         offset = align_up(offset, align);
 
-        let name = func
-            .locals
-            .iter()
-            .find(|l| l.id == local_id)
+        let name = local
             .and_then(|l| l.name.clone())
             .unwrap_or_else(|| format!("_t{}", local_id.0));
 
@@ -434,23 +438,20 @@ fn build_state_layout(
             offset,
             size,
         });
-
         offset += size;
     }
 
-    // Final alignment to 8 bytes
     let total = align_up(offset, 8);
-    (fields, total)
+    (fields, total, capture_stores)
 }
 
 // ── Poll function generation ────────────────────────────────────────
 
 /// Generate the poll function from segments.
 ///
-/// Structure:
 /// ```text
 /// fn poll(state_ptr: Ptr, task_ctx: Ptr) -> I32 {
-///   tag = load state_ptr[0] as I32
+///   tag = load state_ptr+0
 ///   switch tag {
 ///     0 => { segment_0; save; tag=1; return PENDING }
 ///     1 => { restore; segment_1; save; tag=2; return PENDING }
@@ -462,23 +463,26 @@ fn build_state_layout(
 fn generate_poll_fn(
     orig: &MirFunction,
     segments: &[Segment],
-    _yield_indices: &[usize],
     state_fields: &[StateField],
-    _state_size: u32,
-    live_across: &HashSet<LocalId>,
+    _live_across: &HashSet<LocalId>,
+    capture_remap: &HashMap<u32, u32>,
 ) -> MirFunction {
     let poll_name = format!("{}_poll", orig.name);
     let mut builder = BlockBuilder::new(poll_name, MirType::I32);
 
-    // Parameters: state_ptr and task_ctx
     let state_ptr = builder.add_param("__state_ptr".to_string(), MirType::Ptr);
     let _task_ctx = builder.add_param("__task_ctx".to_string(), MirType::Ptr);
 
-    // Re-create all locals from the original function (except the env_ptr param)
+    // Find the original env_ptr param id (to remap LoadCapture instructions)
+    let env_param_id = orig.params.iter()
+        .find(|p| p.name.as_deref() == Some("__env"))
+        .map(|p| p.id);
+
+    // Re-create non-param locals from the original function
     let mut local_map: HashMap<LocalId, LocalId> = HashMap::new();
     for local in &orig.locals {
         if local.is_param {
-            continue; // skip env_ptr — we use state_ptr instead
+            continue;
         }
         let new_id = if let Some(ref name) = local.name {
             builder.alloc_local(name.clone(), local.ty.clone())
@@ -496,22 +500,19 @@ fn generate_poll_fn(
 
     let n_segments = segments.len();
 
-    // Load the state tag
+    // Load state tag from state_ptr+0
     let tag_local = builder.alloc_temp(MirType::I32);
-    builder.push_stmt(MirStmt::Assign {
+    builder.push_stmt(MirStmt::LoadCapture {
         dst: tag_local,
-        rvalue: MirRValue::Field {
-            base: MirOperand::Local(state_ptr),
-            field_index: 0, // state_tag is field 0
-        },
+        env_ptr: state_ptr,
+        offset: 0,
     });
 
-    // Create blocks for each segment
-    let segment_blocks: Vec<BlockId> = (0..n_segments).map(|_| builder.create_block()).collect();
+    // Create segment blocks + default
+    let segment_blocks: Vec<_> = (0..n_segments).map(|_| builder.create_block()).collect();
     let default_block = builder.create_block();
 
-    // Switch on tag
-    let cases: Vec<(u64, BlockId)> = segment_blocks
+    let cases: Vec<_> = segment_blocks
         .iter()
         .enumerate()
         .map(|(i, &block)| (i as u64, block))
@@ -523,18 +524,17 @@ fn generate_poll_fn(
         default: default_block,
     });
 
-    // Default block: return READY (shouldn't happen, but safe fallback)
+    // Default: return READY (unreachable in correct code)
     builder.switch_to_block(default_block);
     builder.terminate(MirTerminator::Return {
-        value: Some(MirOperand::Constant(MirConst::Int(0))), // READY
+        value: Some(MirOperand::Constant(MirConst::Int(0))),
     });
 
-    // Generate each segment block
-    for (seg_idx, segment) in segments.iter().enumerate() {
+    for (seg_idx, seg) in segments.iter().enumerate() {
         builder.switch_to_block(segment_blocks[seg_idx]);
         let is_last = seg_idx == n_segments - 1;
 
-        // Restore live locals from state (except for segment 0)
+        // Restore live locals from state (segments 1+)
         if seg_idx > 0 {
             for (&orig_id, field) in &field_map {
                 if let Some(&new_id) = local_map.get(&orig_id) {
@@ -547,48 +547,37 @@ fn generate_poll_fn(
             }
         }
 
-        // Emit segment statements, remapping locals
-        for stmt in &segment.stmts {
-            let remapped = remap_stmt(stmt, &local_map);
-            // Skip the yield call itself — it was just a marker
-            if let MirStmt::Call { func: ref fref, .. } = remapped {
-                if is_yield_point(&fref.name) {
-                    // Emit the yield call (it submits I/O or timer)
-                    builder.push_stmt(remapped);
-                    continue;
-                }
-            }
+        // Emit segment statements with local remapping
+        for stmt in &seg.stmts {
+            let remapped = remap_stmt(
+                stmt, &local_map, env_param_id, state_ptr, capture_remap,
+            );
             builder.push_stmt(remapped);
         }
 
         if is_last {
-            // Final segment: return READY
             builder.terminate(MirTerminator::Return {
                 value: Some(MirOperand::Constant(MirConst::Int(0))), // READY
             });
         } else {
             // Save live locals to state
             for (&orig_id, field) in &field_map {
-                if live_across.contains(&orig_id) {
-                    if let Some(&new_id) = local_map.get(&orig_id) {
-                        builder.push_stmt(MirStmt::Store {
-                            addr: state_ptr,
-                            offset: field.offset,
-                            value: MirOperand::Local(new_id),
-                        });
-                    }
+                if let Some(&new_id) = local_map.get(&orig_id) {
+                    builder.push_stmt(MirStmt::Store {
+                        addr: state_ptr,
+                        offset: field.offset,
+                        value: MirOperand::Local(new_id),
+                    });
                 }
             }
 
-            // Update state_tag to next segment
-            let next_tag = (seg_idx + 1) as i64;
+            // Advance state_tag
             builder.push_stmt(MirStmt::Store {
                 addr: state_ptr,
-                offset: 0, // state_tag offset
-                value: MirOperand::Constant(MirConst::Int(next_tag)),
+                offset: 0,
+                value: MirOperand::Constant(MirConst::Int((seg_idx + 1) as i64)),
             });
 
-            // Return PENDING
             builder.terminate(MirTerminator::Return {
                 value: Some(MirOperand::Constant(MirConst::Int(1))), // PENDING
             });
@@ -598,8 +587,31 @@ fn generate_poll_fn(
     builder.finish()
 }
 
-/// Remap LocalIds in a statement using the local_map.
-fn remap_stmt(stmt: &MirStmt, map: &HashMap<LocalId, LocalId>) -> MirStmt {
+// ── Statement remapping ─────────────────────────────────────────────
+
+/// Remap locals in a statement. Also rewrites LoadCapture instructions
+/// that reference the original env_ptr to use state_ptr with the
+/// capture's state-struct offset.
+fn remap_stmt(
+    stmt: &MirStmt,
+    map: &HashMap<LocalId, LocalId>,
+    env_param_id: Option<LocalId>,
+    state_ptr: LocalId,
+    capture_remap: &HashMap<u32, u32>,
+) -> MirStmt {
+    // Rewrite LoadCapture from closure env → load from state struct
+    if let MirStmt::LoadCapture { dst, env_ptr, offset } = stmt {
+        if env_param_id == Some(*env_ptr) {
+            if let Some(&state_offset) = capture_remap.get(offset) {
+                return MirStmt::LoadCapture {
+                    dst: remap_id(*dst, map),
+                    env_ptr: state_ptr,
+                    offset: state_offset,
+                };
+            }
+        }
+    }
+
     match stmt {
         MirStmt::Assign { dst, rvalue } => MirStmt::Assign {
             dst: remap_id(*dst, map),
@@ -656,7 +668,6 @@ fn remap_stmt(stmt: &MirStmt, map: &HashMap<LocalId, LocalId>) -> MirStmt {
             pool: remap_id(*pool, map),
             handle: remap_id(*handle, map),
         },
-        // Pass through unchanged
         other => other.clone(),
     }
 }
@@ -674,9 +685,15 @@ fn remap_operand(op: &MirOperand, map: &HashMap<LocalId, LocalId>) -> MirOperand
 
 fn remap_rvalue(rv: &MirRValue, map: &HashMap<LocalId, LocalId>) -> MirRValue {
     match rv {
-        MirRValue::Use(op) => MirRValue::Use(remap_operand(op, map)),
+        MirRValue::Use(op) | MirRValue::Deref(op) => {
+            let remapped = remap_operand(op, map);
+            if matches!(rv, MirRValue::Deref(_)) {
+                MirRValue::Deref(remapped)
+            } else {
+                MirRValue::Use(remapped)
+            }
+        }
         MirRValue::Ref(id) => MirRValue::Ref(remap_id(*id, map)),
-        MirRValue::Deref(op) => MirRValue::Deref(remap_operand(op, map)),
         MirRValue::BinaryOp { op, left, right } => MirRValue::BinaryOp {
             op: *op,
             left: remap_operand(left, map),
@@ -705,15 +722,14 @@ fn remap_rvalue(rv: &MirRValue, map: &HashMap<LocalId, LocalId>) -> MirRValue {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::FunctionRef;
 
     fn make_test_spawn_fn(stmts: Vec<MirStmt>) -> MirFunction {
         let mut builder = BlockBuilder::new("test__spawn_0".to_string(), MirType::Void);
         let _env = builder.add_param("__env".to_string(), MirType::Ptr);
-
         for stmt in stmts {
             builder.push_stmt(stmt);
         }
-
         builder.terminate(MirTerminator::Return { value: None });
         builder.finish()
     }
@@ -725,20 +741,31 @@ mod tests {
             func: FunctionRef { name: "work".to_string() },
             args: vec![],
         }]);
-
         assert!(!has_yield_points(&func));
         assert!(transform(&func).is_none());
     }
 
     #[test]
-    fn detects_sleep_as_yield_point() {
+    fn detects_yield_point() {
         let func = make_test_spawn_fn(vec![MirStmt::Call {
             dst: None,
-            func: FunctionRef { name: "rask_sleep_ns".to_string() },
+            func: FunctionRef { name: "rask_green_sleep_ns".to_string() },
             args: vec![MirOperand::Constant(MirConst::Int(1_000_000))],
         }]);
-
         assert!(has_yield_points(&func));
+    }
+
+    #[test]
+    fn blocking_channel_ops_are_not_yield_points() {
+        let func = make_test_spawn_fn(vec![MirStmt::Call {
+            dst: None,
+            func: FunctionRef { name: "rask_channel_send_async".to_string() },
+            args: vec![
+                MirOperand::Constant(MirConst::Int(0)),
+                MirOperand::Constant(MirConst::Int(42)),
+            ],
+        }]);
+        assert!(!has_yield_points(&func));
     }
 
     #[test]
@@ -751,38 +778,30 @@ mod tests {
             dst: x,
             rvalue: MirRValue::Use(MirOperand::Constant(MirConst::Int(42))),
         });
-
         builder.push_stmt(MirStmt::Call {
             dst: None,
-            func: FunctionRef { name: "rask_sleep_ns".to_string() },
+            func: FunctionRef { name: "rask_green_sleep_ns".to_string() },
             args: vec![MirOperand::Constant(MirConst::Int(1_000_000))],
         });
-
-        // Use x after the yield
         builder.push_stmt(MirStmt::Call {
             dst: None,
             func: FunctionRef { name: "print_i64".to_string() },
             args: vec![MirOperand::Local(x)],
         });
-
         builder.terminate(MirTerminator::Return { value: None });
         let func = builder.finish();
 
         let result = transform(&func).expect("should transform");
 
-        // Poll function should have state_ptr and task_ctx params
         assert_eq!(result.poll_fn.params.len(), 2);
         assert_eq!(result.poll_fn.ret_ty, MirType::I32);
-
-        // State struct should have state_tag + x
         assert!(result.state_fields.len() >= 2);
         assert_eq!(result.state_fields[0].name, "state_tag");
-
-        // State size should be reasonable (tag + one i64)
-        assert!(result.state_size >= 12);
-
-        // Should have at least 3 blocks: entry + 2 segments + default
-        assert!(result.poll_fn.blocks.len() >= 3);
+        // tag(4) + pad(4) + x(8) = 16
+        assert!(result.state_size >= 16);
+        // entry + 2 segments + default = 4 blocks
+        assert!(result.poll_fn.blocks.len() >= 4,
+            "got {} blocks", result.poll_fn.blocks.len());
     }
 
     #[test]
@@ -793,45 +812,33 @@ mod tests {
         let x = builder.alloc_local("x".to_string(), MirType::I64);
         let y = builder.alloc_local("y".to_string(), MirType::I64);
 
-        // x = 1 (used after yield)
         builder.push_stmt(MirStmt::Assign {
             dst: x,
             rvalue: MirRValue::Use(MirOperand::Constant(MirConst::Int(1))),
         });
-
-        // y = 2 (NOT used after yield)
         builder.push_stmt(MirStmt::Assign {
             dst: y,
             rvalue: MirRValue::Use(MirOperand::Constant(MirConst::Int(2))),
         });
-
-        // yield
         builder.push_stmt(MirStmt::Call {
             dst: None,
-            func: FunctionRef { name: "rask_sleep_ns".to_string() },
+            func: FunctionRef { name: "rask_green_sleep_ns".to_string() },
             args: vec![MirOperand::Constant(MirConst::Int(1000))],
         });
-
-        // use x (cross-yield)
+        // Only x used after yield
         builder.push_stmt(MirStmt::Call {
             dst: None,
             func: FunctionRef { name: "print_i64".to_string() },
             args: vec![MirOperand::Local(x)],
         });
-
         builder.terminate(MirTerminator::Return { value: None });
         let func = builder.finish();
 
         let result = transform(&func).expect("should transform");
 
-        // x should be in state struct, y should not
-        let has_x = result
-            .state_fields
-            .iter()
+        let has_x = result.state_fields.iter()
             .any(|f| f.local_id == Some(x) && f.name == "x");
-        let has_y = result
-            .state_fields
-            .iter()
+        let has_y = result.state_fields.iter()
             .any(|f| f.local_id == Some(y));
 
         assert!(has_x, "x should be in state struct (live across yield)");
@@ -843,52 +850,97 @@ mod tests {
         let mut builder = BlockBuilder::new("test__spawn_0".to_string(), MirType::Void);
         let _env = builder.add_param("__env".to_string(), MirType::Ptr);
 
-        // work1
         builder.push_stmt(MirStmt::Call {
             dst: None,
             func: FunctionRef { name: "work1".to_string() },
             args: vec![],
         });
-
-        // yield 1
         builder.push_stmt(MirStmt::Call {
             dst: None,
-            func: FunctionRef { name: "rask_sleep_ns".to_string() },
+            func: FunctionRef { name: "rask_green_sleep_ns".to_string() },
             args: vec![MirOperand::Constant(MirConst::Int(1000))],
         });
-
-        // work2
         builder.push_stmt(MirStmt::Call {
             dst: None,
             func: FunctionRef { name: "work2".to_string() },
             args: vec![],
         });
-
-        // yield 2
         builder.push_stmt(MirStmt::Call {
             dst: None,
             func: FunctionRef { name: "rask_yield".to_string() },
             args: vec![],
         });
-
-        // work3
         builder.push_stmt(MirStmt::Call {
             dst: None,
             func: FunctionRef { name: "work3".to_string() },
             args: vec![],
         });
-
         builder.terminate(MirTerminator::Return { value: None });
         let func = builder.finish();
 
         let result = transform(&func).expect("should transform");
 
-        // 3 segments: [work1+yield1], [work2+yield2], [work3]
-        // Poll function should have entry block + 3 segment blocks + default
+        // entry + 3 segments + default = 5
+        assert!(result.poll_fn.blocks.len() >= 5,
+            "expected >=5 blocks for 3 segments, got {}",
+            result.poll_fn.blocks.len());
+    }
+
+    #[test]
+    fn captures_included_in_state_struct() {
+        let mut builder = BlockBuilder::new("test__spawn_0".to_string(), MirType::Void);
+        let env = builder.add_param("__env".to_string(), MirType::Ptr);
+
+        // LoadCapture: load captured var from env at offset 0
+        let captured = builder.alloc_local("captured".to_string(), MirType::I64);
+        builder.push_stmt(MirStmt::LoadCapture {
+            dst: captured,
+            env_ptr: env,
+            offset: 0,
+        });
+        builder.push_stmt(MirStmt::Call {
+            dst: None,
+            func: FunctionRef { name: "rask_green_sleep_ns".to_string() },
+            args: vec![MirOperand::Constant(MirConst::Int(1000))],
+        });
+        // Use captured var after yield
+        builder.push_stmt(MirStmt::Call {
+            dst: None,
+            func: FunctionRef { name: "print_i64".to_string() },
+            args: vec![MirOperand::Local(captured)],
+        });
+        builder.terminate(MirTerminator::Return { value: None });
+        let func = builder.finish();
+
+        let result = transform(&func).expect("should transform");
+
+        let has_cap = result.state_fields.iter()
+            .any(|f| f.name == "captured");
+        assert!(has_cap, "captured var should be in state struct");
+
+        assert!(!result.capture_stores.is_empty(),
+            "should have capture stores");
+        let (env_off, _state_off) = result.capture_stores[0];
+        assert_eq!(env_off, 0, "capture env offset should be 0");
+    }
+
+    #[test]
+    fn poll_fn_loads_tag_via_load_capture() {
+        let func = make_test_spawn_fn(vec![MirStmt::Call {
+            dst: None,
+            func: FunctionRef { name: "rask_green_sleep_ns".to_string() },
+            args: vec![MirOperand::Constant(MirConst::Int(100))],
+        }]);
+
+        let result = transform(&func).expect("should transform");
+
+        // Entry block should start with LoadCapture (not Field) for the tag
+        let entry = &result.poll_fn.blocks[0];
+        let first_stmt = &entry.statements[0];
         assert!(
-            result.poll_fn.blocks.len() >= 4,
-            "expected >=4 blocks for 3 segments, got {}",
-            result.poll_fn.blocks.len()
+            matches!(first_stmt, MirStmt::LoadCapture { offset: 0, .. }),
+            "tag should be loaded via LoadCapture at offset 0, got {:?}",
+            first_stmt
         );
     }
 }

--- a/compiler/crates/rask-mir/src/types.rs
+++ b/compiler/crates/rask-mir/src/types.rs
@@ -30,6 +30,30 @@ pub enum MirType {
 }
 
 impl MirType {
+    /// Byte size of this type. Structs/enums use pointer size as fallback.
+    pub fn size(&self) -> u32 {
+        match self {
+            MirType::Void => 0,
+            MirType::Bool | MirType::I8 | MirType::U8 => 1,
+            MirType::I16 | MirType::U16 => 2,
+            MirType::I32 | MirType::U32 | MirType::F32 | MirType::Char => 4,
+            MirType::I64 | MirType::U64 | MirType::F64 | MirType::Ptr | MirType::FuncPtr(_) => 8,
+            MirType::String => 16,
+            MirType::Struct(_) | MirType::Enum(_) => 8,
+            MirType::Array { elem, len } => elem.size() * len,
+        }
+    }
+
+    /// Alignment of this type in bytes.
+    pub fn align(&self) -> u32 {
+        match self {
+            MirType::Bool | MirType::I8 | MirType::U8 | MirType::Void => 1,
+            MirType::I16 | MirType::U16 => 2,
+            MirType::I32 | MirType::U32 | MirType::F32 | MirType::Char => 4,
+            _ => 8,
+        }
+    }
+
     /// True for F32 and F64.
     pub fn is_float(&self) -> bool {
         matches!(self, MirType::F32 | MirType::F64)


### PR DESCRIPTION
## Summary

This PR implements a state machine transform that converts spawn closure functions containing yield points into poll-based state machines. This enables the green task scheduler to suspend and resume closures at yield boundaries (sleep, I/O operations, etc.) rather than requiring them to run to completion.

## Key Changes

### State Machine Transform (`rask-mir/src/transform/state_machine.rs`)
- **New module** implementing the core transform that:
  - Detects yield points (calls to `rask_green_sleep_ns`, `rask_yield_*`, etc.)
  - Linearizes function blocks and segments code between yield boundaries
  - Performs liveness analysis to identify locals that must be saved across yields
  - Generates a state struct layout with tag field, captures, and live-across locals
  - Produces a poll function with switch-based state dispatch
  - Includes comprehensive tests for yield detection, liveness tracking, and code generation

### MIR Type System Enhancement (`rask-mir/src/types.rs`)
- Added `size()` and `align()` methods to `MirType` for computing type sizes and alignments
- Centralizes size calculations used throughout the codebase

### Spawn Closure Lowering (`rask-mir/src/lower/expr.rs`)
- Integrated state machine transform into spawn closure generation
- Closures with yield points now generate a poll function instead of direct closure bridge
- Closures without yield points continue using the simple `rask_green_closure_spawn` path
- Removed duplicate `mir_type_size` function in favor of `MirType::size()`

### Runtime Integration (`compiler/runtime/green.c`)
- Added per-task ensure hook stack for LIFO cleanup on cancellation/panic
- Modified task execution to save/restore ensure hooks across context switches
- Ensures cleanup callbacks run before task completion

### Async Channel Operations (`compiler/runtime/channel.c`)
- Implemented `rask_channel_send_async` and `rask_channel_recv_async`
- Use non-blocking try operations with yield loops for green tasks
- Fall back to blocking operations outside green task context

### Stdlib Entries (`rask-codegen/src/dispatch.rs`)
- Updated concurrency function names to use `rask_green_*` prefix
- Added new stdlib entries for:
  - Runtime init/shutdown (`rask_runtime_init`, `rask_runtime_shutdown`)
  - Green spawn with state machine (`rask_green_spawn`)
  - Yield helpers (`rask_yield`, `rask_yield_timeout`, `rask_yield_read/write/accept`)
  - Async I/O operations (`rask_async_read`, `rask_async_write`, `rask_async_accept`)
  - Async channels (`rask_channel_send_async`, `rask_channel_recv_async`)

### Using Block Desugaring (`rask-hidden-params/src/lib.rs`)
- Simplified `using Multitasking` block handling
- Removed complex desugaring in favor of direct MIR-level runtime init/shutdown calls
- MIR lowering now emits `rask_runtime_init` and `rask_runtime_shutdown` directly

### Type Size Consolidation
- Removed duplicate `mir_type_size` functions from `rask-codegen/src/types.rs` and `rask-mir/src/lower/mod.rs`
- Centralized implementation in `MirType::size()` method

## Implementation Details

The state machine transform works by:
1. **Linearization**: Flattens block structure into a linear statement sequence
2. **Segmentation**: Splits statements at yield points into segments
3. **Liveness Analysis**: Identifies locals defined before yields and used after (live-across set)
4. **State Layout**: Builds struct with tag field (for dispatch), captures, and live-across locals
5. **Code Generation**: Creates poll function with:
   - Switch on state tag to dispatch to correct segment
   - Restore live locals before each segment (except first)
   - Save live locals after each segment (except last)
   - Return PENDING after non-final segments, READY after final segment

The transform

https://claude.ai/code/session_01GoTwfKhtbTyJxEGpm4vjQf