### PR TITLE
Implement default parameter and named argument desugaring

### DIFF
--- a/compiler/crates/rask-ast/src/expr.rs
+++ b/compiler/crates/rask-ast/src/expr.rs
@@ -198,9 +198,11 @@ pub enum ArgMode {
     Mutate,
 }
 
-/// A function call argument with optional mode annotation.
+/// A function call argument with optional name label and mode annotation.
 #[derive(Debug, Clone)]
 pub struct CallArg {
+    /// Named argument label (e.g., `timeout:` in `connect(timeout: 60)`).
+    pub name: Option<String>,
     pub mode: ArgMode,
     pub expr: Expr,
 }

--- a/compiler/crates/rask-cli/src/commands/pipeline.rs
+++ b/compiler/crates/rask-cli/src/commands/pipeline.rs
@@ -77,6 +77,7 @@ fn run_frontend_single(path: &str, format: Format) -> FrontendResult {
     }
 
     rask_desugar::desugar(&mut parse_result.decls);
+    rask_desugar::desugar_default_args(&mut parse_result.decls);
 
     let resolved = match rask_resolve::resolve(&parse_result.decls) {
         Ok(r) => r,
@@ -131,6 +132,7 @@ fn run_frontend_package(pkg_ctx: &mut PackageContext, path: &str, format: Format
         .collect();
 
     rask_desugar::desugar(&mut pkg_ctx.all_decls);
+    rask_desugar::desugar_default_args(&mut pkg_ctx.all_decls);
 
     // Resolver handles external packages via collect_package_exports —
     // only pass root package decls here to avoid double registration.

--- a/compiler/crates/rask-desugar/src/defaults.rs
+++ b/compiler/crates/rask-desugar/src/defaults.rs
@@ -1,0 +1,716 @@
+// SPDX-License-Identifier: (MIT OR Apache-2.0)
+//! Default parameter desugaring and named argument resolution.
+//!
+//! Runs after operator desugaring but before name resolution.
+//! Builds a function lookup table from declarations, then rewrites
+//! call sites to fill in default values for missing arguments.
+
+use std::collections::HashMap;
+use rask_ast::decl::{Decl, DeclKind, FnDecl, Param};
+use rask_ast::expr::{ArgMode, CallArg, Expr, ExprKind};
+use rask_ast::stmt::{Stmt, StmtKind};
+use rask_ast::NodeId;
+
+/// Desugar default arguments and named arguments across all declarations.
+///
+/// Builds a lookup table of function signatures, then rewrites call sites
+/// so that missing arguments with defaults are filled in and named
+/// arguments are resolved to positional form.
+pub fn desugar_default_args(decls: &mut [Decl]) {
+    let lookup = FunctionLookup::build(decls);
+    let mut ctx = DefaultDesugarer {
+        lookup,
+        next_id: 2_000_000,
+    };
+    for decl in decls {
+        ctx.desugar_decl(decl);
+    }
+}
+
+/// Check whether an expression is a valid default (comptime-evaluable).
+///
+/// Accepts: literals, negated literals, enum-style paths (Type.Variant),
+/// bool literals, null. Rejects everything else.
+pub fn is_valid_default_expr(expr: &Expr) -> bool {
+    match &expr.kind {
+        // Literals
+        ExprKind::Int(_, _)
+        | ExprKind::Float(_, _)
+        | ExprKind::String(_)
+        | ExprKind::Char(_)
+        | ExprKind::Bool(_)
+        | ExprKind::Null => true,
+
+        // Negated literal: -1, -3.14
+        ExprKind::Unary { op: rask_ast::expr::UnaryOp::Neg, operand } => {
+            matches!(&operand.kind, ExprKind::Int(_, _) | ExprKind::Float(_, _))
+        }
+
+        // Enum-style path: Color.Red, FileMode.Read
+        ExprKind::Field { object, .. } => {
+            matches!(&object.kind, ExprKind::Ident(_))
+        }
+
+        // Array of valid defaults: [1, 2, 3]
+        ExprKind::Array(elems) => elems.iter().all(is_valid_default_expr),
+
+        // Tuple of valid defaults: (1, "a")
+        ExprKind::Tuple(elems) => elems.iter().all(is_valid_default_expr),
+
+        _ => false,
+    }
+}
+
+// ---- Function Lookup Table ----
+
+/// Maps function names and (type, method) pairs to parameter lists.
+struct FunctionLookup {
+    /// Free functions: name → params
+    functions: HashMap<String, Vec<Param>>,
+    /// Methods: (type_name, method_name) → params (excluding self)
+    methods: HashMap<(String, String), Vec<Param>>,
+    /// Methods indexed by name only (for instance method fallback)
+    methods_by_name: HashMap<String, Vec<Vec<Param>>>,
+}
+
+impl FunctionLookup {
+    fn build(decls: &[Decl]) -> Self {
+        let mut functions = HashMap::new();
+        let mut methods: HashMap<(String, String), Vec<Param>> = HashMap::new();
+        let mut methods_by_name: HashMap<String, Vec<Vec<Param>>> = HashMap::new();
+
+        for decl in decls {
+            match &decl.kind {
+                DeclKind::Fn(f) => {
+                    if f.params.iter().any(|p| p.default.is_some()) {
+                        functions.insert(f.name.clone(), f.params.clone());
+                    }
+                }
+                DeclKind::Struct(s) => {
+                    for m in &s.methods {
+                        Self::register_method(
+                            &s.name, m, &mut methods, &mut methods_by_name,
+                        );
+                    }
+                }
+                DeclKind::Enum(e) => {
+                    for m in &e.methods {
+                        Self::register_method(
+                            &e.name, m, &mut methods, &mut methods_by_name,
+                        );
+                    }
+                }
+                DeclKind::Impl(i) => {
+                    for m in &i.methods {
+                        Self::register_method(
+                            &i.target_ty, m, &mut methods, &mut methods_by_name,
+                        );
+                    }
+                }
+                _ => {}
+            }
+        }
+
+        Self { functions, methods, methods_by_name }
+    }
+
+    fn register_method(
+        type_name: &str,
+        method: &FnDecl,
+        methods: &mut HashMap<(String, String), Vec<Param>>,
+        methods_by_name: &mut HashMap<String, Vec<Vec<Param>>>,
+    ) {
+        // Only register methods that have default params
+        let non_self_params: Vec<Param> = method.params.iter()
+            .filter(|p| p.name != "self")
+            .cloned()
+            .collect();
+        if non_self_params.iter().any(|p| p.default.is_some()) {
+            methods.insert(
+                (type_name.to_string(), method.name.clone()),
+                non_self_params.clone(),
+            );
+            methods_by_name
+                .entry(method.name.clone())
+                .or_default()
+                .push(non_self_params);
+        }
+    }
+
+    /// Look up params for a free function call.
+    fn lookup_function(&self, name: &str) -> Option<&[Param]> {
+        self.functions.get(name).map(|v| v.as_slice())
+    }
+
+    /// Look up params for a static method call (Type.method).
+    fn lookup_static_method(&self, type_name: &str, method: &str) -> Option<&[Param]> {
+        self.methods.get(&(type_name.to_string(), method.to_string()))
+            .map(|v| v.as_slice())
+    }
+
+    /// Look up params for an instance method by name only (fallback).
+    /// Returns Some only if there's exactly one signature for this method name.
+    fn lookup_instance_method(&self, method: &str) -> Option<&[Param]> {
+        self.methods_by_name.get(method).and_then(|sigs| {
+            if sigs.len() == 1 {
+                Some(sigs[0].as_slice())
+            } else {
+                None
+            }
+        })
+    }
+}
+
+// ---- Argument Resolution ----
+
+/// Resolve call arguments against function parameters, filling in defaults.
+///
+/// Returns the rewritten args list with defaults inserted and names stripped,
+/// or None if resolution can't be done (error or no changes needed).
+fn resolve_call_args(
+    params: &[Param],
+    args: &[CallArg],
+    fresh_id: &mut impl FnMut() -> NodeId,
+) -> Option<Vec<CallArg>> {
+    // Quick check: if all args are positional and count matches, nothing to do
+    let has_named = args.iter().any(|a| a.name.is_some());
+    let has_defaults = params.iter().any(|p| p.default.is_some());
+
+    if !has_named && args.len() == params.len() {
+        return None; // Already fully resolved
+    }
+    if !has_named && !has_defaults {
+        return None; // No defaults to fill, will error elsewhere
+    }
+    if args.len() > params.len() {
+        return None; // Too many args, let type checker report
+    }
+
+    let mut result = Vec::with_capacity(params.len());
+    let mut arg_idx = 0;
+
+    for param in params {
+        if param.name == "self" {
+            // self is never filled by default
+            if arg_idx < args.len() {
+                result.push(CallArg {
+                    name: None,
+                    mode: args[arg_idx].mode,
+                    expr: args[arg_idx].expr.clone(),
+                });
+                arg_idx += 1;
+            }
+            continue;
+        }
+
+        if arg_idx < args.len() {
+            let arg = &args[arg_idx];
+
+            if let Some(ref name) = arg.name {
+                if name == &param.name {
+                    // Named arg matches this param — use it
+                    result.push(CallArg {
+                        name: None,
+                        mode: arg.mode,
+                        expr: arg.expr.clone(),
+                    });
+                    arg_idx += 1;
+                    continue;
+                }
+                // Named arg doesn't match — this param must have a default
+                if let Some(ref default_expr) = param.default {
+                    result.push(CallArg {
+                        name: None,
+                        mode: ArgMode::Default,
+                        expr: clone_expr_with_fresh_ids(default_expr, fresh_id),
+                    });
+                    continue;
+                }
+                // Required param skipped — bail out, let type checker report
+                return None;
+            }
+
+            // Positional arg — use it directly
+            result.push(CallArg {
+                name: None,
+                mode: arg.mode,
+                expr: arg.expr.clone(),
+            });
+            arg_idx += 1;
+        } else {
+            // No more provided args — fill with default
+            if let Some(ref default_expr) = param.default {
+                result.push(CallArg {
+                    name: None,
+                    mode: ArgMode::Default,
+                    expr: clone_expr_with_fresh_ids(default_expr, fresh_id),
+                });
+            } else {
+                // Required param missing — bail
+                return None;
+            }
+        }
+    }
+
+    // If there are leftover args, bail
+    if arg_idx < args.len() {
+        return None;
+    }
+
+    Some(result)
+}
+
+/// Clone an expression, assigning fresh NodeIds to avoid collisions.
+fn clone_expr_with_fresh_ids(
+    expr: &Expr,
+    fresh_id: &mut impl FnMut() -> NodeId,
+) -> Expr {
+    Expr {
+        id: fresh_id(),
+        kind: clone_expr_kind(&expr.kind, fresh_id),
+        span: expr.span,
+    }
+}
+
+fn clone_expr_kind(
+    kind: &ExprKind,
+    fresh_id: &mut impl FnMut() -> NodeId,
+) -> ExprKind {
+    match kind {
+        ExprKind::Int(v, suffix) => ExprKind::Int(*v, suffix.clone()),
+        ExprKind::Float(v, suffix) => ExprKind::Float(*v, suffix.clone()),
+        ExprKind::String(s) => ExprKind::String(s.clone()),
+        ExprKind::Char(c) => ExprKind::Char(*c),
+        ExprKind::Bool(b) => ExprKind::Bool(*b),
+        ExprKind::Null => ExprKind::Null,
+        ExprKind::Ident(n) => ExprKind::Ident(n.clone()),
+        ExprKind::Field { object, field } => ExprKind::Field {
+            object: Box::new(clone_expr_with_fresh_ids(object, fresh_id)),
+            field: field.clone(),
+        },
+        ExprKind::Unary { op, operand } => ExprKind::Unary {
+            op: *op,
+            operand: Box::new(clone_expr_with_fresh_ids(operand, fresh_id)),
+        },
+        ExprKind::Array(elems) => ExprKind::Array(
+            elems.iter().map(|e| clone_expr_with_fresh_ids(e, fresh_id)).collect(),
+        ),
+        ExprKind::Tuple(elems) => ExprKind::Tuple(
+            elems.iter().map(|e| clone_expr_with_fresh_ids(e, fresh_id)).collect(),
+        ),
+        // For any other expression kind in a default value, just clone as-is
+        // (the validator should have rejected complex expressions)
+        other => other.clone(),
+    }
+}
+
+// ---- Desugaring Traversal ----
+
+struct DefaultDesugarer {
+    lookup: FunctionLookup,
+    next_id: u32,
+}
+
+impl DefaultDesugarer {
+    fn desugar_decl(&mut self, decl: &mut Decl) {
+        match &mut decl.kind {
+            DeclKind::Fn(f) => self.desugar_fn_body(f),
+            DeclKind::Struct(s) => {
+                for m in &mut s.methods { self.desugar_fn_body(m); }
+            }
+            DeclKind::Enum(e) => {
+                for m in &mut e.methods { self.desugar_fn_body(m); }
+            }
+            DeclKind::Impl(i) => {
+                for m in &mut i.methods { self.desugar_fn_body(m); }
+            }
+            DeclKind::Trait(t) => {
+                for m in &mut t.methods { self.desugar_fn_body(m); }
+            }
+            DeclKind::Const(c) => self.desugar_expr(&mut c.init),
+            DeclKind::Test(t) => {
+                for s in &mut t.body { self.desugar_stmt(s); }
+            }
+            DeclKind::Benchmark(b) => {
+                for s in &mut b.body { self.desugar_stmt(s); }
+            }
+            DeclKind::Import(_) | DeclKind::Export(_) | DeclKind::Extern(_)
+            | DeclKind::Package(_) | DeclKind::Union(_) => {}
+        }
+    }
+
+    fn desugar_fn_body(&mut self, f: &mut FnDecl) {
+        for stmt in &mut f.body {
+            self.desugar_stmt(stmt);
+        }
+    }
+
+    fn desugar_stmt(&mut self, stmt: &mut Stmt) {
+        match &mut stmt.kind {
+            StmtKind::Expr(e) => self.desugar_expr(e),
+            StmtKind::Let { init, .. } | StmtKind::Const { init, .. } => self.desugar_expr(init),
+            StmtKind::LetTuple { init, .. } | StmtKind::ConstTuple { init, .. } => {
+                self.desugar_expr(init);
+            }
+            StmtKind::Assign { target, value } => {
+                self.desugar_expr(target);
+                self.desugar_expr(value);
+            }
+            StmtKind::Return(Some(e)) => self.desugar_expr(e),
+            StmtKind::Return(None) => {}
+            StmtKind::Break { value: Some(v), .. } => self.desugar_expr(v),
+            StmtKind::Break { value: None, .. } | StmtKind::Continue(_) => {}
+            StmtKind::While { cond, body } => {
+                self.desugar_expr(cond);
+                for s in body { self.desugar_stmt(s); }
+            }
+            StmtKind::WhileLet { expr, body, .. } => {
+                self.desugar_expr(expr);
+                for s in body { self.desugar_stmt(s); }
+            }
+            StmtKind::Loop { body, .. } => {
+                for s in body { self.desugar_stmt(s); }
+            }
+            StmtKind::For { iter, body, .. } => {
+                self.desugar_expr(iter);
+                for s in body { self.desugar_stmt(s); }
+            }
+            StmtKind::Ensure { body, else_handler } => {
+                for s in body { self.desugar_stmt(s); }
+                if let Some((_, handler)) = else_handler {
+                    for s in handler { self.desugar_stmt(s); }
+                }
+            }
+            StmtKind::Comptime(body) => {
+                for s in body { self.desugar_stmt(s); }
+            }
+        }
+    }
+
+    fn desugar_expr(&mut self, expr: &mut Expr) {
+        // Recurse into child expressions first
+        match &mut expr.kind {
+            ExprKind::Call { func, args } => {
+                self.desugar_expr(func);
+                for arg in args.iter_mut() { self.desugar_expr(&mut arg.expr); }
+            }
+            ExprKind::MethodCall { object, args, .. } => {
+                self.desugar_expr(object);
+                for arg in args.iter_mut() { self.desugar_expr(&mut arg.expr); }
+            }
+            ExprKind::Binary { left, right, .. } => {
+                self.desugar_expr(left);
+                self.desugar_expr(right);
+            }
+            ExprKind::Unary { operand, .. } => self.desugar_expr(operand),
+            ExprKind::Field { object, .. } | ExprKind::OptionalField { object, .. } => {
+                self.desugar_expr(object);
+            }
+            ExprKind::Index { object, index } => {
+                self.desugar_expr(object);
+                self.desugar_expr(index);
+            }
+            ExprKind::Block(stmts) => {
+                for s in stmts { self.desugar_stmt(s); }
+            }
+            ExprKind::If { cond, then_branch, else_branch } => {
+                self.desugar_expr(cond);
+                self.desugar_expr(then_branch);
+                if let Some(e) = else_branch { self.desugar_expr(e); }
+            }
+            ExprKind::IfLet { expr, then_branch, else_branch, .. } => {
+                self.desugar_expr(expr);
+                self.desugar_expr(then_branch);
+                if let Some(e) = else_branch { self.desugar_expr(e); }
+            }
+            ExprKind::Match { scrutinee, arms } => {
+                self.desugar_expr(scrutinee);
+                for arm in arms {
+                    if let Some(g) = &mut arm.guard { self.desugar_expr(g); }
+                    self.desugar_expr(&mut arm.body);
+                }
+            }
+            ExprKind::Try(e) | ExprKind::Unwrap { expr: e, .. } | ExprKind::Cast { expr: e, .. } => {
+                self.desugar_expr(e);
+            }
+            ExprKind::NullCoalesce { value, default } => {
+                self.desugar_expr(value);
+                self.desugar_expr(default);
+            }
+            ExprKind::GuardPattern { expr, else_branch, .. } => {
+                self.desugar_expr(expr);
+                self.desugar_expr(else_branch);
+            }
+            ExprKind::IsPattern { expr, .. } => self.desugar_expr(expr),
+            ExprKind::Range { start, end, .. } => {
+                if let Some(s) = start { self.desugar_expr(s); }
+                if let Some(e) = end { self.desugar_expr(e); }
+            }
+            ExprKind::StructLit { fields, spread, .. } => {
+                for f in fields { self.desugar_expr(&mut f.value); }
+                if let Some(s) = spread { self.desugar_expr(s); }
+            }
+            ExprKind::Array(elems) | ExprKind::Tuple(elems) => {
+                for e in elems { self.desugar_expr(e); }
+            }
+            ExprKind::ArrayRepeat { value, count } => {
+                self.desugar_expr(value);
+                self.desugar_expr(count);
+            }
+            ExprKind::Closure { body, .. } => self.desugar_expr(body),
+            ExprKind::WithAs { bindings, body } => {
+                for b in bindings { self.desugar_expr(&mut b.source); }
+                for s in body { self.desugar_stmt(s); }
+            }
+            ExprKind::Spawn { body } | ExprKind::Unsafe { body }
+            | ExprKind::BlockCall { body, .. } | ExprKind::Comptime { body } => {
+                for s in body { self.desugar_stmt(s); }
+            }
+            ExprKind::Assert { condition, message } | ExprKind::Check { condition, message } => {
+                self.desugar_expr(condition);
+                if let Some(m) = message { self.desugar_expr(m); }
+            }
+            ExprKind::Select { arms, .. } => {
+                for arm in arms {
+                    match &mut arm.kind {
+                        rask_ast::expr::SelectArmKind::Recv { channel, .. } => self.desugar_expr(channel),
+                        rask_ast::expr::SelectArmKind::Send { channel, value } => {
+                            self.desugar_expr(channel);
+                            self.desugar_expr(value);
+                        }
+                        rask_ast::expr::SelectArmKind::Default => {}
+                    }
+                    self.desugar_expr(&mut arm.body);
+                }
+            }
+            ExprKind::UsingBlock { args, body, .. } => {
+                for a in args { self.desugar_expr(&mut a.expr); }
+                for s in body { self.desugar_stmt(s); }
+            }
+            // Terminals
+            ExprKind::Int(_, _) | ExprKind::Float(_, _) | ExprKind::String(_)
+            | ExprKind::Char(_) | ExprKind::Bool(_) | ExprKind::Ident(_) | ExprKind::Null => {}
+        }
+
+        // After recursing, try to resolve defaults at this call site
+        self.try_resolve_call(expr);
+    }
+
+    fn try_resolve_call(&mut self, expr: &mut Expr) {
+        match &mut expr.kind {
+            ExprKind::Call { func, args } => {
+                if let ExprKind::Ident(name) = &func.kind {
+                    if let Some(params) = self.lookup.lookup_function(name) {
+                        let params = params.to_vec();
+                        let next_id = &mut self.next_id;
+                        let mut id_gen = || {
+                            let id = NodeId(*next_id);
+                            *next_id += 1;
+                            id
+                        };
+                        if let Some(resolved) = resolve_call_args(&params, args, &mut id_gen) {
+                            *args = resolved;
+                        }
+                    }
+                }
+            }
+            ExprKind::MethodCall { object, method, args, .. } => {
+                // Static method: Type.method(...)
+                let params = if let ExprKind::Ident(type_name) = &object.kind {
+                    self.lookup.lookup_static_method(type_name, method)
+                        .map(|p| p.to_vec())
+                } else {
+                    // Instance method fallback: look up by method name
+                    self.lookup.lookup_instance_method(method)
+                        .map(|p| p.to_vec())
+                };
+
+                if let Some(params) = params {
+                    let next_id = &mut self.next_id;
+                    let mut id_gen = || {
+                        let id = NodeId(*next_id);
+                        *next_id += 1;
+                        id
+                    };
+                    if let Some(resolved) = resolve_call_args(&params, args, &mut id_gen) {
+                        *args = resolved;
+                    }
+                }
+            }
+            _ => {}
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use rask_ast::Span;
+
+    fn sp() -> Span { Span::new(0, 0) }
+    fn int_expr(v: i64) -> Expr {
+        Expr { id: NodeId(0), kind: ExprKind::Int(v, None), span: sp() }
+    }
+    fn str_expr(s: &str) -> Expr {
+        Expr { id: NodeId(0), kind: ExprKind::String(s.to_string()), span: sp() }
+    }
+
+    fn make_param(name: &str, ty: &str, default: Option<Expr>) -> Param {
+        Param {
+            name: name.to_string(),
+            name_span: sp(),
+            ty: ty.to_string(),
+            is_take: false,
+            is_mutate: false,
+            default,
+        }
+    }
+
+    fn make_arg(expr: Expr) -> CallArg {
+        CallArg { name: None, mode: ArgMode::Default, expr }
+    }
+
+    fn make_named_arg(name: &str, expr: Expr) -> CallArg {
+        CallArg { name: Some(name.to_string()), mode: ArgMode::Default, expr }
+    }
+
+    #[test]
+    fn trailing_defaults_filled() {
+        let params = vec![
+            make_param("host", "string", None),
+            make_param("port", "i32", Some(int_expr(8080))),
+            make_param("timeout", "i32", Some(int_expr(30))),
+        ];
+        let args = vec![make_arg(str_expr("localhost"))];
+        let mut next = 100;
+        let resolved = resolve_call_args(&params, &args, &mut || {
+            next += 1;
+            NodeId(next)
+        });
+        let resolved = resolved.expect("should resolve");
+        assert_eq!(resolved.len(), 3);
+    }
+
+    #[test]
+    fn named_arg_skips_middle_param() {
+        let params = vec![
+            make_param("host", "string", None),
+            make_param("port", "i32", Some(int_expr(8080))),
+            make_param("timeout", "i32", Some(int_expr(30))),
+        ];
+        // connect("localhost", timeout: 60)
+        let args = vec![
+            make_arg(str_expr("localhost")),
+            make_named_arg("timeout", int_expr(60)),
+        ];
+        let mut next = 100;
+        let resolved = resolve_call_args(&params, &args, &mut || {
+            next += 1;
+            NodeId(next)
+        });
+        let resolved = resolved.expect("should resolve");
+        assert_eq!(resolved.len(), 3);
+        // Second arg should be the default 8080
+        match &resolved[1].expr.kind {
+            ExprKind::Int(v, _) => assert_eq!(*v, 8080),
+            _ => panic!("expected default int 8080"),
+        }
+        // Third arg should be the provided 60
+        match &resolved[2].expr.kind {
+            ExprKind::Int(v, _) => assert_eq!(*v, 60),
+            _ => panic!("expected provided int 60"),
+        }
+    }
+
+    #[test]
+    fn all_named_args() {
+        let params = vec![
+            make_param("host", "string", None),
+            make_param("port", "i32", Some(int_expr(8080))),
+            make_param("timeout", "i32", Some(int_expr(30))),
+        ];
+        // connect(host: "localhost", timeout: 60)
+        let args = vec![
+            make_named_arg("host", str_expr("localhost")),
+            make_named_arg("timeout", int_expr(60)),
+        ];
+        let mut next = 100;
+        let resolved = resolve_call_args(&params, &args, &mut || {
+            next += 1;
+            NodeId(next)
+        });
+        let resolved = resolved.expect("should resolve");
+        assert_eq!(resolved.len(), 3);
+    }
+
+    #[test]
+    fn no_defaults_no_change() {
+        let params = vec![
+            make_param("a", "i32", None),
+            make_param("b", "i32", None),
+        ];
+        let args = vec![make_arg(int_expr(1)), make_arg(int_expr(2))];
+        let mut next = 100;
+        let resolved = resolve_call_args(&params, &args, &mut || {
+            next += 1;
+            NodeId(next)
+        });
+        assert!(resolved.is_none(), "fully positional with no defaults should return None");
+    }
+
+    #[test]
+    fn missing_required_bails() {
+        let params = vec![
+            make_param("host", "string", None),
+            make_param("port", "i32", None),
+        ];
+        let args = vec![make_arg(str_expr("localhost"))];
+        let mut next = 100;
+        let resolved = resolve_call_args(&params, &args, &mut || {
+            next += 1;
+            NodeId(next)
+        });
+        assert!(resolved.is_none(), "missing required param should bail");
+    }
+
+    #[test]
+    fn valid_default_exprs() {
+        assert!(is_valid_default_expr(&int_expr(42)));
+        assert!(is_valid_default_expr(&str_expr("hello")));
+        assert!(is_valid_default_expr(&Expr {
+            id: NodeId(0),
+            kind: ExprKind::Bool(true),
+            span: sp(),
+        }));
+        // Enum path: Color.Red
+        assert!(is_valid_default_expr(&Expr {
+            id: NodeId(0),
+            kind: ExprKind::Field {
+                object: Box::new(Expr {
+                    id: NodeId(0),
+                    kind: ExprKind::Ident("Color".to_string()),
+                    span: sp(),
+                }),
+                field: "Red".to_string(),
+            },
+            span: sp(),
+        }));
+    }
+
+    #[test]
+    fn invalid_default_rejects_function_call() {
+        let call_expr = Expr {
+            id: NodeId(0),
+            kind: ExprKind::Call {
+                func: Box::new(Expr {
+                    id: NodeId(0),
+                    kind: ExprKind::Ident("compute".to_string()),
+                    span: sp(),
+                }),
+                args: vec![],
+            },
+            span: sp(),
+        };
+        assert!(!is_valid_default_expr(&call_expr));
+    }
+}

--- a/compiler/crates/rask-desugar/src/lib.rs
+++ b/compiler/crates/rask-desugar/src/lib.rs
@@ -1,13 +1,19 @@
 // SPDX-License-Identifier: (MIT OR Apache-2.0)
-//! Operator desugaring pass for Rask.
+//! Desugaring passes for Rask.
 //!
-//! Transforms binary operators into method calls:
+//! Operator desugaring transforms binary operators into method calls:
 //! - `a + b` → `a.add(b)`
 //! - `a - b` → `a.sub(b)`
 //! - `a == b` → `a.eq(b)`
 //! - etc.
 //!
-//! This pass runs before type checking.
+//! Default argument desugaring fills in missing call arguments from
+//! parameter defaults and resolves named arguments to positional form.
+//!
+//! These passes run before type checking.
+
+mod defaults;
+pub use defaults::{desugar_default_args, is_valid_default_expr};
 
 use rask_ast::decl::{Decl, DeclKind, FnDecl, StructDecl, EnumDecl, TraitDecl, ImplDecl};
 use rask_ast::expr::{ArgMode, BinOp, CallArg, Expr, ExprKind, MatchArm, UnaryOp};
@@ -354,7 +360,7 @@ impl Desugarer {
                             object: Box::new(left_expr),
                             method: "eq".to_string(),
                             type_args: None,
-                            args: vec![CallArg { mode: ArgMode::Default, expr: right_expr }],
+                            args: vec![CallArg { name: None, mode: ArgMode::Default, expr: right_expr }],
                         },
                         span,
                     };
@@ -367,7 +373,7 @@ impl Desugarer {
                         object: Box::new(left_expr),
                         method: method.to_string(),
                         type_args: None,
-                        args: vec![CallArg { mode: ArgMode::Default, expr: right_expr }],
+                        args: vec![CallArg { name: None, mode: ArgMode::Default, expr: right_expr }],
                     };
                 }
             }
@@ -464,7 +470,7 @@ impl Desugarer {
                     object: Box::new(result),
                     method: "concat".to_string(),
                     type_args: None,
-                    args: vec![CallArg { mode: ArgMode::Default, expr: seg_expr }],
+                    args: vec![CallArg { name: None, mode: ArgMode::Default, expr: seg_expr }],
                 },
                 span,
             };

