### PR TITLE
Fix loop desugaring spec, A4 contradiction, and Copy semantics

### DIFF
--- a/compiler/crates/rask-cli/tests/compile_run.rs
+++ b/compiler/crates/rask-cli/tests/compile_run.rs
@@ -146,3 +146,19 @@ fn run_native_multi_func() {
     assert_eq!(code, 0);
     assert_eq!(stdout, "25\n");
 }
+
+// ─── Copy semantics tests ─────────────────────────────────
+
+#[test]
+fn compile_copy_rebind() {
+    let (stdout, code) = compile_and_run("copy_rebind.rk");
+    assert_eq!(code, 0);
+    assert_eq!(stdout, "42 42\n");
+}
+
+#[test]
+fn run_native_copy_rebind() {
+    let (stdout, code) = run_native("copy_rebind.rk");
+    assert_eq!(code, 0);
+    assert_eq!(stdout, "42 42\n");
+}

--- a/compiler/crates/rask-cli/tests/fixtures/copy_rebind.rk
+++ b/compiler/crates/rask-cli/tests/fixtures/copy_rebind.rk
@@ -1,0 +1,11 @@
+// SPDX-License-Identifier: (MIT OR Apache-2.0)
+// Copy types survive let rebinding — source stays valid after copy.
+
+func main() {
+    let x = 42
+    let y = x
+    print(x)
+    print(" ")
+    print(y)
+    print("\n")
+}

--- a/compiler/crates/rask-desugar/src/defaults.rs
+++ b/compiler/crates/rask-desugar/src/defaults.rs
@@ -335,7 +335,7 @@ impl DefaultDesugarer {
                 for s in &mut b.body { self.desugar_stmt(s); }
             }
             DeclKind::Import(_) | DeclKind::Export(_) | DeclKind::Extern(_)
-            | DeclKind::Package(_) | DeclKind::Union(_) => {}
+            | DeclKind::Package(_) | DeclKind::Union(_) | DeclKind::TypeAlias(_) => {}
         }
     }
 

