### PR TITLE
Remove field projection syntax; use direct field passing instead

### DIFF
--- a/LANGUAGE_GUIDE.md
+++ b/LANGUAGE_GUIDE.md
@@ -377,30 +377,27 @@ One-liner shorthand (parallels `if cond: expr`):
 with pool[h] as e: e.health -= damage
 ```
 
-### Field Projections: Partial Borrowing
+### Disjoint Field Borrowing
 
-Sometimes a function only needs one field of a struct. Field projections let the compiler
-know, so other fields remain available:
+When a function only needs one field of a struct, pass the field directly. The borrow
+checker tracks which field is borrowed, so other fields remain available:
 
 ```rask
-func movement_system(mutate state: GameState.{entities}, dt: f32) {
-    // Only touches state.entities
+func movement_system(mutate entities: Pool<Entity>, dt: f32) {
+    // Works with any Pool<Entity>, not coupled to GameState
 }
 
-func scoring_system(mutate state: GameState.{score}, points: i32) {
-    // Only touches state.score
+func update_score(mutate score: i32, points: i32) {
+    score += points
 }
 
-// These can run in parallel—they touch different fields
-movement_system(state.{entities}, dt)
-scoring_system(state.{score}, 10)
+// Borrow checker knows these touch different fields — no conflict
+movement_system(state.entities, dt)
+update_score(state.score, 10)
 ```
 
-**Why `.{entities}` with braces, not just `.entities`?** Because `state.entities` is
-normal field access—it gives you the value. `state.{entities}` creates a *projection*—a
-restricted view of the struct where only that field is accessible. The braces
-disambiguate "I'm reading a field" from "I'm creating a partial view for borrowing
-purposes." The compiler verifies you don't touch anything outside the projection.
+For parallel access, closures capture at field granularity too — two spawned closures
+accessing disjoint fields of the same struct don't conflict.
 
 ---
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -109,9 +109,7 @@ Design the IR for function-level granularity now — this can't be retrofitted. 
 ## Open design questions
 
 - Package granularity — folder = package (Go-style) vs file = package (Zig-style)
-- Field projections for `ThreadPool.spawn` closures (disjoint field access)
 - Task-local storage syntax
-- `Projectable` trait — custom containers with `with...as`
 - String C interop — `as_c_str()`, `string.from_c()`
 - `pool.remove_with(h, |val| { ... })` — cascading @resource cleanup
 - Style guideline: max 3 context clauses per function

--- a/TODO.md
+++ b/TODO.md
@@ -54,9 +54,7 @@
 ## Design Questions
 
 - [ ] Package granularity — folder = package (Go-style) vs file = package (Zig-style)
-- [ ] Field projections for `ThreadPool.spawn` closures — disjoint field access across threads
 - [ ] Task-local storage syntax
-- [ ] `Projectable` trait — custom containers with `with...as`
 - [ ] String interop — `as_c_str()`, `string.from_c()`
 - [ ] `pool.remove_with(h, |val| { ... })` — cascading @resource cleanup helper
 - [ ] Style guideline: max 3 context clauses per function

--- a/compiler/crates/rask-interp/src/interp/call.rs
+++ b/compiler/crates/rask-interp/src/interp/call.rs
@@ -42,35 +42,7 @@ impl Interpreter {
         self.env.push_scope();
 
         for (param, arg) in func.params.iter().zip(args.into_iter()) {
-            if let Some(proj_start) = param.ty.find(".{") {
-                let proj_fields_str = &param.ty[proj_start + 2..param.ty.len() - 1];
-                let proj_fields: Vec<&str> = proj_fields_str.split(',').map(|s| s.trim()).collect();
-                if proj_fields.len() == 1 && param.name == proj_fields[0] {
-                    if let Value::Struct { fields, .. } = &arg {
-                        if let Some(field_val) = fields.get(proj_fields[0]) {
-                            self.env.define(param.name.clone(), field_val.clone());
-                        } else {
-                            return Err(RuntimeDiagnostic::new(
-                                RuntimeError::TypeError(format!(
-                                    "struct has no field '{}' for projection", proj_fields[0]
-                                )),
-                                Span::new(0, 0)
-                            ));
-                        }
-                    } else {
-                        return Err(RuntimeDiagnostic::new(
-                            RuntimeError::TypeError(format!(
-                                "projection parameter expects struct, got {}", arg.type_name()
-                            )),
-                            Span::new(0, 0)
-                        ));
-                    }
-                } else {
-                    self.env.define(param.name.clone(), arg);
-                }
-            } else {
-                self.env.define(param.name.clone(), arg);
-            }
+            self.env.define(param.name.clone(), arg);
         }
 
         let result = self.exec_stmts(&func.body);

--- a/compiler/crates/rask-ownership/src/lib.rs
+++ b/compiler/crates/rask-ownership/src/lib.rs
@@ -18,7 +18,7 @@ use rask_ast::decl::{Decl, DeclKind, FnDecl};
 use rask_ast::expr::{Expr, ExprKind, Pattern};
 use rask_ast::stmt::{ForBinding, Stmt, StmtKind};
 use rask_ast::Span;
-use rask_types::{Type, TypedProgram, extract_projection};
+use rask_types::{Type, TypedProgram};
 
 /// Result of ownership analysis.
 #[derive(Debug)]
@@ -154,17 +154,12 @@ impl<'a> OwnershipChecker<'a> {
                         scope: BorrowScope::Persistent { block_id: 0 },
                     },
                 );
-                // Track field projection if parameter has one (e.g., `state: GameState.{entities}`)
-                let projection = extract_projection(&param.ty);
-                let mut borrow = ActiveBorrow::new(
+                let borrow = ActiveBorrow::new(
                     param.name.clone(),
                     mode,
                     BorrowScope::Persistent { block_id: 0 },
                     Span::new(0, 0),
                 );
-                if let Some(fields) = projection {
-                    borrow = borrow.with_projection(fields);
-                }
                 self.borrows.push(borrow);
             }
         }
@@ -611,8 +606,8 @@ impl<'a> OwnershipChecker<'a> {
                     self.borrows.push(borrow);
                 }
                 BindingState::Borrowed { mode: existing_mode, .. } => {
-                    // Check if there's an actual conflict considering projections.
-                    // Non-overlapping projections on the same binding don't conflict.
+                    // Check if there's an actual conflict considering field-level borrows.
+                    // Non-overlapping field borrows on the same binding don't conflict.
                     let has_conflict = self.borrows.iter().any(|b| {
                         b.source == source_name && b.overlaps(&projection) && (
                             *existing_mode == BorrowMode::Exclusive

--- a/compiler/crates/rask-ownership/src/state.rs
+++ b/compiler/crates/rask-ownership/src/state.rs
@@ -49,7 +49,7 @@ pub struct ActiveBorrow {
     pub scope: BorrowScope,
     /// Where the borrow was created.
     pub span: Span,
-    /// Field projection — `None` means whole-object borrow,
+    /// Disjoint field borrow — `None` means whole-object borrow,
     /// `Some(fields)` means only those fields are borrowed.
     pub projection: Option<Vec<String>>,
 }
@@ -64,7 +64,7 @@ impl ActiveBorrow {
         self
     }
 
-    /// Check if this borrow overlaps with a given projection.
+    /// Check if this borrow overlaps with another field-level borrow.
     /// Two borrows overlap if either is whole-object or they share fields.
     pub fn overlaps(&self, other_projection: &Option<Vec<String>>) -> bool {
         match (&self.projection, other_projection) {

--- a/compiler/crates/rask-parser/src/parser.rs
+++ b/compiler/crates/rask-parser/src/parser.rs
@@ -1010,21 +1010,6 @@ impl Parser {
             name.push('?');
         }
 
-        if self.check(&TokenKind::Dot) && matches!(self.peek(1), TokenKind::LBrace) {
-            self.advance();
-            self.advance();
-            name.push_str(".{");
-            let mut first = true;
-            while !self.check(&TokenKind::RBrace) && !self.at_end() {
-                if !first { name.push_str(", "); }
-                first = false;
-                name.push_str(&self.expect_ident()?);
-                if !self.match_token(&TokenKind::Comma) { break; }
-            }
-            self.expect(&TokenKind::RBrace)?;
-            name.push('}');
-        }
-
         Ok(name)
     }
 

--- a/compiler/crates/rask-types/src/checker/check_fn.rs
+++ b/compiler/crates/rask-types/src/checker/check_fn.rs
@@ -7,8 +7,7 @@ use rask_ast::stmt::{Stmt, StmtKind};
 use rask_ast::Span;
 
 use super::errors::TypeError;
-use super::parse_type::{parse_type_string, extract_projection};
-use super::type_defs::TypeDef;
+use super::parse_type::parse_type_string;
 use super::TypeChecker;
 
 use crate::types::Type;
@@ -36,20 +35,7 @@ impl TypeChecker {
                 }
                 continue;
             }
-            if let Ok(mut ty) = parse_type_string(&param.ty, &self.types) {
-                // Single-field projections resolve to the field's type:
-                // `entities: GameState.{entities}` → entities has type Pool<Entity>
-                if let Some(proj_fields) = extract_projection(&param.ty) {
-                    if proj_fields.len() == 1 {
-                        if let Type::Named(type_id) = &ty {
-                            if let Some(TypeDef::Struct { fields: struct_fields, .. }) = self.types.get(*type_id) {
-                                if let Some((_, field_ty)) = struct_fields.iter().find(|(n, _)| *n == proj_fields[0]) {
-                                    ty = field_ty.clone();
-                                }
-                            }
-                        }
-                    }
-                }
+            if let Ok(ty) = parse_type_string(&param.ty, &self.types) {
                 if param.is_mutate || param.is_take {
                     self.define_local(param.name.clone(), ty);
                 } else {

--- a/compiler/crates/rask-types/src/checker/mod.rs
+++ b/compiler/crates/rask-types/src/checker/mod.rs
@@ -29,7 +29,7 @@ pub use type_defs::{TypeDef, MethodSig, SelfParam, ParamMode, TypedProgram};
 pub use type_table::TypeTable;
 pub use inference::{TypeConstraint, InferenceContext};
 pub use errors::TypeError;
-pub use parse_type::{parse_type_string, extract_projection};
+pub use parse_type::parse_type_string;
 
 use borrow::{ActiveBorrow, PersistentBorrow};
 

--- a/compiler/crates/rask-types/src/checker/parse_type.rs
+++ b/compiler/crates/rask-types/src/checker/parse_type.rs
@@ -12,11 +12,6 @@ use crate::types::{GenericArg, Type};
 pub fn parse_type_string(s: &str, types: &TypeTable) -> Result<Type, TypeError> {
     let s = s.trim();
 
-    // Strip field projection syntax: `Type.{field1, field2}` → `Type`
-    // Projections affect borrowing, not the type itself.
-    let s = strip_projection(s);
-    let s = s.as_ref();
-
     if s.is_empty() || s == "()" {
         return Ok(Type::Unit);
     }
@@ -293,35 +288,3 @@ fn parse_fn_type(s: &str, types: &TypeTable) -> Result<Type, TypeError> {
     })
 }
 
-/// Strip field projection suffix from a type string.
-/// `"GameState.{entities, score}"` → `"GameState"`
-/// `"Vec<i32>"` → `"Vec<i32>"` (unchanged)
-fn strip_projection(s: &str) -> std::borrow::Cow<'_, str> {
-    if let Some(pos) = s.find(".{") {
-        // Verify it ends with `}`
-        if s.ends_with('}') {
-            return std::borrow::Cow::Owned(s[..pos].to_string());
-        }
-    }
-    std::borrow::Cow::Borrowed(s)
-}
-
-/// Extract projection fields from a type string, if any.
-/// `"GameState.{entities, score}"` → `Some(vec!["entities", "score"])`
-/// `"Vec<i32>"` → `None`
-pub fn extract_projection(s: &str) -> Option<Vec<String>> {
-    if let Some(pos) = s.find(".{") {
-        if s.ends_with('}') {
-            let fields_str = &s[pos + 2..s.len() - 1];
-            let fields: Vec<String> = fields_str
-                .split(',')
-                .map(|f| f.trim().to_string())
-                .filter(|f| !f.is_empty())
-                .collect();
-            if !fields.is_empty() {
-                return Some(fields);
-            }
-        }
-    }
-    None
-}

--- a/compiler/crates/rask-types/src/lib.rs
+++ b/compiler/crates/rask-types/src/lib.rs
@@ -11,7 +11,7 @@ pub use types::{GenericArg, Type, TypeId, TypeVarId};
 pub use checker::{
     typecheck, TypeChecker, TypedProgram, TypeTable, TypeDef,
     TypeError, InferenceContext, TypeConstraint, MethodSig, SelfParam,
-    parse_type_string, extract_projection,
+    parse_type_string,
 };
 pub use traits::{
     TraitBound, TraitChecker, TraitError,

--- a/examples/game_loop.rk
+++ b/examples/game_loop.rk
@@ -108,13 +108,13 @@ extend GameState {
 }
 
 // System: Update positions based on velocities
-// Only borrows the entities field — other GameState fields remain available
-func movement_system(mutate state: GameState.{entities}, dt: f32) {
-    for h in state.entities {
-        if !state.entities[h].active: continue
+// Takes Pool<Entity> directly — decoupled from GameState, works with any entity pool
+func movement_system(mutate entities: Pool<Entity>, dt: f32) {
+    for h in entities {
+        if !entities[h].active: continue
 
-        state.entities[h].position.x += state.entities[h].velocity.dx * dt
-        state.entities[h].position.y += state.entities[h].velocity.dy * dt
+        entities[h].position.x += entities[h].velocity.dx * dt
+        entities[h].position.y += entities[h].velocity.dy * dt
     }
 }
 
@@ -209,11 +209,11 @@ func spawn_system(mutate state: GameState, time_since_last_spawn: f32) -> f32 {
 }
 
 // Parallel movement update - processes entity batches across threads
-// NOTE: Sending projections to threads requires scoped threading (type.structs/P4 — mechanism TBD)
-func parallel_movement_system(mutate state: GameState.{entities}, dt: f32, num_threads: usize)
+// Takes Pool<Entity> directly — borrow checker tracks field-level borrow at call site
+func parallel_movement_system(mutate entities: Pool<Entity>, dt: f32, num_threads: usize)
     using ThreadPool
 {
-    let handles = state.entities.handles()
+    let handles = entities.handles()
     let chunk_size = (handles.len() + num_threads - 1) / num_threads
 
     // Split work across thread pool
@@ -222,9 +222,9 @@ func parallel_movement_system(mutate state: GameState.{entities}, dt: f32, num_t
         let chunk = chunk.to_vec()
         let task = ThreadPool.spawn(|| {
             for h in chunk {
-                if !state.entities[h].active: continue
-                state.entities[h].position.x += state.entities[h].velocity.dx * dt
-                state.entities[h].position.y += state.entities[h].velocity.dy * dt
+                if !entities[h].active: continue
+                entities[h].position.x += entities[h].velocity.dx * dt
+                entities[h].position.y += entities[h].velocity.dy * dt
             }
         })
         thread_handles.push(task).ok()
@@ -275,7 +275,8 @@ func main() -> () or Error {
 
             // Parallel physics: split entity updates across thread pool
             // Each thread processes a batch of entities
-            parallel_movement_system(mutate state, dt, NUM_PHYSICS_THREADS)
+            // Borrow checker tracks that only state.entities is borrowed
+            parallel_movement_system(state.entities, dt, NUM_PHYSICS_THREADS)
 
             // Collision runs single-threaded (needs to see all entities)
             collision_system(mutate state)

--- a/specs/CONVENTIONS.md
+++ b/specs/CONVENTIONS.md
@@ -60,8 +60,8 @@ The prefix abbreviates the concept, not the filename. Keep it 1-3 uppercase lett
 | Spec | Prefixes | Examples |
 |------|----------|---------|
 | ownership.md | O, T, D | O1 (ownership), T2 (cross-task), D3 (drop) |
-| borrowing.md | B, S, E, W, P, A | B1 (borrow tier), S3 (scope), E1 (expression), W2 (with), P1 (projection), A1 (aliasing) |
-| structs.md | S, M, P | S1 (struct), M3 (method), P2 (projection) |
+| borrowing.md | B, S, E, W, F, A | B1 (borrow tier), S3 (scope), E1 (expression), W2 (with), F1 (field borrow), A1 (aliasing) |
+| structs.md | S, M | S1 (struct), M3 (method) |
 
 Multiple prefixes per file are fine — they group related rules.
 

--- a/specs/CORE_DESIGN.md
+++ b/specs/CORE_DESIGN.md
@@ -44,7 +44,7 @@ There's no `Box<T>` because there's no need to distinguish "heap-allocated value
 
 **Why this matters:** When everything is a value, the ownership rules apply everywhere identically. Move a `Vec` and the buffer moves. Move a `Cell` and the inner value moves. Move an `any Widget` and the heap data moves. One model, no exceptions.
 
-**Design space:** This approach is called *mutable value semantics* (MVS). The core idea: ban aliasing instead of banning mutation, then provide controlled mutation through parameter modes (`mutate`) and scoped access (`with`). [Hylo](https://www.hylo-lang.org/) (formerly Val, from Google Research) pioneered this as a formal model. [Rue](https://github.com/steveklabnik/rue) (by Steve Klabnik, author of *The Rust Programming Language*) explores the same tradeoff with `inout` parameters. Swift's value types are a partial version. Where Rask differs: `with` blocks for multi-statement collection access, `Pool`+`Handle` for graphs, field projections for partial borrows, and context clauses for implicit state threading — solutions to problems that pure MVS hits once you go beyond simple value passing.
+**Design space:** This approach is called *mutable value semantics* (MVS). The core idea: ban aliasing instead of banning mutation, then provide controlled mutation through parameter modes (`mutate`) and scoped access (`with`). [Hylo](https://www.hylo-lang.org/) (formerly Val, from Google Research) pioneered this as a formal model. [Rue](https://github.com/steveklabnik/rue) (by Steve Klabnik, author of *The Rust Programming Language*) explores the same tradeoff with `inout` parameters. Swift's value types are a partial version. Where Rask differs: `with` blocks for multi-statement collection access, `Pool`+`Handle` for graphs, disjoint field borrowing for partial borrows, and context clauses for implicit state threading — solutions to problems that pure MVS hits once you go beyond simple value passing.
 
 ### 3. No Storable References
 
@@ -177,7 +177,7 @@ Each mechanism has its own spec with full details. This section gives the shape 
 
 **Borrowing.** References are block-scoped for fixed-layout sources (struct fields, arrays — valid until end of enclosing block). Growable sources (Vec, Pool, Map, string) use inline access: expression-scoped for one-liners, `with...as` blocks for multi-statement operations. Cannot be stored in structs, returned, or sent cross-task. See [borrowing.md](memory/borrowing.md).
 
-**Parameters.** Three modes declared in the signature: borrow (default, read-only), `mutate` (mutable access, caller keeps ownership), and `take` (ownership transfer). Projections like `mutate p: Player.{health}` enable disjoint field borrows. See [parameters.md](memory/parameters.md).
+**Parameters.** Three modes declared in the signature: borrow (default, read-only), `mutate` (mutable access, caller keeps ownership), and `take` (ownership transfer). Passing `value.field` to a `mutate` parameter borrows only that field — disjoint fields don't conflict. See [parameters.md](memory/parameters.md), [borrowing.md](memory/borrowing.md).
 
 **Collections.** `Vec<T>` for sequences, `Map<K,V>` for key-value lookup, `Pool<T>` for handle-based sparse storage (graphs, entities, caches). All growth operations return `Result` — allocation is fallible. `with pool[h] as entity { ... }` for multi-statement element access. See [collections.md](stdlib/collections.md), [pools.md](memory/pools.md).
 

--- a/specs/SYNTAX.md
+++ b/specs/SYNTAX.md
@@ -785,12 +785,13 @@ const result = search: loop {
 
 ## Ownership & Memory Syntax
 
-Pool access, `ensure` cleanup, `@resource` types, and projection syntax are shown in the sections above (see [Structs](#structs), [Generics](#generics), [Parameter modes](#functions)). For full semantics, see:
+Pool access, `ensure` cleanup, and `@resource` types are shown in the sections above (see [Structs](#structs), [Generics](#generics), [Parameter modes](#functions)). For full semantics, see:
 
 - [pools.md](memory/pools.md) — Handle-based access, context clauses
 - [ensure.md](control/ensure.md) — Deferred cleanup
 - [resource-types.md](memory/resource-types.md) — Must-consume types
-- [parameters.md](memory/parameters.md) — Projections (`Type.{field}`)
+- [parameters.md](memory/parameters.md) — Parameter modes (borrow, mutate, take)
+- [borrowing.md](memory/borrowing.md) — Disjoint field borrowing
 
 ---
 
@@ -1114,7 +1115,6 @@ println("{sum}")
 | Closures | `\|x\| expr` | Rust-style pipes |
 | Named args | `name: value` | Order-fixed, optional (IDE ghosts) |
 | Default args | `param = value` | Constants only, after required |
-| Projections | `Type.{field}` | Partial borrows |
 | Interpolation | `"{x}"` | In all strings |
 | Comments | `//` and `/* */` | Standard |
 

--- a/specs/analysis/complexity-stress-test.md
+++ b/specs/analysis/complexity-stress-test.md
@@ -70,7 +70,7 @@ struct GameWorld {
 | 4: Render | 6 | PASS | |
 | 5: Parallel | **12** | **FAIL** | |
 
-**Root cause:** Not any single mechanism. ECS-with-FFI sits at the intersection of ALL mechanisms simultaneously. The 4-step destruction dance (Phase 3) and thread+snapshot+projection pile-up (Phase 5) break the budget.
+**Root cause:** Not any single mechanism. ECS-with-FFI sits at the intersection of ALL mechanisms simultaneously. The 4-step destruction dance (Phase 3) and thread+snapshot pile-up (Phase 5) break the budget.
 
 **Metrics impact:** Game engines carry only 5% weight in UCC, so failing here doesn't sink the language. But ED target (≤ 1.2 vs simplest alternative) is at risk — Odin or Jai would handle Phase 3 in 2 lines.
 
@@ -209,13 +209,14 @@ world.entities.remove_with(h, |entity| {
 })
 ```
 
-### 2. Field projections for `spawn thread` closures
+### 2. Disjoint field borrows in thread closures
 
 <!-- test: skip -->
 ```rask
-const physics_handle = spawn thread(world.{physics}) {
+// Compiler tracks that the closure only captures world.physics
+const physics_handle = spawn thread(|| {
     world.physics.step(dt)
-}
+})
 ```
 
 ### 3. `ensure` ordering lint for @resource cleanup
@@ -224,7 +225,7 @@ Warn when LIFO ordering might close a dependency before its dependent is drained
 
 ### 4. Style guideline: max 3 context clauses
 
-If a function needs >3, restructure (pass struct, use field projections, split function). Lint, not language rule.
+If a function needs >3, restructure (pass struct, pass individual fields, split function). Lint, not language rule.
 
 ---
 
@@ -236,4 +237,4 @@ If a function needs >3, restructure (pass struct, use field projections, split f
 - `mem.resources` — @resource types, ensure cleanup
 - `mem.context` — context clauses
 - `conc.async` — spawn, must-use handles
-- `mem.borrowing` — inline access, `with` blocks, field projections
+- `mem.borrowing` — inline access, `with` blocks, disjoint field borrowing

--- a/specs/memory/borrowing.md
+++ b/specs/memory/borrowing.md
@@ -251,16 +251,16 @@ Shared requires explicit `.read()` or `.write()` — bare `with shared as v` is 
 
 See [cell.md](cell.md) for Cell specifics, [sync.md](../concurrency/sync.md) for Shared/Mutex specifics.
 
-## Field Projections for Partial Borrowing
+## Disjoint Field Borrowing
 
-Borrowing a struct borrows all of it. Field projections (`Type.{field1, field2}`) borrow only specific fields.
+When you pass `value.field` to a function, the borrow checker tracks the borrow at field granularity. Two borrows on different fields of the same struct don't conflict.
 
 | Rule | Description |
 |------|-------------|
-| **P1: Syntax** | `value.{field1, field2}` creates a projection of the named fields |
-| **P2: Type syntax** | `Type.{field1}` in function params accepts a projection |
-| **P3: Non-overlapping** | Projections with disjoint fields can be borrowed simultaneously |
-| **P4: Parallel safe** | Non-overlapping mutable projections can be sent to different scoped threads |
+| **F1: Field-level tracking** | Passing `value.field` to a `mutate` parameter borrows only that field |
+| **F2: Non-overlapping** | Borrows on disjoint fields of the same struct can coexist |
+| **F3: Whole-object conflict** | A borrow of the whole struct conflicts with any field-level borrow |
+| **F4: Closure captures** | Closures capture variables at field granularity — disjoint field captures on different threads don't conflict |
 
 <!-- test: skip -->
 ```rask
@@ -269,36 +269,44 @@ struct GameState {
     score: i32
 }
 
-// Only borrows `entities` - other fields remain available
-func movement_system(mutate state: GameState.{entities}, dt: f32) {
-    for h in state.entities {
-        state.entities[h].position.x += state.entities[h].velocity.dx * dt
+// Takes the field directly — decoupled from GameState
+func movement_system(mutate entities: Pool<Entity>, dt: f32) {
+    for h in entities {
+        entities[h].position.x += entities[h].velocity.dx * dt
     }
 }
 
-// Only borrows `score` - can run alongside movement_system
-func update_score(mutate state: GameState.{score}, points: i32) {
-    state.score += points
+func update_score(mutate score: i32, points: i32) {
+    score += points
+}
+
+func update(mutate state: GameState, dt: f32) {
+    movement_system(state.entities, dt)   // Borrows state.entities
+    update_score(state.score, 10)          // Borrows state.score (no conflict — F2)
 }
 ```
 
-**Local projections (P1):**
+**Parallel field access (F4):**
 
 <!-- test: skip -->
 ```rask
-func update(mutate state: GameState) {
-    // Local projection — borrows only the named fields
-    const proj = state.{entities}
-    proj.entities[h].health -= 10   // OK: entities is projected
-    state.score += 100               // OK: score not in projection
-
-    // Disjoint local projections
-    const a = state.{entities}
-    const b = state.{score}          // OK: disjoint from a
+func parallel_update(mutate state: GameState, dt: f32) {
+    scoped {
+        // Compiler sees: captures state.entities mutably
+        spawn(|| {
+            for h in state.entities {
+                state.entities[h].position.x += state.entities[h].velocity.dx * dt
+            }
+        })
+        // Compiler sees: captures state.score mutably — disjoint, no conflict
+        spawn(|| {
+            state.score += 10
+        })
+    }
 }
 ```
 
-See [types/structs.md](../types/structs.md) for full projection type rules (`type.structs/P1`–`P10`).
+Functions take concrete field types, not struct-coupled projections. This means `movement_system` works with any `Pool<Entity>`, not just one from `GameState`.
 
 ## Access Rules
 
@@ -410,11 +418,9 @@ FIX: Move the structural mutation outside the with block:
 | Inline read of other element inside `with` | W2 | Allowed |
 | Inline write of other element inside `with` | W2 | Allowed (runtime panic if same handle) |
 | Structural mutation inside `with` | W2 | Compile error |
-| Projection stored in local | P1 | Block-scoped, follows S1–S3 (`type.structs/P8`) |
-| Overlapping projections | P3 | Compile error: fields overlap |
-| Projection + full struct borrow | P3 | Compile error: struct already borrowed |
-| Method on projection | — | Compile error (`type.structs/P7`) |
-| Nested field projection | P1 | Invalid: `T.{a.b}` (`type.structs/P6`) |
+| Disjoint field borrows | F2 | Non-overlapping fields can be borrowed simultaneously |
+| Field borrow + whole-struct borrow | F3 | Compile error: struct already borrowed |
+| Same field borrowed twice | F2 | Compile error: field already borrowed |
 
 ## Quick Reference
 
@@ -585,3 +591,4 @@ Hover information shows the access type, duration, and suggested patterns for th
 - [Collections](../stdlib/collections.md) — Vec, Map APIs (`std.collections`)
 - [Cell](cell.md) — Single-value `with` access (`mem.cell`)
 - [Synchronization](../concurrency/sync.md) — `Shared<T>`/`Mutex<T>` `with` access (`conc.sync`)
+- [Structs](../types/structs.md) — Struct definition, methods, value semantics (`type.structs`)

--- a/specs/memory/parameters.md
+++ b/specs/memory/parameters.md
@@ -95,32 +95,27 @@ try file.close()      // takes file
 try file.read(buf)    // ERROR: file was taken
 ```
 
-## Projections (Partial Borrows)
+## Disjoint Field Borrows
 
-Projections borrow only specific fields, enabling disjoint borrows across function calls.
-
-| Rule | Description |
-|------|-------------|
-| **PM4: Projection syntax** | `Type.{field1, field2}` in function params accepts a projection |
-| **PM5: Disjoint** | Non-overlapping projections can coexist |
-| **PM6: Scope** | Only projected fields are accessible |
+When passing `value.field` to a `mutate` parameter, the borrow checker tracks the borrow at field granularity. Functions take the field's concrete type — no special projection syntax needed.
 
 <!-- test: skip -->
 ```rask
-func heal(mutate p: Player.{health}) {
-    p.health += 10       // OK: health is projected
-    p.inventory          // ERROR: not in projection
+func heal(mutate health: Health) {
+    health.current += 10
 }
 
-func loot(mutate p: Player.{inventory}) {
-    p.inventory.push(item)
+func loot(mutate inventory: Inventory) {
+    inventory.push(item)
 }
 
 func update(mutate player: Player) {
-    heal(player)         // Borrows player.health
-    loot(player)         // OK: borrows player.inventory (disjoint)
+    heal(player.health)         // Borrows player.health
+    loot(player.inventory)      // OK: borrows player.inventory (disjoint)
 }
 ```
+
+See `mem.borrowing/F1`–`F4` for the full disjoint field borrowing rules.
 
 ## Interaction with Copy Types
 
@@ -208,9 +203,7 @@ ERROR [mem.parameters/PM3]: value used after being taken
 | Closure captures | — | Captured borrows follow closure lifetime rules (`mem.closures`) |
 | Pattern matching | PM2 | Mutation only allowed if parameter is `mutate` |
 | Copy type + mutate | PM2 | Value is copied in; mutations affect the copy |
-| Nested fields in projection | PM4 | `Player.{stats.health}` is invalid — projections are flat (`type.structs/P6`). Project `stats`, access `.health` normally |
-| `take` on projection | PM4 | Invalid — projections support borrow and `mutate` only (`type.structs/P9`) |
-| Projection in generic param | PM4 | Invalid — `T.{field}` where T is generic is a compile error (`type.structs/P10`) |
+| Disjoint field borrows | — | Passing `value.field` to `mutate` borrows only that field (`mem.borrowing/F1`) |
 
 ---
 
@@ -288,4 +281,4 @@ This bridges the gap between source-level simplicity and full visibility. In an 
 - [Resource Types](resource-types.md) — Must-consume resources (`mem.resources`)
 - [Borrowing](borrowing.md) — Borrow scope rules (`mem.borrowing`)
 - [Closures](closures.md) — Closure parameter modes (`mem.closures`)
-- [Structs](../types/structs.md) — Projection type syntax (`type.structs`)
+- [Structs](../types/structs.md) — Struct definition, methods (`type.structs`)

--- a/specs/types/structs.md
+++ b/specs/types/structs.md
@@ -247,129 +247,6 @@ let Point { x, .. } = point    // Ignore other fields
 
 Visibility in patterns: same package gets all fields; external gets only `public` fields and MUST use `..` for non-public fields.
 
-## Field Projection Types
-
-Projection types let functions accept only specific fields, enabling partial borrowing without lifetime annotations. A projection `T.{a, b}` is a restricted struct view — you see only the named fields, nothing else.
-
-### Core Rules
-
-| Rule | Description |
-|------|-------------|
-| **P1: Field subset** | `T.{a, b}` creates a type with only the named fields from `T` |
-| **P2: Borrow scope** | Each projected field follows normal borrowing independently |
-| **P3: No overlap** | Multiple projections can borrow simultaneously if fields don't overlap |
-| **P4: Parallel safe** | Non-overlapping mutable projections can be sent to different scoped threads |
-
-<!-- test: skip -->
-```rask
-struct GameState {
-    entities: Pool<Entity>
-    player: Handle<Entity>?
-    score: i32
-    game_over: bool
-}
-
-// Only borrows the `entities` field, leaving other fields available
-func movement_system(mutate state: GameState.{entities}, dt: f32) {
-    for h in state.entities {
-        state.entities[h].position.x += state.entities[h].velocity.dx * dt
-    }
-}
-
-// Only borrows `score` — can run alongside movement_system
-func update_score(mutate state: GameState.{score}, points: i32) {
-    state.score += points
-}
-
-// Can call multiple systems that use different projections
-func update(mutate state: GameState, dt: f32) {
-    movement_system(state.{entities}, dt)     // Borrows entities
-    update_score(state.{score}, 10)           // Borrows score (no conflict)
-}
-```
-
-### Access and Restrictions
-
-| Rule | Description |
-|------|-------------|
-| **P5: Field access by name** | Projected fields accessed by name: `proj.field`. Non-projected fields are a compile error |
-| **P6: Flat projections** | Projections name direct fields only. `T.{a.b}` is invalid — project `a`, then access `.b` normally |
-| **P7: No method dispatch** | Methods defined on `T` cannot be called on `T.{a, b}`. Methods on individual fields work normally |
-| **P8: Local binding** | `const p = value.{a, b}` creates a block-scoped projection (`mem.borrowing/S1`–`S3`) |
-| **P9: Borrow and mutate only** | Projections combine with borrow (default) and `mutate`. `take` is invalid — partial ownership transfer not supported |
-| **P10: Not a type constructor** | Projection types cannot appear as generic type arguments, struct field types, or return types |
-
-**P5 — field access:**
-
-<!-- test: skip -->
-```rask
-func heal(mutate state: Player.{health}) {
-    state.health += 10       // OK: health is projected
-    state.inventory          // ERROR: not in projection
-}
-```
-
-**P6 — flat projections:**
-
-<!-- test: skip -->
-```rask
-// INVALID: nested projection
-func bad(state: Player.{stats.health}) { ... }
-
-// VALID: project the parent, access subfields normally
-func good(mutate state: Player.{stats}) {
-    state.stats.health += 10
-}
-```
-
-**P7 — no method dispatch:**
-
-<!-- test: skip -->
-```rask
-func example(state: GameState.{entities}) {
-    state.entities.len()      // OK: method on Pool<Entity>
-    state.is_game_over()      // ERROR: GameState method, not available on projection
-}
-```
-
-**P8 — local binding:**
-
-<!-- test: skip -->
-```rask
-func update(mutate state: GameState) {
-    const proj = state.{entities, score}  // Block-scoped projection
-    proj.entities[h].health -= 10         // OK: entities is projected
-    proj.score += 100                     // OK: score is projected
-    state.game_over                       // ERROR: state borrowed through projection
-}   // proj released at block end
-```
-
-**P9 — no take:**
-
-<!-- test: skip -->
-```rask
-func bad(take state: GameState.{entities}) { ... }  // ERROR: take on projection
-func ok(mutate state: GameState.{entities}) { ... }  // OK: mutable borrow
-func ok2(state: GameState.{entities}) { ... }         // OK: read-only borrow
-```
-
-**P10 — not a type constructor:**
-
-<!-- test: skip -->
-```rask
-// ALL INVALID:
-struct Holder { partial: GameState.{entities} }  // No projection in struct fields
-func bad() -> GameState.{entities} { ... }       // No projection return types
-func bad2<T>(x: T.{field}) { ... }               // No projection of generic types
-```
-
-| Pattern | Benefit |
-|---------|---------|
-| ECS systems | Each system borrows only the components it needs |
-| Parallel access | Non-overlapping projections can be sent to scoped threads |
-| API clarity | Function signature shows exactly which fields are accessed |
-| Local splitting | `const a = val.{x}; const b = val.{y}` — disjoint local borrows |
-
 ## Edge Cases
 
 | Case | Rule | Handling |
@@ -382,16 +259,6 @@ func bad2<T>(x: T.{field}) { ... }               // No projection of generic typ
 | Struct in Vec | — | Allowed if non-linear |
 | Linear field | — | Struct becomes linear; must be consumed |
 | Generic instantiation | — | Bounds checked; Copy determined per instantiation |
-| Projection of non-existent field | P1 | Compile error: "field 'x' does not exist on T" |
-| Nested field projection | P6 | Compile error: "projections are flat — project 'stats', then access subfields" |
-| Overlapping projections | P3 | Compile error: "projection 'entities' overlaps with existing borrow" |
-| Projection with `take` | P9 | Compile error: "cannot take partial ownership — use borrow or mutate" |
-| Projection in struct field | P10 | Compile error: "projection types cannot appear in struct definitions" |
-| Projection as return type | P10 | Compile error: "projection types cannot be returned" |
-| Projection of generic type | P10 | Compile error: "cannot project generic type parameter" |
-| Method call on projection | P7 | Compile error: "method 'foo' is defined on T, not on T.{a}" |
-| Closure capturing projection | P8 | Follows `mem.closures/SL1` — closure scope-limited to projection |
-| Projection to scoped thread | P4 | Valid if thread joined before projection expires (mechanism TBD) |
 
 ## Examples
 
@@ -490,31 +357,13 @@ Zero-initialization is not automatic. Explicit factory if needed.
 
 ### Patterns & Guidance
 
-**Projection use cases (P1-P10):** See `mem.borrowing` for how projections enable parallelism without lifetime annotations. See `mem.parameters` for projection parameter modes.
-
-**When to use projections vs passing fields directly:**
-
-| Scenario | Approach |
-|----------|----------|
-| Function needs one field, no parallel concern | Pass the field directly: `func f(pool: Pool<Entity>)` |
-| Parallel systems need disjoint access | Projections: `func f(mutate state: State.{entities})` |
-| Function signature should document field usage | Projections |
-| Generic function accepting any pool | Pass the field directly |
-
-**P6 (flat projections):** I considered `T.{stats.health}` for deep projections but it requires tracking borrow paths through multiple struct levels — cross-struct analysis the borrow checker deliberately avoids. Project the parent field and access subfields normally. If deep splitting is needed, flatten the struct.
-
-**P7 (no methods):** Allowing methods on projections would require analyzing which fields a method reads — that's cross-function analysis. Methods are contracts with the full type; projections are borrowing constraints. Different concerns, kept separate.
-
-**P9 (no take):** Taking a projection would leave the struct partially moved. Rust allows this in limited cases; I think the complexity isn't worth it. Destructure the struct if you need to take individual fields.
-
-**P10 (not a type constructor):** Projections are a borrowing mechanism, not a type system feature. Storing them would require tracking borrow provenance in the type system — exactly the lifetime annotations I'm trying to avoid. They live at parameter boundaries and in local blocks, nowhere else.
+**Disjoint field borrowing:** Functions that need a single field should take that field's type directly: `func f(mutate entities: Pool<Entity>)`. The borrow checker tracks field-level borrows at call sites — passing `state.entities` borrows only that field. See `mem.borrowing/F1`–`F4`.
 
 ### See Also
 
 - `mem.ownership` — Copy/move semantics, 16-byte threshold
 - `mem.value-semantics` — Value semantics foundation
-- `mem.borrowing` — View scoping, projection borrowing (`mem.borrowing/P1`–`P4`)
-- `mem.parameters` — Projection parameter modes (`mem.parameters/PM4`–`PM6`)
+- `mem.borrowing` — View scoping, disjoint field borrowing (`mem.borrowing/F1`–`F4`)
 - `type.generics` — Generic bounds and instantiation
 - `struct.modules` — C interop details
 - [Binary Structs](binary.md) — `@binary` wire format layout
@@ -522,4 +371,3 @@ Zero-initialization is not automatic. Explicit factory if needed.
 ### Remaining Issues
 
 1. **Tuple structs** — Should `struct Point(i32, i32)` be supported for positional construction?
-2. **Scoped thread projections (P4)** — The mechanism for sending projections to scoped threads needs design. See TODO.md.


### PR DESCRIPTION
## Summary

This PR removes the field projection type syntax (`Type.{field1, field2}`) from the language and replaces it with a simpler model: functions take concrete field types directly, and the borrow checker tracks field-level borrows at call sites.

## Key Changes

**Specification updates:**
- Removed entire "Field Projection Types" section from `specs/types/structs.md` (P1-P10 rules)
- Replaced "Field Projections for Partial Borrowing" with "Disjoint Field Borrowing" in `specs/memory/borrowing.md` (F1-F4 rules)
- Simplified `specs/memory/parameters.md` to remove projection parameter modes (PM4-PM6)
- Updated `LANGUAGE_GUIDE.md` with simpler disjoint field borrowing examples
- Removed projection-related edge cases and error messages from specs

**Compiler changes:**
- Removed `strip_projection()` and `extract_projection()` functions from `rask-types/src/checker/parse_type.rs`
- Removed projection parsing logic from `rask-parser/src/parser.rs` (`.{field}` syntax)
- Removed projection type resolution from `rask-types/src/checker/check_fn.rs`
- Removed projection handling from `rask-interp/src/interp/call.rs`
- Removed projection field tracking from `rask-ownership/src/lib.rs`
- Updated exports in `rask-types/src/lib.rs` and `rask-types/src/checker/mod.rs`

**Example updates:**
- Updated `examples/game_loop.rk` to pass fields directly instead of using projections
- Changed `movement_system(mutate state: GameState.{entities})` to `movement_system(mutate entities: Pool<Entity>)`
- Updated parallel system examples to use direct field passing

## Design Rationale

Functions now take the concrete field type directly (e.g., `Pool<Entity>` instead of `GameState.{entities}`). This:
- Decouples functions from struct definitions (functions work with any pool, not just GameState's)
- Simplifies the type system (no special projection syntax needed)
- Maintains disjoint field borrowing through field-level borrow tracking at call sites
- Supports parallel access via closure captures at field granularity (F4)

The borrow checker still prevents conflicts when different fields are borrowed simultaneously, but this is now implicit in how fields are passed rather than explicit in the type signature.

https://claude.ai/code/session_0141PwCeZeWJUQKo2g3vcqfs