### PR TITLE
Clarify borrowing rules: drop "value-based access", lead with intuition

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -225,7 +225,7 @@ Start with [CORE_DESIGN.md](specs/CORE_DESIGN.md). For specs: [specs/README.md](
 | Area | Decision | Spec |
 |------|----------|------|
 | Ownership | Single owner, move semantics, 16-byte copy threshold | [memory/](specs/memory/) |
-| Borrowing | Block-scoped (fixed sources), value-based + `with` (collections) | [borrowing.md](specs/memory/borrowing.md) |
+| Borrowing | Block-scoped (fixed sources), inline + `with` (growable sources) | [borrowing.md](specs/memory/borrowing.md) |
 | Collections | Vec, Map, Pool+Handle for graphs | [collections.md](specs/stdlib/collections.md), [pools.md](specs/memory/pools.md) |
 | Resource types | Must-consume (linear resources), `ensure` cleanup | [resource-types.md](specs/memory/resource-types.md) |
 | Types | Primitives, structs, enums, generics, traits, unions, tuples, type aliases | [types/](specs/types/) |

--- a/LANGUAGE_GUIDE.md
+++ b/LANGUAGE_GUIDE.md
@@ -1659,7 +1659,7 @@ specific way. It's more flexible than RAII—you can ensure different cleanup pa
 (commit vs rollback) and the cleanup is visible in the code rather than hidden in a
 destructor.
 
-### Why value-based access for collections?
+### Why inline access for collections?
 
 If you hold a reference to `vec[0]` and then `vec.push(x)`, the push might reallocate
 the vector's backing array. Your reference now points to freed memory.

--- a/specs/CORE_DESIGN.md
+++ b/specs/CORE_DESIGN.md
@@ -175,7 +175,7 @@ Each mechanism has its own spec with full details. This section gives the shape 
 
 **Value semantics.** Types ≤16 bytes with all-Copy fields copy implicitly. Larger types move. The threshold is fixed (not configurable) for semantic stability across platforms. `@unique` prevents copying; `@resource` requires exactly-once consumption. See [value-semantics.md](memory/value-semantics.md).
 
-**Borrowing.** References are block-scoped for fixed-layout sources (struct fields, arrays — valid until end of enclosing block). Heap-buffered sources (Vec, Pool, Map, string) use value-based access: inline expression access for one-liners, `with...as` blocks for multi-statement operations. Cannot be stored in structs, returned, or sent cross-task. See [borrowing.md](memory/borrowing.md).
+**Borrowing.** References are block-scoped for fixed-layout sources (struct fields, arrays — valid until end of enclosing block). Growable sources (Vec, Pool, Map, string) use inline access: expression-scoped for one-liners, `with...as` blocks for multi-statement operations. Cannot be stored in structs, returned, or sent cross-task. See [borrowing.md](memory/borrowing.md).
 
 **Parameters.** Three modes declared in the signature: borrow (default, read-only), `mutate` (mutable access, caller keeps ownership), and `take` (ownership transfer). Projections like `mutate p: Player.{health}` enable disjoint field borrows. See [parameters.md](memory/parameters.md).
 

--- a/specs/memory/borrowing.md
+++ b/specs/memory/borrowing.md
@@ -1,19 +1,23 @@
 <!-- id: mem.borrowing -->
 <!-- status: decided -->
-<!-- summary: Block-scoped views for fixed-layout sources, value-based access for collections with `with` for multi-statement binding -->
+<!-- summary: Block-scoped views for fixed-layout sources, inline access + `with` for growable sources -->
 <!-- depends: memory/ownership.md, memory/value-semantics.md -->
 <!-- implemented-by: compiler/crates/rask-ownership/, compiler/crates/rask-interp/ -->
 
 # Borrowing
 
-Views last as long as the source is stable. Sources with fixed layout (struct fields, arrays) keep views until the block ends. Sources with heap buffers (collections, strings) give you values — copy for Copy types, error for non-Copy. Multi-statement access to collection elements uses `with`.
+A view into `point.x` can't go stale — struct fields sit at fixed offsets. But `vec[i]` points into a heap buffer that any `push` could reallocate, invalidating every reference into it. That difference determines how long you can hold a view.
+
+**Fixed-layout sources** (struct fields, arrays) can't resize. Views persist until the block ends.
+
+**Growable sources** (Vec, Pool, Map, string) own heap buffers that can reallocate. Each access is temporary — copy out the value for one expression, or use `with` for multi-statement access.
 
 | Rule | Source | Access model | Why |
 |------|--------|-------------|-----|
-| **B1: Fixed = block-scoped** | Struct fields, arrays | View valid until block ends | Fixed layout, no reallocation possible |
-| **B2: Growable = value access** | Vec, Pool, Map, string | Copy out (Copy types) or use `with` | Heap buffer could reallocate |
+| **B1: Fixed = block-scoped** | Struct fields, arrays | View valid until block ends | Layout can't change |
+| **B2: Growable = inline + `with`** | Vec, Pool, Map, string | Copy out (Copy types) or use `with` | Heap buffer can reallocate |
 
-The dividing line is **"has a heap buffer"** vs **"doesn't."** Strings own heap-allocated UTF-8 buffers — they go in B2 regardless of `const`/`let`. Struct fields and arrays have fixed in-place layout — they go in B1.
+**The test:** can the source resize? Strings own heap-allocated UTF-8 buffers — they're growable, same as Vec. Struct fields and arrays have fixed in-place layout.
 
 ## Parameter and Receiver Borrows
 
@@ -82,7 +86,7 @@ const x = {
 // x would outlive p
 ```
 
-**Strings are value-access (B2), not block-scoped:**
+**Strings are growable (B2), not block-scoped:**
 <!-- test: compile-fail -->
 ```rask
 const s = "hello world"
@@ -458,7 +462,7 @@ func apply_buff(pool: Pool<Entity>, h: Handle<Entity>) -> () or Error {
 
 ### Rationale
 
-**B1/B2 (fixed vs growable):** I wanted to avoid "borrow checker wrestling" — code that looks fine then explodes 20 lines later. Collections can change structurally — `Vec` reallocates, `Pool` compacts, `Map` rehashes. Block-scoped views into them would dangle. Value-based access kills this bug class.
+**B1/B2 (fixed vs growable):** I wanted to avoid "borrow checker wrestling" — code that looks fine then explodes 20 lines later. Collections can change structurally — `Vec` reallocates, `Pool` compacts, `Map` rehashes. Block-scoped views into them would dangle. Inline access + `with` kills this bug class.
 
 **S3 (no escape):** The cost is more `.clone()` calls. I think that's better than scope annotations leaking into function signatures.
 

--- a/specs/stdlib/collections.md
+++ b/specs/stdlib/collections.md
@@ -1,11 +1,11 @@
 <!-- id: std.collections -->
 <!-- status: decided -->
-<!-- summary: Vec and Map with fallible allocation, value-based access, optional capacity bounds -->
+<!-- summary: Vec and Map with fallible allocation, inline access + `with`, optional capacity bounds -->
 <!-- depends: memory/borrowing.md, memory/pools.md, memory/value-semantics.md -->
 
 # Collections (Vec and Map)
 
-Vec and Map with optional capacity constraints, value-based access, fallible allocation. For handle-based sparse storage, see `mem.pools`.
+Vec and Map with optional capacity constraints, inline element access, fallible allocation. For handle-based sparse storage, see `mem.pools`.
 
 ## Collection Types
 
@@ -13,7 +13,7 @@ Vec and Map with optional capacity constraints, value-based access, fallible all
 |------|-------------|
 | **C1: Value ownership** | Collections own their data. No lifetime parameters |
 | **C2: Fallible allocation** | All growth operations return `Result` with rejected value on failure |
-| **C3: Value-based access** | Element access via `[]` is inline (expression-scoped). Multi-statement access via `with` |
+| **C3: Inline access** | Element access via `[]` is inline (expression-scoped). Multi-statement access via `with` |
 | **C4: No linear resources** | `Vec<Linear>` and `Map<K, Linear>` are compile errors. Use `Pool<Linear>` |
 
 | Type | Purpose | Creation |
@@ -360,7 +360,7 @@ FIX: Process existing items first, or use an unbounded collection:
 
 **C2 (fallible allocation):** All allocations can fail. Returning the rejected value in the error lets callers retry or log without losing data.
 
-**C3 (value-based access):** Collections can grow/shrink, invalidating any held views. Inline expression access kills this bug class. Multi-statement access uses `with`. See `mem.borrowing/B2`.
+**C3 (inline access):** Collections can grow/shrink, invalidating any held views. Inline expression access kills this bug class. Multi-statement access uses `with`. See `mem.borrowing/B2`.
 
 **C4 (no linear resources):** Collection drop can't propagate errors from linear resource cleanup. `Pool<T>` with explicit consumption is the right pattern.
 


### PR DESCRIPTION
The fixed-vs-growable borrowing split was unintuitive — the spec opened
with classification rules before explaining why the split exists, and
"value-based access" didn't convey what actually happens. Replaced with
concrete framing: lead with the physical reason (reallocation invalidates
references), promote "can it resize?" as the dividing-line test, and use
"inline + with" to describe the actual mechanisms instead of an umbrella
term that obscures them.

https://claude.ai/code/session_01YCMZ8VZQNxQpYAxckVTHGG