### PR TITLE
Relax W2: allow reading/writing other elements inside with blocks

### DIFF
--- a/specs/memory/aliasing-detection.md
+++ b/specs/memory/aliasing-detection.md
@@ -6,7 +6,7 @@
 
 # Aliasing Detection
 
-Compile-time analysis that prevents closures from mutating collections already borrowed by the calling method. Local to each function, O(function size).
+Compile-time analysis that prevents structural mutations on collections with active element borrows, and prevents closures from violating borrow invariants. Local to each function, O(function size).
 
 ## Borrow Stack
 
@@ -58,17 +58,17 @@ Method signatures declare borrow modes. The compiler infers from each method bod
 
 ## Error Messages
 
-**Mutation during frozen source [AL5]:**
+**Structural mutation during element borrow [AL5]:**
 ```
-ERROR [mem.aliasing/AL5]: cannot access `pool` inside its own with block
+ERROR [mem.aliasing/AL5]: cannot structurally mutate `pool` inside with block
    |
 1  |  with pool[h] as e {
-   |  ---- pool frozen here
+   |  ---- element borrowed here
 2  |      pool.remove(h)
-   |      ^^^^^^^^^^^^^^ cannot access pool here
+   |      ^^^^^^^^^^^^^^ structural mutation not allowed
 
-WHY: with block freezes the collection. No access to the source
-     is allowed inside the block.
+WHY: insert, remove, and clear can invalidate the borrowed element.
+     Reading and writing other elements is fine.
 
 FIX: Separate the check from the mutation:
 
@@ -78,21 +78,31 @@ FIX: Separate the check from the mutation:
   }
 ```
 
-**Mutation during shared borrow [AL4]:**
+**Structural mutation during element borrow (different handle) [AL4]:**
 ```
-ERROR [mem.aliasing/AL4]: cannot mutate `pool` while access active
+ERROR [mem.aliasing/AL4]: cannot structurally mutate `pool` inside with block
    |
 1  |  with pool[h] as e {
-   |  ---- pool frozen here
+   |  ---- element borrowed here
 2  |      pool.remove(other_h)
-   |      ^^^^^^^^^^^^^^^^^^^^ cannot access pool here
+   |      ^^^^^^^^^^^^^^^^^^^^ structural mutation not allowed
 
-WHY: with block freezes the collection. Mutation would invalidate it.
+WHY: remove can trigger reallocation, invalidating the borrowed element.
 
-FIX: Copy what you need, then mutate:
+FIX: Move the mutation outside the with block:
 
-  const data = pool[h].clone()
-  pool.remove(other_h)
+  const should_remove = with pool[h] as e { e.health <= 0 }
+  if should_remove {
+      pool.remove(other_h)
+  }
+```
+
+Non-structural access to other elements is allowed:
+```rask
+with pool[h] as e {
+    e.health -= pool[other_h].bonus    // OK: inline read of other element
+    pool[other_h].hit_count += 1       // OK: inline write to other element
+}
 ```
 
 ## Edge Cases
@@ -112,7 +122,7 @@ FIX: Copy what you need, then mutate:
 
 ### Rationale
 
-**AL1-AL2 (borrow stack + closure scan):** Expression-scoped closures (`mem.closures/EC4`) access outer scope directly. Without detection, a closure could mutate a collection while the calling method holds a borrow — causing handle invalidation, generation counter desync, or panics. Compile-time detection kills this bug class with zero runtime cost.
+**AL1-AL2 (borrow stack + closure scan):** Expression-scoped closures (`mem.closures/EC4`) access outer scope directly. Without detection, a closure could structurally mutate a collection while the calling method holds an element borrow — causing reallocation, handle invalidation, or panics. Compile-time detection kills this bug class with zero runtime cost. Non-structural access (reading/writing other elements) is safe because element borrows don't conflict with access to different slots.
 
 **AL7 (local analysis):** Method signatures provide borrow requirements without examining method bodies. Same cost as existing type checking.
 
@@ -120,14 +130,24 @@ FIX: Copy what you need, then mutate:
 
 ### Patterns & Guidance
 
-**Basic conflict — frozen source blocks all access:**
+**Basic conflict — structural mutations are forbidden:**
 <!-- test: skip -->
 ```rask
 with pool[h] as e {
-    pool.remove(h)    // ERROR: pool frozen inside with block
+    pool.remove(h)    // ERROR: structural mutation inside with block
 }
-// Borrow stack: [Exclusive(pool)]
-// with body accesses: [Call(pool.remove)] — conflicts with Exclusive(pool)
+// Borrow stack: [ElementBorrow(pool, h)]
+// with body accesses: [Call(pool.remove)] — structural mutation conflicts with ElementBorrow
+```
+
+**Non-structural access — reading/writing other elements is fine:**
+<!-- test: skip -->
+```rask
+with pool[h] as e {
+    e.health -= pool[other_h].attack    // OK: inline read of different element
+}
+// Borrow stack: [ElementBorrow(pool, h)]
+// with body accesses: [Read(pool[other_h])] — non-structural, different element, OK
 ```
 
 **Disjoint variables — different collections never conflict:**

