### PR TITLE
Clarify FrozenPool safety model: checked access, not zero-cost indexing

### DIFF
--- a/LANGUAGE_GUIDE.md
+++ b/LANGUAGE_GUIDE.md
@@ -517,7 +517,8 @@ Self-referential structures work naturally. No lifetime annotations anywhere.
 **Mitigations for the cost:**
 - The compiler coalesces checks: `pool[h].x = 1; pool[h].y = 2; pool[h].z = 3` becomes
   one check, not three.
-- Frozen pools (`pool.freeze()`) skip all checks—you promise no inserts/removes happen.
+- Frozen pools (`pool.freeze()`) provide zero-cost iteration—no inserts/removes can happen,
+  so iterating with `values()`/`entries()` skips all checks.
 - Copy out values you need: `const hp = pool[h].health` does one check, then `hp` is
   just a number.
 

--- a/specs/analysis/complexity-stress-test.md
+++ b/specs/analysis/complexity-stress-test.md
@@ -139,15 +139,15 @@ func render_frame(world: GameWorld) {
     const frozen_entities = world.entities.freeze_ref()
     const frozen_meshes = world.meshes.freeze_ref()
 
-    for h in frozen_entities.handles() {
-        const entity = frozen_entities[h]
-        const mesh = frozen_meshes[entity.mesh]
-        draw_mesh(mesh.vertex_buffer, mesh.index_count, entity.position)
+    for (h, entity) in frozen_entities.entries() {
+        if frozen_meshes.get(entity.mesh) is Some(mesh) {
+            draw_mesh(mesh.vertex_buffer, mesh.index_count, entity.position)
+        }
     }
 }
 ```
 
-**Concepts: 6** — frozen pools, cross-pool handles, zero gen checks, unsafe FFI, read-only borrowing, two frozen pools. **PASS.**
+**Concepts: 6** — frozen pools, cross-pool handles, checked random access, unsafe FFI, read-only borrowing, two frozen pools. **PASS.**
 
 ## Phase 5: Parallel Variant
 
@@ -160,10 +160,10 @@ func game_loop_parallel(mutate world: GameWorld, dt: f32) -> () or Error
     const mesh_snap = world.meshes.freeze_ref()
 
     const render_handle = ThreadPool.spawn(|| {
-        for h in snapshot.handles() {
-            const entity = snapshot[h]
-            const mesh = mesh_snap[entity.mesh]
-            draw_mesh(mesh.vertex_buffer, mesh.index_count, entity.position)
+        for (h, entity) in snapshot.entries() {
+            if mesh_snap.get(entity.mesh) is Some(mesh) {
+                draw_mesh(mesh.vertex_buffer, mesh.index_count, entity.position)
+            }
         }
     }
 

--- a/specs/compiler/advanced-analyses.md
+++ b/specs/compiler/advanced-analyses.md
@@ -166,7 +166,7 @@ Formalize Rask's `using Pool<T>` context clauses as a lightweight effect system 
 | **EF2: Frozen context** | `using frozen Pool<T>` forbids Grow and Shrink effects |
 | **EF3: Effect inference** | Private functions infer effects; public functions must declare frozen explicitly |
 | **EF4: Effect checking** | Calling a Shrink function from frozen context is a compile error |
-| **EF5: Generation elimination** | Frozen contexts guarantee no generation checks needed |
+| **EF5: Frozen iteration** | Frozen pool iteration requires no generation checks (see `comp.gen-coalesce/FZ1`). `h.field` auto-resolution in frozen contexts uses standard generation checks |
 | **EF6: Effect polymorphism** | Functions can be effect-polymorphic: work with both frozen and mutable pools |
 
 <!-- test: compile-fail -->
@@ -185,9 +185,9 @@ func render(entities: Vec<Handle<Entity>>) using frozen Pool<Entity> {
 | Annotation | Allowed Effects | Generation Checks | Use Case |
 |------------|-----------------|-------------------|----------|
 | `using Pool<T>` | Access, Grow, Shrink | Normal (coalesced) | Default |
-| `using frozen Pool<T>` | Access only | Zero (eliminated) | Read-only passes |
+| `using frozen Pool<T>` | Access only | Checked (`h.field`), zero (iteration) | Read-only passes |
 | `using name: Pool<T>` | Access, Grow, Shrink | Normal | Structural ops via name |
-| `using frozen name: Pool<T>` | Access only | Zero | Explicit frozen access |
+| `using frozen name: Pool<T>` | Access only | Checked (`h.field`), zero (iteration) | Explicit frozen access |
 
 ### Effect Lattice
 
@@ -287,7 +287,7 @@ ERROR [comp.advanced/EF4]: structural mutation in frozen context
 3  |      pool.remove(h)
    |      ^^^^^^^^^^^^^^ Shrink effect forbidden in frozen context
 
-WHY: Frozen contexts guarantee no structural mutations, enabling zero-cost generation checks.
+WHY: Frozen contexts guarantee no structural mutations.
 
 FIX: Remove the frozen annotation if mutation is needed:
 
@@ -321,7 +321,7 @@ NOTE: Consider adding a range check:
 | Loop with conditional remove | TS4, FN4 | Each iteration resets to pre-loop state |
 | Range analysis timeout | BE2 | Conservative: keep the check |
 | Effect inference failure | EF3 | Public functions require explicit annotation |
-| Frozen pool with mutable handle | EF1 | Allowed: field writes (Access effect) permitted |
+| Frozen pool with external handle | PF6 | `frozen[h]` is compile error; use `frozen.get(h)` or iterate |
 | Typestate at merge with Unknown | TS2 | Join takes lower bound (e.g., Valid ∧ Unknown = Unknown) |
 | Generation overflow | — | Not addressed by static analysis (runtime invariant) |
 | Concurrent mutation | — | Not addressed (use Mutex for cross-task pools) |
@@ -338,7 +338,7 @@ I chose a four-state lattice (Fresh > Valid > Unknown > Invalid) because it bala
 
 **IV1–IV7 (interval analysis):** GCC's Project Ranger showed that demand-driven VRP is nearly free — you only pay for queries you make. By triggering analysis lazily at bounds checks, we avoid computing ranges for all variables. The backward SSA walk (IV3) is fast because SSA has no cycles (except through φ-nodes at loop headers, where we widen conservatively).
 
-**EF1–EF6 (effect system):** Rask already has `using Pool<T>` clauses. I formalized them as an effect system to make the guarantees explicit. The key insight: frozen contexts enable zero-cost generation checks (EF5), same as `FrozenPool<T>` but at the function level. This is more ergonomic than manually calling `pool.freeze()`. Effect inference (EF3) means most code doesn't need annotations — the compiler figures it out.
+**EF1–EF6 (effect system):** Rask already has `using Pool<T>` clauses. I formalized them as an effect system to make the guarantees explicit. Frozen contexts forbid structural mutations, making it safe to accept `FrozenPool<T>` values. `h.field` auto-resolution in frozen contexts uses standard generation checks; zero-cost access is available through frozen pool iteration (`values()`, `entries()`). Effect inference (EF3) means most code doesn't need annotations — the compiler figures it out.
 
 **5× compilation speed vs Rust:** This is achievable because:
 1. **No lifetime inference** — Rust's region inference is expensive. Rask has no lifetimes.
@@ -409,10 +409,10 @@ func process(h: Handle<Entity>) using Pool<Entity> {
 
 **Optimization patterns for frozen contexts:**
 ```rask
-// Hot read path — zero generation checks
-func render_all(entities: Vec<Handle<Entity>>) using frozen Pool<Entity> {
-    for h in entities {
-        renderer.draw(pool[h])  // Zero checks: frozen context guarantee
+// Hot read path — zero generation checks via frozen iteration
+func render_all() using frozen entities: Pool<Entity> {
+    for entity in entities.values() {
+        renderer.draw(entity)  // Zero checks: frozen iteration (FZ1)
     }
 }
 
@@ -425,10 +425,8 @@ func tick(mut pool: Pool<Entity>) {
 
     // Phase 2: Frozen render
     pool.with_frozen(|frozen_pool| {
-        using frozen Pool<Entity> = frozen_pool {
-            for h in pool.handles() {
-                render(pool[h])  // Zero checks
-            }
+        for entity in frozen_pool.values() {
+            render(entity)  // Zero checks (frozen iteration)
         }
     })
 }

--- a/specs/compiler/generation-coalescing.md
+++ b/specs/compiler/generation-coalescing.md
@@ -36,8 +36,8 @@ pool[h].z = 3
 
 | Guarantee Level | Mechanism | Checks | Use Case |
 |-----------------|-----------|--------|----------|
-| Guaranteed zero | Frozen pool | 0 | Read-only hot paths |
-| Guaranteed 1 | `with_valid(h, f)` | 1 | Write hot paths (safe) |
+| Guaranteed zero | Frozen pool iteration (FZ1) | 0 | Read-only hot paths |
+| Guaranteed 1 | `frozen.get(h)` / `with_valid(h, f)` | 1 | Random access (safe) |
 | Guaranteed zero | `get_unchecked(h)` (unsafe) | 0 | Caller-validated handles |
 | Expected 1 or fewer per handle | Coalescing | 1 or fewer | General code |
 | Worst case | No coalescing | 1/access | Compiler can't prove safety |
@@ -111,7 +111,9 @@ using pool {
 
 | Rule | Description |
 |------|-------------|
-| **FP1: No checks** | Frozen pools skip all generation checks; coalescing irrelevant |
+| **FZ1: Iteration zero-check** | Handles from `frozen.values()`, `frozen.entries()`, `frozen.handles()` require no generation checks — the iterator only yields occupied slots from an immutable pool |
+| **FZ2: get() checked** | `frozen.get(h)` performs a standard generation check and returns `Option<T>` |
+| **FZ3: No index access** | `frozen[h]` is a compile error (`mem.pools/PF6`). Coalescing does not apply |
 
 ## Debug vs Release
 
@@ -149,7 +151,9 @@ store %slot2.y, 2
 | Mutation between accesses | Fresh check after mutation | GC2, MT1 |
 | Unknown function with `&mut pool` | Fresh check after call | MT3 |
 | Async: after await point | Fresh check | CF5 |
-| Frozen pool accesses | No checks at all (coalescing irrelevant) | FP1 |
+| Frozen pool iteration | No checks (valid by construction) | FZ1 |
+| Frozen pool `get(h)` | One generation check, returns Option | FZ2 |
+| Frozen pool `frozen[h]` | Compile error | FZ3 |
 
 ---
 

--- a/specs/memory/context-clauses.md
+++ b/specs/memory/context-clauses.md
@@ -18,6 +18,8 @@
 
 Without `frozen`, contexts are mutable by default — writes through handles are allowed, but only `Pool<T>` satisfies the context (not `FrozenPool<T>`). See `mem.pools` for the full subsumption rule.
 
+**Note:** `h.field` auto-resolution in frozen contexts performs generation checks (same as mutable contexts). The `frozen` modifier means "no structural mutations" — it doesn't skip validity checks. Zero-cost access on frozen pools is available through iteration (`values()`, `entries()`), not through handle auto-resolution.
+
 <!-- test: skip -->
 ```rask
 // Named — binding + auto-resolution
@@ -34,7 +36,7 @@ func damage(h: Handle<Player>, amount: i32) using Pool<Player> {
     // players.remove(h)      // ERROR: 'players' not in scope
 }
 
-// Frozen — read-only
+// Frozen — read-only (h.field still generation-checked)
 func get_health(h: Handle<Player>) using frozen Pool<Player> -> i32 {
     return h.health
 }

--- a/specs/memory/pools.md
+++ b/specs/memory/pools.md
@@ -216,19 +216,29 @@ Automatically invalidated when the element is removed, the pool is cleared, or t
 
 ## Frozen Pools
 
-`pool.freeze()` returns an immutable view where all generation checks are skipped.
+`pool.freeze()` returns an immutable view. No structural mutations are possible while frozen.
 
 | Rule | Description |
 |------|-------------|
 | **PF5: Freeze guarantees** | No insert/remove while frozen — all handles valid at freeze time remain valid |
-| **PF6: Zero checks** | Generation matching is guaranteed, so checks are skipped |
-| **PF7: Stale handle UB** | Using a handle that was invalid at freeze time is undefined behavior |
+| **PF6: No index access** | `frozen[h]` is a compile error. Use iteration or `frozen.get(h)` |
+| **PF7: Safe random access** | `frozen.get(h)` returns `Option<T>` with a generation check — stale handles return `None` |
+
+FrozenPool provides two access paths: **iteration** (zero-cost, handles are valid by construction) and **checked get** (one generation check, returns Option).
 
 ```rask
 const frozen = pool.freeze()
-for h in frozen.handles() {
-    render(frozen[h])       // Zero generation checks
+
+// Iteration — zero generation checks (handles valid by construction)
+for (h, entity) in frozen.entries() {
+    render(entity)
 }
+
+// Random access — checked, returns Option
+if frozen.get(h) is Some(val) {
+    use(val)
+}
+
 const pool = frozen.thaw()
 ```
 
@@ -239,8 +249,10 @@ const pool = frozen.thaw()
 | `pool.freeze()` | `Pool<T> -> FrozenPool<T>` | Freeze, consume ownership |
 | `pool.freeze_ref()` | `Pool<T> -> FrozenPool<T>` | Freeze reference (scoped) |
 | `pool.with_frozen(f)` | `(|FrozenPool<T>| -> R) -> R` | Scoped freeze |
+| `frozen.get(h)` | `(Handle<T>) -> Option<T>` | Checked random access |
+| `frozen.with_valid(h, f)` | `(Handle<T>, \|T\| -> R) -> Option<R>` | One check, callback access |
 
-**NOT available on FrozenPool:** `insert()`, `remove()`, `clear()`, `with` mutable bindings
+**NOT available on FrozenPool:** `insert()`, `remove()`, `clear()`, `frozen[h]`, `with` mutable bindings
 
 ### FrozenPool Context Subsumption
 
@@ -254,7 +266,7 @@ func damage(h: Handle<Entity>, amount: i32) using Pool<Entity> {
 
 // Frozen — read-only, accepts both Pool<T> and FrozenPool<T>
 func get_health(h: Handle<Entity>) using frozen Pool<Entity> -> i32 {
-    return h.health
+    return h.health    // Generation-checked (h came from outside)
 }
 ```
 
@@ -266,6 +278,8 @@ func get_health(h: Handle<Entity>) using frozen Pool<Entity> -> i32 {
 | `using frozen name: Pool<T>` | Accepted | Accepted |
 
 Writing through handles in a `frozen` context is a compile error. Private functions can have `frozen` inferred; public functions must declare it.
+
+**Note:** `h.field` auto-resolution in frozen contexts performs generation checks (same as mutable contexts). The `frozen` modifier means "no structural mutations" — it doesn't skip validity checks. Zero-cost access is available through iteration on the frozen pool itself.
 
 ## Generation Check Coalescing
 
@@ -323,8 +337,8 @@ Split a pool for parallel processing.
 ```rask
 entities.with_partition(4, |chunks| {
     parallel_for(chunks) { |chunk|
-        for h in chunk.handles() {
-            analyze(chunk[h])  // Zero generation checks (frozen)
+        for (h, entity) in chunk.entries() {
+            analyze(entity)  // Zero generation checks (frozen iteration)
         }
     }
 })  // Auto-reunifies here
@@ -335,7 +349,7 @@ entities.with_partition(4, |chunks| {
 ```rask
 let (snapshot, mut pool) = entities.snapshot()
 
-// Readers see frozen state (zero checks)
+// Readers see frozen state (iterate for zero-check access)
 spawn(|| { render_frame(snapshot) }
 
 // Writer can mutate concurrently
@@ -472,6 +486,19 @@ ERROR [mem.pools/PF5]: cannot write through handle in frozen context
    |      ^^^^^^^^^^^^^^ cannot write in frozen context
 ```
 
+**Frozen pool index access [PF6]:**
+```
+ERROR [mem.pools/PF6]: FrozenPool does not support index access
+   |
+3  |  const entity = frozen[h]
+   |                 ^^^^^^^^^ cannot index FrozenPool with handle
+
+FIX: Use get() for checked random access, or iterate:
+
+  if frozen.get(h) is Some(entity) { ... }
+  for (h, entity) in frozen.entries() { ... }
+```
+
 ## Edge Cases
 
 | Case | Rule | Handling |
@@ -486,6 +513,8 @@ ERROR [mem.pools/PF5]: cannot write through handle in frozen context
 | Nested cursors | — | Compile error (pool already borrowed) |
 | Drop Pool<Resource> while non-empty | R5 | Runtime panic |
 | `clear()` on Pool<Resource> | — | Compile error (would abandon resources) |
+| `frozen[h]` index access | PF6 | Compile error (use `get()` or iterate) |
+| `frozen.get(h)` with stale handle | PF7 | Returns `None` |
 | `get_unchecked` with stale handle | — | **Undefined behavior** |
 | `with_partition(0, f)` | — | Compile error (n must be > 0) |
 | Partition while borrowed | — | Compile error |
@@ -541,10 +570,10 @@ func render_frame(world: World) {
         entity.update_physics()
     }
 
-    // Render pass (read-only, zero-cost)
+    // Render pass (read-only, zero-cost iteration)
     const frozen = world.entities.freeze()
-    for h in frozen.handles() {
-        renderer.draw(frozen[h])
+    for entity in frozen.values() {
+        renderer.draw(entity)
     }
     world.entities = frozen.thaw()
 }
@@ -560,7 +589,7 @@ func render_frame(world: World) {
 
 **PH3 (handle identity):** Handles are database primary keys. You can have 10 copies of the key `42` — they all access the same row. The keys aren't borrowed; only the access is.
 
-**PF5–PF7 (frozen pools):** When frozen, no structural changes can happen, so generation checks are redundant. ~10% faster for access-heavy code.
+**PF5–PF7 (frozen pools):** Frozen pools don't support `frozen[h]` indexing — this prevents stale handle access from being possible in safe code. Zero-cost access is available through iteration (`values()`, `entries()`, `handles()`), which only yields occupied slots from an immutable pool. Random access with external handles uses `frozen.get(h)` which returns `Option<T>` with a generation check. The common pattern (iterate all entities for a render pass) is zero-cost; the uncommon pattern (follow stored handles) has a checked fallback.
 
 **PL9 (handle stability):** This is why handles exist — stable identifiers that don't break when memory moves. Pointers would become dangling; handles never do.
 
@@ -607,8 +636,7 @@ func physics_tick(mut entities: Pool<Entity>, dt: f32) {
     // Phase 1: Parallel read (compute forces)
     const forces = entities.with_partition(num_cpus(), |chunks| {
         parallel_map(chunks) { |chunk|
-            chunk.handles().map(|h| {
-                const e = chunk[h]
+            chunk.entries().map(|(h, e)| {
                 (h, compute_forces(e.position, e.mass))
             }).collect<Vec<_>>()
         }
@@ -623,8 +651,8 @@ func physics_tick(mut entities: Pool<Entity>, dt: f32) {
 ```
 
 **Self-referential patterns:** Doubly-linked lists, trees with parent pointers, graphs with cycles, and arena-allocated ASTs all use the pool+handle pattern. Key guidance:
-- Use `freeze_ref()` for read-only traversal (zero generation checks)
-- Stale handles in graphs are detected on access — run `gc_edges()` periodically
+- Use `freeze_ref()` for read-only traversal (zero-cost iteration via `values()`/`entries()`)
+- Follow stored handles across a frozen pool with `frozen.get(h)` (checked, returns Option)
 - ASTs: build once, then freeze for analysis passes
 
 **Shared state:** Share handles, not data. Handles are 12-byte copyable values that can be sent anywhere. The pool stays in one thread; commands flow back to it.
@@ -662,7 +690,8 @@ func process_by_type(mut entities: Pool<Entity>) {
 |-----------|------|-------|
 | `pool[h]` | ~1 ns | Generation check + index |
 | `pool.get(h)` | ~1 ns | Same + Option wrap |
-| Frozen `frozen[h]` | ~0 ns | No generation check |
+| Frozen iteration | ~0 ns/element | No generation check (valid by construction) |
+| `frozen.get(h)` | ~1 ns | Generation check + Option wrap |
 | `insert()` | Amortized O(1) | May allocate (unbounded) |
 | `remove()` | O(1) | Bumps generation |
 | `cursor()` iteration | O(capacity) | Scans all slots |


### PR DESCRIPTION
## Summary

This PR revises the FrozenPool specification to clarify that zero-cost access is achieved through **iteration**, not through index operations. The key safety change is that `frozen[h]` is now a compile error (PF6), while `frozen.get(h)` provides safe checked random access returning `Option<T>`.

## Changes

- **Reframed FrozenPool guarantees (PF5–PF7):**
  - PF6 now forbids `frozen[h]` indexing (compile error)
  - PF7 now specifies `frozen.get(h)` returns `Option<T>` with generation check
  - Removed claim that generation checks are "skipped" in frozen contexts

- **Clarified zero-cost access path:**
  - Zero-cost access is available only through frozen pool iteration (`values()`, `entries()`, `handles()`)
  - These iterators yield only occupied slots from an immutable pool, so no generation checks are needed
  - Added FZ1 rule: "Iteration zero-check" — handles from iterators require no checks

- **Updated handle auto-resolution semantics:**
  - `h.field` in frozen contexts still performs generation checks (same as mutable contexts)
  - The `frozen` modifier means "no structural mutations," not "no validity checks"
  - Added explicit note in context-clauses and pools specs clarifying this distinction

- **Updated API surface:**
  - Added `frozen.get(h)` and `frozen.with_valid(h, f)` to method table
  - Removed `frozen[h]` from available operations
  - Updated examples to use `entries()` / `values()` instead of `handles()` + indexing

- **Updated coalescing rules (FZ1–FZ3):**
  - FZ1: Frozen iteration requires zero checks (valid by construction)
  - FZ2: `frozen.get(h)` performs one generation check, returns Option
  - FZ3: `frozen[h]` is a compile error; coalescing does not apply

- **Updated performance table:**
  - Changed "Frozen `frozen[h]`" entry to "Frozen iteration" (~0 ns/element, no check)
  - Added separate entry for `frozen.get(h)` (~1 ns, with check)

- **Updated examples throughout:**
  - Render loops now use `frozen.entries()` or `frozen.values()` instead of `handles()` + indexing
  - Cross-pool handle access now uses `frozen.get(h)` with `is Some()` pattern
  - Partition examples updated to use `entries()` iterator

## Rationale

This change makes the safety model explicit: FrozenPool prevents stale handle access in safe code by disallowing index operations entirely. The common case (iterating all entities) is zero-cost because the iterator only yields valid slots. The uncommon case (following stored handles) has a checked fallback (`get()`) that returns `Option<T>`, making stale handles impossible to dereference unsafely.

This is more conservative than the previous spec (which claimed zero checks everywhere) but more ergonomic than requiring unsafe code for random access.

https://claude.ai/code/session_01453vMC3egMQZg3quAeuFMs