### PR TITLE
Add mutable iteration mode (`for mutate`) to loops and collections

### DIFF
--- a/specs/control/ensure.md
+++ b/specs/control/ensure.md
@@ -117,6 +117,7 @@ Cleanup actions may fail. Errors are ignored by default; opt-in handling with `e
 | **ER2: Opt-in else clause** | `ensure expr else \|e\| handler` passes error to handler |
 | **ER3: Infallible handler** | `else` handler must not use `try`—nowhere to propagate |
 | **ER4: try forbidden** | Cannot use `try` inside ensure body |
+| **ER5: Multi-failure independent** | When multiple ensures run (LIFO), each runs regardless of whether previous ensures failed. Errors are independent — each is ignored (ER1) or handled by its own `else` clause (ER2). The function's return value is unaffected by ensure failures |
 
 <!-- test: skip -->
 ```rask
@@ -128,6 +129,31 @@ ensure file.close() else |_| panic("!")   // ER2: panic on error
 
 ensure { try file.close() }                     // ❌ Error: ER4
 ensure file.close() else |e| { try fallible() }   // ❌ Error: ER3
+```
+
+**Multiple ensure failures (ER5):**
+
+<!-- test: skip -->
+```rask
+func process() -> () or Error {
+    const a = try open("a.txt")
+    ensure a.close() else |e| log("a close failed: {e}")
+
+    const b = try open("b.txt")
+    ensure b.close() else |e| log("b close failed: {e}")
+
+    const c = try open("c.txt")
+    ensure c.close() else |e| log("c close failed: {e}")
+
+    try do_work()
+    Ok(())
+}
+// If do_work() fails with WorkError:
+//   1. c.close() runs — if it fails, logs and continues
+//   2. b.close() runs — if it fails, logs and continues
+//   3. a.close() runs — if it fails, logs and continues
+//   4. WorkError is returned to the caller
+// Ensure failures never replace the function's own error.
 ```
 
 **When cleanup errors matter, use explicit handling instead:**
@@ -163,6 +189,43 @@ func process() -> () or Error {
     log(config.summary)
     Ok(())
 }
+```
+
+## Loop Iteration Scoping
+
+`ensure` inside a loop body runs at the end of **each iteration**, not at loop exit. The loop body `{ ... }` is the enclosing block per EN1.
+
+| Rule | Description |
+|------|-------------|
+| **EN7: Per-iteration** | `ensure` in a loop body runs when that iteration's block exits — on every iteration, not once at loop end |
+
+<!-- test: skip -->
+```rask
+for path in paths {
+    const file = try open(path)
+    ensure file.close()         // Runs at end of THIS iteration
+
+    try process(file)
+}
+// After each iteration: file.close() runs
+// NOT: all files accumulate and close at loop exit
+```
+
+This is the correct behavior — accumulating resources until loop exit would be a resource leak for long-running loops. Each iteration acquires, uses, and releases its resources independently.
+
+<!-- test: skip -->
+```rask
+// LIFO within an iteration
+for item in items {
+    const a = try acquire_a(item)
+    ensure a.release()
+
+    const b = try acquire_b(item)
+    ensure b.release()
+
+    try process(a, b)
+}
+// Each iteration: b.release(), then a.release() (LIFO within iteration)
 ```
 
 ## Explicit Consumption Cancellation
