### PR TITLE
Add try...else syntax and ContextError for error context chains

### DIFF
--- a/examples/file_copy.rk
+++ b/examples/file_copy.rk
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: (MIT OR Apache-2.0)
 // File Copy Utility
 // Demonstrates: CLI arg parsing, structs, enums, match, error propagation,
-//               closures (map_err), string interpolation, file I/O
+//               try...else error wrapping, string interpolation, file I/O
 
 import fs
 import cli
@@ -92,7 +92,7 @@ func copy_file(opts: CopyOptions) -> i64 or CopyError {
 
     // Check not same file (using canonical paths)
     const src_canonical = try fs.canonicalize(opts.source.clone())
-        .map_err(|e| CopyError.ReadError(e))
+        else |e| CopyError.ReadError(e)
     const dst_canonical = fs.canonicalize(opts.dest.clone()).ok()
 
     if dst_canonical is Some(dst) {
@@ -103,7 +103,7 @@ func copy_file(opts: CopyOptions) -> i64 or CopyError {
 
     // Copy the file
     const bytes = try fs.copy(opts.source.clone(), opts.dest.clone())
-        .map_err(|e| CopyError.WriteError(e))
+        else |e| CopyError.WriteError(e)
 
     return Ok(bytes)
 }

--- a/examples/grep_clone.rk
+++ b/examples/grep_clone.rk
@@ -95,7 +95,7 @@ func line_matches(line: string, pattern: string, ignore_case: bool) -> bool {
 
 func grep_file(path: string, opts: Options) -> i64 or GrepError {
     const content = try fs.read_file(path.clone())
-        .map_err(|e| GrepError.FileError(e))
+        else |e| GrepError.FileError(e)
 
     const lines = content.lines()
     let match_count: i64 = 0

--- a/specs/canonical-patterns.md
+++ b/specs/canonical-patterns.md
@@ -138,10 +138,10 @@ Future stdlib additions must follow these patterns; `rask lint` enforces them. S
 
 ## Error Handling
 
-Propagate with `try`, handle with `match`. There's no third style.
+Propagate with `try`, handle with `match`, add context with `try...else`.
 
 ```rask
-// Propagation — pass the error up to the caller
+// Propagation — pass the error up as-is
 func load_config(path: string) -> Config or IoError {
     const text = try fs.read_file(path)
     const config = try Config.from_str(text)
@@ -161,10 +161,36 @@ func get_user(id: i64) -> User or NotFound {
 }
 ```
 
+### Error context
+
+Use `try...else` to add context when propagating errors. Two tiers depending on who consumes the error:
+
+```rask
+// Application code — human-readable context chains
+func load_config(path: string) -> Config or ContextError {
+    const text = try fs.read_file(path) else |e| context("reading {path}", e)
+    return try Config.parse(text) else |e| context("parsing {path}", e)
+}
+// Output: "reading /app.toml: file not found"
+
+// Library code — typed domain errors (callers can match)
+func load_config(path: string) -> Config or ConfigError {
+    const text = try fs.read_file(path) else |e| ConfigError.Io { path, source: e }
+    return try Config.parse(text) else |e| ConfigError.Parse { path, source: e }
+}
+
+// Block form — when you need side effects before propagating
+const text = try fs.read_file(path) else |e| {
+    log("failed to read {path}: {e.message()}")
+    context("reading {path}", e)
+}
+```
+
 **Anti-patterns:**
 - `x!` in production code — crashes on error. Use `try` or `match`.
 - Long `if result is Err(e)` chains — use `try` for propagation.
 - Ignoring errors silently — always handle or propagate.
+- Using `context()` in library code where callers need to match on error types — use typed domain errors with `try...else` instead.
 
 See [types/error-types.md](types/error-types.md).
 
@@ -551,7 +577,7 @@ why: `own` transfers ownership — the caller can no longer access the value.
 |-----------|------------------|
 | Construct | Struct literal, `from_*`, `.new()`, `.with_*` |
 | Convert | `as_*` (free), `to_*` (allocates), `into_*` (consumes) |
-| Handle errors | `try` (propagate), `match` (handle) |
+| Handle errors | `try` (propagate), `try...else` (propagate with context), `match` (handle) |
 | Clean up resources | `ensure` |
 | Handle options | `if x is Some`, `??`, guard, `match` |
 | Access collections | `get` (safe), `[i]` (panic), `for` (iterate) |

--- a/specs/types/error-types.md
+++ b/specs/types/error-types.md
@@ -264,6 +264,137 @@ match result {
 }
 ```
 
+## Error Context
+
+Real-world error handling needs context. "IoError: file not found" is useless in production — you need "loading config from /app.toml: file not found". `map_err` handles this but is verbose enough that people skip it.
+
+| Rule | Description |
+|------|-------------|
+| **ER15: try-else** | `try expr else \|e\| error_expr` extracts `Ok` or transforms the error and returns `Err(error_expr)` from the current function |
+| **ER16: ContextError type** | `ContextError` is a stdlib type with `context: string` and `source: string` fields, satisfying `Error` |
+| **ER17: context() function** | `context(msg, err)` creates a `ContextError` from any `Error`, stringifying the source |
+| **ER18: Linear incompatibility** | `context()` is a compile error when the error type contains linear resources — must handle resources explicitly |
+
+### try-else
+
+`try...else` extends `try` with an error transformation clause. Follows the same `else |e|` pattern established by `ensure` ([ctrl.ensure/ER2](../control/ensure.md)).
+
+<!-- test: skip -->
+```rask
+// ensure's else (existing) — same pattern
+ensure file.close() else |e| log(e)
+
+// try's else (new) — transforms error, then propagates
+const text = try fs.read_file(path) else |e| context("reading {path}", e)
+```
+
+Desugars to:
+
+<!-- test: skip -->
+```rask
+const text = match fs.read_file(path) {
+    Ok(v) => v,
+    Err(e) => return Err(context("reading {path}", e)),
+}
+```
+
+Both expression and block forms work, matching Rask's block semantics (last expression = value):
+
+<!-- test: skip -->
+```rask
+// Expression form
+const text = try fs.read_file(path) else |e| context("reading {path}", e)
+
+// Block form — when you need multiple statements
+const text = try fs.read_file(path) else |e| {
+    log("failed to read {path}: {e.message()}")
+    context("reading {path}", e)
+}
+```
+
+`try...else` is general-purpose — works for string context AND typed error wrapping:
+
+<!-- test: skip -->
+```rask
+// Application code — string context chains
+func load_config(path: string) -> Config or ContextError {
+    const text = try fs.read_file(path) else |e| context("reading {path}", e)
+    return try Config.parse(text) else |e| context("parsing {path}", e)
+}
+
+// Library code — typed domain errors
+func load_config(path: string) -> Config or ConfigError {
+    const text = try fs.read_file(path) else |e| ConfigError.Io { path, source: e }
+    return try Config.parse(text) else |e| ConfigError.Parse { path, source: e }
+}
+```
+
+`try`, `map_err`, and `try...else` are complementary:
+- `map_err` — transforms the error type without propagating
+- `try` — propagates without transforming
+- `try...else` — transforms AND propagates in one step
+
+### ContextError and context()
+
+`ContextError` is a stdlib type for application-level code that doesn't need typed errors. The `context()` free function wraps any error into a `ContextError`, stringifying the source.
+
+<!-- test: parse -->
+```rask
+struct ContextError {
+    context: string
+    source: string
+}
+
+extend ContextError {
+    func message(self) -> string {
+        return "{self.context}: {self.source}"
+    }
+}
+
+func context<E: Error>(msg: string, err: E) -> ContextError {
+    return ContextError { context: msg, source: err.message() }
+}
+```
+
+`ContextError` satisfies `Error` (has `message()`), so context chains naturally:
+
+<!-- test: skip -->
+```rask
+func main() -> () or ContextError {
+    const config = try load_config("app.toml") else |e| context("starting app", e)
+    // Chain: "starting app: reading config: file not found: /app.toml"
+}
+```
+
+### Linear resource constraint
+
+`context()` stringifies errors via `message()`. If the error contains a linear resource, the original error would be discarded without consuming the resource — compile error. Handle resources explicitly in the `else` block instead:
+
+<!-- test: skip -->
+```rask
+// Compile error: context() cannot stringify errors with linear resources
+const data = try file.read_all() else |e| context("reading", e)
+
+// OK: explicitly handle the resource
+const data = try file.read_all() else |e| {
+    match e {
+        FileError.ReadFailed(file, reason) => {
+            file.close()
+            context("reading", reason)
+        }
+    }
+}
+```
+
+### When to use which
+
+| Consumer | Tool | Error type |
+|----------|------|-----------|
+| Machine (match, retry, status codes) | `try...else \|e\| DomainError.Variant { ... }` | Typed enums |
+| Human (logs, stderr, CLI) | `try...else \|e\| context("msg", e)` | `ContextError` |
+
+The boundary is who consumes the error, not lib vs app.
+
 ## Operator Family
 
 | Syntax | Option | Result |
@@ -288,6 +419,8 @@ Optional sugar (`T?`, `x?.field`, `x ?? y`) is distinct from `try` propagation �
 | Wildcard on linear error payload | ER14 | Compile error — must consume |
 | Nested `try` in closures | ER4 | Propagates to closure's return, not enclosing function |
 | `try` binding with method chain | ER5 | Binds to full expression; use parens to chain after |
+| `try...else` error type mismatch | ER15 | Compile error — else expression must match function's error return type |
+| `context()` on linear error type | ER18 | Compile error — must handle linear resources explicitly |
 
 ---
 
@@ -304,6 +437,12 @@ Optional sugar (`T?`, `x?.field`, `x ?? y`) is distinct from `try` propagation �
 **Operator split (`try` vs `?`):** `try` is for propagation (both Result and Option). `?` is reserved for Option sugar only — type suffix, chaining, defaults, smart unwrap. This avoids Rust's overloading where `?` means different things in different contexts.
 
 **`??` not on Result:** Silently discarding errors masks real problems. `.on_err(default)` makes the intent explicit.
+
+**ER15 (try-else):** `try + map_err` is the most common error handling pattern — nearly every `try` in real code transforms the error. Fusing them into `try...else` reduces ceremony. The `else |e|` pattern already exists in `ensure` (ctrl.ensure/ER2), so no new concepts needed.
+
+**ER16/ER17 (ContextError):** Typed domain errors (`map_err` with custom enums) are right for code that callers match on. But application-level code — `main()`, CLI handlers, request handlers — just needs human-readable chains. `ContextError` fills that gap without forcing every app to define boilerplate error enums.
+
+**ER18 (linear incompatibility):** `context()` stringifies errors, which borrows via `message()` but doesn't consume linear resources in the error payload. Silently dropping a `@resource` would violate linear consumption guarantees. The `else` block form lets you explicitly consume the resource before wrapping.
 
 ### Patterns & Guidance
 

--- a/stdlib/error_context.rk
+++ b/stdlib/error_context.rk
@@ -1,0 +1,24 @@
+// SPDX-License-Identifier: (MIT OR Apache-2.0)
+
+import error.Error
+
+/// An error wrapping a human-readable context message around a stringified source error.
+/// Use with `try...else` for application-level error chains.
+public struct ContextError {
+    public context: string
+    public source: string
+}
+
+extend ContextError {
+    public func message(self) -> string {
+        return "{self.context}: {self.source}"
+    }
+}
+
+/// Wrap any error with a context message, stringifying the source.
+///
+/// Intended for use with `try...else`:
+///     const text = try fs.read_file(path) else |e| context("reading {path}", e)
+public func context<E: Error>(msg: string, err: E) -> ContextError {
+    return ContextError { context: msg, source: err.message() }
+}


### PR DESCRIPTION
## Summary

This PR introduces error context handling to Rask through two complementary features: `try...else` syntax for transforming errors during propagation, and `ContextError` stdlib type for building human-readable error chains in application code.

## Key Changes

- **try...else syntax (ER15)**: Extends `try` expressions with an `else |e|` clause that transforms errors before propagating them. Desugars to a `match` with error transformation in the `Err` branch. Supports both expression and block forms.

- **ContextError type (ER16/ER17)**: New stdlib type with `context` and `source` string fields, plus a `context()` free function that wraps any `Error` into a `ContextError` by stringifying the source via `message()`.

- **Linear resource constraint (ER18)**: `context()` is a compile error when the error type contains linear resources, since stringification would discard the resource without consuming it. Users must explicitly handle resources in the `else` block.

- **Documentation**: Added comprehensive spec section covering syntax, desugaring, use cases (typed domain errors vs. human-readable chains), and guidance on when to use `try...else` vs. `map_err` vs. plain `try`.

- **Examples**: Updated `file_copy.rk` and `grep_clone.rk` to use `try...else` instead of `.map_err()` for error transformation, demonstrating the new pattern in practice.

- **Canonical patterns**: Updated error handling guidance to include `try...else` as the standard way to add context when propagating errors, with examples of both application-level (`ContextError`) and library-level (typed domain errors) approaches.

## Implementation Details

- `try...else` is general-purpose and works for both string context chains (via `ContextError`) and typed error wrapping (custom enum variants).
- The `else |e|` pattern reuses the established syntax from `ensure` (ER2), maintaining consistency across the language.
- `ContextError` satisfies the `Error` trait via its `message()` method, enabling natural error chaining.
- The linear resource constraint is enforced at compile time to prevent silent resource leaks.

https://claude.ai/code/session_015K2oDtSB9BKSHEURefUcsv