### PR TITLE
Clarify terminology: replace jargon with plain language

### DIFF
--- a/specs/GLOSSARY.md
+++ b/specs/GLOSSARY.md
@@ -1,0 +1,18 @@
+# Glossary
+
+Quick reference for technical terms used across specs. Each term is explained where it first appears — this page is for lookup.
+
+| Term | Plain meaning | Spec |
+|------|---------------|------|
+| **Block-scoped** (view/borrow) | A temporary reference valid until the end of the enclosing `{ }` block. Used for fixed-size data like strings and struct fields. | `mem.borrowing` |
+| **Borrow** / **View** | A temporary reference to data you don't own. The compiler tracks it so it can't outlive the data or conflict with mutations. | `mem.borrowing` |
+| **Capture** (closures) | When a closure uses a variable from outside its body, that variable is *captured* — copied or moved into the closure so it's available when the closure runs later. | `mem.closures` |
+| **Desugaring** | Expanding syntactic shortcuts into their full form before the compiler processes them. Example: `a + b` becomes `a.add(b)`. | `comp.semantic-hash` |
+| **Exclusive access** | Only one mutable reference exists, and no other references (read or write) can coexist. Prevents data races. Sometimes called "aliasing XOR mutation." | `mem.borrowing` |
+| **Monomorphization** | When you call a generic function like `sort<i32>`, the compiler generates a specialized version of `sort` just for `i32`. Fast (direct calls, no runtime type checks) but increases binary size. | `type.generics` |
+| **Move** | Transferring a value from one variable to another. After a move, the original variable is unusable — the compiler forbids reading it. Only applies to types larger than 16 bytes. | `mem.ownership` |
+| **Must-consume** (resource types) | A type marked `@resource` that the compiler forces you to use exactly once — you can't forget to close a file or commit a transaction. Sometimes called "linear types" in academic literature. | `mem.resources` |
+| **Must-use** (task handles) | `TaskHandle` must be explicitly joined (wait for result) or detached (fire-and-forget). Dropping it without doing either is a compile error. Sometimes called "affine" in type theory. | `conc.async` |
+| **Statement-scoped** (view/borrow) | A temporary reference that's released at the end of the statement (the semicolon). Used for growable collections (Vec, Pool, Map) because they might reallocate between statements. | `mem.borrowing` |
+| **Structural trait matching** | The compiler checks if a type has all the methods a trait requires — matching by shape, not by explicit declaration. If your type has a `compare(self, other: T) -> Ordering` method, it satisfies `Comparable` automatically. | `type.generics` |
+| **Vtable** | A table of function pointers, one per trait method. When you use `any Trait`, the runtime looks up the right function in this table and calls it. Costs one pointer indirection per call. | `type.traits` |

--- a/specs/README.md
+++ b/specs/README.md
@@ -4,7 +4,8 @@ Organized by what each category does.
 
 ## Reading Order
 
-**New to Rask?** Start here:
+**New to Rask?** Start here. If you hit unfamiliar terms, check the [Glossary](GLOSSARY.md).
+
 1. [memory/ownership.md](memory/ownership.md) — Single ownership, move semantics
 2. [memory/value-semantics.md](memory/value-semantics.md) — Copy vs move, 16-byte threshold
 3. [memory/borrowing.md](memory/borrowing.md) — One rule: views last as long as source is stable

--- a/specs/analysis/complexity-stress-test.md
+++ b/specs/analysis/complexity-stress-test.md
@@ -97,7 +97,7 @@ func sync_physics(mutate world: GameWorld) {
 }
 ```
 
-**Concepts: 8** — cursor iteration, instant views, cross-pool handles, two pools active, @resource in pool, raw value extraction, safe FFI wrapper, borrowing modes.
+**Concepts: 8** — cursor iteration, statement-scoped views, cross-pool handles, two pools active, @resource in pool, raw value extraction, safe FFI wrapper, borrowing modes.
 
 **Friction:** Cross-pool handle chaining — three mechanism boundaries in four lines. **MARGINAL.**
 
@@ -127,7 +127,7 @@ func update_entities(mutate world: GameWorld) -> () or Error {
 }
 ```
 
