### PR TITLE
Simplify error origin tracking and Shared<T> lock access patterns

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -109,8 +109,9 @@ Add `// SPDX-License-Identifier: (MIT OR Apache-2.0)` to the top of source code 
 | Error propagation | `try expr` | `expr?` |
 | Pool context | `func f() using Pool<T>` | N/A |
 | Runtime context | `using Multitasking { }` | N/A |
-| Element binding | `with pool[h] as x { }` (mutable default) / `with pool[h] as const x { }` | N/A |
-| Cell/Shared/Mutex | `with cell as v { }` (mutable default) / `with shared as const v { }` (read lock) | N/A |
+| Element binding | `with pool[h] as x { }` (always mutable) | N/A |
+| Cell/Mutex | `with cell as v { }` / `with mutex as v { }` | N/A |
+| Shared read/write | `with shared.read() as v { }` / `with shared.write() as v { }` | N/A |
 | Async spawn | `spawn(\|\| {})` | `tokio::spawn(async {})` |
 | Thread pool spawn | `ThreadPool.spawn(\|\| {})` | N/A |
 | OS thread spawn | `Thread.spawn(\|\| {})` | `std::thread::spawn(\|\| {})` |
@@ -158,13 +159,14 @@ using Multitasking {                         // runtime executor
     spawn(|| { work() }).detach()
 }
 
