### PR TITLE
Add error origin tracking, auto-boxing, and context wrapping

### DIFF
--- a/specs/memory/borrowing.md
+++ b/specs/memory/borrowing.md
@@ -470,6 +470,41 @@ with pool[h] as entity {
 with pool[h] as e: e.health -= damage
 ```
 
+**The pattern for parsers (zero-copy via indices):**
+
+Block-scoped borrowing means parsers can't return references into input buffers. Two patterns handle this.
+
+*Simple case:* `string_view` stores `(start, end)` indices. Resolve against the original input inline:
+
+<!-- test: parse -->
+```rask
+struct Token {
+    kind: TokenKind
+    span: string_view
+}
+
+func tokenize(input: string) -> Vec<Token> {
+    let tokens = Vec.new()
+    let pos = 0
+    // scan() returns positions — no allocations per token
+    for (start, end, kind) in scan(input) {
+        tokens.push(Token { kind, span: string_view(start, end) })
+    }
+    return tokens
+}
+
+// Caller resolves spans against original input
+const source = try read_file(path)
+const tokens = tokenize(source)
+for tok in tokens {
+    process(source[tok.span])  // inline access, no copy
+}
+```
+
+*Shared buffer case:* `StringPool` gives validated handle-based access when multiple functions share the buffer. See `std.strings` for the full tokenizer pattern.
+
+The cost vs Rust: one `.to_string()` call per token if you need owned strings, zero copies if you keep spans and resolve inline. For hot parsers, the StringPool pattern avoids allocations entirely.
+
 ### IDE Integration
 
 The IDE makes access patterns visible through ghost annotations.

--- a/specs/stdlib/strings.md
+++ b/specs/stdlib/strings.md
@@ -54,7 +54,7 @@ Strings have internal heap buffers that can reallocate — same as Vec. This mak
 
 ## The `string_view` Type
 
-Plain indices for lightweight stored references. No validation -- user ensures source string validity (like storing a Vec index).
+Plain indices for lightweight stored references — the span type for parsers, tokenizers, and diagnostics. No validation — user ensures source string validity (like storing a Vec index). 16 bytes, copy-eligible.
 
 | Operation | Return | Notes |
 |-----------|--------|-------|

--- a/specs/types/error-types.md
+++ b/specs/types/error-types.md
@@ -1,6 +1,6 @@
 <!-- id: type.errors -->
 <!-- status: decided -->
-<!-- summary: Errors are values with try propagation, union composition, and auto-Ok wrapping -->
+<!-- summary: Errors are values with try propagation, union composition, auto-Ok wrapping, origin tracking, and any Error auto-boxing -->
 <!-- depends: types/enums.md, types/optionals.md -->
 <!-- implemented-by: compiler/crates/rask-types/, compiler/crates/rask-interp/ -->
 
@@ -134,23 +134,44 @@ func main() -> () or Error {
 | Rule | Description |
 |------|-------------|
 | **ER9: Auto-widen** | `try` auto-widens when return type is a union — succeeds if expression error type ⊆ return error union |
+| **ER10: Auto-box to `any Trait`** | `try` auto-boxes when return error type is `any Error` (or any `any Trait`) — succeeds if expression error type satisfies the trait |
 
 <!-- test: skip -->
 ```rask
+// Union widening — library code with precise types
 func load() -> Config or (IoError | ParseError) {
     const content = try read_file(path)   // IoError widens to union
     const config = try parse(content)     // ParseError widens to union
     config
 }
+
+// Auto-boxing — application code with type-erased errors
+func start_app() -> App or any Error {
+    const config = try read_config(path)     // IoError | ParseError → boxed to any Error
+    const db = try connect(config.db_url)    // DbError → boxed to any Error
+    const schema = try validate(db)          // ValidationError → boxed to any Error
+    App.new(config, db, schema)
+}
 ```
 
-See [Union Types](union-types.md) for union type semantics.
+The pattern: libraries use union types (precise, matchable). Applications use `any Error` (ergonomic, sufficient for logging/reporting). Downcast with `is` for recovery:
+
+<!-- test: skip -->
+```rask
+match start_app() {
+    Ok(app) => app.run(),
+    Err(e) if e is IoError => retry(),
+    Err(e) => log("fatal: {} at {}", e.message(), e.origin),
+}
+```
+
+See [Union Types](union-types.md) for union type semantics. See [Traits](traits.md) for `any Trait` semantics.
 
 ## Custom Error Types
 
 | Rule | Description |
 |------|-------------|
-| **ER10: Enum errors** | Errors are defined as enums with a `message()` method |
+| **ER11: Enum errors** | Errors are defined as enums with a `message()` method |
 
 <!-- test: parse -->
 ```rask
@@ -193,9 +214,9 @@ extend IoError {
 
 | Rule | Description |
 |------|-------------|
-| **ER11: Same type** | Same error type propagates directly |
-| **ER12: Union** | Different error types compose via union (`A \| B`) |
-| **ER13: Union compose** | Union return types accept any subset union via `try` |
+| **ER12: Same type** | Same error type propagates directly |
+| **ER13: Union** | Different error types compose via union (`A \| B`) |
+| **ER14: Union compose** | Union return types accept any subset union via `try` |
 
 ### Same error type — direct propagation
 
@@ -247,7 +268,7 @@ match load() {
 
 | Rule | Description |
 |------|-------------|
-| **ER14: Linear payloads** | Errors can contain linear resources; wildcard on linear payloads is a compile error |
+| **ER19: Linear payloads** | Errors can contain linear resources; wildcard on linear payloads is a compile error |
 
 <!-- test: skip -->
 ```rask
@@ -263,6 +284,68 @@ match result {
     }
 }
 ```
+
+## Error Origin Tracking
+
+| Rule | Description |
+|------|-------------|
+| **ER15: Origin capture** | `try` records `(file, line)` on the error at the first propagation site. Available in both debug and release builds |
+| **ER16: Propagation trace** | In debug builds, each subsequent `try` appends its `(file, line)` to the error's trace. Stripped in release |
+| **ER17: Origin access** | All errors have `.origin` (always available) and `.trace()` (debug builds; empty in release) |
+
+<!-- test: skip -->
+```rask
+func load_config(path: string) -> Config or (IoError | ParseError) {
+    const content = try read_file(path)    // origin set: "config.rk:2"
+    const config = try parse(content)      // origin set: "config.rk:3"
+    config
+}
+
+func start() -> () or any Error {
+    const config = try load_config(path)   // trace appended: "main.rk:2" (debug only)
+    try run(config)
+}
+
+// In the error handler:
+match start() {
+    Err(e) => {
+        log("{}: {}", e.origin, e.message())
+        // "config.rk:2: file not found: /etc/app.conf"
+
+        // Debug builds only — full propagation chain
+        for loc in e.trace() {
+            log("  at {}", loc)
+        }
+        // "  at config.rk:2"
+        // "  at main.rk:2"
+    }
+    Ok(_) => {}
+}
+```
+
+Cost: `origin` is ~16 bytes per error (file pointer + line number) — negligible on the exceptional path. The propagation trace allocates in debug builds only.
+
+## Context Wrapping
+
+| Rule | Description |
+|------|-------------|
+| **ER18: context method** | `.context(msg)` wraps an error with a human-readable message, preserving the original error and its origin |
+
+<!-- test: skip -->
+```rask
+func load_app() -> App or any Error {
+    const config = try read_config(path)
+        .context("loading app config")          // wraps with context string
+    const db = try connect(config.db_url)
+        .context("connecting to database")
+    App.new(config, db)
+}
+
+// Error output: "loading app config: file not found: /etc/app.conf"
+//         at: config.rk:2
+```
+
+`.context()` is explicit and opt-in — use it at boundaries where semantic meaning matters. `origin` is automatic and free. Together they cover both "where did this fail" and "what was I trying to do."
 
 ## Operator Family
 
@@ -285,7 +368,10 @@ Optional sugar (`T?`, `x?.field`, `x ?? y`) is distinct from `try` propagation �
 | Reach end of `() or E` function | ER8 | Implicit `Ok(())` |
 | `try` on error type not in return union | ER9 | Compile error — type not subset |
 | `try` on `Option` in `Result` function | ER6 | `None` maps to `Err` (types must align) |
-| Wildcard on linear error payload | ER14 | Compile error — must consume |
+| Wildcard on linear error payload | ER19 | Compile error — must consume |
+| `try` when return type is `any Error` | ER10 | Auto-box concrete error to `any Error` |
+| `.origin` in release build | ER15 | Always available (~16 bytes per error) |
+| `.trace()` in release build | ER16 | Returns empty — trace only in debug |
 | Nested `try` in closures | ER4 | Propagates to closure's return, not enclosing function |
 | `try` binding with method chain | ER5 | Binds to full expression; use parens to chain after |
 
@@ -300,6 +386,10 @@ Optional sugar (`T?`, `x?.field`, `x ?? y`) is distinct from `try` propagation �
 **ER7/ER8 (auto-Ok):** If you wanted an error, you'd use `return Err(...)` or `try`. Reaching the end means success. Eliminates noisy `Ok(())` at function ends.
 
 **ER9 (auto-widen):** Without auto-widening, every `try` on a narrower error type would need an explicit conversion. The subset check keeps it type-safe without boilerplate.
+
+**ER10 (auto-box):** Libraries should use precise union error types — callers can match on them. But application code that calls 5 libraries shouldn't need `-> T or (IoError | ParseError | DbError | ValidationError | AuthError)` on every function. `any Error` is the escape hatch: type-erased, sufficient for logging/reporting, with `is` downcast for recovery. This mirrors Rust's thiserror (libraries) + anyhow (applications) split, but built into the language.
+
+**ER15–ER17 (error origin):** When an `IoError` propagates through 10 functions, "file not found" tells you nothing. `origin` captures where the error first surfaced — always available, ~16 bytes, negligible on the exceptional path. The full propagation trace is debug-only because it allocates per hop. `.context()` adds semantic meaning at boundaries where "what was I trying to do" matters more than "what file:line."
 
 **Operator split (`try` vs `?`):** `try` is for propagation (both Result and Option). `?` is reserved for Option sugar only — type suffix, chaining, defaults, smart unwrap. This avoids Rust's overloading where `?` means different things in different contexts.
 
@@ -390,9 +480,6 @@ panic("invalid state")
 IDE shows `→ returns Err` as ghost text after `try` for visibility.
 
 ### Remaining Issues
-
-#### Low Priority
-1. **Stack traces** — Debug builds could capture (not specified)
 
 #### Dependencies
 - **Union types** — See [Union Types](union-types.md) (TODO: create spec)


### PR DESCRIPTION
## Summary

This PR extends the error handling specification with three major features: automatic origin tracking (file:line capture), type-erased error auto-boxing to `any Error`, and explicit context wrapping for semantic error messages. These features bridge the gap between library code (precise union error types) and application code (ergonomic type-erased errors).

## Key Changes

- **Error Origin Tracking (ER15–ER17):** `try` now automatically captures `(file, line)` at the first propagation site. Debug builds maintain a full propagation trace; release builds strip it for size. All errors expose `.origin` (~16 bytes) and `.trace()` methods.

- **Auto-boxing to `any Error` (ER10):** When a function returns `-> T or any Error`, `try` automatically boxes concrete error types (e.g., `IoError`, `ParseError`) to the trait-erased type. Enables application code to call multiple libraries without union explosion. Downcast with `is` for recovery.

- **Context Wrapping (ER18):** New `.context(msg)` method wraps errors with human-readable messages while preserving origin. Explicit and opt-in — used at semantic boundaries.

- **Updated Rule Numbering:** Renumbered subsequent rules (ER10→ER11, ER11→ER12, etc.) to accommodate new features. ER19 now covers linear payloads.

- **Documentation & Examples:** Added comprehensive examples showing:
  - Library code using precise union types
  - Application code using `any Error` for ergonomics
  - Error handler patterns with origin and trace access
  - Context wrapping at I/O boundaries

- **Borrowing Spec Update:** Added parser pattern documentation showing how `string_view` (indices) enables zero-copy tokenization without violating block-scoped borrowing rules.

- **Stdlib Clarification:** Updated `string_view` description to emphasize its role as the span type for parsers and diagnostics.

## Design Rationale

The origin tracking and auto-boxing features mirror Rust's ecosystem split (thiserror for libraries, anyhow for applications) but integrate them into the language. Origin is always available at negligible cost (~16 bytes per error, only on exceptional paths). The propagation trace is debug-only to avoid allocation overhead in release builds. Context wrapping is explicit to keep error semantics clear at call sites.

https://claude.ai/code/session_01NPyzzfk3EQzfWEEud322YU