-**Concepts: 10** — cursor iteration, instant views, move semantics, cross-pool handles, pool removal, @resource consumption, error handling, handle collection pattern, Pool\<@resource> rules, ownership transfer.
+**Concepts: 10** — cursor iteration, statement-scoped views, move semantics, cross-pool handles, pool removal, @resource consumption, error handling, handle collection pattern, Pool\<@resource> rules, ownership transfer.
 
 **The 4-step destruction dance is unavoidable:** remove entity → extract handle → remove body → consume body. Miss any step → compile error or runtime panic. **FAIL.**
 
@@ -180,7 +180,7 @@ func game_loop_parallel(mutate world: GameWorld, dt: f32) -> () or Error
 }
 ```
 
-**Concepts: 12** — ThreadPool, spawn thread, affine handles, snapshot isolation, FrozenPool, freeze_ref, cross-pool handles, Send/Sync constraints, disjoint field access, error handling, @resource across threads, copy-on-write. **FAIL.**
+**Concepts: 12** — ThreadPool, spawn thread, must-use handles, snapshot isolation, FrozenPool, freeze_ref, cross-pool handles, Send/Sync constraints, disjoint field access, error handling, @resource across threads, copy-on-write. **FAIL.**
 
 ## Friction Points
 
@@ -235,5 +235,5 @@ If a function needs >3, restructure (pass struct, use field projections, split f
 - `mem.pools` — Pool\<T>, Handle\<T>, frozen pools, snapshots
 - `mem.resources` — @resource types, ensure cleanup
 - `mem.context` — context clauses
-- `conc.async` — spawn, affine handles
-- `mem.borrowing` — instant views, field projections
+- `conc.async` — spawn, must-use handles
+- `mem.borrowing` — statement-scoped views, field projections

--- a/specs/compiler/memory-layout.md
+++ b/specs/compiler/memory-layout.md
@@ -512,6 +512,6 @@ FIX: Use heap indirection or split into smaller chunks.
 ## See Also
 
 - `type.enums` — Enum semantics and discriminant rules
-- `type.traits` — Trait objects and object safety
+- `type.traits` — Trait objects and `any` compatibility
 - `mem.closures` — Closure capture semantics
 - `mem.value` — Copy vs move threshold (16 bytes)

--- a/specs/concurrency/README.md
+++ b/specs/concurrency/README.md
@@ -4,15 +4,15 @@ Concurrency model for Rask.
 
 ## Design Philosophy
 
-**Go-like ergonomics, compile-time safety.** Spawn syntax with affine handles. Forgotten tasks become compile errors.
+**Go-like ergonomics, compile-time safety.** Spawn syntax with must-use handles. Forgotten tasks become compile errors.
 
 **Concurrency vs parallelism:**
 - **Concurrency** (green tasks): Interleaved execution on few threads. I/O-bound work.
 - **Parallelism** (thread pool): Simultaneous execution. CPU-bound work.
 
-**No function coloring.** Functions work the same way regardless of I/O. Pausing happens automatically—IDEs show pause points as ghost annotations. No ecosystem split.
+**No async/await split.** Functions work the same way regardless of I/O — no "function coloring" that forces separate async and sync versions. Pausing happens automatically—IDEs show pause points as ghost annotations. No ecosystem split.
 
-**Affine handles.** All spawn constructs return handles that must be consumed (joined or detached). Forgetting one is a compile error.
+**Must-use handles.** All spawn constructs return handles that must be consumed (joined or detached). Forgetting one is a compile error.
 
 **Explicit resources.** `using Multitasking { }` and `using ThreadPool { }` declare available capabilities.
 
@@ -128,9 +128,9 @@ try h.join()
 - `using Multitasking { }` creates M:N scheduler for green tasks
 - `using ThreadPool { }` creates thread pool for CPU work
 - Configuration via numbers: `Multitasking(workers: N)`, `ThreadPool(workers: N)`
-- Affine handles must be joined or detached
+- Must-use handles must be joined or detached
 - `.join()` pauses in async mode, blocks in sync mode
 - Tasks own their data—no shared mutable state
 - Channels work everywhere—pause in async, block in sync
-- No function coloring, no async/await keywords
+- No async/await split, no function coloring
 - Sync mode is default—multitasking optional for CLI/embedded

--- a/specs/concurrency/io-context.md
+++ b/specs/concurrency/io-context.md
@@ -5,7 +5,7 @@
 
 # I/O Context Integration
 
-Stdlib I/O functions accept a hidden `RuntimeContext` parameter. When present, I/O is non-blocking (task parks). When absent, I/O blocks the thread. Same function, two code paths, no function coloring.
+Stdlib I/O functions accept a hidden `RuntimeContext` parameter. When present, I/O is non-blocking (task parks). When absent, I/O blocks the thread. Same function, two code paths, no async/await split.
 
 ## RuntimeContext Type
 

--- a/specs/control/loops.md
+++ b/specs/control/loops.md
@@ -186,7 +186,7 @@ for item in vec.take_all() { body }
 
 **LP2 (index mode explicit):** Mutation requires explicit syntax (`0..vec.len()` or `.handles()`). This makes the mutation intent clear and matches the "transparency of cost" principle — you see you're doing index-based access, not value iteration.
 
-**LP3 (collection accessible):** Each element access in value mode is expression-scoped (per `mem.borrowing/V1`), so the collection remains accessible. No persistent borrow exists. This enables natural patterns without borrow conflicts.
+**LP3 (collection accessible):** Each element access in value mode is statement-scoped (per `mem.borrowing/V1`), so the collection remains accessible. No block-scoped borrow exists. This enables natural patterns without borrow conflicts.
 
 **LP7 (take_all):** Ownership transfer is explicit. `vec.take_all()` empties the collection and yields owned items. This prevents accidental consumption while keeping consuming iteration ergonomic.
 

--- a/specs/memory/pools.md
+++ b/specs/memory/pools.md
@@ -76,7 +76,7 @@ pool.modify(h, |v| ...)  // Returns Option<R>
 
 ## Expression-Scoped Access
 
-Pool access follows instant-view borrowing rules (`mem.borrowing/B1`). Borrow released at semicolon.
+Pool access follows statement-scoped borrowing rules (`mem.borrowing/B1`). View released at the semicolon.
 
 ```rask
 pool[h].health -= damage     // Borrow released
