### PR TITLE
Add iterator terminal operations and sorting to spec

### DIFF
--- a/specs/stdlib/collections.md
+++ b/specs/stdlib/collections.md
@@ -173,6 +173,31 @@ for item in vec.take_all() { }   // item: T (consuming iteration)
 | `vec.drain_where(\|x\| bool)` | `Vec<T>` | Remove and collect. Allocates |
 | `vec.retain(\|x\| bool)` | `()` | Retain non-matching |
 
+## Sorting
+
+| Rule | Description |
+|------|-------------|
+| **SO1: Stable by default** | `sort()` preserves relative order of equal elements |
+| **SO2: In-place** | Sorting mutates the Vec. No new allocation (may use O(log n) stack) |
+| **SO3: Comparable required** | `sort()` requires `T: Comparable`. Custom ordering uses `sort_by` |
+
+| Method | Signature | Semantics |
+|--------|-----------|-----------|
+| `vec.sort()` | `() -> ()` | Stable sort, `T: Comparable` |
+| `vec.sort_by(cmp)` | `(\|T, T\| -> Ordering) -> ()` | Stable sort with custom comparator |
+| `vec.sort_by_key(f)` | `(\|T\| -> K) -> ()` where `K: Comparable` | Stable sort by extracted key |
+
+<!-- test: skip -->
+```rask
+let scores = [3, 1, 4, 1, 5]
+scores.sort()
+// [1, 1, 3, 4, 5]
+
+let users = get_users()
+users.sort_by_key(|u| u.name)
+users.sort_by(|a, b| b.score.compare(a.score))  // descending
+```
+
 ## Shrinking
 
 Infallible, best-effort. If the allocator can't provide a smaller block, the collection keeps its current allocation.
@@ -318,6 +343,9 @@ FIX: Process existing items first, or use an unbounded collection:
 | ZST in `Vec<()>` | — | `len()` tracks count, no storage allocated |
 | `Vec<LinearResource>` | C4 | Compile error |
 | Panic inside `with` | — | Collection left in valid state |
+| `sort()` on empty Vec | SO1 | No-op |
+| `sort()` where `T: !Comparable` | SO3 | Compile error — use `sort_by` |
+| `sort_by` comparator panics | SO2 | Vec left in valid but unspecified order |
 
 ---
 