--- a/compiler/crates/rask-ownership/src/lib.rs
+++ b/compiler/crates/rask-ownership/src/lib.rs
@@ -197,7 +197,8 @@ impl<'a> OwnershipChecker<'a> {
         match &stmt.kind {
             StmtKind::Let { name, name_span: _, ty, init } => {
                 self.check_expr(init);
-                // let creates mutable binding - moves the value
+                // let: Copy types are copied (source stays valid),
+                // non-Copy types are moved (source invalidated)
                 self.handle_assignment(init, stmt.span, true);
                 self.bindings.insert(name.clone(), BindingState::Owned);
                 if let Some(t) = self.program.node_types.get(&init.id).cloned() {
@@ -221,7 +222,8 @@ impl<'a> OwnershipChecker<'a> {
             }
             StmtKind::Const { name, name_span: _, ty, init } => {
                 self.check_expr(init);
-                // const creates immutable binding - borrows the value
+                // const: Copy types are copied, non-Copy types create
+                // a block-scoped borrow (source stays valid but frozen)
                 self.handle_assignment(init, stmt.span, false);
                 self.bindings.insert(name.clone(), BindingState::Owned);
                 if let Some(t) = self.program.node_types.get(&init.id).cloned() {
@@ -523,48 +525,53 @@ impl<'a> OwnershipChecker<'a> {
         }
     }
 
-    /// Handle assignment: borrow or move depending on context.
+    /// Handle assignment semantics based on Copy status:
     ///
-    /// For `let` statements: check if borrowed, then move (is_mutable = true)
-    /// For `const` statements: create block-scoped borrow (is_mutable = false)
+    /// Copy types (VS1/VS2): implicit bitwise copy, source stays valid.
+    /// Non-Copy + `let` (is_mutable=true): move, source invalidated.
+    /// Non-Copy + `const` (is_mutable=false): block-scoped borrow.
     fn handle_assignment(&mut self, expr: &Expr, span: Span, is_mutable: bool) {
         if let Some(ty) = self.program.node_types.get(&expr.id) {
-            if !self.is_copy(ty) {
-                if let ExprKind::Ident(source_name) = &expr.kind {
-                    if is_mutable {
-                        // Mutable binding (let): check not borrowed, then move
-                        if let Some(state) = self.bindings.get(source_name) {
-                            match state {
-                                BindingState::Borrowed { .. } => {
-                                    self.errors.push(OwnershipError {
-                                        kind: OwnershipErrorKind::MutateWhileBorrowed {
-                                            name: source_name.clone(),
-                                            borrow_span: span,
-                                        },
-                                        span,
-                                    });
-                                    return;
-                                }
-                                BindingState::Moved { at } => {
-                                    let reason = self.move_reason_for(&source_name);
-                                    self.errors.push(OwnershipError {
-                                        kind: OwnershipErrorKind::UseAfterMove {
-                                            name: source_name.clone(),
-                                            moved_at: *at,
-                                            reason,
-                                        },
-                                        span,
-                                    });
-                                    return;
-                                }
-                                BindingState::Owned => {}
+            // Copy types: both source and target remain valid (VS1/VS2)
+            if self.is_copy(ty) {
+                return;
+            }
+
+            // Non-Copy types: move or borrow depending on binding mutability
+            if let ExprKind::Ident(source_name) = &expr.kind {
+                if is_mutable {
+                    // Mutable binding (let): check not borrowed, then move
+                    if let Some(state) = self.bindings.get(source_name) {
+                        match state {
+                            BindingState::Borrowed { .. } => {
+                                self.errors.push(OwnershipError {
+                                    kind: OwnershipErrorKind::MutateWhileBorrowed {
+                                        name: source_name.clone(),
+                                        borrow_span: span,
+                                    },
+                                    span,
+                                });
+                                return;
                             }
+                            BindingState::Moved { at } => {
+                                let reason = self.move_reason_for(&source_name);
+                                self.errors.push(OwnershipError {
+                                    kind: OwnershipErrorKind::UseAfterMove {
+                                        name: source_name.clone(),
+                                        moved_at: *at,
+                                        reason,
+                                    },
+                                    span,
+                                });
+                                return;
+                            }
+                            BindingState::Owned => {}
                         }
-                        self.bindings.insert(source_name.clone(), BindingState::Moved { at: span });
-                    } else {
-                        // Immutable binding (const): create block-scoped borrow
-                        self.create_borrow(source_name.clone(), BorrowMode::Shared, span);
                     }
+                    self.bindings.insert(source_name.clone(), BindingState::Moved { at: span });
+                } else {
+                    // Immutable binding (const): create block-scoped borrow
+                    self.create_borrow(source_name.clone(), BorrowMode::Shared, span);
                 }
             }
         }

--- a/specs/control/loops.md
+++ b/specs/control/loops.md
@@ -155,6 +155,14 @@ for h in pool.handles() {
 }
 ```
 
+## Loop Binding Scope
+
+| Rule | Description |
+|------|-------------|
+| **LP17: Binding is alias** | Loop bindings are inline aliases — each use of `item` desugars to `collection[_pos]` at point of use. Not a regular `const` binding; no copy or move at binding creation. `mem.borrowing/E4` and `std.iteration/A4` do not apply to loop bindings |
+
+In value mode, `item` is a read-only alias. In mutable mode, `item` is a mutable alias. The binding doesn't exist as a separate variable — it's syntactic shorthand for indexed access into the collection.
+
 ## Desugaring
 
 Value iteration creates inline access per element. Mutable iteration creates mutable inline access.
@@ -169,7 +177,9 @@ for item in vec { body }
     const _len = vec.len()
     let _pos = 0
     while _pos < _len {
-        const item = vec[_pos]  // Inline access (read-only)
+        // `item` is a read-only alias for vec[_pos]  (LP17)
+        // item.field  → vec[_pos].field  (inline access, E1)
+        // item.method() → vec[_pos].method()  (expression borrow, E2)
         body
         _pos += 1
     }

--- a/specs/stdlib/iteration.md
+++ b/specs/stdlib/iteration.md
@@ -29,7 +29,7 @@ Four iteration modes per collection: value (default, read-only), mutable (read-w
 | **A1: Copy out** | `collection[i]` copies T when T: Copy (≤16 bytes) |
 | **A2: Field copy** | `collection[i].field` copies field when field: Copy |
 | **A3: Expression borrow** | `collection[i].method()` borrows for call, released at `;` |
-| **A4: No move** | `collection[i]` where T: !Copy is a compile error. Use `.clone()` or `.take_all()` |
+| **A4: No move** | `collection[i]` where T: !Copy is a compile error in user code. Use `.clone()` or `.take_all()`. Loop bindings bypass this — see `ctrl.loops/LP17` |
 
 <!-- test: skip -->
 ```rask


### PR DESCRIPTION
The value iteration desugaring showed `const item = vec[_pos]` which
contradicts mem.borrowing/E4 and std.iteration/A4 for non-Copy types.
Added LP17 rule clarifying loop bindings are inline aliases, not regular
const bindings. Amended A4 to note loop bindings bypass the no-move rule.

Refactored ownership checker's handle_assignment() to make Copy type
handling explicit rather than accidental — early return for Copy types
instead of relying on the negated is_copy() check skipping the move path.
Behavior is unchanged but the intent is now clear.

Also fixed pre-existing DeclKind::TypeAlias match exhaustiveness in
rask-desugar.

https://claude.ai/code/session_01HSRADjzT2PgyZyiovqoHto