--- a/specs/memory/borrowing.md
+++ b/specs/memory/borrowing.md
@@ -132,7 +132,7 @@ For non-Copy types, `const x = collection[key]` is a compile error. Use `.clone(
 | Rule | Description |
 |------|-------------|
 | **W1: First-class block** | `with` is a real scope — `return` exits the function, `try` propagates to the enclosing function, `break`/`continue` work for surrounding loops |
-| **W2: Source frozen** | Source collection cannot be accessed inside the `with` block (no structural mutations, no other element access) |
+| **W2: No structural mutation** | Source collection cannot be structurally mutated inside the `with` block (no insert, remove, clear). Reading and writing other elements via inline access is allowed |
 | **W3: Aliasing check** | Multiple bindings from same collection: runtime panic if same key/handle |
 | **W4: Error semantics** | Panics on invalid handle/OOB (matches direct indexing) |
 | **W5: Mutable binding** | `with` bindings are always mutable. Read-only access is enforced by the source (e.g., `shared.read()` prevents mutation). Compiler warns when binding is never mutated |
@@ -184,33 +184,38 @@ func apply_buff(pool: Pool<Entity>, h: Handle<Entity>) -> () or Error {
 }
 ```
 
-### Source freezing (W2)
+### Structural mutation restriction (W2)
 
-The source is frozen for the duration of the `with` block. No access to the collection is allowed inside the block — not even reading other elements.
-
-<!-- test: compile-fail -->
-```rask
-with pool[h] as entity {
-    entity.health -= 10
-    pool.remove(other_h)     // ERROR: pool frozen inside with block
-}
-```
+Structural mutations on the source collection are forbidden inside the `with` block — operations that add, remove, or reallocate elements (insert, remove, push, pop, clear). Reading and writing other elements via inline access works normally.
 
 <!-- test: compile-fail -->
 ```rask
 with pool[h] as entity {
     entity.health -= 10
-    const other = pool[other_h].health   // ERROR: pool frozen inside with block
+    pool.remove(other_h)     // ERROR: structural mutation inside with block
 }
 ```
 
-For accessing multiple elements, use the comma syntax:
+Reading and writing other elements is allowed:
+
+<!-- test: skip -->
+```rask
+with pool[h] as entity {
+    entity.health -= pool[other_h].bonus    // OK: inline read of other element
+    pool[other_h].last_attacker = Some(h)   // OK: inline write to other element
+    pool.insert(new_entity)                 // ERROR: structural mutation (insert)
+}
+```
+
+For multi-statement access to multiple elements, the comma syntax is still preferred:
 <!-- test: skip -->
 ```rask
 with pool[h1] as e1, pool[h2] as e2 {
-    e1.health -= e2.attack
+    e1.health -= e2.attack    // Runtime panic if h1 == h2
 }
 ```
+
+The same-handle restriction still applies — accessing `pool[h]` (same handle variable as the `with` binding) inside the block is a compile error. Use the binding instead.
 
 For iteration + mutation, use mutable iteration (`std.iteration/I4`) or collect handles:
 <!-- test: skip -->
@@ -359,20 +364,24 @@ FIX 2: Store indices:
   process(line[view])
 ```
 
-**Source frozen inside with [W2]:**
+**Structural mutation inside with [W2]:**
 ```