@@ -255,8 +318,10 @@ func process_many_files_careful(paths: Vec<string>) -> () or Error {
 | Case | Rule | Handling |
 |------|------|----------|
 | Multiple ensures | EN2 | Run in LIFO order (last scheduled runs first) |
+| Multiple ensures all fail | ER5 | Each runs independently, errors handled per-ensure |
 | Ensure on already-consumed value | — | Compile error: value not available |
 | Ensure in nested blocks | EN1 | Each ensure runs when its enclosing block exits |
+| Ensure in loop body | EN7 | Runs at end of each iteration, not loop exit |
 | Ensure + explicit consumption | C1 | Explicit consumption cancels ensure |
 | Ensure body panics | — | Panic propagates, subsequent ensures don't run |
 | Ensure body returns value | — | Value discarded (ensure is statement, not expression) |

--- a/specs/control/loops.md
+++ b/specs/control/loops.md
@@ -1,31 +1,34 @@
 <!-- id: ctrl.loops -->
 <!-- status: decided -->
-<!-- summary: Value-first iteration (borrowed elements by default), index mode for mutation -->
+<!-- summary: Value-first iteration (borrowed elements by default), mutable iteration for in-place mutation, index mode for structural mutation -->
 <!-- depends: memory/borrowing.md, control/control-flow.md, stdlib/iteration.md -->
 <!-- implemented-by: compiler/crates/rask-parser/, compiler/crates/rask-interp/ -->
 
 # Loops
 
-Loops yield borrowed values by default (read-only). Index/handle mode requires explicit syntax for mutation.
+Loops yield borrowed values by default (read-only). `for mutate` provides in-place element mutation. Index/handle mode for structural mutation.
 
 ## Loop Syntax
 
 | Rule | Description |
 |------|-------------|
 | **LP1: Value iteration** | `for binding in collection` yields borrowed elements (read-only) |
-| **LP2: Index mode explicit** | Use `for i in 0..vec.len()` or `for h in pool.handles()` for mutation |
+| **LP2: Index mode explicit** | Use `for i in 0..vec.len()` or `for h in pool.handles()` for structural mutation |
 | **LP3: Collection accessible** | Loop does not prevent collection access (inline expression access) |
+| **LP11: Mutable iteration** | `for mutate binding in collection` yields mutable access to each element |
+| **LP12: Mutable binding** | The `mutate` keyword applies to the loop binding. Each use of the binding desugars to mutable inline access on the current element |
 
 ```rask
 for <binding> in <collection> { ... }
+for mutate <binding> in <collection> { ... }
 ```
 
-| Collection Type | Value Mode (Default) | Index Mode (Explicit) |
-|----------------|---------------------|----------------------|
-| `Vec<T>` | Borrowed `T` | `0..vec.len()` yields `usize` |
-| `Pool<T>` | Borrowed `T` | `.handles()` yields `Handle<T>` |
-| `Map<K,V>` | `(K, borrowed V)` | `.keys()` yields `K` |
-| `Range` (`0..n`) | Integer | (direct iteration) |
+| Collection Type | Value Mode (Default) | Mutable Mode | Index Mode (Explicit) |
+|----------------|---------------------|--------------|----------------------|
+| `Vec<T>` | Borrowed `T` | Mutable `T` | `0..vec.len()` yields `usize` |
+| `Pool<T>` | Borrowed `T` | Mutable `T` | `.handles()` yields `Handle<T>` |
+| `Map<K,V>` | `(K, borrowed V)` | `(K, mutable V)` | `.keys()` yields `K` |
+| `Range` (`0..n`) | Integer | N/A | (direct iteration) |
 
 <!-- test: skip -->
 ```rask
@@ -35,18 +38,25 @@ for item in items {           // item: borrowed T
     print(item.name)          // Natural iteration
 }
 
-// Index mode for mutation
+// Mutable mode for in-place mutation
+for mutate item in items {
+    item.health -= 10         // Mutate in place
+    item.last_updated = now()
+}
+
+// Index mode for structural mutation
 for i in 0..items.len() {
     items[i].health -= 10     // Mutate in place
-    items.push(new_item)      // OK: no borrow held
+    items.push(new_item)      // OK: structural mutation allowed in index mode
 }
 
 const entities = Pool.new()
-for entity in entities {      // entity: borrowed Entity
-    entity.update()           // Read-only access
+for mutate entity in entities {
+    entity.health -= 10       // Mutate via mutable iteration
+    entity.velocity *= 0.9
 }
 
-// Handle mode for mutation
+// Handle mode for structural mutation (removal)
 for h in entities.handles() {
     entities[h].health -= 10  // Mutate via handle
     entities.remove(h)        // OK if no further access
@@ -71,9 +81,9 @@ for item in items {
     // item.health -= 10      // ERROR: cannot mutate borrowed value
 }
 
-// Index mode for mutation
-for i in 0..items.len() {
-    items[i].health -= 10     // Mutate via index
+// Use mutable iteration instead
+for mutate item in items {
+    item.health -= 10         // OK: mutable access
 }
 
 // Take ownership (consuming)
@@ -82,13 +92,41 @@ for item in vec.take_all() {  // vec now empty
 }
 ```
 
+## Mutable Mode Constraints
+
+| Rule | Description |
+|------|-------------|
+| **LP13: In-place mutation** | `item.field = x` mutates the element in place. `item = x` replaces the entire element |
+| **LP14: No structural mutation** | Cannot insert, remove, or clear during mutable iteration |
+| **LP15: Collection readable** | Other elements accessible via inline expression access (same as LP3) |
+| **LP16: No take parameters** | Cannot pass `item` to `take` parameters (same as LP6) |
+
+<!-- test: skip -->
+```rask
+// Mutable iteration
+for mutate item in items {
+    item.health -= damage          // LP13: in-place mutation
+    item.name = "updated"          // LP13: field replacement
+    const other = items[0].health  // LP15: read other elements
+    // items.push(new_item)        // ERROR LP14: structural mutation
+}
+
+// Map: keys are always copies, values are mutable
+for mutate (key, value) in config {
+    value.count += 1
+    value.last_access = now()
+    // key = "new_key"             // ERROR: keys are copies, not mutable bindings
+}
+```
+
 ## Collection Mutation
 
 | Rule | Description |
 |------|-------------|
-| **LP8: Value mode read-only** | Value iteration prevents structural mutation (insert/remove) |
-| **LP9: Index mode allows mutation** | Index/handle mode allows mutation (programmer responsibility) |
-| **LP10: Length captured** | Index loops capture length at start — new items not visited |
+| **LP8: Value mode read-only** | Value iteration prevents all mutation (element and structural) |
+| **LP8a: Mutable mode in-place only** | Mutable iteration allows element mutation, prevents structural mutation |
+| **LP9: Index mode allows mutation** | Index/handle mode allows all mutation (programmer responsibility) |
+| **LP10: Length captured** | Index and mutable loops capture length at start — new items not visited |
 
 <!-- test: skip -->
 ```rask
@@ -98,7 +136,13 @@ for item in vec {
     // vec.push(x)            // ERROR: cannot mutate during value iteration
 }
 
-// Index mode: mutation allowed
+// Mutable mode: element mutation, no structural changes
+for mutate item in vec {
+    item.field = x            // OK: in-place mutation
+    // vec.push(new_item)     // ERROR: structural mutation forbidden
+}
+
+// Index mode: all mutation allowed
 for i in 0..vec.len() {
     vec[i].field = x          // OK: mutate element
     vec.push(new_item)        // OK: not visited (length captured at start)
@@ -113,7 +157,7 @@ for h in pool.handles() {
 
 ## Desugaring
 
-Value iteration creates inline access per element.
+Value iteration creates inline access per element. Mutable iteration creates mutable inline access.
 
 <!-- test: skip -->
 ```rask
@@ -125,9 +169,63 @@ for item in vec { body }
     const _len = vec.len()
     let _pos = 0
     while _pos < _len {
-        const item = vec[_pos]  // Inline access
+        const item = vec[_pos]  // Inline access (read-only)
         body
         _pos += 1
+    }
+}
+```
+
+<!-- test: skip -->
+```rask
+// Mutable iteration (Vec):
+for mutate item in vec { body }
+
+// Equivalent to:
+{
+    const _len = vec.len()
+    let _pos = 0
+    while _pos < _len {
+        // `item` is a mutable alias for vec[_pos]
+        // item.field  → vec[_pos].field  (inline access)
+        // item.field = x → vec[_pos].field = x  (in-place mutation, E3)
+        // item = x → vec[_pos] = x  (element replacement)
+        body
+        _pos += 1
+    }
+}
+```
+
+<!-- test: skip -->
+```rask
+// Mutable iteration (Pool):
+for mutate item in pool { body }
+
+// Equivalent to:
+{
+    const _handles = pool._snapshot_handles()  // Handle snapshot
+    let _idx = 0
+    while _idx < _handles.len() {
+        const _h = _handles[_idx]
+        // `item` is a mutable alias for pool[_h]
+        body
+        _idx += 1
+    }
+}
+```
+
+<!-- test: skip -->
+```rask
+// Mutable iteration (Map):
+for mutate (k, v) in map { body }
+
+// Equivalent to:
+{
+    // Internal key snapshot
+    for _k in map._snapshot_keys() {
+        const k = _k                    // Copy of key (immutable)
+        // `v` is a mutable alias for map[_k]
+        body
     }
 }
 ```
@@ -169,10 +267,13 @@ for item in vec.take_all() { body }
 | Case | Rule | Handling |
 |------|------|----------|
 | Mutate in value loop | LP8 | Compile error (value mode is read-only) |
+| Structural mutation in mutable loop | LP8a/LP14 | Compile error |
 | Grow during index iteration | LP10 | New items not visited (length captured at start) |
 | Shrink during index iteration | LP10 | Stale index may panic — programmer responsibility |
 | Remove current handle (Pool) | LP9 | OK in handle mode if no further access |
 | Nested loops same collection | LP3 | Allowed (inline access) |
+| Nested mutable + value loops | LP3/LP15 | Allowed — mutable loop allows inline reads of collection |
+| `for mutate` on Range | — | Compile error (ranges are not collections) |
 | Break/continue | — | Standard semantics (exit or skip iteration) |
 | Empty collection | — | Zero iterations |
 
@@ -184,7 +285,9 @@ for item in vec.take_all() { body }
 
 **LP1 (value iteration default):** I chose borrowed values as the default because it matches Python, Rust, Go, JavaScript expectations. Most iteration is read-only (80%+ of real code), so optimizing for the common case reduces ceremony. This decision was validated against METRICS.md targets — natural iteration should not require index manipulation.
 
-**LP2 (index mode explicit):** Mutation requires explicit syntax (`0..vec.len()` or `.handles()`). This makes the mutation intent clear and matches the "transparency of cost" principle — you see you're doing index-based access, not value iteration.
+**LP2 (index mode explicit):** Structural mutation requires explicit syntax (`0..vec.len()` or `.handles()`). This makes the structural mutation intent clear and matches the "transparency of cost" principle — you see you're doing index-based access, not value iteration.
+
+**LP11 (mutable iteration):** In-place element mutation is the second most common iteration pattern after read-only. Index mode works but forces you to repeat `collection[i]` for every access — noisy and error-prone. `for mutate` provides a named binding that desugars to mutable inline access, keeping the code clean while making mutation intent visible via the `mutate` keyword. The keyword is consistent with function parameter annotations (`func f(mutate x: T)`). Structural mutation (insert/remove) still requires index mode because it can invalidate iteration state.
 
 **LP3 (collection accessible):** Each element access in value mode is inline (per `mem.borrowing/E1`), so the collection remains accessible. No block-scoped borrow exists. This enables natural patterns without borrow conflicts.
 
@@ -199,7 +302,8 @@ for item in vec.take_all() { body }
 | Goal | Pattern | Example |
 |------|---------|---------|
 | Read all elements | Value iteration | `for item in vec { process(item) }` |
-| Mutate elements in place | Index iteration | `for i in 0..vec.len() { vec[i].field = x }` |
+| Mutate elements in place | Mutable iteration | `for mutate item in vec { item.field = x }` |
+| Structural mutation (insert/remove) | Index iteration | `for i in 0..vec.len() { vec.swap_remove(i) }` |
 | Clone values | Value iteration + clone | `for item in vec { const v = item.clone(); use(v) }` |
 | Take ownership (consume) | `take_all()` | `for item in vec.take_all() { own(item) }` |
 | Iterate Pool by handle | `.handles()` | `for h in pool.handles() { pool[h].update() }` |
@@ -208,7 +312,6 @@ for item in vec.take_all() { body }
 
 <!-- test: skip -->
 ```rask
