### PR TITLE
Add encoding spec with comptime field iteration and auto-derive traits

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -232,6 +232,7 @@ Start with [CORE_DESIGN.md](specs/CORE_DESIGN.md). For specs: [specs/README.md](
 | Comptime | Compile-time execution | [comptime.md](specs/control/comptime.md) |
 | C interop | Unsafe blocks, raw pointers | [unsafe.md](specs/memory/unsafe.md) |
 | Rust interop | compile_rust() in build scripts, C ABI, cbindgen | [build.md](specs/structure/build.md) |
+| Encoding | `comptime for` + field access, auto-derived Encode/Decode, field annotations | [encoding.md](specs/stdlib/encoding.md) |
 
 ### Open
 

--- a/TODO.md
+++ b/TODO.md
@@ -37,6 +37,10 @@
 - [x] **Workspace support** — `members: ["app", "lib"]` in root build.rk. Single `rask.lock` at workspace root. Members discovered independently, path deps between them (WS1-WS3).
 - [ ] **Conditional compilation** — `comptime if cfg.os/arch/features` (CC1-CC2).
 
+## Design — Decided
+
+- [x] **Serialization / encoding** — `comptime for` + field access, auto-derived `Encode`/`Decode` marker traits, field annotations (`@rename`, `@skip`, `@default`). See [encoding.md](specs/stdlib/encoding.md)
+
 ## Design Questions
 
 - [ ] Package granularity — folder = package (Go-style) vs file = package (Zig-style)

--- a/specs/SYNTAX.md
+++ b/specs/SYNTAX.md
@@ -865,6 +865,21 @@ test "addition" {
 | `@binary` | Struct | Wire format with bit-level fields |
 | `@unique` | Struct | Disable implicit copy |
 | `@resource` | Struct | Must consume, cannot copy or drop |
+| `@no_encode` | Struct | Prevent auto-derive of `Encode` (`std.encoding/E16`) |
+| `@no_decode` | Struct | Prevent auto-derive of `Decode` (`std.encoding/E16`) |
+| `@tag("field")` | Enum | Internally tagged serialization (`std.encoding/E24`) |
+| `@rename("name")` | Field, Variant | Override serialized name (`std.encoding/E18`) |
+| `@skip` | Field | Exclude from serialization (`std.encoding/E19`) |
+| `@default(expr)` | Field | Default value when field missing during decode (`std.encoding/E20`) |
+
+### Comptime Field Access
+
+Access a struct field by comptime-known string. Resolves at compile time to a direct field access (`ctrl.comptime/CT49`):
+
+```rask
+value.(field.name)              // inside comptime for over reflect.fields<T>()
+value.("x")                     // string literal
+```
 
 ---
 

--- a/specs/control/comptime.md
+++ b/specs/control/comptime.md
@@ -37,6 +37,36 @@ func fixed_array<comptime N: usize>() -> [u8; N] {
 const buf = repeat<16>(0xff)  // OK: 16 is comptime-known
 ```
 
+## Comptime For and Field Access
+
+| Rule | Form | Syntax | Meaning |
+|------|------|--------|---------|
+| **CT48: Comptime for** | Loop | `comptime for x in comptime_iterable { body }` | Loop fully unrolled at compile time. Each iteration generates separate monomorphized code |
+| **CT49: Field access** | Expression | `value.(comptime_expr)` | Access struct field by comptime-known string. Resolves at compile time to direct field access |
+
+<!-- test: skip -->
+```rask
+import std.reflect
+
+func print_fields<T>(value: T) {
+    comptime for field in reflect.fields<T>() {
+        // Each iteration: field.name is a different comptime string
+        // value.(field.name) resolves to value.x, value.y, etc.
+        print("{field.name} = {value.(field.name)}")
+    }
+}
+```
+
+| Rule | Description |
+|------|-------------|
+| **CT50: Unrolling** | `comptime for` fully unrolls at monomorphization time. Not a runtime loop — each iteration may have different types via comptime field access |
+| **CT51: Comptime iterable** | The iterable must be comptime-known: `reflect.fields<T>()`, `reflect.variants<T>()`, or any comptime array |
+| **CT52: No branch quota** | `comptime for` unrolling doesn't count against the backwards branch quota (CT35). The quota applies to comptime *interpreter* execution, not monomorphization-time unrolling |
+| **CT53: Field name must be comptime** | The expression in `value.(expr)` must be comptime-known. Runtime strings are a compile error |
+| **CT54: Field must exist** | Compile error if the comptime string doesn't match any field on the value's type |
+
+Primary use case: serialization format libraries. See `std.encoding` for the full pattern.
+
 ## Comptime Function Restrictions
 
 | Rule | Description |
@@ -163,6 +193,8 @@ const BAD = comptime {
 | **CT24: Arrays** | Arrays | ✅ Full: fixed-size arrays, indexing, iteration |
 | **CT25: Enums** | Enums | ✅ Full: variant construction, pattern matching |
 | **CT26: Collections** | Vec, Map, string | ✅ With freeze: must call `.freeze()` to escape |
+| **CT48: Comptime for** | Loop unrolling | ✅ Full: unrolls over comptime arrays, each iteration separate code |
+| **CT49: Field access** | `value.(name)` | ✅ Full: resolves to direct field access at compile time |
 
 ## Restricted Features
 
@@ -284,6 +316,10 @@ const B = comptime get_value(5)  // Compile error: "Index out of bounds: 5 >= 3"
 | Recursive comptime (within limit) | CT35 | Works; memoized to avoid recomputation |
 | Comptime type mismatch | - | Regular type error (type checking still applies) |
 | Unfrozen collection escape | CT19 | Compile error: "cannot return unfrozen Vec from comptime" |
+| Runtime string in field access | CT53 | Compile error: "runtime string in comptime field access" |
+| Non-existent field in field access | CT54 | Compile error: "no field X on type Y" |
+| Comptime for over runtime iterable | CT51 | Compile error: "comptime for requires comptime-known iterable" |
+| Nested comptime for | CT48 | Works — each level unrolls independently |
 
 ## Error Messages
 
@@ -634,5 +670,7 @@ IDEs should provide:
 ### See Also
 
 - [Generics](../types/generics.md) — Generic parameters and specialization (`type.generics`)
+- [Encoding](../stdlib/encoding.md) — Serialization via comptime for + field access (`std.encoding`)
+- [Reflect](../stdlib/reflect.md) — Comptime type introspection (`std.reflect`)
 - [Build System](../structure/build.md) — Build scripts and package configuration (`struct.build`)
 - [Error Types](../types/error-types.md) — Result and error handling (`type.errors`)

--- a/specs/stdlib/encoding.md
+++ b/specs/stdlib/encoding.md
@@ -1,0 +1,553 @@
+<!-- id: std.encoding -->
+<!-- status: decided -->
+<!-- summary: Comptime field iteration and auto-derived Encode/Decode for format-agnostic serialization -->
+<!-- depends: control/comptime.md, stdlib/reflect.md, types/generics.md, types/traits.md -->
+
+# Encoding
+
+Two language primitives — `comptime for` over struct fields and comptime field access — plus auto-derived `Encode`/`Decode` traits. Format libraries (JSON, TOML, MessagePack) use these to serialize any compatible struct with zero user ceremony.
+
+## Core Mechanism
+
+| Rule | Description |
+|------|-------------|
+| **E1: Comptime field access** | `value.(name)` where `name` is a comptime-known string resolves at compile time to a direct field access. Compile error if field doesn't exist on the type |
+| **E2: Comptime for** | `comptime for field in reflect.fields<T>() { body }` unrolls the loop at compile time. Each iteration generates separate monomorphized code — the body may use different types per iteration |
+| **E3: Per-iteration typing** | Inside a `comptime for` body, `value.(field.name)` has the concrete type of that field. Generic calls like `encode_value(value.(field.name))` monomorphize per-field |
+
+<!-- test: skip -->
+```rask
+import std.reflect
+
+func print_fields<T>(value: T) {
+    comptime for field in reflect.fields<T>() {
+        print("{field.name} = {value.(field.name)}")
+    }
+}
+
+struct Point { public x: f64, public y: f64 }
+
+// print_fields(Point { x: 1.0, y: 2.0 }) unrolls to:
+//   print("x = {value.x}")
+//   print("y = {value.y}")
+```
+
+### Comptime Field Access
+
+| Rule | Description |
+|------|-------------|
+| **E4: String must be comptime** | The expression in `value.(expr)` must be comptime-known. Runtime strings are a compile error |
+| **E5: Field must exist** | Compile error if the comptime string doesn't match any field of the value's type |
+| **E6: Visibility respected** | Same visibility rules as direct field access — private fields accessible only in the defining module |
+
+<!-- test: skip -->
+```rask
+const name = comptime "x"
+const v = point.(name)         // OK: comptime-known string
+
+let name = get_name()
+const v = point.(name)         // ERROR: runtime string in comptime field access
+
+const v = point.("z")          // ERROR: Point has no field "z"
+```
+
+### Comptime For
+
+| Rule | Description |
+|------|-------------|
+| **E7: Unrolling** | `comptime for` fully unrolls at monomorphization time. Each iteration becomes separate code |
+| **E8: Comptime iterable** | The iterable must be comptime-known: `reflect.fields<T>()`, `reflect.variants<T>()`, or any comptime array |
+| **E9: No branch quota** | `comptime for` unrolling doesn't count against the backwards branch quota (`ctrl.comptime/CT35`). The quota applies to comptime *interpreter* execution, not monomorphization-time unrolling |
+| **E10: Comptime if in body** | `comptime if` inside the loop body enables per-field conditional code generation (e.g., skip fields, type dispatch) |
+
+<!-- test: skip -->
+```rask
+func encode_struct<T: Encode>(value: T, w: mutate JsonWriter) -> () or JsonError {
+    try w.begin_object()
+    comptime for field in reflect.fields<T>() {
+        comptime if !field.is_skipped {
+            try w.key(field.serial_name)
+            try encode_value(value.(field.name), mutate w)
+        }
+    }
+    try w.end_object()
+}
+```
+
+## Encode and Decode Traits
+
+| Rule | Description |
+|------|-------------|
+| **E11: Marker traits** | `Encode` and `Decode` are marker traits with no methods. They signal that a type's structure is serialization-compatible |
+| **E12: Auto-derive** | The compiler auto-derives `Encode` for any struct where all public fields have `Encode` types, unless the struct is marked `@no_encode`. Same for `Decode` |
+| **E13: Public fields only** | Auto-derived encoding covers public fields only. Non-public fields are invisible to external serialization code (`std.reflect/R4`) |
+| **E14: Base types** | `bool`, `i8`–`i64`, `u8`–`u64`, `f32`, `f64`, `string` are `Encode` and `Decode` |
+| **E15: Collection types** | `Vec<T>` where `T: Encode`, `Map<string, T>` where `T: Encode`, `T?` where `T: Encode` — all auto-implement `Encode`. Same for `Decode` |
+| **E16: Opt-out** | `@no_encode` on a struct prevents auto-derive of `Encode`. `@no_decode` prevents `Decode`. For types where automatic serialization is semantically wrong |
+| **E17: Enum auto-derive** | Enums auto-derive `Encode`/`Decode` when all variant payloads are `Encode`/`Decode` types |
+
+<!-- test: parse -->
+```rask
+trait Encode { }
+trait Decode { }
+```
+
+<!-- test: skip -->
+```rask
+struct User {
+    public name: string
+    public age: i32
+    public email: string?
+}
+// Auto-derives Encode and Decode — all public fields are compatible types
+
+@no_encode
+struct InternalState {
+    public data: Vec<u8>
+    secret: string
+}
+// Opted out — won't satisfy Encode bound
+```
+
+### Generic Bounds
+
+<!-- test: skip -->
+```rask
+func send_json<T: Encode>(endpoint: string, value: T) -> () or HttpError {
+    const body = json.encode(value)
+    return http.post(endpoint, body)
+}
+
+func load_config<T: Decode>(path: string) -> T or ConfigError {
+    const text = try fs.read_string(path)
+    return try toml.decode<T>(text)
+}
+```
+
+### Manual Implementation
+
+For types where auto-derive doesn't apply (private fields, custom invariants), implement encoding in the same module where the type is defined:
+
+<!-- test: skip -->
+```rask
+@no_encode
+struct DateTime {
+    year: i32
+    month: u8
+    day: u8
+    hour: u8
+    minute: u8
+    second: u8
+}
+
+// In the same module — can access private fields
+extend DateTime {
+    public func to_json(self) -> JsonValue {
+        return JsonValue.String(self.to_iso8601())
+    }
+
+    public func from_json(value: JsonValue) -> DateTime or JsonError {
+        const s = value.as_string() is Some else {
+            return Err(JsonError.TypeError("expected string for DateTime"))
+        }
+        return try DateTime.parse_iso8601(s)
+    }
+}
+```
+
+## Field Annotations
+
+| Rule | Description |
+|------|-------------|
+| **E18: @rename** | `@rename("name")` on a struct field overrides the serialized key name. Reflected as `FieldInfo.serial_name` |
+| **E19: @skip** | `@skip` excludes a field from serialization and deserialization. Reflected as `FieldInfo.is_skipped` |
+| **E20: @default** | `@default(expr)` provides a comptime value used when the field is missing during deserialization. The field becomes optional in the input. Reflected as `FieldInfo.has_default` |
+| **E21: Comptime expressions** | `@rename` takes a string literal. `@default` takes a comptime expression. Both validated at compile time |
+
+<!-- test: skip -->
+```rask
+struct ApiUser {
+    @rename("user_name")
+    public name: string
+
+    @skip
+    public cache_key: string
+
+    @default(0)
+    public login_count: i32
+
+    @default("unknown")
+    public role: string
+}
+
+// JSON: {"user_name": "alice", "login_count": 5, "role": "admin"}
+// Missing login_count → defaults to 0
+// Missing role → defaults to "unknown"
+// cache_key never appears in output, never expected in input
+```
+
+### @skip and Auto-Derive
+
+A `@skip` field doesn't need to be `Encode`/`Decode`. A struct with a non-serializable private field that's also `@skip` still auto-derives `Encode`:
+
+<!-- test: skip -->
+```rask
+struct CachedUser {
+    public name: string
+    public age: i32
+
+    @skip
+    internal_id: u64          // Not Encode, but skipped — doesn't block auto-derive
+}
+// CachedUser: Encode — the compiler ignores @skip fields for auto-derive eligibility
+```
+
+## Enum Serialization
+
+| Rule | Description |
+|------|-------------|
+| **E22: External tagging** | Default: variant name is the key. `{"Circle": {"radius": 1.0}}` for struct payloads, `"Point"` for unit variants |
+| **E23: Single payload** | Variants with one unnamed field: `{"Circle": 1.0}` — payload directly as the value |
+| **E24: Internal tagging** | `@tag("field")` on the enum: tag is a field inside the object. `{"type": "Circle", "radius": 1.0}` |
+| **E25: Variant rename** | `@rename` on individual variants overrides the serialized variant name |
+
+<!-- test: skip -->
+```rask
+enum Shape {
+    Circle { radius: f64 }
+    Rectangle { width: f64, height: f64 }
+    Point
+}
+// External (default):
+//   Circle    → {"Circle": {"radius": 1.0}}
+//   Rectangle → {"Rectangle": {"width": 2.0, "height": 3.0}}
+//   Point     → "Point"
+```
+
+<!-- test: skip -->
+```rask
+@tag("type")
+enum Event {
+    Click { x: i32, y: i32 }
+
+    @rename("key_press")
+    KeyPress { code: u32 }
+}
+// Internal:
+//   Click    → {"type": "Click", "x": 10, "y": 20}
+//   KeyPress → {"type": "key_press", "code": 65}
+```
+
+## Format Library Pattern
+
+Format libraries use `comptime for` + `reflect` to implement encoding generically. Each format is self-contained.
+
+### Encoding
+
+<!-- test: skip -->
+```rask
+import std.reflect
+
+// Type dispatch — monomorphizes per concrete type
+func encode_value<T: Encode>(value: T, w: mutate JsonWriter) -> () or JsonError {
+    comptime if T == bool {
+        return w.write_bool(value)
+    } else if T == string {
+        return w.write_string(value)
+    } else if reflect.is_integer<T>() {
+        return w.write_number(value as f64)
+    } else if reflect.is_float<T>() {
+        return w.write_number(value)
+    } else if reflect.is_optional<T>() {
+        if value is Some(v) {
+            return encode_value(v, mutate w)
+        } else {
+            return w.write_null()
+        }
+    } else if reflect.is_vec<T>() {
+        try w.begin_array()
+        for item in value {
+            try encode_value(item, mutate w)
+        }
+        return w.end_array()
+    } else if reflect.is_map<T>() {
+        try w.begin_object()
+        for key, val in value {
+            try w.key(key)
+            try encode_value(val, mutate w)
+        }
+        return w.end_object()
+    } else if reflect.is_struct<T>() {
+        try w.begin_object()
+        comptime for field in reflect.fields<T>() {
+            comptime if !field.is_skipped {
+                try w.key(field.serial_name)
+                try encode_value(value.(field.name), mutate w)
+            }
+        }
+        return w.end_object()
+    } else if reflect.is_enum<T>() {
+        return encode_enum(value, mutate w)
+    }
+}
+
+// Top-level entry point
+public func encode<T: Encode>(value: T) -> string or JsonError {
+    let w = JsonWriter.new()
+    try encode_value(value, mutate w)
+    return w.finish()
+}
+```
+
+### Decoding
+
+<!-- test: skip -->
+```rask
+func decode_value<T: Decode>(parser: mutate JsonParser) -> T or JsonError {
+    comptime if T == bool {
+        return parser.read_bool()
+    } else if T == string {
+        return parser.read_string()
+    } else if reflect.is_integer<T>() {
+        const n = try parser.read_number()
+        return n as T
+    } else if reflect.is_optional<T>() {
+        if parser.peek_null() {
+            parser.skip()
+            return None
+        }
+        return Some(try decode_value(parser))
+    } else if reflect.is_vec<T>() {
+        let result = Vec.new()
+        try parser.begin_array()
+        while !parser.end_array() {
+            result.push(try decode_value(parser))
+        }
+        return result
+    } else if reflect.is_struct<T>() {
+        return decode_struct<T>(mutate parser)
+    }
+}
+
+func decode_struct<T: Decode>(parser: mutate JsonParser) -> T or JsonError {
+    try parser.begin_object()
+    let fields = Map<string, JsonValue>.new()
+    while !parser.end_object() {
+        const key = try parser.read_key()
+        fields.insert(key, try parser.read_value())
+    }
+
+    return T {
+        comptime for field in reflect.fields<T>() {
+            comptime if !field.is_skipped {
+                (field.name): comptime if field.has_default {
+                    match fields.get(field.serial_name) {
+                        Some(v) => try decode_from_value(v),
+                        None => field.default_value,
+                    }
+                } else {
+                    try decode_from_value(
+                        fields.get(field.serial_name) is Some else {
+                            return Err(JsonError.MissingField(field.serial_name))
+                        }
+                    )
+                },
+            }
+        }
+    }
+}
+```
+
+### Struct Literal Construction
+
+| Rule | Description |
+|------|-------------|
+| **E26: Comptime for in struct literal** | `comptime for` inside `T { ... }` produces field initializers. Each iteration must produce exactly one `(field.name): value` pair |
+| **E27: All fields required** | The compiler verifies every non-skipped field is initialized. Missing fields are a compile error |
+
+## Error Messages
+
+**Non-encodable field [E12]:**
+```
+ERROR [std.encoding/E12]: struct `Connection` is not Encode
+   |
+5  |  json.encode(conn)
+   |               ^^^^ field `socket` has type `Socket` which is not Encode
+   |
+3  |  struct Connection {
+4  |      public socket: Socket    ← Socket is not Encode
+   |
+
+WHY: Auto-derive requires all public fields to be Encode types.
+
+FIX: Mark the field @skip, mark the struct @no_encode and implement custom
+     encoding, or make Socket implement Encode.
+```
+
+**Opted-out type used as Encode [E16]:**
+```
+ERROR [std.encoding/E16]: `InternalState` does not implement Encode
+   |
+8  |  json.encode(state)
+   |               ^^^^^ type marked @no_encode
+
+WHY: @no_encode prevents auto-derive of Encode.
+
+FIX: Remove @no_encode, or implement a custom encoding method.
+```
+
+**Runtime string in field access [E4]:**
+```
+ERROR [std.encoding/E4]: runtime string in comptime field access
+   |
+5  |  const v = point.(name)
+   |                   ^^^^ `name` is not comptime-known
+
+WHY: Comptime field access resolves at compile time. The field name must be
+     a comptime-known string.
+
+FIX: Use a comptime-known string:
+
+  const v = point.("x")              // string literal
+  const v = point.(field.name)       // inside comptime for
+```
+
+**Unknown field [E5]:**
+```
+ERROR [std.encoding/E5]: no field "z" on type `Point`
+   |
+5  |  const v = point.("z")
+   |                    ^^^ Point has fields: x, y
+```
+
+## Edge Cases
+
+| Case | Rule | Handling |
+|------|------|----------|
+| Struct with no public fields | E13 | Encodes as empty object `{}` |
+| Recursive types (`struct Node { children: Vec<Node> }`) | E15 | Works — `Vec<Node>` where `Node: Encode` |
+| All fields `@skip` | E19, E27 | Encodes as `{}`; decode produces struct with all defaults |
+| `@default` on non-optional required field | E20 | Field becomes optional in input, required in struct definition. Default fills the gap |
+| `@rename` collision (two fields same serial name) | E18 | Compile error: duplicate serial name |
+| `@skip` field without `@default` during decode | E19 | Field must have a type-level default (zero for integers, empty for string, `None` for optionals) or compile error |
+| Nested comptime for (struct within struct) | E3 | Works — `encode_value` recursively monomorphizes |
+| Private field with `@rename` | E6 | Annotation accepted but ineffective — field not encoded externally. Useful for same-module custom encoding |
+| Generic struct `Wrapper<T>` | E12 | `Encode` if `T: Encode`. Checked at monomorphization |
+| Enum with non-Encode payload | E17 | Enum is not `Encode`. Error points to the non-Encode variant |
+
+---
+
+## Appendix (non-normative)
+
+### Rationale
+
+**E1-E3 (comptime for + field access):** I chose Zig's proven approach adapted to Rask. The reflect spec listed "derive-style code generation" as the primary use case but showed code-as-string generation with no compilation mechanism. `comptime for` + `value.(name)` solves this with two focused primitives: loop unrolling and dynamic-name field access, both resolved at compile time. No macros, no string evaluation, no hidden code generation.
+
+**E11 (marker traits):** I wanted Encode/Decode for generic bounds (`T: Encode`) but Rask doesn't have associated types in MVP. A Serializer trait hierarchy (like serde) would need them. Marker traits are the simplest option that enables compile-time checked generic bounds. Format libraries use `comptime for` directly instead of dispatching through trait methods — each format writes ~100 lines, which is acceptable since formats differ genuinely in how they handle nulls, numbers, nesting.
+
+**E12-E13 (auto-derive, public fields only):** Matches Go's exported-fields-only behavior. I chose auto-derive with opt-out because the zero-ceremony path should be the common path. Adding a `File` field to a struct naturally breaks `Encode` — good. The error message tells you exactly which field is the problem.
+
+**E16 (@no_encode):** The opt-out exists for types where automatic serialization is semantically wrong — connection pools, caches, types with invariants that can't survive a round-trip. The compiler won't silently serialize something you've explicitly excluded.
+
+**E18-E20 (field annotations):** Field-level annotations keep customization at the point of use. I chose format-agnostic annotations (`@rename`, not `@json_rename`) because format-specific renaming is rare enough to handle with custom encoding. The annotations are typed and compiler-checked, unlike Go's stringly-typed struct tags.
+
+**E22-E24 (enum serialization):** Externally tagged is the simplest default — unambiguous, requires no configuration. `@tag("type")` for internal tagging covers the common API pattern. I intentionally left out adjacently tagged and untagged — they add complexity and the escape hatch (custom encoding) covers the rare cases.
+
+### Patterns & Guidance
+
+**Second format (TOML):**
+
+```rask
+import std.reflect
+
+func encode_value<T: Encode>(value: T, w: mutate TomlWriter, key: string?) -> () or TomlError {
+    comptime if T == bool {
+        return w.write_bool(key, value)
+    } else if T == string {
+        return w.write_string(key, value)
+    } else if reflect.is_integer<T>() {
+        return w.write_integer(key, value as i64)
+    } else if reflect.is_struct<T>() {
+        try w.begin_table(key)
+        comptime for field in reflect.fields<T>() {
+            comptime if !field.is_skipped {
+                try encode_value(value.(field.name), mutate w, Some(field.serial_name))
+            }
+        }
+        return w.end_table()
+    }
+    // TOML has no null — optionals with None are omitted
+    // TOML arrays, inline tables, etc.
+}
+```
+
+Each format library is self-contained. The comptime dispatch handles format-specific differences naturally (TOML omits null, MessagePack uses binary tags, etc.).
+
+**Full round-trip example:**
+
+```rask
+import json
+
+struct Config {
+    @rename("server_host")
+    public host: string
+
+    @default(8080)
+    public port: i32
+
+    @skip
+    public cached_at: i64
+}
+
+func main() -> () or Error {
+    // Encode
+    const config = Config { host: "localhost", port: 3000, cached_at: 0 }
+    const text = json.encode(config)
+    // → {"server_host": "localhost", "port": 3000}
+
+    // Decode (port defaults to 8080 if missing)
+    const loaded = try json.decode<Config>("{\"server_host\": \"example.com\"}")
+    // → Config { host: "example.com", port: 8080, cached_at: 0 }
+}
+```
+
+**HTTP JSON API server (validation target #1):**
+
+```rask
+import json
+import http
+
+struct CreateUserRequest {
+    public name: string
+    public email: string
+    public age: i32?
+}
+
+struct UserResponse {
+    public id: i64
+    public name: string
+    public email: string
+}
+
+func handle_create_user(req: http.Request) -> http.Response {
+    const body = req.body() is Some else {
+        return http.Response.bad_request("missing body")
+    }
+    const input = json.decode<CreateUserRequest>(body) is Ok else {
+        return http.Response.bad_request("invalid JSON")
+    }
+    const user = create_user(input.name, input.email, input.age)
+    const response = UserResponse { id: user.id, name: user.name, email: user.email }
+    return http.Response.ok(json.encode(response))
+}
+```
+
+Zero serialization boilerplate. Comparable to Go.
+
+### See Also
+
+- `ctrl.comptime` — Compile-time execution, `comptime if` (`ctrl.comptime/CT5`)
+- `std.reflect` — Field reflection, type introspection (`std.reflect/R1`)
+- `std.json` — JSON format library using this mechanism (`std.json/J6`)
+- `type.generics` — Trait bounds, auto-derive pattern (`type.generics/CL1`)
+- `type.traits` — Trait definitions, structural matching (`type.traits/TR1`)

--- a/specs/stdlib/json.md
+++ b/specs/stdlib/json.md
@@ -1,7 +1,7 @@
 <!-- id: std.json -->
 <!-- status: decided -->
 <!-- summary: Untyped JsonValue enum plus zero-ceremony struct encoding/decoding -->
-<!-- depends: stdlib/collections.md, types/error-types.md -->
+<!-- depends: stdlib/collections.md, types/error-types.md, stdlib/encoding.md -->
 
 # JSON
 
@@ -64,10 +64,10 @@ json.stringify_pretty(value: JsonValue) -> string
 
 | Rule | Description |
 |------|-------------|
-| **J6: Auto-encode** | Any struct with JSON-compatible fields can be encoded without manual implementation |
+| **J6: Auto-encode** | Any struct satisfying `Encode` can be encoded without manual implementation. Uses `comptime for` + field access (`std.encoding/E1`–`E3`) |
 | **J7: Compatible types** | `bool`, `i32`, `i64`, `u32`, `u64`, `f32`, `f64`, `string`, `Vec<T>`, `Map<string, T>`, `T?`, nested structs |
-| **J8: Field mapping** | Struct field name = JSON key (snake_case preserved) |
-| **J9: Optional fields** | `T?` fields decode `null` or missing as `None`; missing required fields produce `MissingField` |
+| **J8: Field mapping** | Struct field `serial_name` = JSON key. Defaults to field name (snake_case). Override with `@rename` (`std.encoding/E18`) |
+| **J9: Optional fields** | `T?` fields decode `null` or missing as `None`; missing required fields produce `MissingField`. `@default` fields (`std.encoding/E20`) also tolerate missing keys |
 | **J10: Extra keys ignored** | JSON keys not matching any struct field are silently skipped |
 
 <!-- test: skip -->
@@ -84,13 +84,33 @@ json.from_value<T>(value: JsonValue) -> T or JsonError
 import json
 
 struct User {
-    name: string
-    age: i64
-    email: string?
+    public name: string
+    public age: i64
+    public email: string?
 }
 
 const user = try json.decode<User>(input)
 const output = json.encode(user)
+```
+
+With field annotations:
+
+<!-- test: skip -->
+```rask
+struct ApiUser {
+    @rename("user_name")
+    public name: string
+
+    public age: i64
+
+    @default("user")
+    public role: string
+
+    @skip
+    public cache_key: string
+}
+// encode → {"user_name": "alice", "age": 30, "role": "admin"}
+// decode with missing role → role defaults to "user"
 ```
 
 ## Error Messages
@@ -135,19 +155,23 @@ WHY: Only primitive, collection, optional, and nested-struct types can be encode
 
 **J2 (f64 numbers):** Matches JavaScript's `JSON.parse()` behavior. Exact large integers would need a `JsonValue.Integer(i64)` variant — deferred until there's a real use case.
 
-**J6 (auto-encode):** Compiler generates conversion code for any struct with compatible fields. No derive macro or trait implementation needed.
+**J6 (auto-encode):** Uses `comptime for` over `reflect.fields<T>()` to generate per-field encoding at monomorphization time. No derive macro needed — any struct satisfying `Encode` (`std.encoding/E12`) works automatically.
 
-**J8 (snake_case):** Field renaming attributes (`@json(rename = "fieldName")`) deferred. Snake_case is the default; most JSON APIs use it.
+**J8 (field mapping):** `@rename` (`std.encoding/E18`) overrides the serialized key name. Default is the field name (snake_case). Format-agnostic — works for TOML, MessagePack, etc.
 
 ### Deferred
 
-- `@json(rename = "fieldName")` — field renaming attributes
-- `JsonEncodable` / `JsonDecodable` — custom serialization traits
 - `json.Parser` — streaming parser for large files
 - `JsonValue.Integer(i64)` — lossless integer round-trips
 - Date/time handling — dates are strings, parse with `time` module
 
+### Resolved (by std.encoding)
+
+- ~~`@json(rename = "fieldName")`~~ → `@rename("fieldName")` — format-agnostic field annotation (`std.encoding/E18`)
+- ~~`JsonEncodable` / `JsonDecodable`~~ → `Encode` / `Decode` marker traits (`std.encoding/E11`)
+
 ### See Also
 
+- `std.encoding` — Encode/Decode traits, comptime field iteration, field annotations
 - `std.collections` — `Vec`, `Map` used in JsonValue
 - `type.errors` — `JsonError` follows standard error pattern

--- a/specs/stdlib/reflect.md
+++ b/specs/stdlib/reflect.md
@@ -1,7 +1,7 @@
 <!-- id: std.reflect -->
 <!-- status: decided -->
 <!-- summary: Compile-time type introspection via stdlib module -->
-<!-- depends: control/comptime.md -->
+<!-- depends: control/comptime.md, stdlib/encoding.md -->
 
 # Reflect Module
 
@@ -34,12 +34,29 @@ const FIELD_COUNT = comptime reflect.fields(MyStruct).len
 | `is_copy<T>()` | `-> bool` | Whether T is implicitly copyable (≤16 bytes, all fields Copy) |
 | `is_resource<T>()` | `-> bool` | Whether T is a linear resource type |
 
+### Type Category
+
+| Function | Signature | Description |
+|----------|-----------|-------------|
+| `is_struct<T>()` | `-> bool` | Whether T is a struct |
+| `is_enum<T>()` | `-> bool` | Whether T is an enum |
+| `is_optional<T>()` | `-> bool` | Whether T is `U?` for some U |
+| `is_vec<T>()` | `-> bool` | Whether T is `Vec<U>` for some U |
+| `is_map<T>()` | `-> bool` | Whether T is `Map<K, V>` for some K, V |
+| `is_integer<T>()` | `-> bool` | Whether T is an integer type (`i8`–`i64`, `u8`–`u64`, `usize`) |
+| `is_float<T>()` | `-> bool` | Whether T is `f32` or `f64` |
+
+These enable comptime type dispatch without string-comparing type names. Primary use case: format libraries (`std.encoding`).
+
 <!-- test: skip -->
 ```rask
 comptime {
     const size = reflect.size_of<Point>()       // 8
     const align = reflect.align_of<Point>()     // 4
     const copy = reflect.is_copy<Point>()       // true (two i32 = 8 bytes)
+
+    const yes = reflect.is_struct<Point>()      // true
+    const no = reflect.is_enum<Point>()         // false
 }
 ```
 
@@ -58,8 +75,13 @@ struct FieldInfo {
     offset: usize
     size: usize
     is_public: bool
+    serial_name: string       // @rename value, or same as name
+    is_skipped: bool          // @skip present
+    has_default: bool         // @default present
 }
 ```
+
+`serial_name` equals `name` unless the field has `@rename("...")`. See `std.encoding` for field annotation semantics.
 
 ## Methods
 
@@ -99,6 +121,8 @@ struct VariantInfo {
     name: string
     has_fields: bool
     field_count: usize
+    fields: []FieldInfo       // payload fields (empty for unit variants)
+    serial_name: string       // @rename value, or same as name
 }
 ```
 
@@ -148,26 +172,18 @@ WHY: Reflection operates on imported types only. Type discovery requires whole-p
 
 ### Patterns & Guidance
 
-**Derive-style code generation** — the primary use case:
+**Comptime field iteration** — the primary use case. Uses `comptime for` + field access (`std.encoding/E1`–`E3`):
 
-<!-- test: parse -->
+<!-- test: skip -->
 ```rask
 import std.reflect
 
-comptime func gen_display<T>() -> string {
-    const code = string.new()
-    code.push_str("extend {reflect.name_of<T>()} {\n")
-    code.push_str("    func display(self) -> string {\n")
-    code.push_str("        const parts = Vec<string>.new()\n")
-
-    for field in reflect.fields<T>() {
-        code.push_str("        parts.push(\"{field.name}: \" + self.{field.name}.to_string())\n")
+func debug_print<T>(value: T) {
+    print("{reflect.name_of<T>()}(")
+    comptime for field in reflect.fields<T>() {
+        print("  {field.name}: {value.(field.name)}")
     }
-
-    code.push_str("        return \"{reflect.name_of<T>()}(\" + parts.join(\", \") + \")\"\n")
-    code.push_str("    }\n")
-    code.push_str("}\n")
-    return code.freeze()
+    print(")")
 }
 ```
 
@@ -175,25 +191,27 @@ comptime func gen_display<T>() -> string {
 
 <!-- test: skip -->
 ```rask
-comptime func assert_serializable<T>() {
+comptime func assert_all_public<T>() {
     for field in reflect.fields<T>() {
         @comptime_assert(
-            reflect.is_copy<T>() || reflect.has_method<T>("to_string"),
-            "Field '{field.name}' of {reflect.name_of<T>()} is not serializable"
+            field.is_public,
+            "Field '{field.name}' of {reflect.name_of<T>()} must be public"
         )
     }
 }
 ```
 
-**Conditional logic based on type properties:**
+**Conditional logic based on type category:**
 
 <!-- test: skip -->
 ```rask
-func serialize<T>(value: T) -> []u8 {
-    comptime if reflect.is_copy<T>() && reflect.size_of<T>() <= 8 {
-        return unsafe { mem_as_bytes(value) }
-    } else {
-        return serialize_fields(value)
+func encode_value<T: Encode>(value: T, w: mutate Writer) -> () or Error {
+    comptime if reflect.is_struct<T>() {
+        comptime for field in reflect.fields<T>() {
+            try encode_value(value.(field.name), mutate w)
+        }
+    } else if reflect.is_optional<T>() {
+        if value is Some(v) { try encode_value(v, mutate w) }
     }
 }
 ```
@@ -205,5 +223,6 @@ Ghost annotations show reflected values on hover (e.g., hovering `reflect.fields
 ### See Also
 
 - `ctrl.comptime` — Compile-time execution context
+- `std.encoding` — Comptime field iteration and serialization (`std.encoding/E1`–`E3`)
 - `type.traits` — Trait definitions and structural typing
 - `type.structs` — Struct field layout and visibility

--- a/specs/types/generics.md
+++ b/specs/types/generics.md
@@ -280,6 +280,8 @@ public func insert<K: HashKey, V>(map: HashMap<K, V>, key: K, val: V) {
 | `Numeric<T>` | `add, sub, mul, div, neg, zero, one, from_int` |
 | `Default<T>` | `default() -> T` |
 | `Convert<From, Into>` | `convert(self: From) -> Into` |
+| `Encode` | Marker — no methods. Auto-derived for structs with all-Encode public fields (`std.encoding/E12`) |
+| `Decode` | Marker — no methods. Auto-derived for structs with all-Decode public fields (`std.encoding/E12`) |
 
 ### See Also
 


### PR DESCRIPTION
## Summary

This PR introduces a comprehensive encoding specification for format-agnostic serialization in Rask, built on two core compile-time primitives: `comptime for` loop unrolling over struct fields and `value.(name)` comptime field access. It defines auto-derived `Encode`/`Decode` marker traits, field-level annotations (`@rename`, `@skip`, `@default`), and establishes the pattern for format libraries (JSON, TOML, MessagePack) to implement serialization generically.

## Key Changes

- **New spec: `specs/stdlib/encoding.md`** — Complete encoding specification with 27 rules covering:
  - Comptime field access (`value.(comptime_string)`) and `comptime for` loop unrolling (E1–E3)
  - Auto-derived `Encode`/`Decode` marker traits with public-fields-only semantics (E11–E17)
  - Field annotations: `@rename`, `@skip`, `@default` with compile-time validation (E18–E21)
  - Enum serialization strategies: external tagging (default), internal tagging with `@tag("field")` (E22–E25)
  - Struct literal construction with `comptime for` (E26–E27)
  - Detailed error messages and edge case handling
  - Format library pattern with full JSON encode/decode examples

- **Updated `specs/control/comptime.md`** — Added rules CT48–CT54 documenting:
  - `comptime for` syntax and unrolling semantics
  - `value.(expr)` comptime field access syntax
  - Clarification that unrolling doesn't count against backwards branch quota

- **Updated `specs/stdlib/reflect.md`** — Extended with:
  - Type category predicates: `is_struct<T>()`, `is_enum<T>()`, `is_optional<T>()`, `is_vec<T>()`, `is_map<T>()`, `is_integer<T>()`, `is_float<T>()`
  - `FieldInfo` struct extended with `serial_name`, `is_skipped`, `has_default` fields
  - `VariantInfo` struct extended with `fields` and `serial_name`
  - Updated patterns section to show comptime field iteration use case

- **Updated `specs/stdlib/json.md`** — Aligned with encoding spec:
  - J6 rule now references `Encode` trait and `comptime for` mechanism
  - J8 clarifies field mapping uses `serial_name` and `@rename` annotation
  - J9 documents `@default` field behavior
  - Added example with field annotations

- **Updated `specs/SYNTAX.md`** — Added attribute documentation:
  - `@no_encode`, `@no_decode` for struct opt-out
  - `@tag("field")` for enum internal tagging
  - `@rename("name")` for field/variant renaming
  - `@skip` for field exclusion
  - `@default(expr)` for default values
  - New "Comptime Field Access" section documenting `value.(field.name)` syntax

- **Updated `specs/types/generics.md`** — Added `Encode` and `Decode` to stdlib trait list

- **Updated `CLAUDE.md`** — Added encoding spec to navigation

## Notable Implementation Details

- **Zero-ceremony serialization**: Any struct with public `Encode` fields automatically satisfies `Encode` unless marked `@no_encode`. No derive macro or trait impl boilerplate required.

- **Format-agnostic design**: Marker traits + `comptime for` enable each format library to implement its own dispatch logic (~100 lines per format). No shared serializer trait hierarchy needed in MVP.

- **Compile-time safety**: Field names in `@rename`, `@skip`, `@default` are validated at compile time. Duplicate serial names produce compile errors. Missing required fields during decode are caught at compile time.

- **Recursive types supported**: `Vec<Node>` where `Node: Encode` works naturally — `comptime for` recursively monomorphizes through `encode_value` calls.

https://claude.ai/code/session_016Jn2UzQ8Huebw622gQjHjX