### PR TITLE
Fix Shared<T> and Channel<T> codegen for struct types

### DIFF
--- a/compiler/crates/rask-codegen/src/builder.rs
+++ b/compiler/crates/rask-codegen/src/builder.rs
@@ -2022,10 +2022,77 @@ impl<'a> FunctionBuilder<'a> {
             // Pool get/index: result is void*, deref to get value
             "Pool_get" | "Pool_index" | "Pool_checked_access" => CallAdapt::DerefResult,
 
-            // Channel_unbuffered: MIR has no args, C expects capacity=0
+            // Channel_unbuffered: MIR injects elem_size; builder appends capacity=0
             "Channel_unbuffered" => {
                 let zero = builder.ins().iconst(types::I64, 0);
                 args.push(zero);
+                CallAdapt::None
+            }
+
+            // Shared_new: args are [data, data_size]. Ensure data is a pointer.
+            // Compute actual data_size from struct layout (overrides MIR default
+            // which may be 8 when Shared.new(val) lacks explicit generic arg).
+            "Shared_new" => {
+                if args.len() >= 2 {
+                    let mut data_size: i64 = 8;
+                    let mut is_struct = false;
+                    if let Some(MirOperand::Local(arg_id)) = mir_args.first() {
+                        if let Some(local) = locals.iter().find(|l| l.id == *arg_id) {
+                            if let MirType::Struct(layout_id) = &local.ty {
+                                if let Some(layout) = struct_layouts.get(layout_id.0 as usize) {
+                                    data_size = layout.size as i64;
+                                    is_struct = true;
+                                }
+                            }
+                        }
+                    }
+                    if !is_struct {
+                        let val = args[0];
+                        args[0] = Self::value_to_ptr(builder, val);
+                    }
+                    // Override data_size with actual computed value
+                    args[1] = builder.ins().iconst(types::I64, data_size);
+                }
+                CallAdapt::None
+            }
+
+            // Sender_send / send: wrap value as pointer (scalars need value_to_ptr,
+            // structs are already pointers in the all-i64 model).
+            "Sender_send" | "send" => {
+                if args.len() >= 2 {
+                    let mut is_struct = false;
+                    if let Some(MirOperand::Local(arg_id)) = mir_args.get(1) {
+                        if let Some(local) = locals.iter().find(|l| l.id == *arg_id) {
+                            if matches!(&local.ty, MirType::Struct(_)) {
+                                is_struct = true;
+                            }
+                        }
+                    }
+                    if !is_struct {
+                        let val = args[1];
+                        args[1] = Self::value_to_ptr(builder, val);
+                    }
+                }
+                CallAdapt::None
+            }
+
+            // Receiver_recv_struct: allocate buffer for received struct data.
+            // MIR args: [rx, elem_size]. Replace elem_size with stack buffer address.
+            "Receiver_recv_struct" => {
+                let elem_size = match mir_args.get(1) {
+                    Some(MirOperand::Constant(MirConst::Int(size))) => *size as u32,
+                    _ => 8,
+                };
+                let ss = builder.create_sized_stack_slot(StackSlotData::new(
+                    StackSlotKind::ExplicitSlot, elem_size, 0,
+                ));
+                let addr = builder.ins().stack_addr(types::I64, ss, 0);
+                if args.len() >= 2 {
+                    args[1] = addr;
+                } else {
+                    args.push(addr);
+                }
+                // recv_ptr returns out_ptr, which IS the struct pointer
                 CallAdapt::None
             }
 

--- a/compiler/crates/rask-codegen/src/dispatch.rs
+++ b/compiler/crates/rask-codegen/src/dispatch.rs
@@ -1435,17 +1435,18 @@ pub fn stdlib_entries() -> Vec<StdlibEntry> {
 
         // ── Concurrency: channels ──────────────────────────────────
         // Channel construction (MIR produces Channel_buffered / Channel_unbuffered)
+        // Pointer-based: elem_size is injected by builder from struct layout.
         StdlibEntry {
             mir_name: "Channel_buffered",
-            c_name: "rask_channel_new_i64",
-            params: &[types::I64],
+            c_name: "rask_channel_new_ptr",
+            params: &[types::I64, types::I64],  // elem_size (injected), capacity
             ret_ty: Some(types::I64),
             can_panic: false,
         },
         StdlibEntry {
             mir_name: "Channel_unbuffered",
-            c_name: "rask_channel_new_i64",
-            params: &[types::I64],  // builder injects capacity=0
+            c_name: "rask_channel_new_ptr",
+            params: &[types::I64, types::I64],  // elem_size (injected), capacity=0 (injected)
             ret_ty: Some(types::I64),
             can_panic: false,
         },
@@ -1473,9 +1474,11 @@ pub fn stdlib_entries() -> Vec<StdlibEntry> {
         },
 
         // Sender methods (qualified: Sender_send, etc.)
+        // Pointer-based: works for both scalars (builder wraps via value_to_ptr)
+        // and structs (already pointers in the all-i64 model).
         StdlibEntry {
             mir_name: "Sender_send",
-            c_name: "rask_channel_send_i64",
+            c_name: "rask_channel_send_ptr",
             params: &[types::I64, types::I64],
             ret_ty: Some(types::I64),
             can_panic: false,
@@ -1504,7 +1507,7 @@ pub fn stdlib_entries() -> Vec<StdlibEntry> {
         // Legacy bare names
         StdlibEntry {
             mir_name: "send",
-            c_name: "rask_channel_send_i64",
+            c_name: "rask_channel_send_ptr",
             params: &[types::I64, types::I64],
             ret_ty: Some(types::I64),
             can_panic: false,
@@ -1529,6 +1532,14 @@ pub fn stdlib_entries() -> Vec<StdlibEntry> {
             mir_name: "Receiver_recv",
             c_name: "rask_channel_recv_i64",
             params: &[types::I64],
+            ret_ty: Some(types::I64),
+            can_panic: true,
+        },
+        // Struct variant: builder allocates out-buffer, passes as second arg
+        StdlibEntry {
+            mir_name: "Receiver_recv_struct",
+            c_name: "rask_channel_recv_ptr",
+            params: &[types::I64, types::I64],
             ret_ty: Some(types::I64),
             can_panic: true,
         },
@@ -1563,23 +1574,25 @@ pub fn stdlib_entries() -> Vec<StdlibEntry> {
         },
 
         // ── Concurrency: Shared<T> ──────────────────────────────────
+        // Pointer-based: new takes (data_ptr, data_size), read/write pass
+        // data pointer to closure instead of loading as i64.
         StdlibEntry {
             mir_name: "Shared_new",
-            c_name: "rask_shared_new_i64",
-            params: &[types::I64],
+            c_name: "rask_shared_new_ptr",
+            params: &[types::I64, types::I64],  // data_ptr, data_size (injected by builder)
             ret_ty: Some(types::I64),
             can_panic: false,
         },
         StdlibEntry {
             mir_name: "Shared_read",
-            c_name: "rask_shared_read_i64",
+            c_name: "rask_shared_read_ptr",
             params: &[types::I64, types::I64],
             ret_ty: Some(types::I64),
             can_panic: false,
         },
         StdlibEntry {
             mir_name: "Shared_write",
-            c_name: "rask_shared_write_i64",
+            c_name: "rask_shared_write_ptr",
             params: &[types::I64, types::I64],
             ret_ty: Some(types::I64),
             can_panic: false,

--- a/compiler/crates/rask-mir/src/lower/expr.rs
+++ b/compiler/crates/rask-mir/src/lower/expr.rs
@@ -545,6 +545,24 @@ impl<'a> MirLowerer<'a> {
                                 let (op, _) = self.lower_expr(&arg.expr)?;
                                 arg_operands.push(op);
                             }
+
+                            // Inject elem_size/data_size for generic constructors.
+                            // The C runtime needs actual sizes for struct types;
+                            // the dispatch table expects these as extra arguments.
+                            if (base_name == "Channel" && (method == "buffered" || method == "unbuffered"))
+                                || (base_name == "Shared" && method == "new")
+                            {
+                                let elem_size = self.generic_inner_struct_size(name);
+                                let size_op = MirOperand::Constant(MirConst::Int(elem_size));
+                                if base_name == "Channel" {
+                                    // Channel: elem_size goes first → (elem_size, capacity)
+                                    arg_operands.insert(0, size_op);
+                                } else {
+                                    // Shared: data_size goes last → (data_ptr, data_size)
+                                    arg_operands.push(size_op);
+                                }
+                            }
+
                             let ret_ty = self
                                 .func_sigs
                                 .get(&func_name)
@@ -891,6 +909,24 @@ impl<'a> MirLowerer<'a> {
                         }
                     }
                 }
+
+                // Channel recv with struct elements: switch to struct variant
+                // and inject elem_size so the builder can allocate the right buffer.
+                let qualified_name = if qualified_name == "Receiver_recv" {
+                    let elem_size = if let ExprKind::Ident(var_name) = &object.kind {
+                        self.channel_elem_sizes.get(var_name).copied().unwrap_or(8)
+                    } else {
+                        8
+                    };
+                    if elem_size > 8 {
+                        all_args.push(MirOperand::Constant(MirConst::Int(elem_size)));
+                        "Receiver_recv_struct".to_string()
+                    } else {
+                        qualified_name
+                    }
+                } else {
+                    qualified_name
+                };
 
                 // Use tracked element type for Vec_get return instead of default I64.
                 // Checks per-function map first, then shared cross-function map.
@@ -1664,6 +1700,39 @@ impl<'a> MirLowerer<'a> {
 
             // With-as binding
             ExprKind::WithAs { bindings, body } => {
+                // Detect Shared.read() / Shared.write() pattern:
+                //   with shared.read() as d { body }
+                // Synthesize a closure from the body and call Shared_read(handle, closure).
+                if bindings.len() == 1 {
+                    let binding = &bindings[0];
+                    if let ExprKind::MethodCall { object, method, args: call_args, .. } = &binding.source.kind {
+                        let is_shared_access = (method == "read" || method == "write") && call_args.is_empty();
+                        if is_shared_access {
+                            // Check if the object type is Shared
+                            let obj_raw_type = self.ctx.lookup_raw_type(object.id);
+                            let is_shared = obj_raw_type.map(|ty| {
+                                matches!(ty,
+                                    rask_types::Type::UnresolvedGeneric { name, .. }
+                                    | rask_types::Type::UnresolvedNamed(name)
+                                    if name == "Shared"
+                                )
+                            }).unwrap_or(false)
+                            // Fallback: check local_type_prefix
+                            || if let ExprKind::Ident(var_name) = &object.kind {
+                                self.local_type_prefix.get(var_name)
+                                    .map(|p| p == "Shared")
+                                    .unwrap_or(false)
+                            } else {
+                                false
+                            };
+                            if is_shared {
+                                return self.lower_shared_with_block(object, method, &binding.name, body);
+                            }
+                        }
+                    }
+                }
+
+                // Default: simple alias binding (Pool, Cell, Mutex, etc.)
                 for binding in bindings {
                     let (val, val_ty) = self.lower_expr(&binding.source)?;
                     let local = self.builder.alloc_local(binding.name.clone(), val_ty.clone());
@@ -2606,6 +2675,176 @@ impl<'a> MirLowerer<'a> {
         });
 
         Ok((MirOperand::Local(result_local), MirType::Ptr))
+    }
+
+    /// Extract the inner struct size from a generic type name like "Channel<LogEntry>".
+    /// Returns 8 (scalar size) if the inner type is not a known struct.
+    fn generic_inner_struct_size(&self, generic_name: &str) -> i64 {
+        let inner = generic_name.split('<').nth(1)
+            .and_then(|s| s.strip_suffix('>'));
+        if let Some(type_name) = inner {
+            if let Some((_, layout)) = self.ctx.find_struct(type_name) {
+                return layout.size as i64;
+            }
+        }
+        8 // scalar default
+    }
+
+
+    /// Extract the inner type name from a Shared variable expression.
+    /// Tries type checker info first, falls back to local_type_prefix context.
+    fn resolve_shared_inner_type_name(&self, object: &Expr) -> Option<String> {
+        // Try type checker: Shared<Database> → "Database"
+        if let Some(raw_ty) = self.ctx.lookup_raw_type(object.id) {
+            if let rask_types::Type::UnresolvedGeneric { args, .. } = raw_ty {
+                if let Some(rask_types::GenericArg::Type(inner)) = args.first() {
+                    if let rask_types::Type::UnresolvedNamed(name) = inner.as_ref() {
+                        return Some(name.clone());
+                    }
+                    // Also handle Named types
+                    if let Some(prefix) = super::MirContext::type_prefix(inner) {
+                        return Some(prefix);
+                    }
+                }
+            }
+        }
+        // Fallback: parse inner type from stored full type annotation (e.g. "Shared<Database>" → "Database")
+        if let ExprKind::Ident(var_name) = &object.kind {
+            if let Some(full_type) = self.local_full_type.get(var_name) {
+                let inner = full_type.split('<').nth(1)
+                    .and_then(|s| s.strip_suffix('>'));
+                if let Some(name) = inner {
+                    return Some(name.to_string());
+                }
+            }
+        }
+        None
+    }
+
+    /// Lower `with shared.read() as d { body }` / `with shared.write() as d { body }`.
+    ///
+    /// Synthesizes a closure from the body with `d` as a parameter, then calls
+    /// Shared_read(handle, closure) or Shared_write(handle, closure).
+    /// The C runtime acquires the lock, passes data to the closure, and releases.
+    fn lower_shared_with_block(
+        &mut self,
+        object: &Expr,
+        method: &str,
+        binding_name: &str,
+        body: &[rask_ast::stmt::Stmt],
+    ) -> Result<TypedOperand, LoweringError> {
+        // 1. Evaluate the Shared object to get the handle
+        let (shared_op, _) = self.lower_expr(object)?;
+
+        // 2. Collect free variables from the body, excluding the binding name
+        let mut free_vars = Vec::new();
+        let mut seen = std::collections::HashSet::new();
+        let mut bound = std::collections::HashSet::new();
+        bound.insert(binding_name.to_string());
+        self.walk_free_vars_block(body, &bound, &mut seen, &mut free_vars);
+
+        // 3. Build closure environment layout
+        let closure_name = format!("{}__with_{}", self.parent_name, self.closure_counter);
+        self.closure_counter += 1;
+
+        let mut captures = Vec::new();
+        let mut env_offset = 0u32;
+        for (_name, local_id, ty) in &free_vars {
+            let size = ty.size();
+            let aligned_offset = (env_offset + 7) & !7;
+            captures.push(ClosureCapture {
+                local_id: *local_id,
+                offset: aligned_offset,
+                size,
+            });
+            env_offset = aligned_offset + size;
+        }
+
+        // 4. Synthesize closure: fn(env_ptr: ptr, data: i64) -> i64
+        let mut closure_builder = BlockBuilder::new(closure_name.clone(), MirType::I64);
+
+        // env_ptr is the implicit first parameter
+        let env_param_id = closure_builder.add_param("__env".to_string(), MirType::Ptr);
+
+        // Resolve the Shared's inner type: struct layout for field offsets, prefix for method dispatch.
+        let mut data_param_ty = MirType::I64;
+        let inner_type_name = self.resolve_shared_inner_type_name(object);
+        if let Some(ref type_name) = inner_type_name {
+            if let Some((layout_idx, _)) = self.ctx.find_struct(type_name) {
+                data_param_ty = MirType::Struct(StructLayoutId(layout_idx));
+            }
+            self.local_type_prefix.insert(binding_name.to_string(), type_name.clone());
+        }
+
+        // data parameter — the Shared's inner data, passed by the C runtime
+        let data_param_id = closure_builder.add_param(binding_name.to_string(), data_param_ty.clone());
+
+        let mut closure_locals = std::collections::HashMap::new();
+        closure_locals.insert(binding_name.to_string(), (data_param_id, data_param_ty));
+
+        // Emit LoadCapture for each free variable
+        for (i, (name, _outer_id, ty)) in free_vars.iter().enumerate() {
+            let cap = &captures[i];
+            let local_id = closure_builder.alloc_local(name.clone(), ty.clone());
+            closure_builder.push_stmt(MirStmt::LoadCapture {
+                dst: local_id,
+                env_ptr: env_param_id,
+                offset: cap.offset,
+            });
+            closure_locals.insert(name.clone(), (local_id, ty.clone()));
+        }
+
+        // 5. Lower the body
+        let body_result;
+        {
+            let saved_builder = std::mem::replace(&mut self.builder, closure_builder);
+            let saved_locals = std::mem::replace(&mut self.locals, closure_locals);
+            let saved_loop_stack = std::mem::take(&mut self.loop_stack);
+
+            body_result = self.lower_block(body);
+
+            closure_builder = std::mem::replace(&mut self.builder, saved_builder);
+            self.locals = saved_locals;
+            self.loop_stack = saved_loop_stack;
+        }
+
+        let (body_val, _) = body_result?;
+
+        if closure_builder.current_block_unterminated() {
+            closure_builder.terminate(MirTerminator::Return {
+                value: Some(body_val),
+            });
+        }
+
+        let closure_fn = closure_builder.finish();
+        self.func_sigs.insert(closure_name.clone(), super::FuncSig {
+            ret_ty: MirType::I64,
+        });
+        self.synthesized_functions.push(closure_fn);
+
+        // 6. In the parent: create closure, call Shared_read/Shared_write
+        let closure_local = self.builder.alloc_temp(MirType::Ptr);
+        self.builder.push_stmt(MirStmt::ClosureCreate {
+            dst: closure_local,
+            func_name: closure_name,
+            captures,
+            heap: false,
+        });
+
+        let func_name = if method == "read" {
+            "Shared_read".to_string()
+        } else {
+            "Shared_write".to_string()
+        };
+
+        let result_local = self.builder.alloc_temp(MirType::I64);
+        self.builder.push_stmt(MirStmt::Call {
+            dst: Some(result_local),
+            func: FunctionRef::internal(func_name),
+            args: vec![shared_op, MirOperand::Local(closure_local)],
+        });
+
+        Ok((MirOperand::Local(result_local), MirType::I64))
     }
 
     /// Spawn lowering: synthesize a closure function from the body block,

--- a/compiler/crates/rask-mir/src/lower/mod.rs
+++ b/compiler/crates/rask-mir/src/lower/mod.rs
@@ -447,6 +447,13 @@ pub struct MirLowerer<'a> {
     /// Variable name → stdlib type prefix (e.g. "Rng", "File", "Vec")
     /// Used as fallback when the type checker leaves types unresolved.
     local_type_prefix: HashMap<String, String>,
+    /// Channel/Shared element sizes: variable name → elem_size in bytes.
+    /// Populated when destructuring Channel<T>.buffered() results.
+    /// Used by Receiver_recv to allocate correctly-sized output buffers.
+    channel_elem_sizes: HashMap<String, i64>,
+    /// Full type annotation string: variable name → type annotation (e.g. "Shared<Database>").
+    /// Used to resolve generic inner types when the type checker leaves types unresolved.
+    local_full_type: HashMap<String, String>,
 }
 
 impl<'a> MirLowerer<'a> {
@@ -582,6 +589,8 @@ impl<'a> MirLowerer<'a> {
                 ok: Box::new(MirType::I64),
                 err: Box::new(MirType::I64),
             }),
+            // Struct recv: panics on closed channel, returns struct pointer directly
+            ("Receiver_recv_struct", MirType::Ptr),
             ("Receiver_try_recv", MirType::Result {
                 ok: Box::new(MirType::I64),
                 err: Box::new(MirType::I64),
@@ -628,6 +637,8 @@ impl<'a> MirLowerer<'a> {
             closure_locals: std::collections::HashSet::new(),
             collection_elem_types: HashMap::new(),
             local_type_prefix: HashMap::new(),
+            channel_elem_sizes: HashMap::new(),
+            local_full_type: HashMap::new(),
         };
 
         // Resolve Self type from function name: "Document_delete_line" → "Document"
@@ -656,6 +667,10 @@ impl<'a> MirLowerer<'a> {
                 lowerer.local_type_prefix.insert(param.name.clone(), prefix);
             } else if let Some(prefix) = type_prefix_from_str(param_ty_str) {
                 lowerer.local_type_prefix.insert(param.name.clone(), prefix);
+            }
+            // Store full annotation for generic types (Shared<T>, Channel<T>, etc.)
+            if param_ty_str.contains('<') {
+                lowerer.local_full_type.insert(param.name.clone(), param_ty_str.to_string());
             }
         }
 
@@ -1324,6 +1339,9 @@ fn func_return_type_prefix(func_name: &str) -> Option<&'static str> {
         | "string_lines" | "string_split" | "string_split_whitespace"
         | "Map_keys" | "Map_values" => Some("Vec"),
         "Vec_pop" | "Vec_get" | "Map_get" => Some("Option"),
+        "Shared_clone" => Some("Shared"),
+        "Sender_clone" => Some("Sender"),
+        "Receiver_clone" => Some("Receiver"),
         _ if func_name.starts_with("AtomicBool_") => Some("AtomicBool"),
         _ if func_name.starts_with("f32x4_") && !is_scalar_return(func_name) => Some("f32x4"),
         _ if func_name.starts_with("f32x8_") && !is_scalar_return(func_name) => Some("f32x8"),

--- a/compiler/crates/rask-mir/src/lower/stmt.rs
+++ b/compiler/crates/rask-mir/src/lower/stmt.rs
@@ -392,6 +392,42 @@ impl<'a> MirLowerer<'a> {
                     if let Some(prefix) = super::func_return_type_prefix(&func_name) {
                         self.local_type_prefix.insert(name.to_string(), prefix.to_string());
                     }
+                    // Propagate full generic type through clone (Shared, Sender, Receiver)
+                    if method == "clone" {
+                        if let Some(full_ty) = self.local_full_type.get(obj_name).cloned() {
+                            self.local_full_type.insert(name.to_string(), full_ty);
+                        }
+                    }
+                }
+            }
+        }
+        // Track full generic type for Shared.new(data) calls:
+        // infer inner type from the constructor argument.
+        if let ExprKind::MethodCall { object, method, args: call_args, .. } = &init.kind {
+            if let ExprKind::Ident(obj_name) = &object.kind {
+                if obj_name == "Shared" && method == "new" && !call_args.is_empty() {
+                    // Infer inner type from the first arg
+                    let inner_name = match &call_args[0].expr.kind {
+                        ExprKind::StructLit { name: sn, .. } => Some(sn.clone()),
+                        ExprKind::MethodCall { object: inner_obj, .. } => {
+                            if let ExprKind::Ident(tn) = &inner_obj.kind {
+                                if tn.chars().next().map_or(false, |c| c.is_uppercase()) {
+                                    Some(tn.clone())
+                                } else { None }
+                            } else { None }
+                        }
+                        ExprKind::Ident(vn) => {
+                            // Look up variable type from local_type_prefix
+                            self.local_type_prefix.get(vn).cloned()
+                        }
+                        _ => None,
+                    };
+                    if let Some(inner) = inner_name {
+                        self.local_full_type.insert(
+                            name.to_string(),
+                            format!("Shared<{}>", inner),
+                        );
+                    }
                 }
             }
         }
@@ -528,6 +564,17 @@ impl<'a> MirLowerer<'a> {
                                 _ => continue,
                             };
                             self.local_type_prefix.insert(name.clone(), prefix.to_string());
+                            // Track channel element size for struct-aware recv
+                            let inner = type_name.split('<').nth(1)
+                                .and_then(|s| s.strip_suffix('>'));
+                            let elem_size = if let Some(tn) = inner {
+                                self.ctx.find_struct(tn)
+                                    .map(|(_, l)| l.size as i64)
+                                    .unwrap_or(8)
+                            } else {
+                                8
+                            };
+                            self.channel_elem_sizes.insert(name.clone(), elem_size);
                         }
                     }
                 }