--- a/specs/types/iterator-protocol.md
+++ b/specs/types/iterator-protocol.md
@@ -34,10 +34,17 @@ trait Iterator<Item> {
 | Adapter | Behavior | Signature |
 |---------|----------|-----------|
 | `.filter(pred)` | Yields items where predicate is true | `(\|Item\| -> bool) -> Filter<Item, Pred>` |
+| `.map(f)` | Transforms each item | `(\|Item\| -> R) -> Map<Item, R, F>` |
+| `.enumerate()` | Pairs each item with its index | `() -> Enumerate<Item>` yielding `(usize, Item)` |
 | `.take(n)` | Yields first n items | `(usize) -> Take<Item>` |
 | `.skip(n)` | Skips first n items | `(usize) -> Skip<Item>` |
 | `.rev()` | Reverses iteration order (requires bidirectional) | `() -> Rev<Item>` |
-| `.map(f)` | Transforms each item | `(\|Item\| -> R) -> Map<Item, R, F>` |
+| `.zip(other)` | Pairs items from two iterators | `(Iterator<U>) -> Zip<Item, U>` yielding `(Item, U)` |
+| `.chain(other)` | Concatenates two iterators | `(Iterator<Item>) -> Chain<Item>` |
+| `.flat_map(f)` | Maps then flattens one level | `(\|Item\| -> Iterator<R>) -> FlatMap<Item, R, F>` |
+| `.flatten()` | Flattens nested iterators one level | `() -> Flatten<Item>` (Item must be Iterator) |
+| `.chunks(n)` | Yields non-overlapping groups of n | `(usize) -> Chunks<Item>` yielding `Vec<Item>` |
+| `.windows(n)` | Yields overlapping windows of n | `(usize) -> Windows<Item>` yielding `Vec<Item>` |
 
 <!-- test: skip -->
 ```rask
@@ -54,6 +61,86 @@ for i in vec.indices().filter(|i| vec[i].active).take(10) {
 | `let iter = vec.indices()` | Yes | No closure yet |
 | `let f = vec.filter(\|i\| vec[i].x)` | No | Closure accesses scope |
 | `let f = range.filter(\|i\| *i > 10)` | Yes | Closure doesn't access scope |
+
+## Terminal Operations
+
+Terminal operations consume the iterator and produce a final value. No further chaining after a terminal.
+
+| Rule | Description |
+|------|-------------|
+| **TE1: Consumption** | Terminal operations take ownership of the iterator. The chain is gone after the call |
+| **TE2: Eager evaluation** | Terminals drive the full chain — nothing runs until a terminal is called |
+| **TE3: Type inference** | `.collect()` infers target collection from context. Defaults to `Vec<Item>` |
+
+### Collection
+
+| Terminal | Behavior | Returns |
+|----------|----------|---------|
+| `.collect()` | Materializes into collection | `Vec<Item>` (default) or inferred from context |
+| `.collect<C>()` | Materializes into specific collection type | `C` where `C: FromIterator<Item>` |
+
+<!-- test: skip -->
+```rask
+const names = users.map(|u| u.name).collect()
+// names: Vec<string>, inferred
+
+const active = users
+    .filter(|u| u.is_active())
+    .map(|u| u.name)
+    .collect()
+
+// Explicit target type via annotation
+const lookup: Map<string, User> = users.map(|u| (u.name, u)).collect()
+```
+
+### Reduction
+
+| Terminal | Behavior | Returns |
+|----------|----------|---------|
+| `.fold(init, f)` | Reduces with initial value | `Acc` |
+| `.reduce(f)` | Reduces without initial value | `Option<Item>` (None if empty) |
+| `.sum()` | Sums items | `Item` (requires `Item: Numeric`) |
+| `.product()` | Multiplies items | `Item` (requires `Item: Numeric`) |
+| `.count()` | Counts elements | `usize` |
+| `.min()` | Smallest item | `Option<Item>` (requires `Item: Comparable`) |
+| `.max()` | Largest item | `Option<Item>` (requires `Item: Comparable`) |
+
+<!-- test: skip -->
+```rask
+const total = orders.map(|o| o.amount).sum()
+const biggest = scores.max()
+
+const csv = names.fold(string.new(), |acc, name| {
+    if acc.is_empty(): return name
+    return format("{acc},{name}")
+})
+```
+
+### Search
+
+| Terminal | Behavior | Returns |
+|----------|----------|---------|
+| `.find(pred)` | First item matching predicate | `Option<Item>` |
+| `.any(pred)` | True if any item matches | `bool` |
+| `.all(pred)` | True if all items match | `bool` |
+
+<!-- test: skip -->
+```rask
+const admin = users.find(|u| u.role == Role.Admin)
+if items.any(|i| i.is_expired()) { alert() }
+```
+
+### Application
+
+| Terminal | Behavior | Returns |
+|----------|----------|---------|
+| `.for_each(f)` | Applies function to each item | `()` |
+
+<!-- test: skip -->
+```rask
+let total = 0
+items.for_each(|item, mutate total| { total += item.value })
+```
 
 ## Built-In Iterator Types
 
@@ -192,6 +279,14 @@ FIX: Store Copy-able indices or handles instead.
 | Nested loops same collection | L3 | Independent iterators, cheap for index-based |
 | `.iterate()` returns non-Iterator | D5 | Compile error |
 | Closure escapes expression scope | AD3 | Compile error |
+| `.collect()` with no type context | TE3 | Defaults to `Vec<Item>` |
+| `.reduce()` on empty iterator | TE1 | Returns `None` |
+| `.sum()` on empty iterator | — | Returns zero value for the type |
+| `.min()` / `.max()` on empty | — | Returns `None` |
+| `.chunks(0)` | — | Panic (chunk size must be > 0) |
+| `.windows(0)` | — | Panic (window size must be > 0) |
+| `.windows(n)` where n > len | — | Yields nothing |
+| `.zip()` unequal lengths | — | Stops at shorter iterator |
 
 ---
 
@@ -202,6 +297,8 @@ FIX: Store Copy-able indices or handles instead.
 **I4 (no stored references):** Rask's "no storable references" rule applies to iterators. Storing a reference to the collection would create lifetime complexity. Index-based iteration avoids this entirely.
 
 **CU3 (iterate doesn't consume):** Vec's `.iterate()` returns a value iterator (borrowed elements), not an owning iterator. The collection remains accessible in the loop body. Use `.take_all()` for ownership transfer.
+
+**TE3 (collect defaults to Vec):** Most `.collect()` calls want a Vec. Requiring a type annotation for the common case adds noise. Annotate only when you want something else (Map, etc.).
 
 ### Patterns & Guidance
 
@@ -236,9 +333,36 @@ for h in pool.handles() {
 }
 ```
 
+**Chained adapter + terminal:**
+
+<!-- test: skip -->
+```rask
+// Filter-map-collect (most common pattern)
+const active_names = users
+    .filter(|u| u.is_active())
+    .map(|u| u.name)
+    .collect()
+
+// Enumerate for indexed processing
+for (i, item) in items.enumerate() {
+    print("{i}: {item}")
+}
+
+// Zip for parallel iteration
+for (name, score) in names.zip(scores) {
+    print("{name}: {score}")
+}
+
+// Fold for custom accumulation
+const csv = names.fold(string.new(), |acc, name| {
+    if acc.is_empty(): return name
+    return format("{acc},{name}")
+})
+```
+
 **Performance guarantees:**
 - Iterator chains must match hand-written loop performance
-- No heap allocations for standard adapters
+- No heap allocations for standard adapters (`.chunks()` and `.windows()` allocate per yield)
 - Closure inlining eliminates call overhead
 - Optimizer fuses chains into single loops
 


### PR DESCRIPTION
## Summary
Expanded the iterator protocol specification with comprehensive documentation of terminal operations and added sorting methods to the Vec collection spec.

## Key Changes

**Iterator Protocol (`specs/types/iterator-protocol.md`):**
- Reorganized adapter methods table for better logical grouping
- Added 6 new adapter methods: `.map()`, `.enumerate()`, `.zip()`, `.chain()`, `.flat_map()`, `.flatten()`, `.chunks()`, `.windows()`
- Added new "Terminal Operations" section documenting operations that consume iterators and produce final values:
  - **Collection**: `.collect()` and `.collect<C>()` with type inference rules
  - **Reduction**: `.fold()`, `.reduce()`, `.sum()`, `.product()`, `.count()`, `.min()`, `.max()`
  - **Search**: `.find()`, `.any()`, `.all()`
  - **Application**: `.for_each()`
- Added terminal operation rules (TE1-TE3) covering consumption, eager evaluation, and type inference
- Expanded edge cases table with terminal operation behaviors (empty iterators, zero-sized chunks/windows, unequal zip lengths)
- Added rationale for `.collect()` defaulting to `Vec<Item>`
- Added comprehensive code examples for chained adapter + terminal patterns (filter-map-collect, enumerate, zip, fold)
- Updated performance guarantees note to clarify that `.chunks()` and `.windows()` allocate per yield

**Collections (`specs/stdlib/collections.md`):**
- Added new "Sorting" section with three sorting rules (SO1-SO3):
  - Stable sort by default
  - In-place mutation semantics
  - Comparable trait requirement
- Added three sorting methods: `sort()`, `sort_by()`, `sort_by_key()`
- Included code examples demonstrating stable sort, custom comparators, and key-based sorting
- Added edge cases for sorting (empty Vec, non-comparable types, panicking comparators)

## Notable Details
- Terminal operations are clearly distinguished from adapters with explicit consumption semantics
- Type inference for `.collect()` defaults to `Vec<Item>` to reduce annotation noise
- Sorting is stable by default and in-place, matching common language conventions
- Edge case documentation covers both common scenarios and error conditions

https://claude.ai/code/session_01VhZH2FtB5C67KpGzsuqRxw