-with pool[h] as entity {                     // mutable element binding (default)
+with pool[h] as entity {                     // mutable element binding
     entity.health -= 10
 }
 
-with cell as v { v.count += 1 }             // Cell access (mutable default)
-with shared as const v { v.timeout }         // Shared read lock (explicit const)
-with mutex as v { v.push(item) }             // Mutex exclusive lock (mutable default)
+with cell as v { v.count += 1 }             // Cell access (mutable)
+with shared.read() as v { v.timeout }        // Shared read lock (explicit)
+with shared.write() as v { v.count += 1 }    // Shared write lock (explicit)
+with mutex as v { v.push(item) }             // Mutex exclusive lock
 
 // Spawning (functions, not keywords)
 import async.spawn

--- a/specs/SYNTAX.md
+++ b/specs/SYNTAX.md
@@ -854,8 +854,8 @@ select {
 
 // Shared state
 const config = Shared.new(AppConfig.default())
-const timeout = with config as const c { c.timeout }
-with config as c { c.timeout = 60.seconds }
+const timeout = with config.read() as c { c.timeout }
+with config.write() as c { c.timeout = 60.seconds }
 ```
 
 See [concurrency/](concurrency/).

--- a/specs/canonical-patterns.md
+++ b/specs/canonical-patterns.md
@@ -163,7 +163,7 @@ func get_user(id: i64) -> User or NotFound {
 
 ### Error context
 
-Use `try...else` to add context when propagating errors. Two tiers depending on who consumes the error:
+Use `try...else` to add context when propagating errors. Stdlib provides `ContextError` and `context()` for human-readable chains. Two tiers depending on who consumes the error:
 
 ```rask
 // Application code — human-readable context chains
@@ -337,12 +337,12 @@ Message passing for communication, `Shared<T>` for shared data.
 // Shared data — with-based access, no lock leaks
 const db = Shared.new(Database.new())
 
-with db as const d {
+with db.read() as d {
     const user = d.users.get(id)
     respond(user)
 }
 
-with db as d {
+with db.write() as d {
     d.users.insert(id, new_user)
 }
 
@@ -353,8 +353,8 @@ const result = try ch.receiver.recv()
 ```
 
 **Anti-patterns:**
-- Global mutable state — use `Shared<T>` with explicit read/write scopes.
-- Holding locks across await points — `Shared` closures prevent this by design.
+- Global mutable state — use `Shared<T>` with explicit `.read()`/`.write()` scopes.
+- Holding locks across await points — `Shared` `with` blocks prevent this by design.
 
 See [concurrency/sync.md](concurrency/sync.md).
 

--- a/specs/concurrency/sync.md
+++ b/specs/concurrency/sync.md
@@ -27,10 +27,11 @@ Cross-task shared state when channels aren't enough.
 
 | Rule | Description |
 |------|-------------|
-| **R1: Read** | `with shared as const v { ... }` — shared read lock; multiple readers concurrent |
-| **R2: Write** | `with shared as v { ... }` — exclusive write lock (default); blocks until readers finish |
-| **R2a: Unused write warning** | Compiler warns when write lock taken but binding never mutated — suggests `const` |
+| **R1: Read** | `with shared.read() as v { ... }` — shared read lock; multiple readers concurrent. Mutation through binding is a compile error |
+| **R2: Write** | `with shared.write() as v { ... }` — exclusive write lock; blocks until readers finish |
+| **R2a: Unused write warning** | Compiler warns when `.write()` used but binding never mutated — suggests `.read()` |
 | **R3: Try variants** | `try_read(f)` / `try_write(f)` — non-blocking closures, return `None` if contended |
+| **R4: Bare access forbidden** | `with shared as v { ... }` is a compile error — must use `.read()` or `.write()` |
 
 <!-- test: skip -->
 ```rask
@@ -39,8 +40,8 @@ let config = Shared.new(AppConfig {
     max_retries: 3,
 })
 
-const timeout = with config as const c { c.timeout }
-with config as c { c.timeout = 60.seconds }
+const timeout = with config.read() as c { c.timeout }
+with config.write() as c { c.timeout = 60.seconds }
 ```
 
 ### API
@@ -56,20 +57,20 @@ extend Shared<T> {
 }
 ```
 
-`with shared as const v { ... }` (read lock) and `with shared as v { ... }` (write lock, default) are the primary access patterns. `try_read`/`try_write` remain as closure-based non-blocking variants.
+`with shared.read() as v { ... }` (shared read lock) and `with shared.write() as v { ... }` (exclusive write lock) are the primary access patterns. `try_read`/`try_write` remain as closure-based non-blocking variants. Bare `with shared as v` is a compile error — the lock type must be explicit.
 
 ## Mutex\<T\>
 
 | Rule | Description |
 |------|-------------|
-| **MX1: Lock** | `with mutex as [const] v { ... }` — exclusive lock; blocks until available |
+| **MX1: Lock** | `with mutex as v { ... }` — exclusive lock; blocks until available |
 | **MX2: Try lock** | `try_lock(f)` — non-blocking closure, returns `None` if held |
 
 <!-- test: skip -->
 ```rask
 const queue = Mutex.new(Vec.new())
 with queue as q { q.push(item) }
-const len = with queue as const q { q.len() }
+const len = with queue as q { q.len() }
 ```
 
 ### API
@@ -84,9 +85,7 @@ extend Mutex<T> {
 }
 ```
 
-`with mutex as v { ... }` (mutable, default) and `with mutex as const v { ... }` (read-only) are the primary access patterns. `try_lock` remains as a closure-based non-blocking variant.
-
-Mutex always takes an exclusive lock regardless of `const`. The keyword controls whether the binding is mutable inside the block, not the lock mode.
+`with mutex as v { ... }` is the primary access pattern. Mutex always takes an exclusive lock. `try_lock` remains as a closure-based non-blocking variant.
 
 ## `with`-Based Access
 
@@ -114,7 +113,7 @@ with mutex as data {
 | Rule | Description |
 |------|-------------|
 | **DL1: Direct nesting** | Nested `with` on different sync primitives is a compile error |
-| **DL2: Same lock** | `with shared as const v { with shared as v2 { ... } }` is a compile error |
+| **DL2: Same lock** | `with shared.read() as v { with shared.write() as v2 { ... } }` is a compile error |
 | **DL3: Indirect — your responsibility** | Locks acquired through function calls or dynamic dispatch are NOT detected |
 
 ```
@@ -130,8 +129,8 @@ WHY: Nested locks risk deadlock. Copy values out, then lock separately.
 ```
 ERROR [conc.sync/DL2]: same lock re-acquisition
    |
-5  |  with shared as const c {
-6  |      with shared as c2 {
+5  |  with shared.read() as c {
+6  |      with shared.write() as c2 {
    |      ^^^^ cannot acquire write lock — already holding read lock
 
 WHY: Re-acquiring the same lock inside a with block would deadlock.
@@ -179,6 +178,8 @@ const got_it = mutex.try_lock(|v| v.push(item))
 
 **SY1 (Shared naming):** `Shared<T>` describes intent, not mechanism. `RwLock<T>` is implementation jargon.
 
+**R1/R2 (explicit .read()/.write()):** With implicit lock selection via `const`, the same keyword means different things for Shared (changes lock type) vs Mutex (changes only binding mutability). Explicit `.read()`/`.write()` makes the lock type visible and removes the semantic inconsistency.
+
 **try_* stay as closures:** Non-blocking access is uncommon. The inconsistency is justified — `with` is inherently blocking (it's a scope, not a conditional). Could add `with try mutex as v { ... } else { ... }` later if the pattern is common enough.
 
 ### When to Use What
@@ -210,15 +211,15 @@ For patterns that genuinely need multiple locks:
 ```rask
 // Lock ordering — copy out, then lock separately
 func transfer(from: Mutex<Account>, to: Mutex<Account>, amount: u64) {
-    const from_balance = with from as const f { f.balance }
+    const from_balance = with from as f { f.balance }
     with from as f { f.balance -= amount }
     with to as t { t.balance += amount }
 }
 
 // Copy out, modify, copy back
 func swap_values(a: Mutex<i32>, b: Mutex<i32>) {
-    const a_val = with a as const v { v }
-    const b_val = with b as const v { v }
+    const a_val = with a as v { v }
+    const b_val = with b as v { v }
     with a as v { v = b_val }
     with b as v { v = a_val }
 }
@@ -241,7 +242,7 @@ func swap_values(a: Mutex<i32>, b: Mutex<i32>) {
 static CONFIG: Shared<AppConfig> = Shared.new(AppConfig.default())
 
 func get_timeout() -> Duration {
-    return with CONFIG as const c { c.timeout }
+    return with CONFIG.read() as c { c.timeout }
 }
 ```
 
@@ -265,7 +266,7 @@ func record_request(latency: Duration, success: bool) {
 
 | Decision | Chosen | Rejected | Why |
 |----------|--------|----------|-----|
-| Access pattern | `with`-based blocks (mutable default) | Guard-based / closure-based | No escaping references, `return`/`try` work, prevents nested deadlock |
+| Access pattern | `with`-based blocks | Guard-based / closure-based | No escaping references, `return`/`try` work, prevents nested deadlock |
 | Read-heavy primitive | `Shared<T>` | Just `Mutex<T>` | Common pattern deserves optimization |
 | Naming | `Shared<T>` | `RwLock<T>` | Describes intent, not mechanism |
 | Direct nested locks | Compile error (syntactic) | Whole-program analysis | Local analysis only |

--- a/specs/memory/borrowing.md
+++ b/specs/memory/borrowing.md
@@ -135,25 +135,25 @@ For non-Copy types, `const x = collection[key]` is a compile error. Use `.clone(
 | **W2: Source frozen** | Source collection cannot be accessed inside the `with` block (no structural mutations, no other element access) |
 | **W3: Aliasing check** | Multiple bindings from same collection: runtime panic if same key/handle |
 | **W4: Error semantics** | Panics on invalid handle/OOB (matches direct indexing) |
-| **W5: Mutable default** | `as v` is mutable (default); `as const v` is read-only (explicit). Compiler warns when Shared takes write lock but binding is never mutated |
+| **W5: Mutable binding** | `with` bindings are always mutable. Read-only access is enforced by the source (e.g., `shared.read()` prevents mutation). Compiler warns when binding is never mutated |
 | **W6: Value production** | Block can produce a value (last expression) — `with` works in expression context |
 | **W7: One-liner shorthand** | `with X as v: expr` — no braces for single expressions (parallels `if cond: expr`) |
 
 ### Syntax
 
 ```
-with <source>[<key>] as [const] <binding> { <body> }
-with <source>[<key>] as [const] <binding>: <expr>
+with <source>[<key>] as <binding> { <body> }
+with <source>[<key>] as <binding>: <expr>
 
 // Multiple elements
-with <source>[<key1>] as [const] <binding1>, <source>[<key2>] as [const] <binding2> { <body> }
+with <source>[<key1>] as <binding1>, <source>[<key2>] as <binding2> { <body> }
 ```
 
 ### Examples
 
 <!-- test: skip -->
 ```rask
-// Mutable multi-statement access (default — no keyword needed)
+// Multi-statement access
 with pool[h] as entity {
     entity.health -= damage
     entity.last_hit = now()
@@ -162,18 +162,13 @@ with pool[h] as entity {
     }
 }
 
-// Read-only access (explicit const)
-with pool[h] as const entity {
-    log("{entity.name} at {entity.position}")
-}
-
 // Multiple elements from same collection
 with pool[h1] as e1, pool[h2] as e2 {
     e1.health -= e2.attack    // Runtime panic if h1 == h2
 }
 
 // Expression context — produces a value
-const name = with pool[h] as const entity { entity.name.clone() }
+const name = with pool[h] as entity { entity.name.clone() }
 
 // One-liner shorthand
 with pool[h] as e: e.health -= 10
@@ -212,7 +207,7 @@ with pool[h] as entity {
 For accessing multiple elements, use the comma syntax:
 <!-- test: skip -->
 ```rask
-with pool[h1] as e1, pool[h2] as const e2 {
+with pool[h1] as e1, pool[h2] as e2 {
     e1.health -= e2.attack
 }
 ```
@@ -234,16 +229,16 @@ for h in handles {
 
 ### Unified `with` across container types
 
-One syntax for all container types that hold values behind indirection.
+One syntax for all container types that hold values behind indirection. Bindings are always mutable — read-only access is enforced by the source.
 
-| Container | Mutate (default) | Read-only |
-|-----------|------------------|-----------|
-| Pool/Vec/Map | `with pool[h] as e { ... }` | `with pool[h] as const e { ... }` |
-| Cell | `with cell as v { ... }` | `with cell as const v { ... }` |
-| Shared | `with shared as v { ... }` (write lock) | `with shared as const v { ... }` (read lock) |
-| Mutex | `with mutex as v { ... }` (exclusive lock) | `with mutex as const v { ... }` (exclusive lock) |
+| Container | Access | Read-only access |
+|-----------|--------|------------------|
+| Pool/Vec/Map | `with pool[h] as e { ... }` | — (just don't mutate) |
+| Cell | `with cell as v { ... }` | — (just don't mutate) |
+| Shared | `with shared.write() as v { ... }` | `with shared.read() as v { ... }` (mutation is compile error) |
+| Mutex | `with mutex as v { ... }` | — (always exclusive) |
 
-Mutex always takes an exclusive lock regardless. The `const` distinction controls whether the binding is mutable inside the block, not the lock mode. For Shared, the distinction matters: `as const v` takes a shared read lock (concurrent readers OK), `as v` takes an exclusive write lock. The compiler warns when a Shared write lock is taken but the binding is never mutated — suggests adding `const`.
+Shared requires explicit `.read()` or `.write()` — bare `with shared as v` is a compile error. For all other types, `with` gives mutable access. The compiler warns if a binding is never mutated (consider whether you need the `with` block at all, or use `.read()` for Shared).
 
 See [cell.md](cell.md) for Cell specifics, [sync.md](../concurrency/sync.md) for Shared/Mutex specifics.
 
@@ -471,7 +466,7 @@ func apply_buff(pool: Pool<Entity>, h: Handle<Entity>) -> () or Error {
 
 **W2 (source frozen):** Start strict — freeze the entire collection during `with`. The comma syntax handles the multi-element case. Relaxing to "structural mutations only" is a future option if real code needs it.
 
-**W5 (mutable default):** `with` exists for multi-statement access — and 3 out of 4 container types (Pool/Vec/Map, Cell, Mutex) are used for mutation in the overwhelming majority of cases. If you just need to read, inline access often suffices. Defaulting to mutable saves `mutate` on every `with` block. The outlier is `Shared<T>` (read-heavy by design), where the compiler warns when a write lock is taken but the binding is never mutated. Function parameters default to immutable because they're contracts affecting all callers — `with` bindings are local to the block, different context, different default.
+**W5 (always mutable):** `with` exists for multi-statement access — and the overwhelming majority of cases involve mutation. If you just need to read, inline access often suffices. Making bindings always mutable eliminates the `const` keyword from `with` entirely, removing a concept that caused confusion: for `Shared<T>`, `const` previously changed the lock type (shared vs exclusive), while for everything else it only controlled binding mutability. With explicit `.read()`/`.write()` on Shared, there's no need for `const` on `with` bindings. The compiler warns when a `with` binding is never mutated.
 
 **Why strings are value-access, not block-scoped:** Strings own heap buffers — structurally the same as Vec. Block-scoped string views would require a hidden view type distinct from `string` and borrow-of-borrow tracking when views are passed to functions. This contradicts the "no storable references" principle. The cost is `.to_string()` calls or `string_view` indices — visible, simple, no borrow tracking needed.
 

--- a/specs/memory/cell.md
+++ b/specs/memory/cell.md
@@ -32,7 +32,7 @@ button.on_click(|event, state| {
 | **CE1: Heap-allocated** | `Cell.new(value)` heap-allocates the value |
 | **CE2: Value semantics** | `Cell<T>` is a value that owns its heap data (like Vec, string) |
 | **CE3: Move-only** | `Cell<T>` is never Copy; assignment moves |
-| **CE4: with access** | Access through `with cell as const v { ... }` (read) and `with cell as v { ... }` (mutate, default) |
+| **CE4: with access** | Access through `with cell as v { ... }` — always mutable binding |
 | **CE5: Exclusive mutation** | `with...as v` (mutable, default) takes exclusive access; no concurrent reads or writes |
 
 ## API
@@ -49,8 +49,8 @@ Access is through `with`:
 ```rask
 const counter = Cell.new(0)
 
-// Read (explicit const)
-const current = with counter as const c { c }
+// Read
+const current = with counter as c { c }
 
 // Mutate
 with counter as c { c += 1 }
@@ -59,7 +59,7 @@ with counter as c { c += 1 }
 with counter as c: c += 1
 
 // Expression context
-const doubled = with counter as const c { c * 2 }
+const doubled = with counter as c { c * 2 }
 
 // Replace
 const old = counter.replace(0)

--- a/specs/memory/closures.md
+++ b/specs/memory/closures.md
@@ -328,7 +328,7 @@ button2.on_click(|event, counter| {
     with counter as c { c += 10 }
 })
 
-// After clicks: const value = with counter as const c { c }
+// After clicks: const value = with counter as c { c }
 ```
 
 See `mem.cell` for `Cell<T>` details.

--- a/specs/memory/pools.md
+++ b/specs/memory/pools.md
@@ -107,11 +107,6 @@ with pool[h] as entity {
     }
 }
 
-// Read-only access (explicit const)
-with pool[h] as const entity {
-    log("{entity.name} at {entity.position}")
-}
-
 // One-liner shorthand
 with pool[h] as e: e.health -= damage
 ```
@@ -596,7 +591,7 @@ if should_remove {
 }
 
 // Pattern 3: Multi-element access
-with pool[h1] as e1, pool[h2] as const e2 {
+with pool[h1] as e1, pool[h2] as e2 {
     e1.health -= e2.attack
 }
 ```

--- a/specs/rejected-features.md
+++ b/specs/rejected-features.md
@@ -122,8 +122,8 @@ Kotlin has `.let`, `.apply`, `.also` with implicit receivers—`it` or `this`. T
 Rask already has the pattern, just with explicit parameters:
 
 ```rask
-const users = with db as const d { d.users.values().collect() }
-with db as d { d.users.insert(id, user) }
+const users = with db.read() as d { d.users.values().collect() }
+with db.write() as d { d.users.insert(id, user) }
 ```
 
 Compare `obj.let { it.field }` vs `with obj as d { d.field }`. The `with...as` syntax shows intent—you're entering a scoped access, not just "letting" something happen. The binding name is explicit. And `return`/`try`/`break` work naturally.

--- a/specs/stdlib/collections.md
+++ b/specs/stdlib/collections.md
@@ -84,8 +84,7 @@ const users = Map.from([
 | `vec[i].field` | inline access (expression-scoped) | None | Yes (OOB) |
 | `vec.get(i)` | `Option<T>` | `T: Copy` | No |
 | `vec.get_clone(i)` | `Option<T>` | `T: Clone` | No |
-| `with vec[i] as v { ... }` | block value (mutable, default) | None | Yes (OOB) |
-| `with vec[i] as const v { ... }` | block value (read-only) | None | Yes (OOB) |
+| `with vec[i] as v { ... }` | block value (mutable) | None | Yes (OOB) |
 | `vec.insert(i, x)` | `Result<(), InsertError<T>>` | None | Yes (OOB) |
 | `vec.remove(i)` | `T` | None | Yes (OOB) |
 
@@ -112,7 +111,7 @@ with vec[i] as v {
 with vec[i] as v: v.count += 1
 
 // Expression context — produces a value
-const name = with vec[i] as const v { v.name.clone() }
+const name = with vec[i] as v { v.name.clone() }
 ```
 
 ## Map Key Constraints
@@ -129,8 +128,7 @@ const name = with vec[i] as const v { v.name.clone() }
 | `map[k].field` | inline access (expression-scoped) | Panics if missing |
 | `map.get(k)` | `Option<V>` | Copy out (V: Copy) |
 | `map.get_clone(k)` | `Option<V>` | Clone out (V: Clone) |
-| `with map[k] as v { ... }` | block value (mutable, default) | Panics if missing |
-| `with map[k] as const v { ... }` | block value (read-only) | Panics if missing |
+| `with map[k] as v { ... }` | block value (mutable) | Panics if missing |
 | `map.remove(k)` | `Option<V>` | Remove and return |
 
 ### Entry API

--- a/specs/stdlib/encoding.md
+++ b/specs/stdlib/encoding.md
@@ -9,11 +9,13 @@ Two language primitives — `comptime for` over struct fields and comptime field
 
 ## Core Mechanism
 
-| Rule | Description |
-|------|-------------|
-| **E1: Comptime field access** | `value.(name)` where `name` is a comptime-known string resolves at compile time to a direct field access. Compile error if field doesn't exist on the type |
-| **E2: Comptime for** | `comptime for field in reflect.fields<T>() { body }` unrolls the loop at compile time. Each iteration generates separate monomorphized code — the body may use different types per iteration |
-| **E3: Per-iteration typing** | Inside a `comptime for` body, `value.(field.name)` has the concrete type of that field. Generic calls like `encode_value(value.(field.name))` monomorphize per-field |
+Encoding uses `comptime for` and comptime field access — see `ctrl.comptime/CT48–CT54` for the full rules. In brief:
+
+- `comptime for field in reflect.fields<T>()` unrolls at compile time, each iteration monomorphized per-field type
+- `value.(field.name)` accesses a field by comptime-known string, resolving to direct field access
+- `comptime if` inside the loop body enables per-field conditional code generation
+
+Visibility rules apply: private fields are accessible only in the defining module.
 
 <!-- test: skip -->
 ```rask
@@ -30,48 +32,6 @@ struct Point { public x: f64, public y: f64 }
 // print_fields(Point { x: 1.0, y: 2.0 }) unrolls to:
 //   print("x = {value.x}")
 //   print("y = {value.y}")
-```
-
-### Comptime Field Access
-
-| Rule | Description |
-|------|-------------|
-| **E4: String must be comptime** | The expression in `value.(expr)` must be comptime-known. Runtime strings are a compile error |
-| **E5: Field must exist** | Compile error if the comptime string doesn't match any field of the value's type |
-| **E6: Visibility respected** | Same visibility rules as direct field access — private fields accessible only in the defining module |
-
-<!-- test: skip -->
-```rask
-const name = comptime "x"
-const v = point.(name)         // OK: comptime-known string
-
-let name = get_name()
-const v = point.(name)         // ERROR: runtime string in comptime field access
-
-const v = point.("z")          // ERROR: Point has no field "z"
-```
-
-### Comptime For
-
-| Rule | Description |
-|------|-------------|
-| **E7: Unrolling** | `comptime for` fully unrolls at monomorphization time. Each iteration becomes separate code |
-| **E8: Comptime iterable** | The iterable must be comptime-known: `reflect.fields<T>()`, `reflect.variants<T>()`, or any comptime array |
-| **E9: No branch quota** | `comptime for` unrolling doesn't count against the backwards branch quota (`ctrl.comptime/CT35`). The quota applies to comptime *interpreter* execution, not monomorphization-time unrolling |
-| **E10: Comptime if in body** | `comptime if` inside the loop body enables per-field conditional code generation (e.g., skip fields, type dispatch) |
-
-<!-- test: skip -->
-```rask
-func encode_struct<T: Encode>(value: T, w: mutate JsonWriter) -> () or JsonError {
-    try w.begin_object()
-    comptime for field in reflect.fields<T>() {
-        comptime if !field.is_skipped {
-            try w.key(field.serial_name)
-            try encode_value(value.(field.name), mutate w)
-        }
-    }
-    try w.end_object()
-}
 ```
 
 ## Encode and Decode Traits
@@ -410,9 +370,9 @@ WHY: @no_encode prevents auto-derive of Encode.
 FIX: Remove @no_encode, or implement a custom encoding method.
 ```
 
-**Runtime string in field access [E4]:**
+**Runtime string in field access [CT53]:**
 ```
-ERROR [std.encoding/E4]: runtime string in comptime field access
+ERROR [ctrl.comptime/CT53]: runtime string in comptime field access
    |
 5  |  const v = point.(name)
    |                   ^^^^ `name` is not comptime-known
@@ -426,9 +386,9 @@ FIX: Use a comptime-known string:
   const v = point.(field.name)       // inside comptime for
 ```
 
-**Unknown field [E5]:**
+**Unknown field [CT54]:**
 ```
-ERROR [std.encoding/E5]: no field "z" on type `Point`
+ERROR [ctrl.comptime/CT54]: no field "z" on type `Point`
    |
 5  |  const v = point.("z")
    |                    ^^^ Point has fields: x, y
@@ -461,8 +421,8 @@ FIX: Add @default with an explicit value:
 | `@default` on non-optional required field | E20 | Field becomes optional in input, required in struct definition. Default fills the gap |
 | `@rename` collision (two fields same serial name) | E18 | Compile error: duplicate serial name |
 | `@skip` field without `@default` during decode | E19, E28 | Field must have a known zero value (E28) or `@default`. Compile error otherwise |
-| Nested comptime for (struct within struct) | E3 | Works — `encode_value` recursively monomorphizes |
-| Private field with `@rename` | E6 | Annotation accepted but ineffective — field not encoded externally. Useful for same-module custom encoding |
+| Nested comptime for (struct within struct) | CT48 | Works — `encode_value` recursively monomorphizes |
+| Private field with `@rename` | — | Annotation accepted but ineffective — field not encoded externally. Useful for same-module custom encoding |
 | Generic struct `Wrapper<T>` | E12 | `Encode` if `T: Encode`. Checked at monomorphization |
 | Enum with non-Encode payload | E17 | Enum is not `Encode`. Error points to the non-Encode variant |
 
@@ -471,8 +431,6 @@ FIX: Add @default with an explicit value:
 ## Appendix (non-normative)
 
 ### Rationale
-
-**E1-E3 (comptime for + field access):** I chose Zig's proven approach adapted to Rask. The reflect spec listed "derive-style code generation" as the primary use case but showed code-as-string generation with no compilation mechanism. `comptime for` + `value.(name)` solves this with two focused primitives: loop unrolling and dynamic-name field access, both resolved at compile time. No macros, no string evaluation, no hidden code generation.
 
 **E11 (marker traits):** I wanted Encode/Decode for generic bounds (`T: Encode`) but Rask doesn't have associated types in MVP. A Serializer trait hierarchy (like serde) would need them. Marker traits are the simplest option that enables compile-time checked generic bounds. Format libraries use `comptime for` directly instead of dispatching through trait methods — each format writes ~100 lines, which is acceptable since formats differ genuinely in how they handle nulls, numbers, nesting.
 

--- a/specs/types/error-types.md
+++ b/specs/types/error-types.md
@@ -1,6 +1,6 @@
 <!-- id: type.errors -->
 <!-- status: decided -->
-<!-- summary: Errors are values with try propagation, union composition, auto-Ok wrapping, origin tracking, and any Error auto-boxing -->
+<!-- summary: Errors are values with try propagation, try-else context, union composition, auto-Ok wrapping, origin tracking, and any Error auto-boxing -->
 <!-- depends: types/enums.md, types/optionals.md -->
 <!-- implemented-by: compiler/crates/rask-types/, compiler/crates/rask-interp/ -->
 
@@ -290,8 +290,7 @@ match result {
 | Rule | Description |
 |------|-------------|
 | **ER15: Origin capture** | `try` records `(file, line)` on the error at the first propagation site. Available in both debug and release builds |
-| **ER16: Propagation trace** | In debug builds, each subsequent `try` appends its `(file, line)` to the error's trace. Stripped in release |
-| **ER17: Origin access** | All errors have `.origin` (always available) and `.trace()` (debug builds; empty in release) |
+| **ER16: Origin access** | All errors have `.origin` — always available in both debug and release |
 
 <!-- test: skip -->
 ```rask
@@ -302,7 +301,7 @@ func load_config(path: string) -> Config or (IoError | ParseError) {
 }
 
 func start() -> () or any Error {
-    const config = try load_config(path)   // trace appended: "main.rk:2" (debug only)
+    const config = try load_config(path)
     try run(config)
 }
 
@@ -311,19 +310,12 @@ match start() {
     Err(e) => {
         log("{}: {}", e.origin, e.message())
         // "config.rk:2: file not found: /etc/app.conf"
-
-        // Debug builds only — full propagation chain
-        for loc in e.trace() {
-            log("  at {}", loc)
-        }
-        // "  at config.rk:2"
-        // "  at main.rk:2"
     }
     Ok(_) => {}
 }
 ```
 
-Cost: `origin` is ~16 bytes per error (file pointer + line number) — negligible on the exceptional path. The propagation trace allocates in debug builds only.
+Cost: `origin` is ~16 bytes per error (file pointer + line number) — negligible on the exceptional path.
 
 ## Error Context
 
@@ -332,9 +324,6 @@ Real-world error handling needs context. "IoError: file not found" is useless in
 | Rule | Description |
 |------|-------------|
 | **ER18: try-else** | `try expr else \|e\| error_expr` extracts `Ok` or transforms the error and returns `Err(error_expr)` from the current function |
-| **ER20: ContextError type** | `ContextError` is a stdlib type with `context: string` and `source: string` fields, satisfying `Error` |
-| **ER21: context() function** | `context(msg, err)` creates a `ContextError` from any `Error`, stringifying the source |
-| **ER22: Linear incompatibility** | `context()` is a compile error when the error type contains linear resources — must handle resources explicitly |
 
 ### try-else
 
@@ -395,66 +384,7 @@ func load_config(path: string) -> Config or ConfigError {
 - `try` — propagates without transforming
 - `try...else` — transforms AND propagates in one step
 
-### ContextError and context()
-
-`ContextError` is a stdlib type for application-level code that doesn't need typed errors. The `context()` free function wraps any error into a `ContextError`, stringifying the source.
-
-<!-- test: parse -->
-```rask
-struct ContextError {
-    context: string
-    source: string
-}
-
-extend ContextError {
-    func message(self) -> string {
-        return "{self.context}: {self.source}"
-    }
-}
-
-func context<E: Error>(msg: string, err: E) -> ContextError {
-    return ContextError { context: msg, source: err.message() }
-}
-```
-
-`ContextError` satisfies `Error` (has `message()`), so context chains naturally:
-
-<!-- test: skip -->
-```rask
-func main() -> () or ContextError {
-    const config = try load_config("app.toml") else |e| context("starting app", e)
-    // Chain: "starting app: reading config: file not found: /app.toml"
-}
-```
-
-### Linear resource constraint
-
-`context()` stringifies errors via `message()`. If the error contains a linear resource, the original error would be discarded without consuming the resource — compile error. Handle resources explicitly in the `else` block instead:
-
-<!-- test: skip -->
-```rask
-// Compile error: context() cannot stringify errors with linear resources
-const data = try file.read_all() else |e| context("reading", e)
-
-// OK: explicitly handle the resource
-const data = try file.read_all() else |e| {
-    match e {
-        FileError.ReadFailed(file, reason) => {
-            file.close()
-            context("reading", reason)
-        }
-    }
-}
-```
-
-### When to use which
-
-| Consumer | Tool | Error type |
-|----------|------|-----------|
-| Machine (match, retry, status codes) | `try...else \|e\| DomainError.Variant { ... }` | Typed enums |
-| Human (logs, stderr, CLI) | `try...else \|e\| context("msg", e)` | `ContextError` |
-
-The boundary is who consumes the error, not lib vs app. `origin` is automatic (where it failed); `context` is opt-in (what you were doing).
+Stdlib provides `ContextError` and `context()` for application-level string context chains — see `std.errors`.
 
 ## Operator Family
 
@@ -518,11 +448,9 @@ thread panicked at 'entered unreachable code', src/handler.rk:12:21
 | Wildcard on linear error payload | ER19 | Compile error — must consume |
 | `try` when return type is `any Error` | ER10 | Auto-box concrete error to `any Error` |
 | `.origin` in release build | ER15 | Always available (~16 bytes per error) |
-| `.trace()` in release build | ER16 | Returns empty — trace only in debug |
 | Nested `try` in closures | ER4 | Propagates to closure's return, not enclosing function |
 | `try` binding with method chain | ER5 | Binds to full expression; use parens to chain after |
 | `try...else` error type mismatch | ER18 | Compile error — else expression must match function's error return type |
-| `context()` on linear error type | ER22 | Compile error — must handle linear resources explicitly |
 
 ---
 
@@ -538,13 +466,9 @@ thread panicked at 'entered unreachable code', src/handler.rk:12:21
 
 **ER10 (auto-box):** Libraries should use precise union error types — callers can match on them. But application code that calls 5 libraries shouldn't need `-> T or (IoError | ParseError | DbError | ValidationError | AuthError)` on every function. `any Error` is the escape hatch: type-erased, sufficient for logging/reporting, with `is` downcast for recovery. This mirrors Rust's thiserror (libraries) + anyhow (applications) split, but built into the language.
 
-**ER15–ER17 (error origin):** When an `IoError` propagates through 10 functions, "file not found" tells you nothing. `origin` captures where the error first surfaced — always available, ~16 bytes, negligible on the exceptional path. The full propagation trace is debug-only because it allocates per hop.
+**ER15 (error origin):** When an `IoError` propagates through 10 functions, "file not found" tells you nothing. `origin` captures where the error first surfaced — always available, ~16 bytes, negligible on the exceptional path. If you need the full propagation chain, add context with `try...else` at key call sites.
 
 **ER18 (try-else):** `try + map_err` is the most common error handling pattern — nearly every `try` in real code transforms the error. Fusing them into `try...else` reduces ceremony. The `else |e|` pattern already exists in `ensure` (ctrl.ensure/ER2), so no new concepts needed.
-
-**ER20/ER21 (ContextError):** Typed domain errors (`map_err` with custom enums) are right for code that callers match on. But application-level code — `main()`, CLI handlers, request handlers — just needs human-readable chains. `ContextError` fills that gap without forcing every app to define boilerplate error enums. `origin` tells you where; `context` tells you what.
-
-**ER22 (linear incompatibility):** `context()` stringifies errors, which borrows via `message()` but doesn't consume linear resources in the error payload. Silently dropping a `@resource` would violate linear consumption guarantees. The `else` block form lets you explicitly consume the resource before wrapping.
 
 **Operator split (`try` vs `?`):** `try` is for propagation (both Result and Option). `?` is reserved for Option sugar only — type suffix, chaining, defaults, smart unwrap. This avoids Rust's overloading where `?` means different things in different contexts.
 
@@ -609,7 +533,7 @@ func parse_age(input: string) -> u32 or ParseError {
 | Case | Choice | Why |
 |------|--------|-----|
 | Division by zero | Panic | Caller should have checked — this is a logic error |
-| Integer overflow | Panic (debug), wrap (release) | See [integer-overflow.md](integer-overflow.md) |
+| Integer overflow | Panic | See [integer-overflow.md](integer-overflow.md) — panic in all builds |
 | Stack overflow | Panic | Can't meaningfully recover |
 | Out of memory | Panic | Allocation failure is nearly unrecoverable |
 | Missing required config | Error if loading, panic if already validated | Depends on where you are |


### PR DESCRIPTION
## Summary

This PR simplifies two key language features by removing complexity that wasn't justified by real-world usage:

1. **Error origin tracking**: Removes the debug-only propagation trace feature (`ER16`/`ER17`), keeping only the always-available `.origin` field. The full trace was rarely used and added allocation overhead in debug builds.

2. **Shared<T> lock access**: Replaces implicit lock selection via `const` keyword with explicit `.read()` and `.write()` method calls. This eliminates semantic confusion where `const` meant different things for `Shared<T>` (changes lock type) vs other containers (only affects binding mutability).

## Key Changes

- **Error handling** (`specs/types/error-types.md`):
  - Remove `ER16` (propagation trace) and `ER17` (trace access)
  - Keep `ER15` (origin capture) — always available, ~16 bytes per error
  - Remove `ContextError` and `context()` from spec (moved to stdlib documentation)
  - Simplify rationale: if you need full propagation chain, use `try...else` at key call sites
  - Update integer overflow guidance: panic in all builds (not debug-only)

- **Shared<T> access** (`specs/concurrency/sync.md`, `specs/memory/borrowing.md`):
  - Change from `with shared as const v { ... }` (read) / `with shared as v { ... }` (write) to explicit `with shared.read() as v { ... }` / `with shared.write() as v { ... }`
  - Add `R4` rule: bare `with shared as v` is now a compile error — lock type must be explicit
  - Update `Mutex<T>`: remove `const` keyword entirely, always exclusive lock
  - Simplify `with` binding semantics: bindings are always mutable; read-only access is enforced by the source (e.g., `.read()` prevents mutation at compile time)

- **Encoding spec** (`specs/stdlib/encoding.md`):
  - Move comptime field access rules (`E1-E3`) to reference `ctrl.comptime/CT48-CT54`
  - Consolidate into brief summary with visibility rules
  - Remove detailed subsections on comptime field access and comptime for loops
  - Update error references to point to `ctrl.comptime` instead of `std.encoding`

- **Documentation updates**:
  - Update `CLAUDE.md` examples to use explicit `.read()`/`.write()`
  - Update `canonical-patterns.md` to show new Shared access syntax
  - Update `cell.md`, `collections.md`, `pools.md` to remove `const` from `with` examples
  - Update `borrowing.md` table: remove `const` column, clarify that bindings are always mutable
  - Update `rejected-features.md` examples

## Rationale

**Error origin simplification**: The propagation trace feature required allocation per `try` hop in debug builds and was rarely accessed. The `.origin` field (where the error first surfaced) is sufficient for most debugging. If you need the full chain, `try...else` at key call sites provides explicit context.

**Shared<T> explicit locks**: The `const` keyword created confusion because it had different semantics across container types. Making `.read()` and `.write()` explicit at the call site makes the lock type visible and removes the semantic inconsistency. This aligns with the principle that important control flow should be explicit.

**with binding mutability**: Removing `const` from `with` bindings simplifies the syntax. Read-only access is now enforced by the source (e.g., `shared.read()` prevents mutation at compile time), not by the binding keyword.

https://claude.ai/code/session_01NCiaVVC2CuCiQaxgsjrgwU