--- a/compiler/crates/rask-parser/src/parser.rs
+++ b/compiler/crates/rask-parser/src/parser.rs
@@ -3414,8 +3414,8 @@ impl Parser {
     }
 
 
-    /// Build an expression from an already-consumed ident, parsing postfix [index] and .field
-    /// until we reach the `as` keyword.
+    /// Build an expression from an already-consumed ident, parsing postfix
+    /// [index], .field, and .method() until we reach the `as` keyword.
     fn build_with_as_expr(&mut self, start: usize, ident: String) -> Result<Expr, ParseError> {
         let ident_end = self.current().span.start;
         let mut expr = Expr {
@@ -3437,13 +3437,31 @@ impl Parser {
                 };
             } else if self.check(&TokenKind::Dot) {
                 self.advance();
-                let field = self.expect_ident()?;
-                let end = self.tokens[self.pos - 1].span.end;
-                expr = Expr {
-                    id: self.next_id(),
-                    kind: ExprKind::Field { object: Box::new(expr), field },
-                    span: Span::new(start, end),
-                };
+                let field = self.expect_ident_or_keyword()?;
+                // Method call: .field(args...)
+                if self.check(&TokenKind::LParen) {
+                    self.advance();
+                    let args = self.parse_args()?;
+                    self.expect(&TokenKind::RParen)?;
+                    let end = self.tokens[self.pos - 1].span.end;
+                    expr = Expr {
+                        id: self.next_id(),
+                        kind: ExprKind::MethodCall {
+                            object: Box::new(expr),
+                            method: field,
+                            type_args: None,
+                            args,
+                        },
+                        span: Span::new(start, end),
+                    };
+                } else {
+                    let end = self.tokens[self.pos - 1].span.end;
+                    expr = Expr {
+                        id: self.next_id(),
+                        kind: ExprKind::Field { object: Box::new(expr), field },
+                        span: Span::new(start, end),
+                    };
+                }
             } else {
                 break;
             }

--- a/compiler/crates/rask-types/src/checker/check_expr.rs
+++ b/compiler/crates/rask-types/src/checker/check_expr.rs
@@ -673,17 +673,19 @@ impl TypeChecker {
                 for stmt in body {
                     self.check_stmt(stmt);
                 }
-                self.pop_scope();
-                // Check if the block ends with a diverging statement
-                if let Some(last) = body.last() {
+                let result = if let Some(last) = body.last() {
                     match &last.kind {
+                        StmtKind::Expr(e) => self.infer_expr(e),
                         StmtKind::Return(_) | StmtKind::Break { .. } | StmtKind::Continue(_) => {
-                            return Type::Never;
+                            Type::Never
                         }
-                        _ => {}
+                        _ => Type::Unit,
                     }
-                }
-                Type::Unit
+                } else {
+                    Type::Unit
+                };
+                self.pop_scope();
+                result
             }
 
             ExprKind::BlockCall { body, .. } => {

--- a/compiler/runtime/channel.c
+++ b/compiler/runtime/channel.c
@@ -472,6 +472,74 @@ int64_t rask_channel_try_recv_i64(int64_t rx) {
 extern void rask_yield(void);
 extern int  rask_green_task_is_cancelled(void);
 
+// ─── Pointer-based wrappers for aggregate types ──────────
+//
+// These use the actual element size instead of hardcoding sizeof(int64_t).
+// - new_ptr: creates channel with specified elem_size
+// - send_ptr: sends elem_size bytes from data_ptr
+// - recv_ptr: receives elem_size bytes into out_ptr
+
+int64_t rask_channel_new_ptr(int64_t elem_size, int64_t capacity) {
+    RaskSender *tx;
+    RaskRecver *rx;
+    rask_channel_new(elem_size, capacity, &tx, &rx);
+
+    void **pair = (void **)rask_alloc(16);
+    pair[0] = tx;
+    pair[1] = rx;
+    return (int64_t)(intptr_t)pair;
+}
+
+int64_t rask_channel_send_ptr(int64_t tx, int64_t data_ptr) {
+    return rask_channel_send((RaskSender *)(intptr_t)tx, (const void *)(intptr_t)data_ptr);
+}
+
+int64_t rask_channel_recv_ptr(int64_t rx, int64_t out_ptr) {
+    int64_t status = rask_channel_recv((RaskRecver *)(intptr_t)rx, (void *)(intptr_t)out_ptr);
+    if (status != RASK_CHAN_OK) {
+        rask_panic("recv on closed channel");
+    }
+    return out_ptr;
+}
+
+int64_t rask_channel_send_async_ptr(int64_t tx, int64_t data_ptr) {
+    RaskSender *sender = (RaskSender *)(intptr_t)tx;
+    int64_t status = rask_channel_try_send(sender, (const void *)(intptr_t)data_ptr);
+    if (status == RASK_CHAN_OK || status == RASK_CHAN_CLOSED) {
+        return status;
+    }
+    while (status == RASK_CHAN_FULL) {
+        rask_yield();
+        if (rask_green_task_is_cancelled()) {
+            return RASK_CHAN_CLOSED;
+        }
+        status = rask_channel_try_send(sender, (const void *)(intptr_t)data_ptr);
+    }
+    return status;
+}
+
+int64_t rask_channel_recv_async_ptr(int64_t rx, int64_t out_ptr) {
+    RaskRecver *recver = (RaskRecver *)(intptr_t)rx;
+    int64_t status = rask_channel_try_recv(recver, (void *)(intptr_t)out_ptr);
+    if (status == RASK_CHAN_OK) {
+        return out_ptr;
+    }
+    if (status == RASK_CHAN_CLOSED) {
+        rask_panic("recv on closed channel");
+    }
+    while (status == RASK_CHAN_EMPTY) {
+        rask_yield();
+        if (rask_green_task_is_cancelled()) {
+            rask_panic("recv cancelled");
+        }
+        status = rask_channel_try_recv(recver, (void *)(intptr_t)out_ptr);
+    }
+    if (status == RASK_CHAN_CLOSED) {
+        rask_panic("recv on closed channel");
+    }
+    return out_ptr;
+}
+
 int64_t rask_channel_send_async(int64_t tx, int64_t value) {
     RaskSender *sender = (RaskSender *)(intptr_t)tx;
     // Try non-blocking first

--- a/compiler/runtime/rask_runtime.h
+++ b/compiler/runtime/rask_runtime.h
@@ -486,4 +486,16 @@ int64_t rask_shared_write_i64(int64_t shared, int64_t closure);
 int64_t rask_shared_clone_i64(int64_t shared);
 void    rask_shared_drop_i64(int64_t shared);
 
+// Pointer-based wrappers for aggregate types (struct data).
+int64_t rask_shared_new_ptr(int64_t data_ptr, int64_t data_size);
+int64_t rask_shared_read_ptr(int64_t shared, int64_t closure);
+int64_t rask_shared_write_ptr(int64_t shared, int64_t closure);
+
+// Pointer-based channel wrappers for aggregate element types.
+int64_t rask_channel_new_ptr(int64_t elem_size, int64_t capacity);
+int64_t rask_channel_send_ptr(int64_t tx, int64_t data_ptr);
+int64_t rask_channel_recv_ptr(int64_t rx, int64_t out_ptr);
+int64_t rask_channel_send_async_ptr(int64_t tx, int64_t data_ptr);
+int64_t rask_channel_recv_async_ptr(int64_t rx, int64_t out_ptr);
+
 #endif // RASK_RUNTIME_H

--- a/compiler/runtime/sync.c
+++ b/compiler/runtime/sync.c
@@ -175,3 +175,36 @@ int64_t rask_shared_clone_i64(int64_t shared) {
 void rask_shared_drop_i64(int64_t shared) {
     rask_shared_free((RaskShared *)(intptr_t)shared);
 }
+
+// ─── Pointer-based wrappers for aggregate types ──────────
+//
+// These work with any data size. The closure receives a pointer to
+// the data inside the Shared, not a copy. For write, modifications
+// happen in-place through the pointer (no copy-back needed).
+
+int64_t rask_shared_new_ptr(int64_t data_ptr, int64_t data_size) {
+    RaskShared *s = rask_shared_new((const void *)(intptr_t)data_ptr, data_size);
+    return (int64_t)(intptr_t)s;
+}
+
+int64_t rask_shared_read_ptr(int64_t shared, int64_t closure) {
+    RaskShared *s = (RaskShared *)(intptr_t)shared;
+    RaskClosureFn1 fn = (RaskClosureFn1)(intptr_t)CLOSURE_FUNC(closure);
+    int64_t env = CLOSURE_ENV(closure);
+
+    pthread_rwlock_rdlock(&s->lock);
+    int64_t result = fn(env, (int64_t)(intptr_t)s->data);
+    pthread_rwlock_unlock(&s->lock);
+    return result;
+}
+
+int64_t rask_shared_write_ptr(int64_t shared, int64_t closure) {
+    RaskShared *s = (RaskShared *)(intptr_t)shared;
+    RaskClosureFn1 fn = (RaskClosureFn1)(intptr_t)CLOSURE_FUNC(closure);
+    int64_t env = CLOSURE_ENV(closure);
+
+    pthread_rwlock_wrlock(&s->lock);
+    int64_t result = fn(env, (int64_t)(intptr_t)s->data);
+    pthread_rwlock_unlock(&s->lock);
+    return result;
+}


### PR DESCRIPTION
The all-i64 codegen model was passing struct data as single i64 values
to Shared/Channel C runtime functions, causing incorrect allocation
sizes and data corruption. This was the critical blocker for
http_api_server.rk.

Changes across 10 files:

Parser: Support method call syntax in `with` bindings (shared.read()).

MIR lowering (expr.rs): Synthesize closures for `with shared.read/write()
as d { body }` blocks. Detect Shared access via type checker and
local_type_prefix fallback. Resolve inner struct type so the data
parameter carries correct MIR type for field offset computation. Inject
elem_size for Channel constructors and Shared_new. Add struct-aware
Receiver_recv_struct for channels carrying struct payloads.

MIR lowering (mod.rs): Add channel_elem_sizes and local_full_type maps.
Map Shared_clone/Sender_clone/Receiver_clone in func_return_type_prefix
so .clone() propagates type info. Register Receiver_recv_struct return
type as Ptr (not Result, since the C function panics on error).

MIR lowering (stmt.rs): Track channel element sizes during Channel
destructuring. Infer Shared inner type from constructor arguments.
Propagate full generic type through clone operations.

Type checker: Infer WithAs block type from last expression (matching
regular block semantics), fixing type errors when `with` blocks are
used in expression context inside typed functions.

Dispatch table: Route Shared/Channel MIR names to _ptr C runtime
variants. Add Receiver_recv_struct → rask_channel_recv_ptr.

Builder: Adapt Shared_new to compute data_size from struct layout.
Wrap scalar values as pointers for Sender_send. Allocate stack buffers
for Receiver_recv_struct.

C runtime: Add _ptr variants for all Shared and Channel operations
that work with any data size via (data_ptr, size) pairs.

Validated: Shared read/write with multi-field structs, Shared as
function parameter, Shared.clone() in spawn closures, Channel
send/recv with struct payloads, HTTP server with concurrent Shared
write operations.

https://claude.ai/code/session_01CzaHtqkKXyTjXWLTvi1AYc