@@ -85,7 +85,7 @@ if pool[h].health <= 0 {     // New borrow
 }
 ```
 
-Aliased handles are safe because each `pool[h]` creates an independent expression-scoped borrow:
+Aliased handles are safe because each `pool[h]` creates an independent statement-scoped view:
 
 ```rask
 const h1 = try pool.insert(entity)

--- a/specs/memory/resource-types.md
+++ b/specs/memory/resource-types.md
@@ -6,7 +6,7 @@
 
 # Resource Types
 
-`@resource` marks types that must be consumed exactly once. Compiler enforces it. `ensure` provides deferred consumption.
+`@resource` marks types that must be consumed exactly once — you can't forget to close a file or commit a transaction. The compiler enforces it. `ensure` provides deferred consumption. (These are sometimes called "linear types" in academic literature.)
 
 ## Declaration
 
@@ -342,7 +342,7 @@ func handle_connections(pool: Pool<Connection>) -> () or Error {
 
 ### Rationale
 
-**R1–R4 (must-consume):** Resource types prevent leaks by construction. Unlike RAII (automatic destructors), resources need explicit consumption — cleanup is visible while still guaranteed.
+**R1–R4 (must-consume):** Resource types prevent leaks by construction. Unlike RAII (automatic destructors, as in C++ or Rust), resources need explicit consumption — cleanup is visible while still guaranteed.
 
 **R4 (ensure):** `ensure` bridges resources with error handling: commit to cleanup early, then use `try` freely knowing it'll happen.
 

--- a/specs/memory/value-semantics.md
+++ b/specs/memory/value-semantics.md
@@ -80,7 +80,7 @@ const user4 = user3              // Moves, user3 invalid
 | Unique identifiers | Duplication is semantically wrong |
 | Capabilities/tokens | Implicit copy would violate access control |
 | API contracts | Force callers to explicitly clone |
-| Linear-like semantics | Small types that should behave like resources |
+| Must-use semantics | Small types that should behave like resources |
 
 ## Copy Trait and Generics
 
@@ -144,7 +144,7 @@ const p6 = p5                              // ERROR: move, not copy
 | Case | Rule | Handling |
 |------|------|----------|
 | Struct with all Copy fields but >16 bytes | VS1 | Move-only (size exceeds threshold) |
-| Generic type instantiation | VS5 | Copy derived at monomorphization time |
+| Generic type usage | VS5 | Copy derived when the compiler generates code for a specific type |
 | Removing `@unique` from a type | U1 | Non-breaking change (makes type more permissive) |
 | Copy type in `take` parameter | — | Value is copied in; `take` is semantically redundant but allowed |
 

--- a/specs/rejected-features.md
+++ b/specs/rejected-features.md
@@ -43,7 +43,7 @@ I want function-local compilation. Effects require whole-program analysis.
 
 ### They break resource safety
 
-Rask's safety is structural—linear resources, affine handles, block-scoped cleanup. `ensure` blocks run on all exits, LIFO order, guaranteed.
+Rask's safety is structural—must-consume resources, must-use handles, block-scoped cleanup. `ensure` blocks run on all exits, LIFO order, guaranteed.
 
 Effects introduce non-local jumps. Does the handler run before or after cleanup? What if an effect jumps past an `ensure` block? You need to reason about effect boundaries intersecting with resource scopes. Structural guarantees become ambiguous.
 

--- a/specs/stdlib/collections.md
+++ b/specs/stdlib/collections.md
@@ -307,7 +307,7 @@ FIX: Process existing items first, or use an unbounded collection:
 
 **C2 (fallible allocation):** All allocations can fail. Returning the rejected value in the error lets callers retry or log without losing data.
 
-**C3 (expression-scoped):** Collections can grow/shrink, invalidating persistent views. Expression-scoped borrows kill this bug class. See `mem.borrowing/B1`.
+**C3 (statement-scoped):** Collections can grow/shrink, invalidating any held views. Statement-scoped borrows kill this bug class. See `mem.borrowing/B1`.
 
 **C4 (no linear resources):** Collection drop can't propagate errors from linear resource cleanup. `Pool<T>` with explicit consumption is the right pattern.
 


### PR DESCRIPTION
This PR improves spec clarity by replacing technical jargon with more accessible plain-language explanations, making the documentation easier for newcomers to understand.

## Summary

Across the specification, terminology has been standardized and simplified to use clearer, more descriptive language:

- **Closure kinds**: "storable" → "stored", "immediate" → "inline", "local-only" → "scoped"
- **Borrow duration**: "persistent" → "block-scoped", "instant" → "statement-scoped"
- **Type system**: "monomorphization" → "code specialization", "object-safe" → "`any`-compatible"
- **Concurrency**: "affine handles" → "must-use handles", "function coloring" → "async/await split"
- **Access rules**: "aliasing XOR mutation" → "exclusive access"
- **Resource types**: "linear types" → "must-consume types"

## Key Changes

- **memory/closures.md**: Renamed closure kinds and updated all references; clarified capture semantics in introductory text
- **memory/borrowing.md**: Replaced "persistent/instant" with "block-scoped/statement-scoped"; updated section headers and rule descriptions
- **type/generics.md**: Changed "monomorphization" to "code specialization" with plain-language explanation; updated trait matching language
- **type/traits.md**: Replaced "object-safe" with "`any`-compatible"; clarified vtable dispatch explanation
- **concurrency/async.md & runtime.md**: Changed "affine handles" to "must-use handles"; replaced "function coloring" with "async/await split"
- **memory/ownership.md**: Clarified move semantics language
- **GLOSSARY.md** (new): Added comprehensive glossary of technical terms with plain-language definitions and spec references

## Implementation Details

- All terminology changes are consistent across all affected specs
- Plain-language explanations added to rule descriptions and summaries
- Existing rule identifiers (CL1, B1, etc.) preserved for cross-referencing
- New glossary provides lookup reference for all technical terms
- No functional changes to the language design—only documentation clarity improvements

https://claude.ai/code/session_01R5gwy39DQ9V1q3U3g7v6zX