### PR TITLE
Expand field projection rules and add comprehensive guidance

### DIFF
--- a/LANGUAGE_GUIDE.md
+++ b/LANGUAGE_GUIDE.md
@@ -383,15 +383,15 @@ Sometimes a function only needs one field of a struct. Field projections let the
 know, so other fields remain available:
 
 ```rask
-func movement_system(state: GameState.{entities}, dt: f32) {
+func movement_system(mutate state: GameState.{entities}, dt: f32) {
     // Only touches state.entities
 }
 
-func scoring_system(state: GameState.{score}, points: i32) {
+func scoring_system(mutate state: GameState.{score}, points: i32) {
     // Only touches state.score
 }
 
-// These can theoretically run in parallel—they touch different fields
+// These can run in parallel—they touch different fields
 movement_system(state.{entities}, dt)
 scoring_system(state.{score}, 10)
 ```

--- a/examples/game_loop.rk
+++ b/examples/game_loop.rk
@@ -108,14 +108,13 @@ extend GameState {
 }
 
 // System: Update positions based on velocities
-// here we only use the entities pool from GameState, so we can use a projection
-// This allows us to avoid borrowing the entire GameState
-func movement_system(mutate entities: GameState.{entities}, dt: f32) {
-    for h in entities {
-        if !entities[h].active: continue
+// Only borrows the entities field — other GameState fields remain available
+func movement_system(mutate state: GameState.{entities}, dt: f32) {
+    for h in state.entities {
+        if !state.entities[h].active: continue
 
-        entities[h].position.x += entities[h].velocity.dx * dt
-        entities[h].position.y += entities[h].velocity.dy * dt
+        state.entities[h].position.x += state.entities[h].velocity.dx * dt
+        state.entities[h].position.y += state.entities[h].velocity.dy * dt
     }
 }
 
@@ -210,10 +209,11 @@ func spawn_system(mutate state: GameState, time_since_last_spawn: f32) -> f32 {
 }
 
 // Parallel movement update - processes entity batches across threads
-func parallel_movement_system(mutate entities: GameState.{entities}, dt: f32, num_threads: usize)
+// NOTE: Sending projections to threads requires scoped threading (type.structs/P4 — mechanism TBD)
+func parallel_movement_system(mutate state: GameState.{entities}, dt: f32, num_threads: usize)
     using ThreadPool
 {
-    let handles = entities.handles()
+    let handles = state.entities.handles()
     let chunk_size = (handles.len() + num_threads - 1) / num_threads
 
     // Split work across thread pool
@@ -222,9 +222,9 @@ func parallel_movement_system(mutate entities: GameState.{entities}, dt: f32, nu
         let chunk = chunk.to_vec()
         let task = ThreadPool.spawn(|| {
             for h in chunk {
-                if !entities[h].active: continue
-                entities[h].position.x += entities[h].velocity.dx * dt
-                entities[h].position.y += entities[h].velocity.dy * dt
+                if !state.entities[h].active: continue
+                state.entities[h].position.x += state.entities[h].velocity.dx * dt
+                state.entities[h].position.y += state.entities[h].velocity.dy * dt
             }
         })
         thread_handles.push(task).ok()

--- a/specs/memory/borrowing.md
+++ b/specs/memory/borrowing.md
@@ -250,7 +250,7 @@ Borrowing a struct borrows all of it. Field projections (`Type.{field1, field2}`
 | **P1: Syntax** | `value.{field1, field2}` creates a projection of the named fields |
 | **P2: Type syntax** | `Type.{field1}` in function params accepts a projection |
 | **P3: Non-overlapping** | Projections with disjoint fields can be borrowed simultaneously |
-| **P4: Parallel safe** | Non-overlapping mutable projections can be sent to different threads |
+| **P4: Parallel safe** | Non-overlapping mutable projections can be sent to different scoped threads |
 
 <!-- test: skip -->
 ```rask
@@ -260,19 +260,35 @@ struct GameState {
 }
 
 // Only borrows `entities` - other fields remain available
-func movement_system(state: GameState.{entities}, dt: f32) {
+func movement_system(mutate state: GameState.{entities}, dt: f32) {
     for h in state.entities {
         state.entities[h].position.x += state.entities[h].velocity.dx * dt
     }
 }
 
 // Only borrows `score` - can run alongside movement_system
-func update_score(state: GameState.{score}, points: i32) {
+func update_score(mutate state: GameState.{score}, points: i32) {
     state.score += points
 }
 ```
 
-See [types/structs.md](../types/structs.md) for projection type syntax (`type.structs/P1`).
+**Local projections (P1):**
+
+<!-- test: skip -->
+```rask
+func update(mutate state: GameState) {
+    // Local projection — borrows only the named fields
+    const proj = state.{entities}
+    proj.entities[h].health -= 10   // OK: entities is projected
+    state.score += 100               // OK: score not in projection
+
+    // Disjoint local projections
+    const a = state.{entities}
+    const b = state.{score}          // OK: disjoint from a
+}
+```
+
+See [types/structs.md](../types/structs.md) for full projection type rules (`type.structs/P1`–`P10`).
 
 ## Access Rules
 
@@ -377,6 +393,11 @@ FIX: Use comma syntax for multiple elements, or collect handles first:
 | `with` and `try` | W1 | Propagates to enclosing function |
 | `with` and `break`/`continue` | W1 | Applies to surrounding loop |
 | Nested `with` same collection | W2 | Compile error (source frozen) |
+| Projection stored in local | P1 | Block-scoped, follows S1–S3 (`type.structs/P8`) |
+| Overlapping projections | P3 | Compile error: fields overlap |
+| Projection + full struct borrow | P3 | Compile error: struct already borrowed |
+| Method on projection | — | Compile error (`type.structs/P7`) |
+| Nested field projection | P1 | Invalid: `T.{a.b}` (`type.structs/P6`) |
 
 ## Quick Reference
 

--- a/specs/memory/parameters.md
+++ b/specs/memory/parameters.md
@@ -208,7 +208,9 @@ ERROR [mem.parameters/PM3]: value used after being taken
 | Closure captures | — | Captured borrows follow closure lifetime rules (`mem.closures`) |
 | Pattern matching | PM2 | Mutation only allowed if parameter is `mutate` |
 | Copy type + mutate | PM2 | Value is copied in; mutations affect the copy |
-| Nested fields in projection | PM4 | `Player.{stats.health}` (TBD) |
+| Nested fields in projection | PM4 | `Player.{stats.health}` is invalid — projections are flat (`type.structs/P6`). Project `stats`, access `.health` normally |
+| `take` on projection | PM4 | Invalid — projections support borrow and `mutate` only (`type.structs/P9`) |
+| Projection in generic param | PM4 | Invalid — `T.{field}` where T is generic is a compile error (`type.structs/P10`) |
 
 ---
 

--- a/specs/types/structs.md
+++ b/specs/types/structs.md
@@ -249,14 +249,16 @@ Visibility in patterns: same package gets all fields; external gets only `public
 
 ## Field Projection Types
 
-Projection types let functions accept only specific fields, enabling partial borrowing without lifetime annotations.
+Projection types let functions accept only specific fields, enabling partial borrowing without lifetime annotations. A projection `T.{a, b}` is a restricted struct view — you see only the named fields, nothing else.
+
+### Core Rules
 
 | Rule | Description |
 |------|-------------|
-| **P1: Field subset** | `T.{a, b}` accepts only named fields |
-| **P2: Borrow scope** | Each field follows normal borrowing independently |
+| **P1: Field subset** | `T.{a, b}` creates a type with only the named fields from `T` |
+| **P2: Borrow scope** | Each projected field follows normal borrowing independently |
 | **P3: No overlap** | Multiple projections can borrow simultaneously if fields don't overlap |
-| **P4: Nested access** | Projected fields accessed and mutated normally |
+| **P4: Parallel safe** | Non-overlapping mutable projections can be sent to different scoped threads |
 
 <!-- test: skip -->
 ```rask
@@ -268,24 +270,105 @@ struct GameState {
 }
 
 // Only borrows the `entities` field, leaving other fields available
-func movement_system(entities: GameState.{entities}, dt: f32) {
-    for h in entities {
-        entities[h].position.x += entities[h].velocity.dx * dt
+func movement_system(mutate state: GameState.{entities}, dt: f32) {
+    for h in state.entities {
+        state.entities[h].position.x += state.entities[h].velocity.dx * dt
     }
 }
 
+// Only borrows `score` — can run alongside movement_system
+func update_score(mutate state: GameState.{score}, points: i32) {
+    state.score += points
+}
+
 // Can call multiple systems that use different projections
-func update(state: GameState, dt: f32) {
+func update(mutate state: GameState, dt: f32) {
     movement_system(state.{entities}, dt)     // Borrows entities
     update_score(state.{score}, 10)           // Borrows score (no conflict)
 }
 ```
 
+### Access and Restrictions
+
+| Rule | Description |
+|------|-------------|
+| **P5: Field access by name** | Projected fields accessed by name: `proj.field`. Non-projected fields are a compile error |
+| **P6: Flat projections** | Projections name direct fields only. `T.{a.b}` is invalid — project `a`, then access `.b` normally |
+| **P7: No method dispatch** | Methods defined on `T` cannot be called on `T.{a, b}`. Methods on individual fields work normally |
+| **P8: Local binding** | `const p = value.{a, b}` creates a block-scoped projection (`mem.borrowing/S1`–`S3`) |
+| **P9: Borrow and mutate only** | Projections combine with borrow (default) and `mutate`. `take` is invalid — partial ownership transfer not supported |
+| **P10: Not a type constructor** | Projection types cannot appear as generic type arguments, struct field types, or return types |
+
+**P5 — field access:**
+
+<!-- test: skip -->
+```rask
+func heal(mutate state: Player.{health}) {
+    state.health += 10       // OK: health is projected
+    state.inventory          // ERROR: not in projection
+}
+```
+
+**P6 — flat projections:**
+
+<!-- test: skip -->
+```rask
+// INVALID: nested projection
+func bad(state: Player.{stats.health}) { ... }
+
+// VALID: project the parent, access subfields normally
+func good(mutate state: Player.{stats}) {
+    state.stats.health += 10
+}
+```
+
+**P7 — no method dispatch:**
+
+<!-- test: skip -->
+```rask
+func example(state: GameState.{entities}) {
+    state.entities.len()      // OK: method on Pool<Entity>
+    state.is_game_over()      // ERROR: GameState method, not available on projection
+}
+```
+
+**P8 — local binding:**
+
+<!-- test: skip -->
+```rask
+func update(mutate state: GameState) {
+    const proj = state.{entities, score}  // Block-scoped projection
+    proj.entities[h].health -= 10         // OK: entities is projected
+    proj.score += 100                     // OK: score is projected
+    state.game_over                       // ERROR: state borrowed through projection
+}   // proj released at block end
+```
+
+**P9 — no take:**
+
+<!-- test: skip -->
+```rask
+func bad(take state: GameState.{entities}) { ... }  // ERROR: take on projection
+func ok(mutate state: GameState.{entities}) { ... }  // OK: mutable borrow
+func ok2(state: GameState.{entities}) { ... }         // OK: read-only borrow
+```
+
+**P10 — not a type constructor:**
+
+<!-- test: skip -->
+```rask
+// ALL INVALID:
+struct Holder { partial: GameState.{entities} }  // No projection in struct fields
+func bad() -> GameState.{entities} { ... }       // No projection return types
+func bad2<T>(x: T.{field}) { ... }               // No projection of generic types
+```
+
 | Pattern | Benefit |
 |---------|---------|
 | ECS systems | Each system borrows only the components it needs |
-| Parallel access | Non-overlapping projections can be used across threads |
+| Parallel access | Non-overlapping projections can be sent to scoped threads |
 | API clarity | Function signature shows exactly which fields are accessed |
+| Local splitting | `const a = val.{x}; const b = val.{y}` — disjoint local borrows |
 
 ## Edge Cases
 
@@ -299,6 +382,16 @@ func update(state: GameState, dt: f32) {
 | Struct in Vec | — | Allowed if non-linear |
 | Linear field | — | Struct becomes linear; must be consumed |
 | Generic instantiation | — | Bounds checked; Copy determined per instantiation |
+| Projection of non-existent field | P1 | Compile error: "field 'x' does not exist on T" |
+| Nested field projection | P6 | Compile error: "projections are flat — project 'stats', then access subfields" |
+| Overlapping projections | P3 | Compile error: "projection 'entities' overlaps with existing borrow" |
+| Projection with `take` | P9 | Compile error: "cannot take partial ownership — use borrow or mutate" |
+| Projection in struct field | P10 | Compile error: "projection types cannot appear in struct definitions" |
+| Projection as return type | P10 | Compile error: "projection types cannot be returned" |
+| Projection of generic type | P10 | Compile error: "cannot project generic type parameter" |
+| Method call on projection | P7 | Compile error: "method 'foo' is defined on T, not on T.{a}" |
+| Closure capturing projection | P8 | Follows `mem.closures/SL1` — closure scope-limited to projection |
+| Projection to scoped thread | P4 | Valid if thread joined before projection expires (mechanism TBD) |
 
 ## Examples
 
@@ -397,13 +490,31 @@ Zero-initialization is not automatic. Explicit factory if needed.
 
 ### Patterns & Guidance
 
-**Projection use cases (P1-P4):** See `mem.borrowing` for how projections enable parallelism without lifetime annotations.
+**Projection use cases (P1-P10):** See `mem.borrowing` for how projections enable parallelism without lifetime annotations. See `mem.parameters` for projection parameter modes.
+
+**When to use projections vs passing fields directly:**
+
+| Scenario | Approach |
+|----------|----------|
+| Function needs one field, no parallel concern | Pass the field directly: `func f(pool: Pool<Entity>)` |
+| Parallel systems need disjoint access | Projections: `func f(mutate state: State.{entities})` |
+| Function signature should document field usage | Projections |
+| Generic function accepting any pool | Pass the field directly |
+
+**P6 (flat projections):** I considered `T.{stats.health}` for deep projections but it requires tracking borrow paths through multiple struct levels — cross-struct analysis the borrow checker deliberately avoids. Project the parent field and access subfields normally. If deep splitting is needed, flatten the struct.
+
+**P7 (no methods):** Allowing methods on projections would require analyzing which fields a method reads — that's cross-function analysis. Methods are contracts with the full type; projections are borrowing constraints. Different concerns, kept separate.
+
+**P9 (no take):** Taking a projection would leave the struct partially moved. Rust allows this in limited cases; I think the complexity isn't worth it. Destructure the struct if you need to take individual fields.
+
+**P10 (not a type constructor):** Projections are a borrowing mechanism, not a type system feature. Storing them would require tracking borrow provenance in the type system — exactly the lifetime annotations I'm trying to avoid. They live at parameter boundaries and in local blocks, nowhere else.
 
 ### See Also
 
 - `mem.ownership` — Copy/move semantics, 16-byte threshold
 - `mem.value-semantics` — Value semantics foundation
-- `mem.borrowing` — View scoping, projection borrowing
+- `mem.borrowing` — View scoping, projection borrowing (`mem.borrowing/P1`–`P4`)
+- `mem.parameters` — Projection parameter modes (`mem.parameters/PM4`–`PM6`)
 - `type.generics` — Generic bounds and instantiation
 - `struct.modules` — C interop details
 - [Binary Structs](binary.md) — `@binary` wire format layout
@@ -411,3 +522,4 @@ Zero-initialization is not automatic. Explicit factory if needed.
 ### Remaining Issues
 
 1. **Tuple structs** — Should `struct Point(i32, i32)` be supported for positional construction?
+2. **Scoped thread projections (P4)** — The mechanism for sending projections to scoped threads needs design. See TODO.md.


### PR DESCRIPTION
## Summary

This PR significantly expands the field projection specification with detailed rules (P1–P10), practical examples, and comprehensive edge case handling. It clarifies projection semantics, restrictions, and use cases across the language specification and examples.

## Key Changes

- **Extended projection rules** (P1–P10): Added 6 new rules covering field access restrictions (P5), flat projections (P6), method dispatch (P7), local binding (P8), borrow modes (P9), and type constructor restrictions (P10)

- **New "Access and Restrictions" section**: Detailed rules with code examples for each restriction, showing both valid and invalid patterns

- **Clarified core rules**: Refined P1–P4 descriptions for precision:
  - P1: Now explicitly states projections create a restricted view with only named fields
  - P2: Clarified that each projected field follows normal borrowing independently
  - P4: Specified "scoped threads" instead of generic "threads"

- **Added guidance section**: New comparison table for when to use projections vs. passing fields directly, plus detailed rationale for design decisions (P6–P10)

- **Expanded edge cases table**: Added 12 new error cases with rule references and error messages

- **Updated examples**: 
  - `game_loop.rk`: Fixed parameter naming (`entities` → `state`) for consistency and added note about scoped threading mechanism
  - `LANGUAGE_GUIDE.md`: Updated examples to use `mutate` keyword and clarified parallel execution capability

- **Cross-reference improvements**: Added specific rule citations (`type.structs/P1`–`P10`, `mem.parameters/PM4`–`PM6`) throughout specs

- **Documented open issues**: Added TODO for scoped thread projection mechanism design

## Notable Details

- Projections are explicitly **not** type constructors — they live only at parameter boundaries and in local blocks
- Nested field projections (`T.{a.b}`) are invalid to avoid cross-struct borrow analysis complexity
- Methods cannot be called on projections; this keeps borrowing constraints separate from type contracts
- `take` mode is unsupported on projections to avoid partial move semantics complexity
- Local projections follow block-scoped borrowing rules (S1–S3) with disjoint local projections allowed

https://claude.ai/code/session_01FGTJ43yrhuxdfQuTGKngec