### PR TITLE
Gate reqwest and network modules behind cfg(not(wasm32))

### DIFF
--- a/compiler/crates/rask-resolve/Cargo.toml
+++ b/compiler/crates/rask-resolve/Cargo.toml
@@ -8,13 +8,15 @@ edition.workspace = true
 rask-ast = { path = "../rask-ast" }
 rask-lexer = { path = "../rask-lexer" }
 rask-parser = { path = "../rask-parser" }
-flate2 = "1"
-reqwest = { version = "0.12", features = ["blocking"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
+thiserror.workspace = true
+
+[target.'cfg(not(target_arch = "wasm32"))'.dependencies]
+flate2 = "1"
+reqwest = { version = "0.12", features = ["blocking"] }
 sha2 = "0.10"
 tar = "0.4"
-thiserror.workspace = true
 tokio = { version = "1", features = ["rt"] }
 
 [dev-dependencies]

--- a/compiler/crates/rask-resolve/src/lib.rs
+++ b/compiler/crates/rask-resolve/src/lib.rs
@@ -9,13 +9,18 @@ mod scope;
 mod symbol;
 mod resolver;
 pub mod package;
-pub mod lockfile;
 pub mod capabilities;
 pub mod semver;
 pub mod features;
+#[cfg(not(target_arch = "wasm32"))]
+pub mod lockfile;
+#[cfg(not(target_arch = "wasm32"))]
 pub mod registry;
+#[cfg(not(target_arch = "wasm32"))]
 pub mod cache;
+#[cfg(not(target_arch = "wasm32"))]
 pub mod tarball;
+#[cfg(not(target_arch = "wasm32"))]
 pub mod advisory;
 
 pub use error::{ResolveError, ResolveErrorKind};
@@ -23,6 +28,7 @@ pub use scope::{Scope, ScopeId, ScopeKind};
 pub use symbol::{Symbol, SymbolId, SymbolKind, SymbolTable};
 pub use resolver::Resolver;
 pub use package::{Package, PackageId, PackageRegistry, PackageError, SourceFile};
+#[cfg(not(target_arch = "wasm32"))]
 pub use lockfile::LockFile;
 
 use rask_ast::decl::Decl;


### PR DESCRIPTION
reqwest::blocking is unavailable on wasm32 targets, breaking the
rask-wasm build via rask-diagnostics -> rask-resolve -> reqwest.
Move reqwest, flate2, sha2, tar, tokio to target-specific deps
and gate registry, advisory, lockfile, cache, tarball modules
behind cfg(not(target_arch = "wasm32")).

https://claude.ai/code/session_01S9T9rNEjYAqSpGdhiZLYVY