--- a/compiler/crates/rask-fmt/src/printer.rs
+++ b/compiler/crates/rask-fmt/src/printer.rs
@@ -929,6 +929,10 @@ impl<'a> Printer<'a> {
     // --- Expressions ---
 
     fn format_call_arg(&mut self, arg: &CallArg) {
+        if let Some(ref name) = arg.name {
+            self.emit(name);
+            self.emit(": ");
+        }
         match arg.mode {
             ArgMode::Mutate => self.emit("mutate "),
             ArgMode::Own => self.emit("own "),

--- a/compiler/crates/rask-hidden-params/src/lib.rs
+++ b/compiler/crates/rask-hidden-params/src/lib.rs
@@ -403,6 +403,7 @@ impl HiddenParamPass {
 
                             // Resolve: use the hidden param from current scope
                             args.push(CallArg {
+                                name: None,
                                 mode: ArgMode::Default,
                                 expr: Expr {
                                     id: self.fresh_id(),

--- a/compiler/crates/rask-interp/src/interp/call.rs
+++ b/compiler/crates/rask-interp/src/interp/call.rs
@@ -11,14 +11,31 @@ use crate::value::Value;
 use super::{Interpreter, RuntimeDiagnostic, RuntimeError};
 
 impl Interpreter {
-    pub(crate) fn call_function(&mut self, func: &FnDecl, args: Vec<Value>) -> Result<Value, RuntimeDiagnostic> {
+    pub(crate) fn call_function(&mut self, func: &FnDecl, mut args: Vec<Value>) -> Result<Value, RuntimeDiagnostic> {
+        // Fill in default values for missing trailing arguments
+        if args.len() < func.params.len() {
+            for i in args.len()..func.params.len() {
+                if let Some(ref default_expr) = func.params[i].default {
+                    let val = self.eval_expr(default_expr)?;
+                    args.push(val);
+                } else {
+                    return Err(RuntimeDiagnostic::new(
+                        RuntimeError::ArityMismatch {
+                            expected: func.params.len(),
+                            got: i,
+                        },
+                        Span::new(0, 0)
+                    ));
+                }
+            }
+        }
         if args.len() != func.params.len() {
             return Err(RuntimeDiagnostic::new(
                 RuntimeError::ArityMismatch {
                     expected: func.params.len(),
                     got: args.len(),
                 },
-                Span::new(0, 0) // Will be re-wrapped by caller with proper span
+                Span::new(0, 0)
             ));
         }
 

--- a/compiler/crates/rask-mir/src/lower/mod.rs
+++ b/compiler/crates/rask-mir/src/lower/mod.rs
@@ -1513,7 +1513,7 @@ mod tests {
             id: NodeId(106),
             kind: ExprKind::Call {
                 func: Box::new(ident_expr(func)),
-                args: args.into_iter().map(|expr| CallArg { mode: ArgMode::Default, expr }).collect(),
+                args: args.into_iter().map(|expr| CallArg { name: None, mode: ArgMode::Default, expr }).collect(),
             },
             span: sp(),
         }
@@ -1549,7 +1549,7 @@ mod tests {
                 object: Box::new(obj),
                 method: method.to_string(),
                 type_args: None,
-                args: args.into_iter().map(|expr| CallArg { mode: ArgMode::Default, expr }).collect(),
+                args: args.into_iter().map(|expr| CallArg { name: None, mode: ArgMode::Default, expr }).collect(),
             },
             span: sp(),
         }

--- a/compiler/crates/rask-mono/src/instantiate.rs
+++ b/compiler/crates/rask-mono/src/instantiate.rs
@@ -349,7 +349,7 @@ impl TypeSubstitutor {
                 // Calls
                 ExprKind::Call { func, args } => ExprKind::Call {
                     func: Box::new(self.clone_expr(func)),
-                    args: args.iter().map(|a| CallArg { mode: a.mode, expr: self.clone_expr(&a.expr) }).collect(),
+                    args: args.iter().map(|a| CallArg { name: a.name.clone(), mode: a.mode, expr: self.clone_expr(&a.expr) }).collect(),
                 },
                 ExprKind::MethodCall {
                     object,
@@ -364,7 +364,7 @@ impl TypeSubstitutor {
                             .map(|t| self.substitute_type_string(t))
                             .collect()
                     }),
-                    args: args.iter().map(|a| CallArg { mode: a.mode, expr: self.clone_expr(&a.expr) }).collect(),
+                    args: args.iter().map(|a| CallArg { name: a.name.clone(), mode: a.mode, expr: self.clone_expr(&a.expr) }).collect(),
                 },
 
                 // Access
@@ -500,7 +500,7 @@ impl TypeSubstitutor {
                 // Context blocks
                 ExprKind::UsingBlock { name, args, body } => ExprKind::UsingBlock {
                     name: name.clone(),
-                    args: args.iter().map(|a| CallArg { mode: a.mode, expr: self.clone_expr(&a.expr) }).collect(),
+                    args: args.iter().map(|a| CallArg { name: a.name.clone(), mode: a.mode, expr: self.clone_expr(&a.expr) }).collect(),
                     body: body.iter().map(|s| self.clone_stmt(s)).collect(),
                 },
                 ExprKind::WithAs { bindings, body } => ExprKind::WithAs {

--- a/compiler/crates/rask-mono/src/lib.rs
+++ b/compiler/crates/rask-mono/src/lib.rs
@@ -140,7 +140,7 @@ mod tests {
             id: NodeId(102),
             kind: ExprKind::Call {
                 func: Box::new(ident_expr(func_name)),
-                args: args.into_iter().map(|expr| CallArg { mode: ArgMode::Default, expr }).collect(),
+                args: args.into_iter().map(|expr| CallArg { name: None, mode: ArgMode::Default, expr }).collect(),
             },
             span: sp(),
         }
@@ -571,7 +571,7 @@ mod tests {
                 object: Box::new(object),
                 method: method.to_string(),
                 type_args: None,
-                args: args.into_iter().map(|expr| CallArg { mode: ArgMode::Default, expr }).collect(),
+                args: args.into_iter().map(|expr| CallArg { name: None, mode: ArgMode::Default, expr }).collect(),
             },
             span: sp(),
         }

--- a/compiler/crates/rask-parser/src/parser.rs
+++ b/compiler/crates/rask-parser/src/parser.rs
@@ -782,6 +782,23 @@ impl Parser {
             self.skip_newlines();
         }
 
+        // Validate: optional params (with defaults) must come after all required params
+        let mut saw_default = false;
+        for param in &params {
+            if param.name == "self" { continue; }
+            if param.default.is_some() {
+                saw_default = true;
+            } else if saw_default {
+                return Err(ParseError::expected(
+                    "default value",
+                    &TokenKind::Eq,
+                    param.name_span,
+                ).with_hint(
+                    "Required parameters must come before optional ones. Add a default value with `= expr`"
+                ));
+            }
+        }
+
         Ok(params)
     }
 
@@ -3051,13 +3068,23 @@ impl Parser {
         if self.check(&TokenKind::RParen) { return Ok(args); }
 
         loop {
-            // Skip named argument labels (name: expr)
-            if let TokenKind::Ident(_) = self.current_kind().clone() {
+            // Capture named argument labels (name: expr)
+            let arg_name = if let TokenKind::Ident(_) = self.current_kind().clone() {
                 if self.peek(1) == &TokenKind::Colon {
+                    let name = if let TokenKind::Ident(n) = self.current_kind().clone() {
+                        n.clone()
+                    } else {
+                        unreachable!()
+                    };
                     self.advance();
                     self.advance();
+                    Some(name)
+                } else {
+                    None
                 }
-            }
+            } else {
+                None
+            };
 
             // Capture call-site mode keywords
             let mode = if self.check(&TokenKind::MutateKw) {
@@ -3071,7 +3098,7 @@ impl Parser {
             };
 
             let expr = self.parse_expr()?;
-            args.push(CallArg { mode, expr });
+            args.push(CallArg { name: arg_name, mode, expr });
             self.skip_newlines();
             if !self.match_token(&TokenKind::Comma) { break; }
             self.skip_newlines();


### PR DESCRIPTION
## Summary
This PR adds support for default parameters and named arguments in function calls. A new desugaring pass processes function declarations to build a lookup table of function signatures, then rewrites call sites to fill in missing arguments with defaults and resolve named arguments to positional form.

## Key Changes

- **New desugaring module** (`rask-desugar/src/defaults.rs`): Implements the core logic for default argument and named argument resolution
  - `desugar_default_args()`: Main entry point that builds a function lookup table and traverses all declarations
  - `resolve_call_args()`: Resolves call arguments against function parameters, handling named args and filling defaults
  - `is_valid_default_expr()`: Validates that default expressions are compile-time evaluable (literals, enum paths, arrays, tuples)
  - Comprehensive test suite covering trailing defaults, named argument skipping, all-named args, and error cases

- **Parser updates** (`rask-parser/src/parser.rs`):
  - Capture named argument labels in call expressions (previously skipped)
  - Add validation that required parameters must come before optional ones
  - Store argument names in `CallArg` for later resolution

- **AST updates** (`rask-ast/src/expr.rs`):
  - Add `name: Option<String>` field to `CallArg` struct to track named arguments

- **Formatter updates** (`rask-fmt/src/printer.rs`):
  - Format named arguments with `name: expr` syntax when printing

- **Interpreter updates** (`rask-interp/src/interp/call.rs`):
  - Fill in default values for missing trailing arguments at runtime
  - Proper error reporting for arity mismatches

- **Pipeline integration** (`rask-cli/src/commands/pipeline.rs`):
  - Add `desugar_default_args()` call after operator desugaring in the frontend pipeline

- **Test infrastructure updates**: Update test helpers in `rask-mir`, `rask-mono`, and `rask-hidden-params` to include the new `name` field in `CallArg` construction

## Implementation Details

The desugaring pass runs after operator desugaring but before type checking. It uses a two-phase approach:
1. **Lookup table building**: Scans all declarations to extract function signatures with default parameters
2. **Call site rewriting**: Traverses expressions to find call sites and resolve arguments

Named arguments can skip intermediate parameters (e.g., `connect("localhost", timeout: 60)` fills the `port` parameter with its default). The implementation handles both free functions and methods (static and instance), with fallback to method-name-only lookup when type information isn't available.

Default expressions are cloned with fresh NodeIds to avoid collisions when the same default is used multiple times.

https://claude.ai/code/session_01JCsfxqwrqtvo8d9m8HKzX3