### PR TITLE
Add HTTP, UDP, DNS, subprocess, and signal handling specs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -233,12 +233,15 @@ Start with [CORE_DESIGN.md](specs/CORE_DESIGN.md). For specs: [specs/README.md](
 | C interop | Unsafe blocks, raw pointers | [unsafe.md](specs/memory/unsafe.md) |
 | Rust interop | compile_rust() in build scripts, C ABI, cbindgen | [build.md](specs/structure/build.md) |
 | Encoding | `comptime for` + field access, auto-derived Encode/Decode, field annotations | [encoding.md](specs/stdlib/encoding.md) |
+| Networking | TCP, UDP, DNS resolution | [net.md](specs/stdlib/net.md) |
+| HTTP | Client + server, linear Responder, HttpClient | [http.md](specs/stdlib/http.md) |
+| Time | Duration, Instant, SystemTime, Duration scaling | [time.md](specs/stdlib/time.md) |
+| OS | Env, args, subprocess spawning, signal handling | [os.md](specs/stdlib/os.md) |
 
 ### Open
 
 | Area | Status |
 |------|--------|
-| Stdlib I/O | Not specified (io, fs, net, http) |
 | Build system | Skeleton only |
 | Macros/attributes | Not specified |
 

--- a/specs/stdlib/README.md
+++ b/specs/stdlib/README.md
@@ -42,8 +42,8 @@ Foundational types and modules for systems programming.
 ### Networking & Web
 | Module | Purpose | Status |
 |--------|---------|--------|
-| [net](#net) | TCP/UDP sockets | Planned |
-| [http](#http) | HTTP client and server | Planned |
+| [net](net.md) | TCP/UDP sockets, DNS | Specified |
+| [http](http.md) | HTTP client and server | Specified |
 | [tls](#tls) | TLS/SSL connections | Planned |
 | [url](#url) | URL parsing | Planned |
 
@@ -58,8 +58,8 @@ Foundational types and modules for systems programming.
 | Module | Purpose | Status |
 |--------|---------|--------|
 | [cli](cli.md) | Command-line argument parsing | Specified |
-| [time](#time) | Duration, Instant, timestamps | Specified |
-| [os](os.md) | Platform-specific operations | Specified |
+| [time](time.md) | Duration, Instant, SystemTime | Specified |
+| [os](os.md) | Process, env, subprocess, signals | Specified |
 | [fmt](fmt.md) | String formatting | Specified |
 | [math](math.md) | Mathematical functions | Specified |
 | [random](random.md) | Random number generation | Specified |
@@ -211,13 +211,13 @@ try stream.write_all(request)
 const response = try stream.read_all()
 ```
 
-**Status:** Specified — see [io.md](io.md).
+**Status:** Specified — see [net.md](net.md).
 
 ---
 
 ## Time
 
-Duration, Instant, SystemTime. See [time.md](time.md).
+Duration, Instant (monotonic), SystemTime (wall-clock), Duration arithmetic. See [time.md](time.md).
 
 ---
 
@@ -229,7 +229,7 @@ Cross-platform path manipulation (parent, extension, join). See [path.md](path.m
 
 ## OS
 
-Environment variables, process exit, args. See [os.md](os.md).
+Environment variables, process exit, args, subprocess spawning, signal handling. See [os.md](os.md).
 
 ---
 
@@ -318,7 +318,7 @@ const resp = try client.post("https://api.example.com/submit")
 | `resp.status` | `u16` | Status code |
 | `resp.headers` | `Headers` | Response headers |
 
-**Status:** Planned — detailed specification TODO.
+**Status:** Specified — see [http.md](http.md).
 
 ---
 

--- a/specs/stdlib/http.md
+++ b/specs/stdlib/http.md
@@ -1,0 +1,387 @@
+<!-- id: std.http -->
+<!-- status: decided -->
+<!-- summary: HTTP/1.1 client and server with typed requests, linear server handles -->
+<!-- depends: stdlib/net.md, stdlib/io.md, stdlib/time.md, memory/resource-types.md -->
+
+# HTTP
+
+HTTP/1.1 client and server. Convenience functions for simple requests, `HttpClient` for configuration, `HttpServer` for accept loops with linear response handles.
+
+## Types
+
+| Rule | Description |
+|------|-------------|
+| **T1: Request** | Method, URL, headers, body. Constructable for client, received from server |
+| **T2: Response** | Status code, headers, body. Constructable for server, received from client |
+| **T3: Headers** | Case-insensitive header map |
+| **T4: Method** | Standard HTTP method enum |
+
+<!-- test: skip -->
+```rask
+struct Request {
+    public method: Method
+    public url: string
+    public headers: Headers
+    public body: string
+}
+
+struct Response {
+    public status: u16
+    public headers: Headers
+    public body: string
+}
+
+enum Method { Get, Head, Post, Put, Delete, Patch, Options }
+```
+
+## Headers
+
+| Rule | Description |
+|------|-------------|
+| **H1: Case-insensitive** | Header name lookup is case-insensitive (`"Content-Type"` matches `"content-type"`) |
+| **H2: Multi-value** | Multiple values for the same header are comma-joined per RFC 7230 |
+
+<!-- test: skip -->
+```rask
+struct Headers { }
+
+extend Headers {
+    func new() -> Headers
+    func get(self, name: string) -> string?
+    func set(mutate self, name: string, value: string)
+    func has(self, name: string) -> bool
+    func remove(mutate self, name: string) -> string?
+    func len(self) -> usize
+    func iter(self) -> Iterator<(string, string)>
+}
+```
+
+## Request API
+
+<!-- test: skip -->
+```rask
+extend Request {
+    func new(method: Method, url: string) -> Request
+    func with_header(take self, name: string, value: string) -> Request
+    func with_body(take self, body: string) -> Request
+
+    func path(self) -> string                      // URL path before '?'
+    func query_param(self, name: string) -> string? // single query parameter
+    func query_params(self) -> Map<string, string>  // all query parameters
+}
+```
+
+## Response API
+
+| Rule | Description |
+|------|-------------|
+| **R1: Status helpers** | Named constructors for common status codes |
+| **R2: Status categories** | `is_ok()`, `is_error()` etc. check status code ranges |
+
+<!-- test: skip -->
+```rask
+extend Response {
+    // Constructors
+    func new(status: u16, body: string) -> Response
+    func ok(body: string) -> Response                  // 200
+    func json(body: string) -> Response                // 200 + Content-Type: application/json
+    func created(body: string) -> Response             // 201
+    func no_content() -> Response                      // 204
+    func not_found() -> Response                       // 404
+    func bad_request(message: string) -> Response      // 400
+    func internal_error(message: string) -> Response   // 500
+    func redirect(url: string) -> Response             // 302
+
+    // Builder
+    func with_status(take self, status: u16) -> Response
+    func with_header(take self, name: string, value: string) -> Response
+
+    // Status checks
+    func is_ok(self) -> bool            // 200-299
+    func is_redirect(self) -> bool      // 300-399
+    func is_client_error(self) -> bool  // 400-499
+    func is_server_error(self) -> bool  // 500-599
+}
+```
+
+## Client
+
+| Rule | Description |
+|------|-------------|
+| **C1: Module convenience** | `http.get()`, `http.post()` etc. for one-off requests. Uses a shared internal client |
+| **C2: Full request** | `http.request(req)` for custom method, headers, body |
+| **C3: HttpClient** | Configurable client for timeouts, default headers, connection reuse |
+| **C4: Not a resource** | `HttpClient` is not `@resource` — pooled connections close on drop |
+
+<!-- test: skip -->
+```rask
+http.get(url: string) -> Response or HttpError
+http.post(url: string, body: string) -> Response or HttpError
+http.put(url: string, body: string) -> Response or HttpError
+http.delete(url: string) -> Response or HttpError
+http.request(request: Request) -> Response or HttpError
+```
+
+<!-- test: skip -->
+```rask
+import http
+
+const resp = try http.get("http://api.example.com/users")
+if resp.is_ok() {
+    println(resp.body)
+}
+```
+
+### HttpClient
+
+<!-- test: skip -->
+```rask
+struct HttpClient { }
+
+extend HttpClient {
+    func new() -> HttpClient
+    func with_timeout(take self, timeout: Duration) -> HttpClient
+    func with_header(take self, name: string, value: string) -> HttpClient
+    func with_max_redirects(take self, n: u32) -> HttpClient
+
+    func get(self, url: string) -> Response or HttpError
+    func post(self, url: string, body: string) -> Response or HttpError
+    func put(self, url: string, body: string) -> Response or HttpError
+    func delete(self, url: string) -> Response or HttpError
+    func request(self, request: Request) -> Response or HttpError
+}
+```
+
+<!-- test: skip -->
+```rask
+import http
+import time
+
+const client = HttpClient.new()
+    .with_timeout(Duration.seconds(30))
+    .with_header("Authorization", "Bearer token123")
+
+const resp = try client.get("http://api.example.com/users")
+```
+
+## Server
+
+| Rule | Description |
+|------|-------------|
+| **S1: HttpServer** | TCP listener that parses HTTP/1.1. Linear resource — must close |
+| **S2: Responder** | Linear handle for sending exactly one response per request. Compiler guarantees every accepted request gets a response |
+| **S3: Accept loop** | Server yields `(Request, Responder)` pairs. Spawn tasks for concurrent handling |
+
+<!-- test: skip -->
+```rask
+@resource
+struct HttpServer { }
+
+extend HttpServer {
+    func listen(addr: string) -> HttpServer or HttpError
+    func accept(self) -> (Request, Responder) or HttpError
+    func local_addr(self) -> string
+    func close(take self)
+}
+
+@resource
+struct Responder { }
+
+extend Responder {
+    func respond(take self, response: Response) -> () or HttpError
+}
+```
+
+<!-- test: skip -->
+```rask
+import http
+
+func main() -> () or Error {
+    using Multitasking {
+        const server = try HttpServer.listen("0.0.0.0:8080")
+        ensure server.close()
+
+        loop {
+            const (req, responder) = try server.accept()
+            spawn(|| {
+                ensure responder.respond(Response.internal_error("unhandled"))
+                const response = handle(req)
+                responder.respond(response)
+            }).detach()
+        }
+    }
+}
+```
+
+### Convenience Server
+
+| Rule | Description |
+|------|-------------|
+| **S4: listen_and_serve** | One-line server for simple cases. Spawns a green task per request. Requires `using Multitasking` |
+
+<!-- test: skip -->
+```rask
+http.listen_and_serve(
+    addr: string,
+    handler: func(Request) -> Response,
+) -> () or HttpError
+```
+
+<!-- test: skip -->
+```rask
+import http
+
+func main() -> () or Error {
+    using Multitasking {
+        try http.listen_and_serve("0.0.0.0:8080", handle)
+    }
+}
+
+func handle(req: Request) -> Response {
+    return match req.path() {
+        "/health" => Response.ok("ok"),
+        "/users" => handle_users(req),
+        _ => Response.not_found(),
+    }
+}
+
+func handle_users(req: Request) -> Response {
+    if req.method is Method.Get {
+        const users = get_all_users()
+        return Response.json(json.encode(users))
+    }
+    if req.method is Method.Post {
+        const user = json.decode<User>(req.body) is Ok else {
+            return Response.bad_request("invalid json")
+        }
+        save_user(user)
+        return Response.json(json.encode(user)).with_status(201)
+    }
+    return Response.new(405, "method not allowed")
+}
+```
+
+## HttpError
+
+<!-- test: skip -->
+```rask
+enum HttpError {
+    Connection(string)
+    Timeout
+    InvalidUrl(string)
+    InvalidResponse(string)
+    TooManyRedirects
+    Io(IoError)
+}
+```
+
+## Error Messages
+
+```
+ERROR [std.http/S2]: responder not consumed
+   |
+5  |  const (req, responder) = try server.accept()
+   |              ^^^^^^^^^ `Responder` is a @resource that must respond
+
+WHY: Every accepted HTTP request must get a response. Responder is linear.
+
+FIX: Add `ensure responder.respond(Response.internal_error("unhandled"))` after accepting.
+```
+
+```
+ERROR [std.http/C1]: request failed
+   |
+3  |  const resp = try http.get("http://down.example.com")
+   |                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ HttpError.Connection("connection refused")
+
+WHY: Could not establish TCP connection to the remote host.
+```
+
+## Edge Cases
+
+| Case | Behavior | Rule |
+|------|----------|------|
+| Responder not consumed | Compile error | S2 |
+| `ensure` + explicit `respond()` | Safe — ensure's respond is a no-op if already sent | S2 |
+| Redirect loop | `HttpError.TooManyRedirects` (default limit: 10) | C1 |
+| Invalid URL | `HttpError.InvalidUrl` | C1 |
+| Response body too large | Reads fully into memory (no streaming in v1) | T2 |
+| Connection timeout | `HttpError.Timeout` (default: 30s for module functions) | C1 |
+| Malformed HTTP response | `HttpError.InvalidResponse` | C1 |
+| Server accept on closed server | `HttpError.Io(IoError.Other("server closed"))` | S1 |
+| Request with no Content-Type | Header absent, body sent as-is | T1 |
+
+---
+
+## Appendix (non-normative)
+
+### Rationale
+
+**S2 (linear Responder):** I wanted the compiler to guarantee every request gets a response. Forgetting to respond is a common server bug — the client hangs, the connection leaks. Making Responder `@resource` catches this at compile time. The `ensure` pattern provides a fallback response for error paths.
+
+**C4 (HttpClient not @resource):** Connection pools are an optimization, not a correctness obligation. Forcing `.close()` on every client adds ceremony for the 99% case. Pooled connections close on drop — this is the one place I'm OK with implicit cleanup because there's no data loss risk.
+
+**C1 (shared internal client):** Module-level functions (`http.get`, etc.) reuse a shared internal client for connection pooling. Without this, every call does a fresh TCP+TLS handshake. Use `HttpClient.new()` when you need isolation or custom settings.
+
+**S4 (listen_and_serve):** Covers the common pattern of "listen, accept in a loop, spawn a task per request." Three lines instead of ten. For anything more complex (graceful shutdown, connection limits), use the `HttpServer` accept loop directly.
+
+### Deferred
+
+- HTTP/2
+- WebSockets
+- Streaming request/response bodies
+- Server-sent events
+- Cookie jar
+- Proxy support
+- Client certificate authentication
+
+### Validation
+
+This spec enables validation target #1 (HTTP JSON API server):
+
+<!-- test: skip -->
+```rask
+import http
+import json
+
+struct User {
+    public id: u64
+    public name: string
+    public email: string
+}
+
+func main() -> () or Error {
+    using Multitasking {
+        try http.listen_and_serve("0.0.0.0:8080", handle)
+    }
+}
+
+func handle(req: Request) -> Response {
+    return match req.path() {
+        "/health" => Response.ok("ok"),
+        "/users" => match req.method {
+            Method.Get => {
+                const users = db_list_users()
+                Response.json(json.encode(users))
+            },
+            Method.Post => {
+                const user = json.decode<User>(req.body) is Ok else {
+                    return Response.bad_request("invalid json")
+                }
+                const saved = db_create_user(user)
+                Response.json(json.encode(saved)).with_status(201)
+            },
+            _ => Response.new(405, "method not allowed"),
+        },
+        _ => Response.not_found(),
+    }
+}
+```
+
+### See Also
+
+- `std.net` — TCP/UDP transport layer
+- `std.io` — `IoError`, `Reader`/`Writer` traits
+- `std.json` — JSON encoding/decoding for request/response bodies
+- `std.time` — `Duration` for timeouts
+- `mem.resource-types` — `@resource` and `ensure` semantics

--- a/specs/stdlib/http.md
+++ b/specs/stdlib/http.md
@@ -266,7 +266,7 @@ func handle_users(req: Request) -> Response {
 <!-- test: skip -->
 ```rask
 enum HttpError {
-    Connection(string)
+    ConnectionFailed(string)
     Timeout
     InvalidUrl(string)
     InvalidResponse(string)
@@ -292,7 +292,7 @@ FIX: Add `ensure responder.respond(Response.internal_error("unhandled"))` after 
 ERROR [std.http/C1]: request failed
    |
 3  |  const resp = try http.get("http://down.example.com")
-   |                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ HttpError.Connection("connection refused")
+   |                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ HttpError.ConnectionFailed("connection refused")
 
 WHY: Could not establish TCP connection to the remote host.
 ```

--- a/specs/stdlib/net.md
+++ b/specs/stdlib/net.md
@@ -146,8 +146,8 @@ const addrs = try net.resolve("example.com")
 ```rask
 func handle(conn: TcpConnection) -> () or IoError {
     ensure conn.close()
-    const req = try conn.read_http_request()
-    try conn.write_http_response(response)
+    const data = try conn.read_all()
+    try conn.write_all(process(data))
 }
 ```
 

--- a/specs/stdlib/net.md
+++ b/specs/stdlib/net.md
@@ -1,11 +1,11 @@
 <!-- id: std.net -->
 <!-- status: decided -->
-<!-- summary: TCP networking with linear resource handles and string addresses -->
+<!-- summary: TCP/UDP networking and DNS resolution with linear resource handles and string addresses -->
 <!-- depends: stdlib/io.md, memory/resource-types.md -->
 
 # Net
 
-TCP networking with minimal API. String addresses, linear resource handles, built-in HTTP/1.1 convenience methods.
+TCP and UDP networking with DNS resolution. String addresses, linear resource handles. HTTP protocol support is in `std.http`.
 
 ## Types
 
@@ -76,31 +76,63 @@ try conn.write_all("GET / HTTP/1.1\r\nHost: example.com\r\n\r\n")
 const response = try conn.read_all()
 ```
 
-## HTTP Convenience
+## UDP
 
 | Rule | Description |
 |------|-------------|
-| **N6: HTTP on connection** | `read_http_request` and `write_http_response` are methods on `TcpConnection` — no separate HTTP module |
+| **U1: UdpSocket** | Connectionless datagram socket. Linear resource — must close |
+| **U2: Bind** | `net.udp_bind(addr)` creates a socket bound to a local address |
+| **U3: Connect** | `udp.connect(addr)` sets a default peer for `send`/`recv` — no actual handshake |
 
 <!-- test: skip -->
 ```rask
-extend TcpConnection {
-    func read_http_request(self) -> HttpRequest or IoError
-    func write_http_response(self, response: HttpResponse) -> () or IoError
-}
+@resource
+struct UdpSocket { }
 
-struct HttpRequest {
-    public method: string
-    public path: string
-    public headers: Map<string, string>
-    public body: string
-}
+net.udp_bind(addr: string) -> UdpSocket or IoError
+```
 
-struct HttpResponse {
-    public status: i32
-    public headers: Map<string, string>
-    public body: string
+<!-- test: skip -->
+```rask
+extend UdpSocket {
+    func send_to(self, data: []u8, addr: string) -> usize or IoError
+    func recv_from(self, buf: []u8) -> (usize, string) or IoError
+    func connect(self, addr: string) -> () or IoError
+    func send(self, data: []u8) -> usize or IoError     // to connected peer
+    func recv(self, buf: []u8) -> usize or IoError      // from connected peer
+    func local_addr(self) -> string
+    func close(take self)
 }
+```
+
+<!-- test: skip -->
+```rask
+import net
+
+const socket = try net.udp_bind("0.0.0.0:9000")
+ensure socket.close()
+
+let buf = [0u8; 1024]
+const (n, sender) = try socket.recv_from(buf)
+try socket.send_to(buf[0..n], sender)
+```
+
+## DNS
+
+| Rule | Description |
+|------|-------------|
+| **D1: Resolve** | `net.resolve(host)` returns IP address strings for a hostname |
+| **D2: No caching** | The stdlib does not cache DNS results. OS resolver caching applies |
+
+<!-- test: skip -->
+```rask
+net.resolve(host: string) -> Vec<string> or IoError
+```
+
+<!-- test: skip -->
+```rask
+const addrs = try net.resolve("example.com")
+// ["93.184.216.34", "2606:2800:220:1:248:1893:25c8:1946"]
 ```
 
 ## Resource Safety
@@ -150,6 +182,10 @@ WHY: Another process is already listening on this address.
 | Invalid address string | `IoError.Other` | N4, N5 |
 | Remote closes during read | `IoError.ConnectionReset` or empty result | N2 |
 | Accept on closed listener | `IoError.Other("listener closed")` | N1 |
+| UDP `send`/`recv` without `connect` | `IoError.Other("not connected")` | U3 |
+| UDP packet too large for buffer | Truncated, remaining bytes lost | U1 |
+| DNS resolution with no results | Empty `Vec` | D1 |
+| DNS resolution for IP literal | Returns the IP itself | D1 |
 
 ---
 
@@ -159,19 +195,20 @@ WHY: Another process is already listening on this address.
 
 **N3 (string addresses):** No `SocketAddr` or `IpAddr` types. Simpler API, and parsing can be added later without breaking changes.
 
-**N6 (HTTP on TcpConnection):** The common case is "accept, read request, write response, close." A separate `http` module adds ceremony without benefit for simple servers. HTTP/2 or websockets would be a different library.
+**U1 (UDP as linear resource):** Same reasoning as TCP — sockets are OS resources that must be explicitly closed. UDP's connectionless nature doesn't change the resource obligation.
+
+**D1 (string results):** DNS results are IP address strings, consistent with N3's string address philosophy. Parsing into structured types can be added later.
 
 ### Deferred
 
-- UDP sockets
 - Multicast
 - Raw sockets
 - `SocketAddr` / `IpAddr` types
 - TLS / HTTPS
-- HTTP/2, websockets
+- Unix domain sockets
 
 ### See Also
 
+- `std.http` — HTTP/1.1 client and server (application layer)
 - `std.io` — `IoError`, `Reader`/`Writer` traits
-- `std.json` — JSON encoding for HTTP request/response bodies
 - `mem.resource-types` — `@resource` and `ensure` semantics

--- a/specs/stdlib/os.md
+++ b/specs/stdlib/os.md
@@ -1,10 +1,11 @@
 <!-- id: std.os -->
 <!-- status: decided -->
-<!-- summary: Process control, environment variables, platform info -->
+<!-- summary: Process control, environment, platform info, subprocess spawning, signal handling -->
+<!-- depends: stdlib/io.md, stdlib/time.md, concurrency/channels.md -->
 
 # OS
 
-Single `os` module for process and platform interaction: env vars, args, exit, pid, platform info.
+Single `os` module: env vars, args, exit, platform info, subprocess spawning, and signal handling.
 
 ## Environment Variables
 
@@ -53,6 +54,156 @@ func main() {
 }
 ```
 
+## Subprocess
+
+| Rule | Description |
+|------|-------------|
+| **C1: Command builder** | `Command` configures program, args, env, working directory, and I/O before execution |
+| **C2: Run** | `command.run()` executes to completion and captures output |
+| **C3: Spawn** | `command.spawn()` starts the process and returns a linear `Process` handle |
+| **C4: Process resource** | `Process` is `@resource` — must be consumed via `wait()` or `kill_and_wait()` |
+
+<!-- test: skip -->
+```rask
+struct Command { }
+
+extend Command {
+    func new(program: string) -> Command
+    func arg(take self, arg: string) -> Command
+    func args(take self, args: Vec<string>) -> Command
+    func env(take self, key: string, value: string) -> Command
+    func cwd(take self, dir: string) -> Command
+    func stdin(take self, cfg: Stdio) -> Command
+    func stdout(take self, cfg: Stdio) -> Command
+    func stderr(take self, cfg: Stdio) -> Command
+
+    func run(self) -> Output or IoError
+    func spawn(self) -> Process or IoError
+}
+
+enum Stdio { Inherit, Piped, Null }
+```
+
+### Output
+
+<!-- test: skip -->
+```rask
+struct Output {
+    public status: i32
+    public stdout: string
+    public stderr: string
+}
+
+extend Output {
+    func success(self) -> bool    // status == 0
+}
+```
+
+### Process
+
+<!-- test: skip -->
+```rask
+@resource
+struct Process { }
+
+extend Process {
+    func wait(take self) -> Output or IoError
+    func kill_and_wait(take self) -> Output or IoError
+    func try_wait(self) -> Output? or IoError
+    func id(self) -> u32
+    func write_stdin(self, data: string) -> () or IoError
+    func read_stdout(self) -> string or IoError
+}
+```
+
+<!-- test: skip -->
+```rask
+import os
+
+// Run to completion
+const output = try Command.new("ls").arg("-la").run()
+if output.success() {
+    println(output.stdout)
+}
+
+// Spawn and interact
+const proc = try Command.new("grep")
+    .arg("hello")
+    .stdin(Stdio.Piped)
+    .stdout(Stdio.Piped)
+    .spawn()
+ensure proc.kill_and_wait()
+
+try proc.write_stdin("hello world\ngoodbye world\n")
+const result = try proc.read_stdout()
+const output = try proc.wait()
+```
+
+## Signals
+
+| Rule | Description |
+|------|-------------|
+| **SG1: Signal enum** | Named signals for portable handling |
+| **SG2: Channel-based** | `os.on_signal(signals)` returns a `Receiver<Signal>` from the concurrency module |
+| **SG3: Default restored** | When the receiver is dropped, the default OS signal behavior is restored |
+
+<!-- test: skip -->
+```rask
+enum Signal {
+    Interrupt       // SIGINT (Ctrl+C)
+    Terminate       // SIGTERM
+    Hangup          // SIGHUP
+    User1           // SIGUSR1
+    User2           // SIGUSR2
+}
+
+os.on_signal(signals: Vec<Signal>) -> Receiver<Signal> or IoError
+```
+
+<!-- test: skip -->
+```rask
+import os
+
+// Graceful shutdown
+const signals = try os.on_signal([Signal.Interrupt, Signal.Terminate])
+
+// Block until signal received
+const sig = try signals.recv()
+println("Received {sig}, shutting down...")
+cleanup()
+```
+
+<!-- test: skip -->
+```rask
+import os
+
+// Server with graceful shutdown
+func main() -> () or Error {
+    using Multitasking {
+        const signals = try os.on_signal([Signal.Interrupt, Signal.Terminate])
+        const server = try HttpServer.listen("0.0.0.0:8080")
+        ensure server.close()
+
+        const shutdown = spawn(|| {
+            signals.recv()
+        })
+
+        const serve = spawn(|| {
+            loop {
+                const (req, responder) = try server.accept()
+                spawn(|| {
+                    ensure responder.respond(Response.internal_error("error"))
+                    responder.respond(handle(req))
+                }).detach()
+            }
+        })
+
+        // Wait for either shutdown signal or server error
+        select_first(shutdown, serve)
+    }
+}
+```
+
 ## Error Messages
 
 ```
@@ -74,6 +225,14 @@ FIX: Remove unreachable code or move os.exit() to end of block.
 | `os.env("MISSING")` | E1 | Returns `None` |
 | `os.args()` with no args | A1 | Vec contains at least program name |
 | `os.exit(0)` in defer | P1 | Exits immediately, remaining defers skipped |
+| Process not consumed | C4 | Compile error |
+| `wait()` on exited process | C4 | Returns cached Output |
+| `write_stdin` without `Stdio.Piped` | C3 | `IoError.Other("stdin not piped")` |
+| `read_stdout` without `Stdio.Piped` | C3 | `IoError.Other("stdout not piped")` |
+| Program not found | C2 | `IoError.NotFound` |
+| Signal receiver dropped | SG3 | Default OS signal behavior restored |
+| Multiple receivers for same signal | SG2 | Last registration wins, previous receiver gets closed |
+| `SIGKILL` / `SIGSTOP` | SG1 | Not in enum — cannot be caught (OS enforced) |
 
 ---
 
@@ -84,6 +243,14 @@ FIX: Remove unreachable code or move os.exit() to end of block.
 **Single module:** Previous design split env vars, args, and exit across `env`, `cli`, and `std` modules. One `os` import is simpler — these are all process-level operations.
 
 **E1 (returns optional):** Env vars may or may not exist. Returning `string?` forces handling the missing case. `env_or` covers the common "default value" pattern.
+
+**C1 (Command builder):** Builder pattern matches `OpenOptions` in `std.fs`. Each setter returns a new Command. `run()` covers the common case (execute, capture output). `spawn()` is for long-running or interactive processes.
+
+**C4 (linear Process):** A spawned subprocess is an OS resource. Forgetting to wait on it leaves a zombie process. Making it `@resource` catches this at compile time. `kill_and_wait` is the consumption method for `ensure` — guarantees the child is reaped even on error paths.
+
+**SG2 (channel-based signals):** Callbacks in signal context are tricky — limited to async-signal-safe functions, reentrancy issues, can't allocate. Channels avoid all of this. The signal handler writes to a pipe, the channel reads it in normal context. Integrates with `select` for multiplexing.
+
+**SG3 (default restored on drop):** Channels are non-linear (`conc.async/CH1`), so the receiver can go out of scope. When it does, the signal handler is de-registered and the default OS behavior resumes (terminate for SIGINT/SIGTERM). This prevents stale handlers.
 
 ### Patterns & Guidance
 
@@ -131,6 +298,35 @@ func default_config_dir() -> string {
 
 Old import names (`env`, `std`, `cli`) remain as aliases during transition.
 
+**Subprocess pipeline:**
+
+<!-- test: skip -->
+```rask
+// Run a command and check its exit status
+const output = try Command.new("cargo").arg("build").run()
+if !output.success() {
+    println("Build failed: {output.stderr}")
+    os.exit(1)
+}
+```
+
+**Graceful shutdown pattern:**
+
+<!-- test: skip -->
+```rask
+const signals = try os.on_signal([Signal.Interrupt, Signal.Terminate])
+
+// In a select or spawn, wait for signal
+spawn(|| {
+    const sig = try signals.recv()
+    println("Shutting down on {sig}...")
+    shutdown_server()
+}).detach()
+```
+
 ### See Also
 
 - `std.cli` — Structured argument parsing (builds on `os.args()`)
+- `std.io` — `IoError`, `Reader`/`Writer` traits
+- `conc.async` — Channels for signal delivery, `select_first` for shutdown
+- `mem.resource-types` — `@resource` and `ensure` semantics

--- a/specs/stdlib/time.md
+++ b/specs/stdlib/time.md
@@ -1,11 +1,11 @@
 <!-- id: std.time -->
 <!-- status: decided -->
-<!-- summary: Duration (time span) and Instant (monotonic timestamp) for measuring intervals -->
+<!-- summary: Duration, Instant (monotonic), and SystemTime (wall-clock) for time operations -->
 <!-- depends: memory/value-semantics.md -->
 
 # Time
 
-Two types: `Duration` for time spans, `Instant` for monotonic timestamps. Wall-clock time (`SystemTime`) deferred.
+Three types: `Duration` for time spans, `Instant` for monotonic timestamps, `SystemTime` for wall-clock time.
 
 ## Types
 
@@ -87,29 +87,93 @@ ERROR [std.time/S1]: sleep failed
 WHY: Platform-specific sleep failure (rare).
 ```
 
+## SystemTime
+
+| Rule | Description |
+|------|-------------|
+| **W1: Wall-clock** | `SystemTime` represents a point in wall-clock time. Subject to NTP adjustments — can go backward |
+| **W2: UNIX epoch** | Epoch is 1970-01-01 00:00:00 UTC. Serializable (unlike Instant) |
+| **W3: Value type** | Copy, <=16 bytes, no `@resource` |
+
+<!-- test: skip -->
+```rask
+SystemTime.now() -> SystemTime
+SystemTime.unix_epoch() -> SystemTime
+SystemTime.from_unix_secs(secs: i64) -> SystemTime
+SystemTime.from_unix_millis(millis: i64) -> SystemTime
+```
+
+<!-- test: skip -->
+```rask
+extend SystemTime {
+    func unix_secs(self) -> i64
+    func unix_millis(self) -> i64
+    func unix_nanos(self) -> i128
+    func duration_since(self, earlier: SystemTime) -> Duration or TimeError
+    func elapsed(self) -> Duration or TimeError
+}
+```
+
+<!-- test: skip -->
+```rask
+enum TimeError {
+    Backwards    // clock went backward (NTP adjustment)
+}
+```
+
+<!-- test: skip -->
+```rask
+import time
+
+const now = time.SystemTime.now()
+const timestamp = now.unix_secs()         // 1709251200
+const millis = now.unix_millis()          // 1709251200000
+
+// Reconstruct from stored timestamp
+const restored = time.SystemTime.from_unix_secs(timestamp)
+
+// Duration since epoch
+const since_epoch = try now.duration_since(time.SystemTime.unix_epoch())
+```
+
 ## Arithmetic and Comparison
 
 | Rule | Description |
 |------|-------------|
 | **A1: Instant shift** | `instant + duration -> Instant`, `instant - duration -> Instant` |
 | **A2: Instant difference** | `instant - instant -> Duration` |
-| **A3: Duration arithmetic** | `duration + duration -> Duration`, `duration - duration -> Duration` |
-| **A4: Comparison** | `<`, `<=`, `>`, `>=`, `==` on same-type pairs (Instant/Instant or Duration/Duration) |
+| **A3: Duration add/sub** | `duration + duration -> Duration`, `duration - duration -> Duration` |
+| **A4: Duration scaling** | `duration * n -> Duration`, `n * duration -> Duration`, `duration / n -> Duration` |
+| **A5: Duration ratio** | `duration / duration -> u64` (integer ratio, truncated) |
+| **A6: Comparison** | `<`, `<=`, `>`, `>=`, `==` on same-type pairs (Instant, Duration, or SystemTime) |
+| **A7: SystemTime shift** | `systemtime + duration -> SystemTime`, `systemtime - duration -> SystemTime` |
+| **A8: SystemTime difference** | `systemtime - systemtime -> Duration` (wraps if negative — use `duration_since` for checked) |
 
-Both types are nanosecond i64 internally — arithmetic is native integer ops. No overflow checking (wraps).
+Arithmetic is native integer ops on nanosecond values. No overflow checking (wraps).
 
 <!-- test: skip -->
 ```rask
 import time
 
 const start = time.Instant.now()
-time.sleep(time.Duration.from_millis(10))
+time.sleep(time.Duration.millis(10))
 const end = time.Instant.now()
 
 const elapsed = end - start           // Duration
 const later = start + elapsed         // Instant
 const d2 = elapsed + elapsed          // Duration
 const before = end > start            // true
+
+// Duration scaling
+const frame = time.Duration.millis(16)
+const half = frame / 2                // 8ms
+const triple = frame * 3              // 48ms
+const five = 5 * frame                // 80ms
+const ratio = triple / frame          // 3
+
+// SystemTime arithmetic
+const now = time.SystemTime.now()
+const tomorrow = now + time.Duration.seconds(86400)
 ```
 
 ## Edge Cases
@@ -118,9 +182,14 @@ const before = end > start            // true
 |------|----------|------|
 | `Duration.from_secs_f64(0.5000000001)` | Truncated to 500000000 ns | D5 |
 | `Instant` across process restarts | Not comparable — opaque epoch | I2 |
-| `Instant` serialization | Not supported — use `SystemTime` when available | I2 |
+| `Instant` serialization | Not supported — use `SystemTime` | I2 |
 | Sleep interrupted by signal | May return early | S1 |
 | Duration overflow | Wraps (u64 nanoseconds) | D4 |
+| Duration divide by zero | Panic | A4 |
+| `SystemTime` before UNIX epoch | Negative `unix_secs()` | W2 |
+| `SystemTime` NTP adjustment backward | `duration_since` returns `Err(TimeError.Backwards)` | W1 |
+| `SystemTime` serialization | Use `unix_secs()` or `unix_millis()` | W2 |
+| `SystemTime` comparison across machines | Only meaningful if clocks are synchronized | W1 |
 
 ---
 
@@ -132,22 +201,29 @@ const before = end > start            // true
 
 **I2 (opaque epoch):** Monotonic clocks have arbitrary epochs. Exposing the epoch invites bugs where people treat Instant as wall-clock time.
 
-**SystemTime deferred:** Game loops, benchmarks, and timeouts only need Duration + Instant. Wall-clock time adds complexity (leap seconds, NTP adjustments) that can wait.
+**W1 (wall-clock separate from Instant):** Instant is monotonic — always goes forward, perfect for measuring intervals. SystemTime tracks real-world time but can jump (NTP, manual adjustment, leap seconds). Separate types prevent bugs where someone measures a benchmark with wall-clock time or serializes an Instant.
+
+**A4 (Duration scaling):** Scaling is essential for frame timing (`frame_time * frame_count`), timeout adjustment (`base_timeout * retry_count`), and benchmark normalization (`total / iterations`). Deferring this blocked real programs.
 
 ### Platform Mapping
 
-| Platform | Duration | Instant |
-|----------|----------|---------|
-| POSIX | u64 (nanos) | `clock_gettime(CLOCK_MONOTONIC)` |
-| Windows | u64 (nanos) | `QueryPerformanceCounter` |
-| WASM | u64 (nanos) | `performance.now()` |
+| Platform | Duration | Instant | SystemTime |
+|----------|----------|---------|------------|
+| POSIX | u64 (nanos) | `clock_gettime(CLOCK_MONOTONIC)` | `clock_gettime(CLOCK_REALTIME)` |
+| Windows | u64 (nanos) | `QueryPerformanceCounter` | `GetSystemTimePreciseAsFileTime` |
+| WASM | u64 (nanos) | `performance.now()` | `Date.now()` |
 
 ### Deferred
 
-- `SystemTime` — wall-clock with UNIX epoch, serializable
-- Duration scaling: `d1 * n`, `d1 / n`
+- Date/time formatting (RFC 3339, ISO 8601)
+- Time zone support
+- Calendar types (Date, Time, DateTime)
+- Leap second handling
+- `Timer` / periodic tick
 
 ### See Also
 
 - `mem.value-semantics` — Copy types <=16 bytes
 - `std.testing` — Benchmarks use Duration/Instant internally
+- `std.http` — SystemTime used for HTTP Date headers
+- `std.fs` — File timestamps as `u64` (seconds since epoch)


### PR DESCRIPTION
## Summary

This PR adds comprehensive specifications for HTTP/1.1 client and server support, UDP networking, DNS resolution, subprocess spawning, and OS signal handling. It also extends the time module with `SystemTime` for wall-clock operations and updates the net module to clarify the separation of concerns between transport and application layers.

## Key Changes

**New Specifications:**
- **`specs/stdlib/http.md`** — Complete HTTP/1.1 client and server spec with:
  - Typed `Request` and `Response` structs with builder patterns
  - Case-insensitive `Headers` with multi-value support
  - Module-level convenience functions (`http.get()`, `http.post()`, etc.)
  - Configurable `HttpClient` for timeouts, default headers, and connection reuse
  - Linear `HttpServer` and `Responder` resources ensuring every request gets a response
  - `listen_and_serve()` helper for simple server patterns
  - Comprehensive error handling with `HttpError` enum

**Extended Specifications:**
- **`specs/stdlib/os.md`** — Added subprocess and signal handling:
  - `Command` builder for configuring and executing subprocesses
  - `Process` as a linear `@resource` with `wait()`, `kill_and_wait()`, and I/O methods
  - `Output` struct capturing exit status and stdout/stderr
  - `Signal` enum and `os.on_signal()` for channel-based signal handling
  - Graceful shutdown patterns using signal receivers

- **`specs/stdlib/time.md`** — Added `SystemTime` for wall-clock operations:
  - `SystemTime.now()` and UNIX epoch conversions
  - `duration_since()` and `elapsed()` with `TimeError.Backwards` for NTP adjustments
  - Duration scaling operators (`*`, `/`) for frame timing and benchmarks
  - Duration ratio division (`duration / duration -> u64`)
  - Arithmetic with `SystemTime` (addition/subtraction with `Duration`)

- **`specs/stdlib/net.md`** — Clarified transport layer and added UDP/DNS:
  - `UdpSocket` as a linear `@resource` with `send_to()`, `recv_from()`, and connected mode
  - `net.resolve(host)` for DNS resolution returning IP address strings
  - Removed HTTP convenience methods (moved to `std.http`)
  - Updated summary to reflect TCP/UDP + DNS focus

- **`specs/stdlib/README.md`** — Updated module status and links:
  - Marked `net` and `http` as "Specified"
  - Updated `time` and `os` descriptions to reflect new features
  - Fixed links to point to actual spec files

## Notable Design Decisions

1. **Linear Resources for Safety:** `HttpServer`, `Responder`, `Process`, and `UdpSocket` are all `@resource` types, ensuring compile-time guarantees that resources are properly consumed and cleaned up.

2. **Separation of Concerns:** HTTP support is in its own module (`std.http`) rather than on `TcpConnection`, allowing the net module to focus on transport-layer primitives.

3. **Channel-Based Signals:** Signal handling uses channels (`Receiver<Signal>`) rather than callbacks, avoiding async-signal-safety restrictions and integrating naturally with `select` for multiplexing.

4. **Builder Patterns:** Both `Command` and `HttpClient` use builder patterns for ergonomic configuration, consistent with existing stdlib patterns like `OpenOptions`.

5. **Responder Linearity:** The `Responder` type guarantees at compile time that every HTTP request receives exactly one response, preventing common server bugs like forgotten responses or double-sends.

6. **SystemTime vs Instant:** Kept separate to prevent bugs where wall-clock time (subject to NTP adjustments) is used for interval measurement. `SystemTime` is serializable; `Instant` is not.

https://claude.ai/code/session_01KpumzRky1d7maqPPXHsmQu