-ERROR [mem.borrowing/W2]: cannot access collection inside its own with block
+ERROR [mem.borrowing/W2]: cannot structurally mutate collection inside with block
    |
 5  |  with pool[h] as entity {
-   |  ---- pool frozen here
+   |  ---- element borrowed here
 6  |      entity.health -= 10
 7  |      pool.remove(other)
-   |      ^^^^^^^^^^^^^^^^^ cannot access pool here
+   |      ^^^^^^^^^^^^^^^^^ structural mutation not allowed inside with block
 
-FIX: Use comma syntax for multiple elements, or collect handles first:
+WHY: insert, remove, and clear can invalidate the borrowed element.
+     Reading and writing other elements is fine.
 
-  with pool[h] as e1, pool[other] as e2 {
-      e1.health -= e2.attack
+FIX: Move the structural mutation outside the with block:
+
+  const should_remove = pool[h].health <= 0
+  if should_remove {
+      pool.remove(other)
   }
 ```
 
@@ -393,7 +402,10 @@ FIX: Use comma syntax for multiple elements, or collect handles first:
 | `with` and `return` | W1 | Exits the function |
 | `with` and `try` | W1 | Propagates to enclosing function |
 | `with` and `break`/`continue` | W1 | Applies to surrounding loop |
-| Nested `with` same collection | W2 | Compile error (source frozen) |
+| Nested `with` same collection | W2 | Compile error (use comma syntax) |
+| Inline read of other element inside `with` | W2 | Allowed |
+| Inline write of other element inside `with` | W2 | Allowed (runtime panic if same handle) |
+| Structural mutation inside `with` | W2 | Compile error |
 | Projection stored in local | P1 | Block-scoped, follows S1–S3 (`type.structs/P8`) |
 | Overlapping projections | P3 | Compile error: fields overlap |
 | Projection + full struct borrow | P3 | Compile error: struct already borrowed |
@@ -464,7 +476,7 @@ func apply_buff(pool: Pool<Entity>, h: Handle<Entity>) -> () or Error {
 
 **W1 (with as first-class block):** The biggest concrete win over the old closure-based `modify()`. Closures can't propagate `return`/`try`/`break` to the enclosing function — `with` can. One access pattern for every container type.
 
-**W2 (source frozen):** Start strict — freeze the entire collection during `with`. The comma syntax handles the multi-element case. Relaxing to "structural mutations only" is a future option if real code needs it.
+**W2 (no structural mutation):** The compiler categorizes each collection method as structural (changes element count or triggers reallocation: insert, remove, push, pop, clear) or non-structural (reads/writes existing elements). Structural mutations are forbidden inside `with` — they could invalidate the borrowed element. Non-structural access to other elements is allowed because it doesn't affect the held element's memory. This pushes complexity into the compiler (method categorization) to give the user natural access patterns.
 
 **W5 (always mutable):** `with` exists for multi-statement access — and the overwhelming majority of cases involve mutation. If you just need to read, inline access often suffices. Making bindings always mutable eliminates the `const` keyword from `with` entirely, removing a concept that caused confusion: for `Shared<T>`, `const` previously changed the lock type (shared vs exclusive), while for everything else it only controlled binding mutability. With explicit `.read()`/`.write()` on Shared, there's no need for `const` on `with` bindings. The compiler warns when a `with` binding is never mutated.
 

--- a/specs/memory/pools.md
+++ b/specs/memory/pools.md
@@ -111,12 +111,12 @@ with pool[h] as entity {
 with pool[h] as e: e.health -= damage
 ```
 
-The pool is frozen for the duration of the `with` block — no other pool access inside it:
+Structural mutations are forbidden inside the `with` block — but reading and writing other elements is fine (`mem.borrowing/W2`):
 <!-- test: compile-fail -->
 ```rask
 with pool[h] as entity {
-    entity.health -= 10
-    pool.remove(h)    // ERROR: pool frozen inside with block
+    entity.health -= pool[other_h].bonus    // OK: read other element
+    pool.remove(h)    // ERROR: structural mutation inside with block
 }
 ```
 
@@ -454,14 +454,17 @@ FIX: Check validity before access:
   }
 ```
 
-**Pool frozen inside with block [W2]:**
+**Structural mutation inside with block [W2]:**
 ```
-ERROR [mem.borrowing/W2]: cannot access collection inside its own with block
+ERROR [mem.borrowing/W2]: cannot structurally mutate collection inside with block
    |
 2  |  with pool[h] as entity {
-   |  ---- pool frozen here
+   |  ---- element borrowed here
 3  |      pool.remove(h)
-   |      ^^^^^^^^^^^^^^ cannot access pool here
+   |      ^^^^^^^^^^^^^^ structural mutation not allowed inside with block
+
+WHY: insert, remove, and clear can invalidate the borrowed element.
+     Reading and writing other elements is fine.
 
 FIX: Separate the check from the mutation:
 


### PR DESCRIPTION
W2 previously froze the entire collection — no access at all inside
a with block. This pushed complexity to the user (workarounds for
reading a second element). Now the compiler does more work: it
categorizes each collection method as structural (insert, remove,
clear) vs non-structural, and only forbids structural mutations.

The user writes natural code like:
  with pool[h] as entity {
      entity.health -= pool[other_h].bonus
  }

The compiler tracks that inline reads/writes to other elements are
safe because they don't affect the held element's memory slot.

Updated: borrowing.md, pools.md, aliasing-detection.md

https://claude.ai/code/session_01MFQpy6N3wn5x848mh2r36U