-// Natural, readable iteration
 for item in vec {
     print(item.name)
     item.display()
@@ -221,17 +324,30 @@ for entity in entities {
 }
 ```
 
-**Index mode for mutation:**
+**Mutable iteration (in-place mutation):**
 
 <!-- test: skip -->
 ```rask
-// Explicit index mode for mutation
-for i in 0..vec.len() {
-    vec[i].health -= damage
-    vec[i].last_hit = now()
+for mutate item in vec {
+    item.health -= damage
+    item.last_hit = now()
 }
 
-// Handle mode for Pool
+for mutate entity in pool {
+    entity.velocity += entity.acceleration * dt
+    entity.position += entity.velocity * dt
+}
+
+for mutate (key, value) in scores {
+    value.total += value.round_score
+    value.round_score = 0
+}
+```
+
+**Index mode for structural mutation:**
+
+<!-- test: skip -->
+```rask
 for h in pool.handles() {
     pool[h].health -= damage
     if pool[h].health <= 0 {
@@ -280,6 +396,7 @@ The IDE annotates loop bindings with their type and source semantics.
 | Annotation | Meaning |
 |------------|---------|
 | `item: borrowed T` | Loop variable is a borrowed value (read-only) |
+| `item: mutable T` | Loop variable has mutable access to element |
 | `i: usize [index into vec]` | Loop variable is an index |
 | `h: Handle<Entity> [handle into pool]` | Loop variable is a handle |
 
@@ -290,6 +407,11 @@ for item in vec {           // item: borrowed T [read-only]
     // vec.push(x)          // [ERROR: cannot mutate during value iteration]
 }
 
+for mutate item in vec {    // item: mutable T [in-place mutation]
+    item.health -= 10       // [mutable inline access]
+    // vec.push(x)          // [ERROR: structural mutation forbidden]
+}
+
 for i in 0..vec.len() {     // i: usize [index into vec]
     vec[i].process()        // [inline access]
     vec.push(item)          // [OK: no borrow held]
@@ -298,8 +420,13 @@ for i in 0..vec.len() {     // i: usize [index into vec]
 
 Hover on `for item in collection` shows:
 - "Value iteration: yields borrowed elements (read-only)"
-- "Cannot mutate collection structure during iteration"
-- "Use index mode (0..collection.len()) for mutation"
+- "Cannot mutate elements or collection structure"
+- "Use `for mutate` for element mutation, index mode for structural mutation"
+
+Hover on `for mutate item in collection` shows:
+- "Mutable iteration: yields mutable access to each element"
+- "Element mutation allowed, structural mutation forbidden"
+- "Use index mode for insert/remove during iteration"
 
 Hover on `for i in 0..collection.len()` shows:
 - "Index iteration: loop captures length at start, yields indices 0..len"

--- a/specs/memory/borrowing.md
+++ b/specs/memory/borrowing.md
@@ -217,9 +217,15 @@ with pool[h1] as e1, pool[h2] as const e2 {
 }
 ```
 
-For iteration + mutation, collect handles first:
+For iteration + mutation, use mutable iteration (`std.iteration/I4`) or collect handles:
 <!-- test: skip -->
 ```rask
+// Mutable iteration (preferred for in-place mutation)
+for mutate entity in pool {
+    entity.update()
+}
+
+// Handle collection (for structural mutation like remove)
 const handles = pool.handles().collect()
 for h in handles {
     with pool[h] as e { e.update() }

--- a/specs/memory/pools.md
+++ b/specs/memory/pools.md
@@ -168,6 +168,16 @@ for entity in pool.values() {
 }
 ```
 
+**Mutable mode** — `for mutate` provides in-place element mutation (`std.iteration/I4`):
+```rask
+for mutate entity in pool {
+    entity.health -= 10
+    entity.velocity *= 0.9
+}
+```
+
+Structural mutation (insert/remove) is forbidden during mutable iteration. Use handle mode for that.
+
 **Entries mode** — `pool.entries()` yields both:
 ```rask
 for (h, entity) in pool.entries() {
@@ -526,9 +536,9 @@ func build_graph() -> Pool<Node> or Error {
 
 ```rask
 func render_frame(world: World) {
-    // Physics update (needs mutation)
-    for h in world.entities.handles() {
-        world.entities[h].update_physics()
+    // Physics update (mutable iteration — clean)
+    for mutate entity in world.entities {
+        entity.update_physics()
     }
 
     // Render pass (read-only, zero-cost)

--- a/specs/stdlib/collections.md
+++ b/specs/stdlib/collections.md
@@ -115,6 +115,12 @@ with vec[i] as v: v.count += 1
 const name = with vec[i] as const v { v.name.clone() }
 ```
 
+## Map Key Constraints
+
+| Rule | Description |
+|------|-------------|
+| **K1: Float key warning** | `Map<f32, V>` and `Map<f64, V>` produce a compile-time warning. NaN != NaN by IEEE 754, which breaks map lookup invariants — a NaN key can be inserted but never found |
+
 ## Map -- Key-Based Access
 
 | Method | Returns | Semantics |
@@ -317,6 +323,7 @@ FIX: Process existing items first, or use an unbounded collection:
 | `with vec[i] as e1, vec[i] as e2` | D1 | Panic (duplicate index) |
 | ZST in `Vec<()>` | — | `len()` tracks count, no storage allocated |
 | `Vec<LinearResource>` | C4 | Compile error |
+| `Map<f32, V>` or `Map<f64, V>` | K1 | Compile-time warning (NaN breaks lookups) |
 | Panic inside `with` | — | Collection left in valid state |
 
 ---

--- a/specs/stdlib/encoding.md
+++ b/specs/stdlib/encoding.md
@@ -163,6 +163,20 @@ extend DateTime {
 | **E19: @skip** | `@skip` excludes a field from serialization and deserialization. Reflected as `FieldInfo.is_skipped` |
 | **E20: @default** | `@default(expr)` provides a comptime value used when the field is missing during deserialization. The field becomes optional in the input. Reflected as `FieldInfo.has_default` |
 | **E21: Comptime expressions** | `@rename` takes a string literal. `@default` takes a comptime expression. Both validated at compile time |
+| **E28: @skip zero values** | `@skip` without `@default` requires a type with a known zero value. During decode, skipped fields are initialized to this value |
+
+**Types with known zero values (E28):**
+
+| Type | Zero value |
+|------|-----------|
+| `bool` | `false` |
+| `i8`–`i64`, `u8`–`u64` | `0` |
+| `f32`, `f64` | `0.0` |
+| `string` | `""` (empty) |
+| `T?` (optionals) | `None` |
+| `Vec<T>` | empty vec |
+| `Map<K,V>` | empty map |
+| Structs, enums, other types | **No zero value** — `@skip` requires `@default(expr)` or compile error |
 
 <!-- test: skip -->
 ```rask
@@ -420,6 +434,23 @@ ERROR [std.encoding/E5]: no field "z" on type `Point`
    |                    ^^^ Point has fields: x, y
 ```
 
+**@skip without default on type without zero value [E28]:**
+```
+ERROR [std.encoding/E28]: @skip field has no default value
+   |
+4  |  @skip
+5  |  public state: GameState
+   |                ^^^^^^^^^ GameState has no known zero value
+
+WHY: Skipped fields are initialized to a zero value during decode.
+     GameState is a struct — no automatic zero value exists.
+
+FIX: Add @default with an explicit value:
+
+  @skip @default(GameState.initial())
+  public state: GameState
+```
+
 ## Edge Cases
 
 | Case | Rule | Handling |
@@ -429,7 +460,7 @@ ERROR [std.encoding/E5]: no field "z" on type `Point`
 | All fields `@skip` | E19, E27 | Encodes as `{}`; decode produces struct with all defaults |
 | `@default` on non-optional required field | E20 | Field becomes optional in input, required in struct definition. Default fills the gap |
 | `@rename` collision (two fields same serial name) | E18 | Compile error: duplicate serial name |
-| `@skip` field without `@default` during decode | E19 | Field must have a type-level default (zero for integers, empty for string, `None` for optionals) or compile error |
+| `@skip` field without `@default` during decode | E19, E28 | Field must have a known zero value (E28) or `@default`. Compile error otherwise |
 | Nested comptime for (struct within struct) | E3 | Works — `encode_value` recursively monomorphizes |
 | Private field with `@rename` | E6 | Annotation accepted but ineffective — field not encoded externally. Useful for same-module custom encoding |
 | Generic struct `Wrapper<T>` | E12 | `Encode` if `T: Encode`. Checked at monomorphization |

--- a/specs/stdlib/iteration.md
+++ b/specs/stdlib/iteration.md
@@ -5,7 +5,7 @@
 
 # Collection Iteration Patterns
 
-Three iteration modes per collection: value (default), index (explicit), and take-all. Default iteration yields borrowed values (read-only), matching all major languages.
+Four iteration modes per collection: value (default, read-only), mutable (read-write), index (explicit), and take-all (consuming).
 
 ## Iteration Modes
 
@@ -14,12 +14,13 @@ Three iteration modes per collection: value (default), index (explicit), and tak
 | **I1: Value mode** | Default `for x in collection` yields borrowed elements (read-only). Natural, matches all major languages |
 | **I2: Index mode** | Use range `for i in 0..collection.len()` for index-based mutation |
 | **I3: Take-all mode** | `.take_all()` consumes the collection, yields owned values |
+| **I4: Mutable mode** | `for mutate x in collection` yields mutable access to each element. Structural mutation still forbidden |
 
-| Collection | Value Mode (Default) | Index Mode | Take All Mode |
-|------------|---------------------|------------|--------------|
-| `Vec<T>` | `for item in vec` -> borrowed `T` | `for i in 0..vec.len()` -> `usize` | `for item in vec.take_all()` -> `T` |
-| `Pool<T>` | `for item in pool` -> borrowed `T` | `for h in pool.handles()` -> `Handle<T>` | `for item in pool.take_all()` -> `T` |
-| `Map<K,V>` | `for (k, v) in map` -> `(K, borrowed V)` | `for k in map.keys()` -> `K` | `for (k,v) in map.take_all()` -> `(K, V)` |
+| Collection | Value Mode (Default) | Mutable Mode | Index Mode | Take All Mode |
+|------------|---------------------|--------------|------------|--------------|
+| `Vec<T>` | `for item in vec` -> borrowed `T` | `for mutate item in vec` -> mutable `T` | `for i in 0..vec.len()` -> `usize` | `for item in vec.take_all()` -> `T` |
+| `Pool<T>` | `for item in pool` -> borrowed `T` | `for mutate item in pool` -> mutable `T` | `for h in pool.handles()` -> `Handle<T>` | `for item in pool.take_all()` -> `T` |
+| `Map<K,V>` | `for (k, v) in map` -> `(K, borrowed V)` | `for mutate (k, v) in map` -> `(K, mutable V)` | `for k in map.keys()` -> `K` | `for (k,v) in map.take_all()` -> `(K, V)` |
 
 ## Value Access
 
@@ -53,6 +54,81 @@ vec[i] = value            // Mutate in place
 | Read-only access | Allowed | Natural use case |
 | `take` param | Forbidden | Ownership transfer impossible |
 
+## Mutable Iteration
+
+`for mutate` provides mutable access to each element without switching to index mode. The binding acts as a mutable alias for the current element — each use desugars to inline access on the underlying collection.
+
+| Rule | Description |
+|------|-------------|
+| **MI1: No structural mutation** | Cannot insert, remove, or clear during mutable iteration (same as R1) |
+| **MI2: In-place mutation** | `item.field = x` is in-place mutation. `item = x` replaces the entire element |
+| **MI3: Collection readable** | Other elements accessible via inline expression access during iteration |
+| **MI4: No take parameters** | Cannot pass `item` to `take` parameters (same as R3) |
+
+<!-- test: skip -->
+```rask
+// Mutable iteration (clean)
+for mutate entity in entities {
+    entity.health -= damage
+    entity.last_hit = now()
+    if entity.health <= 0 {
+        entity.status = Status.Dead
+    }
+}
+
+// Equivalent index mode (verbose)
+for i in 0..entities.len() {
+    entities[i].health -= damage
+    entities[i].last_hit = now()
+    if entities[i].health <= 0 {
+        entities[i].status = Status.Dead
+    }
+}
+```
+
+Reading other elements is allowed (MI3):
+
+<!-- test: skip -->
+```rask
+for mutate entity in entities {
+    entity.health -= damage
+    const max = entities[0].max_health    // OK: inline read of another element
+    if entity.health > max {
+        entity.health = max
+    }
+}
+```
+
+**Map mutable iteration:** Keys are always copies. `mutate` applies to the value binding:
+
+<!-- test: skip -->
+```rask
+for mutate (key, value) in config {
+    // key is a copy (immutable), value is mutable
+    value.count += 1
+    value.last_access = now()
+}
+```
+
+**Pool mutable iteration:**
+
+<!-- test: skip -->
+```rask
+for mutate entity in pool {
+    entity.health -= 10
+    entity.velocity *= 0.9
+}
+```
+
+### When to use mutable vs index mode
+
+| Need | Use |
+|------|-----|
+| Mutate element fields | `for mutate item in vec` — clean, intent clear |
+| Mutate + access other elements | `for mutate item in vec` — MI3 allows reads |
+| Structural mutation (insert/remove) | Index mode — `for i in 0..` or `for h in pool.handles()` |
+| Swap or reorder elements | Index mode — need indices for `vec.swap(i, j)` |
+
 ## Take-All Iteration
 
 | Rule | Description |
@@ -79,7 +155,7 @@ for file in files.take_all() {
 
 ## Mutation During Iteration
 
-Mutation requires index mode (explicit range or `.handles()`). Programmer responsibility.
+In-place mutation uses mutable mode (`for mutate`). Structural mutation requires index mode (explicit range or `.handles()`). Programmer responsibility for structural changes.
 
 | Rule | Description |
 |------|-------------|
@@ -89,14 +165,21 @@ Mutation requires index mode (explicit range or `.handles()`). Programmer respon
 
 <!-- test: skip -->
 ```rask
-// Mutation requires explicit index mode
-for i in 0..entities.len() {
-    entities[i].health -= 10    // Clear you're mutating via index
+// Mutable mode for in-place mutation
+for mutate entity in entities {
+    entity.health -= 10
+}
+
+// Index mode for structural mutation
+for i in (0..entities.len()).rev() {
+    if entities[i].health <= 0 {
+        entities.swap_remove(i)
+    }
 }
 
 // Value mode is read-only
 for entity in entities {
-    print(entity.health)        // Natural iteration
+    print(entity.health)
 }
 ```
 
@@ -121,6 +204,7 @@ for file in files.take_all() { try file.close() }
 | Rule | Description |
 |------|-------------|
 | **K1: Keys copied** | `for (k, v) in map` copies keys (required K: Copy) to allow lookup. Non-Copy keys: use `.take_all()` |
+| **K2: Float key warning** | `Map<f32, V>` and `Map<f64, V>` produce a compile-time warning. NaN != NaN breaks map lookup invariants |
 
 <!-- test: skip -->
 ```rask
@@ -189,18 +273,63 @@ FIX: Use index mode or collect first:
 ```
 
 ```
-ERROR [std.iteration/M2]: cannot mutate items during value iteration
+ERROR [std.iteration/R2]: cannot mutate items during value iteration
    |
 3  |  for entity in entities {
    |                ^^^^^^^^ value iteration is read-only
 4  |      entity.health -= 10
    |      ^^^^^^^^^^^^^^^^^^ cannot mutate borrowed value
 
-FIX: Use index mode for mutation:
+FIX: Use mutable iteration:
 
-  for i in 0..entities.len() {
-      entities[i].health -= 10
+  for mutate entity in entities {
+      entity.health -= 10
   }
+```
+
+```
+ERROR [std.iteration/MI1]: cannot modify collection structure during mutable iteration
+   |
+3  |  for mutate entity in entities {
+   |                       ^^^^^^^^ mutable iteration active
+4  |      entities.push(new_entity)
+   |      ^^^^^^^^^^^^^^^^^^^^^^^^^ structural mutation forbidden
+
+WHY: Mutable iteration allows in-place element mutation, not structural
+     changes (insert/remove/clear). Structural changes could invalidate
+     the iteration position.
+
+FIX: Use index mode for structural mutation, or collect changes first:
+
+  // Option 1: index mode
+  for i in 0..entities.len() {
+      if entities[i].should_split {
+          entities.push(entities[i].split())
+      }
+  }
+
+  // Option 2: collect first
+  let to_add = Vec.new()
+  for mutate entity in entities {
+      if entity.should_split {
+          to_add.push(entity.split())
+      }
+  }
+  for item in to_add.take_all() { try entities.push(item) }
+```
+
+```
+WARNING [std.iteration/K2]: float type used as map key
+   |
+3  |  const cache: Map<f64, Result> = Map.new()
+   |                   ^^^ f64 keys break map lookups when NaN is present
+
+WHY: NaN != NaN by IEEE 754. A NaN key can be inserted but never
+     found by lookup, silently breaking map semantics.
+
+FIX: Use an integer key or newtype wrapper with defined equality:
+
+  const cache: Map<u64, Result> = Map.new()
 ```
 
 ## Edge Cases
@@ -209,12 +338,15 @@ FIX: Use index mode for mutation:
 |------|------|----------|
 | Empty collection | — | Loop body never executes |
 | `Vec<Linear>` value iteration | L1 | Compile error |
+| `Vec<Linear>` mutable iteration | L1 | Compile error (same reason — use `.take_all()`) |
 | Out-of-bounds index | — | Panic |
 | Invalid handle | — | Panic (generation mismatch) |
 | Mutate in value loop | R2 | Compile error |
+| Structural mutation in mutable loop | MI1 | Compile error |
 | `break value` for !Copy | A4 | Requires `.clone()` |
 | Infinite range (`0..`) | — | Works (lazy) |
 | Zero-sized types (`Vec<()>`) | — | Yields values (all identical) |
+| `Map<f32, V>` or `Map<f64, V>` | K2 | Compile-time warning |
 
 ---
 
@@ -226,8 +358,9 @@ FIX: Use index mode for mutation:
 
 | Mode | Use When |
 |------|----------|
-| Value (default) | Read-only iteration - the common case |
-| Index (explicit) | Need to mutate or remove during iteration |
+| Value (default) | Read-only iteration — the common case |
+| Mutable | In-place element mutation without structural changes |
+| Index (explicit) | Structural mutation (insert/remove), swaps, or need indices |
 | Take All | Consuming all items, transferring ownership |
 
 **Safe removal patterns:**

--- a/specs/types/iterator-protocol.md
+++ b/specs/types/iterator-protocol.md
@@ -69,6 +69,8 @@ for i in vec.indices().filter(|i| vec[i].active).take(10) {
 | `Map<K,V>` | `.take_all()` | `MapTakeAll<K,V>` | `(K, V)` |
 | Range | `0..n` | `RangeIterator` | Integer type |
 
+**Mutable iteration** (`for mutate x in collection`) does not use the Iterator protocol. The compiler desugars it to index-based access with a mutable binding alias (see `ctrl.loops/LP11`). No `iterate_mut()` method or mutable iterator types exist — the binding is syntactic sugar over `collection[_pos]`.
+
 ## For-In Desugaring
 
 | Rule | Description |
@@ -78,6 +80,7 @@ for i in vec.indices().filter(|i| vec[i].active).take(10) {
 | **D3: Consuming** | `for x in collection.take_all()` — takes ownership of elements |
 | **D4: Index mode** | `for i in 0..vec.len()` or `for h in pool.handles()` — explicit index/handle iteration |
 | **D5: Method resolution** | Check Range type first, then explicit method call, then `.iterate()` |
+| **D6: Mutable mode** | `for mutate x in collection` — compiler desugars to index-based mutable access. Does not call `.iterate()` |
 
 <!-- test: skip -->
 ```rask

--- a/specs/types/traits.md
+++ b/specs/types/traits.md
@@ -36,10 +36,9 @@ The vtable only contains slots for compatible methods. Incompatible methods have
 
 | Rule | Description |
 |------|-------------|
-| **TR5: Implicit at assignment** | `let w: any Widget = button` — the `any` type annotation signals the conversion |
-| **TR6: Explicit cast** | `const w = button as any Widget` — converts with `as` |
+| **TR5: Implicit when target is `any`** | Concrete values implicitly convert when the target type is `any Trait` — assignment, function arguments, collection elements, struct fields |
+| **TR6: Explicit cast** | `const w = button as any Widget` — converts with `as` when target type isn't known |
 | **TR7: Collection type** | `[]any Widget`, `Map<string, any Handler>` — heterogeneous collections |
-| **TR8: Explicit at call sites** | Passing a concrete value to a function taking `any Trait` requires `as any Trait` |
 
 <!-- test: parse -->
 ```rask
@@ -52,17 +51,24 @@ func render_all(widgets: []any Widget) {
 }
 ```
 
-TR8 means concrete values need explicit conversion at call sites:
+The `any` keyword in the target type is the cost signal. Conversion is implicit when the target type is known to be `any Trait`:
 
 <!-- test: skip -->
 ```rask
 const button = Button { label: "OK" }
 
-render(button as any Widget)   // OK: explicit conversion
-render(button)                 // ERROR: implicit coercion at call site
+// Implicit — target type is any Widget
+const w: any Widget = button          // TR5: type annotation
+render(button)                        // TR5: parameter type
+const widgets: []any Widget = [       // TR5: collection element type
+    button,
+    slider,
+    label,
+]
+router.add("/home", handler)          // TR5: struct field / parameter type
 
-const w: any Widget = button   // OK: type annotation signals it (TR5)
-render(w)                      // OK: w is already any Widget
+// Explicit — no target type context, or for clarity
+const w = button as any Widget        // TR6: no type annotation to infer from
 ```
 
 ## Boxing
@@ -134,16 +140,17 @@ FIX: Use a generic function for type-preserving operations:
   }
 ```
 
-**Implicit coercion at call site [TR8]:**
+**No target type for `as any` [TR6]:**
 ```
-ERROR [type.traits/TR8]: can't implicitly convert `Button` to `any Widget`
+ERROR [type.traits/TR6]: can't infer trait object type
    |
-5  |  render(button)
-   |         ^^^^^^ expected `any Widget`, found `Button`
+5  |  const w = button
+   |        ^ type `Button` — did you mean `button as any Widget`?
 
-FIX: Use explicit conversion:
+FIX: Add a type annotation or use explicit conversion:
 
-  render(button as any Widget)
+  const w: any Widget = button    // Implicit via type annotation
+  const w = button as any Widget  // Explicit cast
 ```
 
 ## Examples
@@ -204,7 +211,7 @@ extend Container {
 
 **TR1–TR4 (per-method restrictions):** Rust rejects entire traits from `dyn` if any method is incompatible — "trait is not object-safe." I think that's too coarse. A trait with nine compatible methods and one `Self`-returning method should work with `any` — you just can't call that one method. The error appears at the call site where the problem is, not at the coercion site where it isn't.
 
-**TR8 (explicit at call sites):** `render(button)` where `render` takes `any Widget` hides a heap allocation behind what looks like a regular function call. I'd rather make you write `render(button as any Widget)` — the `any` keyword should always appear in the code wherever a conversion happens. Assignment conversion (TR5) is implicit because the `any Widget` type annotation is already visible.
+**TR5 (implicit when target is `any`):** Originally I required explicit `as any Trait` at call sites (the old TR8). The rationale was cost visibility — `render(button)` hides a heap allocation. But in practice, the `any` keyword is already visible in the function signature, the collection type, or the struct field type. Requiring `as any Widget` on every handler registration, every collection element, every callback — it's ceremony that doesn't help readability. The `any` keyword in the *type system* is the cost signal, not the conversion at each use site. If you see `[]any Widget`, you know there's allocation. You don't need `[button as any Widget, slider as any Widget]` to remind you.
 
 **TR9 (heap allocation):** I chose owned heap allocation over alternatives. The `any` keyword is the cost signal — you see it in the type, you know there's indirection and allocation. This is a deliberate tradeoff: ergonomic for the use cases where you need it (handlers, plugins, UI), explicit enough that you won't accidentally use it in hot paths.
 
@@ -318,6 +325,31 @@ extend App {
     }
 }
 ```
+
+### Sealed Traits (future consideration)
+
+Sealed traits would restrict implementations to a known set, enabling exhaustive matching on `any Trait`:
+
+<!-- test: skip -->
+```rask
+// Hypothetical syntax
+@sealed
+trait Widget {
+    draw(self, canvas: Canvas)
+}
+
+// Only implementations in this module allowed.
+// External crates can use any Widget but can't add implementations.
+
+// Exhaustive matching would be possible:
+match widget {
+    w if w is Button => ...,
+    w if w is Slider => ...,
+    // Compiler knows this is exhaustive
+}
+```
+
+Without sealed traits, `any Trait` downcasting can miss implementations added by external code. This matters for UI widget trees, event systems, and protocol handlers where exhaustive handling is important. Not yet decided — needs design for: syntax, cross-module sealing rules, interaction with `any Trait` downcasting.
 
 ### Integration Notes
 

--- a/specs/types/traits.md
+++ b/specs/types/traits.md
@@ -326,31 +326,6 @@ extend App {
 }
 ```
 
-### Sealed Traits (future consideration)
-
-Sealed traits would restrict implementations to a known set, enabling exhaustive matching on `any Trait`:
-
-<!-- test: skip -->
-```rask
-// Hypothetical syntax
-@sealed
-trait Widget {
-    draw(self, canvas: Canvas)
-}
-
-// Only implementations in this module allowed.
-// External crates can use any Widget but can't add implementations.
-
-// Exhaustive matching would be possible:
-match widget {
-    w if w is Button => ...,
-    w if w is Slider => ...,
-    // Compiler knows this is exhaustive
-}
-```
-
-Without sealed traits, `any Trait` downcasting can miss implementations added by external code. This matters for UI widget trees, event systems, and protocol handlers where exhaustive handling is important. Not yet decided — needs design for: syntax, cross-module sealing rules, interaction with `any Trait` downcasting.
-
 ### Integration Notes
 
 - **Ownership**: `any` values own their heap data — the data pointer is owned, not a reference (`mem.ownership`)


### PR DESCRIPTION
## Summary

This PR introduces a new mutable iteration mode (`for mutate`) to the language, providing a cleaner and more ergonomic way to perform in-place element mutation during iteration without requiring index-based access. The feature is added across loop specifications, collection iteration patterns, and related documentation.

## Key Changes

- **New mutable iteration syntax**: `for mutate binding in collection` yields mutable access to each element, desugaring to mutable inline access on the underlying collection
  - Applies to `Vec<T>`, `Pool<T>`, and `Map<K,V>` (keys remain immutable copies)
  - Structural mutation (insert/remove/clear) remains forbidden during mutable iteration

- **Updated loop specification** (`specs/control/loops.md`):
  - Added rules LP11 (mutable iteration) and LP12 (mutable binding semantics)
  - Clarified LP2 and LP8 to distinguish between in-place element mutation and structural mutation
  - Added comprehensive desugaring examples showing how `for mutate` translates to mutable inline access
  - Updated error handling and IDE annotations to cover mutable mode
  - Expanded rationale explaining why mutable iteration is the second most common pattern after read-only iteration

- **Updated iteration patterns** (`specs/stdlib/iteration.md`):
  - Added I4 rule for mutable mode alongside existing value, index, and take-all modes
  - Added new "Mutable Iteration" section with rules MI1–MI4 covering constraints and use cases
  - Updated collection mode table to include mutable column
  - Added guidance on when to use mutable vs index mode
  - Updated error messages and edge cases to cover mutable iteration

- **Updated Pool documentation** (`specs/memory/pools.md`):
  - Added mutable mode example showing in-place element mutation
  - Clarified that structural mutation still requires handle mode

- **Updated borrowing documentation** (`specs/memory/borrowing.md`):
  - Added mutable iteration as preferred approach for in-place mutation in pools

- **Updated collection documentation** (`specs/stdlib/collections.md`):
  - Added K1 rule warning about float keys in maps (NaN != NaN breaks lookup invariants)

- **Minor updates to related specs**:
  - `specs/control/ensure.md`: Added EN7 rule for per-iteration ensure semantics in loops, with ER5 clarifying multi-failure independence
  - `specs/types/traits.md`: Clarified TR5/TR6 implicit vs explicit trait object conversion rules
  - `specs/stdlib/encoding.md`: Added E28 rule for zero-value initialization of skipped fields
  - `specs/types/iterator-protocol.md`: Added mutable iteration protocol note

## Implementation Details

- Mutable iteration maintains the same length-capture semantics as value iteration (new items added during iteration are not visited)
- Each use of a mutable binding desugars to inline access on the current element, allowing reads of other collection elements (MI3)
- The `mutate` keyword is consistent with function parameter annotations (`func f(mutate x: T)`)
- Mutable iteration on `Map<K,V>` keeps keys as immutable copies while making values mutable
- Pool mutable iteration uses a handle snapshot internally to safely iterate while allowing element mutation

https://claude.ai/code/session_01FVVN7gTxP2XFN9DTQxkUDv