### PR TITLE
Simplify frozen pools: remove FrozenPool type, use context modifier

### DIFF
--- a/LANGUAGE_GUIDE.md
+++ b/LANGUAGE_GUIDE.md
@@ -517,8 +517,8 @@ Self-referential structures work naturally. No lifetime annotations anywhere.
 **Mitigations for the cost:**
 - The compiler coalesces checks: `pool[h].x = 1; pool[h].y = 2; pool[h].z = 3` becomes
   one check, not three.
-- Frozen pools (`pool.freeze()`) provide zero-cost iteration—no inserts/removes can happen,
-  so iterating with `values()`/`entries()` skips all checks.
+- Functions with `using frozen Pool<T>` tell the compiler no structural mutations happen,
+  enabling generation check elimination during iteration.
 - Copy out values you need: `const hp = pool[h].health` does one check, then `hp` is
   just a number.
 

--- a/README.md
+++ b/README.md
@@ -122,7 +122,7 @@ Structs hold data, traits define behavior, you extend types with methods. No inh
 
 I'm not pretending there aren't tradeoffs. Here's what you give up:
 
-**Handle overhead:** Accessing through handles costs ~1-2ns (generation check + bounds check, needs actual benchmark proof). In most code this doesn't matter. In tight loops processing millions of items, copy data out and batch process. Compiler coalesces redundant checks; `pool.freeze()` eliminates them entirely for read-heavy phases.
+**Handle overhead:** Accessing through handles costs ~1-2ns (generation check + bounds check, needs actual benchmark proof). In most code this doesn't matter. In tight loops processing millions of items, copy data out and batch process. Compiler coalesces redundant checks; frozen contexts (`using frozen Pool<T>`) enable further elimination during iteration.
 
 **Restructuring some patterns:**
 - Parent pointers → store handles

--- a/specs/SYNTAX.md
+++ b/specs/SYNTAX.md
@@ -453,7 +453,7 @@ func damage(h: Handle<Player>, amount: i32) using Pool<Player> {
     h.health -= amount
 }
 
-// Frozen context (read-only, accepts FrozenPool too)
+// Frozen context (read-only, no structural mutations)
 func get_health(h: Handle<Player>) using frozen Pool<Player> -> i32 {
     return h.health
 }

--- a/specs/analysis/complexity-stress-test.md
+++ b/specs/analysis/complexity-stress-test.md
@@ -136,18 +136,19 @@ func update_entities(mutate world: GameWorld) -> () or Error {
 <!-- test: skip -->
 ```rask
 func render_frame(world: GameWorld) {
-    const frozen_entities = world.entities.freeze_ref()
-    const frozen_meshes = world.meshes.freeze_ref()
+    render_entities(world)
+}
 
-    for (h, entity) in frozen_entities.entries() {
-        if frozen_meshes.get(entity.mesh) is Some(mesh) {
+func render_entities(world: GameWorld) using frozen Pool<Entity>, frozen Pool<Mesh> {
+    for (h, entity) in world.entities.entries() {
+        if world.meshes.get(entity.mesh) is Some(mesh) {
             draw_mesh(mesh.vertex_buffer, mesh.index_count, entity.position)
         }
     }
 }
 ```
 
-**Concepts: 6** — frozen pools, cross-pool handles, checked random access, unsafe FFI, read-only borrowing, two frozen pools. **PASS.**
+**Concepts: 5** — frozen context, cross-pool handles, checked random access, value iteration, context clauses. **PASS.**
 
 ## Phase 5: Parallel Variant
 
@@ -156,20 +157,20 @@ func render_frame(world: GameWorld) {
 func game_loop_parallel(mutate world: GameWorld, dt: f32) -> () or Error
     using ThreadPool
 {
-    const (snapshot, _) = world.entities.snapshot()
-    const mesh_snap = world.meshes.freeze_ref()
+    const (entity_snap, _) = world.entities.snapshot()
+    const (mesh_snap, _) = world.meshes.snapshot()
 
     const render_handle = ThreadPool.spawn(|| {
-        for (h, entity) in snapshot.entries() {
+        for (h, entity) in entity_snap.entries() {
             if mesh_snap.get(entity.mesh) is Some(mesh) {
                 draw_mesh(mesh.vertex_buffer, mesh.index_count, entity.position)
             }
         }
-    }
+    })
 
     const physics_handle = ThreadPool.spawn(|| {
         world.physics.step(dt)
-    }
+    })
 
     try render_handle.join()
     try physics_handle.join()
@@ -180,7 +181,7 @@ func game_loop_parallel(mutate world: GameWorld, dt: f32) -> () or Error
 }
 ```
 
-**Concepts: 12** — ThreadPool, spawn thread, must-use handles, snapshot isolation, FrozenPool, freeze_ref, cross-pool handles, Send/Sync constraints, disjoint field access, error handling, @resource across threads, copy-on-write. **FAIL.**
+**Concepts: 9** — ThreadPool, spawn thread, must-use handles, snapshot (clone), cross-pool handles, Send/Sync constraints, error handling, checked random access, join semantics. **Marginal PASS** (down from 12 — no FrozenPool type, no freeze_ref, no CoW).
 
 ## Friction Points
 
@@ -232,7 +233,7 @@ If a function needs >3, restructure (pass struct, use field projections, split f
 
 ### See Also
 
-- `mem.pools` — Pool\<T>, Handle\<T>, frozen pools, snapshots
+- `mem.pools` — Pool\<T>, Handle\<T>, frozen contexts, snapshots
 - `mem.resources` — @resource types, ensure cleanup
 - `mem.context` — context clauses
 - `conc.async` — spawn, must-use handles

--- a/specs/compiler/advanced-analyses.md
+++ b/specs/compiler/advanced-analyses.md
@@ -166,7 +166,7 @@ Formalize Rask's `using Pool<T>` context clauses as a lightweight effect system 
 | **EF2: Frozen context** | `using frozen Pool<T>` forbids Grow and Shrink effects |
 | **EF3: Effect inference** | Private functions infer effects; public functions must declare frozen explicitly |
 | **EF4: Effect checking** | Calling a Shrink function from frozen context is a compile error |
-| **EF5: Frozen iteration** | Frozen pool iteration requires no generation checks (see `comp.gen-coalesce/FZ1`). `h.field` auto-resolution in frozen contexts uses standard generation checks |
+| **EF5: Frozen iteration** | In frozen contexts, the compiler may eliminate generation checks during iteration (see `comp.gen-coalesce/FZ1`). `h.field` auto-resolution uses standard generation checks |
 | **EF6: Effect polymorphism** | Functions can be effect-polymorphic: work with both frozen and mutable pools |
 
 <!-- test: compile-fail -->
@@ -185,9 +185,9 @@ func render(entities: Vec<Handle<Entity>>) using frozen Pool<Entity> {
 | Annotation | Allowed Effects | Generation Checks | Use Case |
 |------------|-----------------|-------------------|----------|
 | `using Pool<T>` | Access, Grow, Shrink | Normal (coalesced) | Default |
-| `using frozen Pool<T>` | Access only | Checked (`h.field`), zero (iteration) | Read-only passes |
+| `using frozen Pool<T>` | Access only | Checked (optimizable in iteration) | Read-only passes |
 | `using name: Pool<T>` | Access, Grow, Shrink | Normal | Structural ops via name |
-| `using frozen name: Pool<T>` | Access only | Checked (`h.field`), zero (iteration) | Explicit frozen access |
+| `using frozen name: Pool<T>` | Access only | Checked (optimizable in iteration) | Explicit frozen access |
 
 ### Effect Lattice
 
@@ -202,7 +202,6 @@ func render(entities: Vec<Handle<Entity>>) using frozen Pool<Entity> {
 // Effect-polymorphic: works with frozen or mutable
 func count_alive(entities: Vec<Handle<Entity>>) using frozen Pool<Entity> -> usize {
     return entities.filter(|h| pool[h].alive).count()
-    // Compiler eliminates all generation checks in this function
 }
 
 func cleanup(entities: Vec<Handle<Entity>>) using Pool<Entity> {
@@ -321,7 +320,7 @@ NOTE: Consider adding a range check:
 | Loop with conditional remove | TS4, FN4 | Each iteration resets to pre-loop state |
 | Range analysis timeout | BE2 | Conservative: keep the check |
 | Effect inference failure | EF3 | Public functions require explicit annotation |
-| Frozen pool with external handle | PF6 | `frozen[h]` is compile error; use `frozen.get(h)` or iterate |
+| External handle in frozen context | PF5 | Standard generation check; writes are compile error |
 | Typestate at merge with Unknown | TS2 | Join takes lower bound (e.g., Valid ∧ Unknown = Unknown) |
 | Generation overflow | — | Not addressed by static analysis (runtime invariant) |
 | Concurrent mutation | — | Not addressed (use Mutex for cross-task pools) |
@@ -338,7 +337,7 @@ I chose a four-state lattice (Fresh > Valid > Unknown > Invalid) because it bala
 
 **IV1–IV7 (interval analysis):** GCC's Project Ranger showed that demand-driven VRP is nearly free — you only pay for queries you make. By triggering analysis lazily at bounds checks, we avoid computing ranges for all variables. The backward SSA walk (IV3) is fast because SSA has no cycles (except through φ-nodes at loop headers, where we widen conservatively).
 
-**EF1–EF6 (effect system):** Rask already has `using Pool<T>` clauses. I formalized them as an effect system to make the guarantees explicit. Frozen contexts forbid structural mutations, making it safe to accept `FrozenPool<T>` values. `h.field` auto-resolution in frozen contexts uses standard generation checks; zero-cost access is available through frozen pool iteration (`values()`, `entries()`). Effect inference (EF3) means most code doesn't need annotations — the compiler figures it out.
+**EF1–EF6 (effect system):** Rask already has `using Pool<T>` clauses. I formalized them as an effect system to make the guarantees explicit. Frozen contexts forbid structural mutations — the `frozen` modifier is a context property, not a separate type. `h.field` auto-resolution in frozen contexts uses standard generation checks; the compiler may optimize away checks during iteration when it can prove no structural mutations occur. Effect inference (EF3) means most code doesn't need annotations — the compiler figures it out.
 
 **5× compilation speed vs Rust:** This is achievable because:
 1. **No lifetime inference** — Rust's region inference is expensive. Rask has no lifetimes.
@@ -409,10 +408,10 @@ func process(h: Handle<Entity>) using Pool<Entity> {
 
 **Optimization patterns for frozen contexts:**
 ```rask
-// Hot read path — zero generation checks via frozen iteration
+// Hot read path — generation checks optimizable via frozen context (FZ1)
 func render_all() using frozen entities: Pool<Entity> {
     for entity in entities.values() {
-        renderer.draw(entity)  // Zero checks: frozen iteration (FZ1)
+        renderer.draw(entity)
     }
 }
 
@@ -423,12 +422,8 @@ func tick(mut pool: Pool<Entity>) {
         pool[h].update_physics()
     }
 
-    // Phase 2: Frozen render
-    pool.with_frozen(|frozen_pool| {
-        for entity in frozen_pool.values() {
-            render(entity)  // Zero checks (frozen iteration)
-        }
-    })
+    // Phase 2: Read-only render (call frozen-context function)
+    render_all(pool)
 }
 ```
 

--- a/specs/compiler/generation-coalescing.md
+++ b/specs/compiler/generation-coalescing.md
@@ -36,8 +36,8 @@ pool[h].z = 3
 
 | Guarantee Level | Mechanism | Checks | Use Case |
 |-----------------|-----------|--------|----------|
-| Guaranteed zero | Frozen pool iteration (FZ1) | 0 | Read-only hot paths |
-| Guaranteed 1 | `frozen.get(h)` / `with_valid(h, f)` | 1 | Random access (safe) |
+| Optimizable to zero | Frozen context iteration (FZ1) | 0 | Read-only hot paths |
+| Guaranteed 1 | `pool.get(h)` / `with_valid(h, f)` | 1 | Random access (safe) |
 | Guaranteed zero | `get_unchecked(h)` (unsafe) | 0 | Caller-validated handles |
 | Expected 1 or fewer per handle | Coalescing | 1 or fewer | General code |
 | Worst case | No coalescing | 1/access | Compiler can't prove safety |
@@ -107,13 +107,14 @@ using pool {
 }
 ```
 
-## Frozen Pools
+## Frozen Context Optimization
 
 | Rule | Description |
 |------|-------------|
-| **FZ1: Iteration zero-check** | Handles from `frozen.values()`, `frozen.entries()`, `frozen.handles()` require no generation checks — the iterator only yields occupied slots from an immutable pool |
-| **FZ2: get() checked** | `frozen.get(h)` performs a standard generation check and returns `Option<T>` |
-| **FZ3: No index access** | `frozen[h]` is a compile error (`mem.pools/PF6`). Coalescing does not apply |
+| **FZ1: Frozen iteration** | In `using frozen Pool<T>` contexts, iteration via `values()`, `entries()`, `handles()` may skip generation checks — structural mutations are impossible, so handles can't become stale mid-iteration |
+| **FZ2: Random access checked** | `pool.get(h)` and `pool[h]` in frozen contexts still perform standard generation checks — the handle may have been stale before the context began |
+
+This is a compiler optimization, not a type-level guarantee. The compiler applies it when it can prove the pool is not structurally mutated within the iteration scope.
 
 ## Debug vs Release
 
@@ -151,9 +152,8 @@ store %slot2.y, 2
 | Mutation between accesses | Fresh check after mutation | GC2, MT1 |
 | Unknown function with `&mut pool` | Fresh check after call | MT3 |
 | Async: after await point | Fresh check | CF5 |
-| Frozen pool iteration | No checks (valid by construction) | FZ1 |
-| Frozen pool `get(h)` | One generation check, returns Option | FZ2 |
-| Frozen pool `frozen[h]` | Compile error | FZ3 |
+| Frozen context iteration | Optimizable to zero checks | FZ1 |
+| Random access in frozen context | Standard generation check | FZ2 |
 
 ---
 

--- a/specs/memory/context-clauses.md
+++ b/specs/memory/context-clauses.md
@@ -14,11 +14,11 @@
 |------|------|--------|--------|
 | **CC1: Named context** | `using name: Pool<T>` | `func f() using players: Pool<Player>` | Creates binding `players` + enables auto-resolution for `Handle<Player>` |
 | **CC2: Unnamed context** | `using Pool<T>` | `func f() using Pool<Player>` | Auto-resolution only, no binding for structural ops |
-| **CC3: Frozen context** | `using frozen Pool<T>` | `func f() using frozen Pool<Player>` | Read-only, accepts both `Pool<T>` and `FrozenPool<T>` |
+| **CC3: Frozen context** | `using frozen Pool<T>` | `func f() using frozen Pool<Player>` | Read-only — no writes, inserts, removes, or clears |
 
-Without `frozen`, contexts are mutable by default — writes through handles are allowed, but only `Pool<T>` satisfies the context (not `FrozenPool<T>`). See `mem.pools` for the full subsumption rule.
+Without `frozen`, contexts are mutable by default — writes through handles are allowed. The `frozen` modifier means "no structural mutations and no writes" — a context property, not a separate type.
 
-**Note:** `h.field` auto-resolution in frozen contexts performs generation checks (same as mutable contexts). The `frozen` modifier means "no structural mutations" — it doesn't skip validity checks. Zero-cost access on frozen pools is available through iteration (`values()`, `entries()`), not through handle auto-resolution.
+**Note:** `h.field` auto-resolution in frozen contexts performs generation checks (same as mutable contexts). The compiler may optimize away checks during iteration in frozen contexts (see `comp.gen-coalesce/FZ1`).
 
 <!-- test: skip -->
 ```rask

--- a/specs/memory/pools.md
+++ b/specs/memory/pools.md
@@ -209,72 +209,28 @@ Automatically invalidated when the element is removed, the pool is cleared, or t
 | Cross-task communication | `WeakHandle<T>` |
 | Cache that may be invalidated | `WeakHandle<T>` |
 
-## Frozen Pools
+## Frozen Context
 
-`pool.freeze()` returns an immutable view. No structural mutations are possible while frozen.
+The `frozen` modifier on context clauses (`mem.context/CC3`) means "no structural mutations." Writing through handles, inserting, removing, and clearing are all compile errors.
 
 | Rule | Description |
 |------|-------------|
-| **PF5: Freeze guarantees** | No insert/remove while frozen — all handles valid at freeze time remain valid |
-| **PF6: No index access** | `frozen[h]` is a compile error. Use iteration or `frozen.get(h)` |
-| **PF7: Safe random access** | `frozen.get(h)` returns `Option<T>` with a generation check — stale handles return `None` |
-
-FrozenPool provides two access paths: **iteration** (zero-cost, handles are valid by construction) and **checked get** (one generation check, returns Option).
+| **PF5: Frozen guarantees** | No insert/remove/clear/write in `using frozen Pool<T>` context |
+| **PF6: Effect inference** | Private functions can have `frozen` inferred; public functions must declare it |
 
 ```rask
-const frozen = pool.freeze()
-
-// Iteration — zero generation checks (handles valid by construction)
-for (h, entity) in frozen.entries() {
-    render(entity)
-}
-
-// Random access — checked, returns Option
-if frozen.get(h) is Some(val) {
-    use(val)
-}
-
-const pool = frozen.thaw()
-```
-
-**Freezing API:**
-
-| Method | Signature | Description |
-|--------|-----------|-------------|
-| `pool.freeze()` | `Pool<T> -> FrozenPool<T>` | Freeze, consume ownership |
-| `pool.freeze_ref()` | `Pool<T> -> FrozenPool<T>` | Freeze reference (scoped) |
-| `pool.with_frozen(f)` | `(|FrozenPool<T>| -> R) -> R` | Scoped freeze |
-| `frozen.get(h)` | `(Handle<T>) -> Option<T>` | Checked random access |
-| `frozen.with_valid(h, f)` | `(Handle<T>, \|T\| -> R) -> Option<R>` | One check, callback access |
-
-**NOT available on FrozenPool:** `insert()`, `remove()`, `clear()`, `frozen[h]`, `with` mutable bindings
-
-### FrozenPool Context Subsumption
-
-Context clauses (`mem.context`) default to mutable. Add `frozen` for read-only — both `Pool<T>` and `FrozenPool<T>` satisfy it.
-
-```rask
-// Default — mutable, only Pool<T>
+// Default — mutable
 func damage(h: Handle<Entity>, amount: i32) using Pool<Entity> {
     h.health -= amount
 }
 
-// Frozen — read-only, accepts both Pool<T> and FrozenPool<T>
+// Frozen — read-only, no structural mutations
 func get_health(h: Handle<Entity>) using frozen Pool<Entity> -> i32 {
-    return h.health    // Generation-checked (h came from outside)
+    return h.health    // Generation-checked
 }
 ```
 
-| Context | `Pool<T>` | `FrozenPool<T>` |
-|---------|-----------|-----------------|
-| `using Pool<T>` | Accepted | Rejected |
-| `using frozen Pool<T>` | Accepted | Accepted |
-| `using name: Pool<T>` | Accepted | Rejected |
-| `using frozen name: Pool<T>` | Accepted | Accepted |
-
-Writing through handles in a `frozen` context is a compile error. Private functions can have `frozen` inferred; public functions must declare it.
-
-**Note:** `h.field` auto-resolution in frozen contexts performs generation checks (same as mutable contexts). The `frozen` modifier means "no structural mutations" — it doesn't skip validity checks. Zero-cost access is available through iteration on the frozen pool itself.
+In frozen contexts, the compiler may eliminate generation checks during iteration since structural mutations are impossible (see `comp.gen-coalesce`). This is a compiler optimization, not a separate type.
 
 ## Generation Check Coalescing
 
@@ -319,40 +275,27 @@ func cleanup(h: Handle<Entity>) using entities: Pool<Entity> {
 }
 ```
 
-## Pool Partitioning
+## Snapshot
 
-Split a pool for parallel processing.
+`pool.snapshot()` creates a shallow clone for concurrent read access while the original continues to be mutated.
 
 | Method | Signature | Description |
 |--------|-----------|-------------|
-| `pool.with_partition(n, f)` | `(usize, \|[FrozenChunk<T>]\| -> R) -> R` | Scoped read-only partition |
-| `pool.with_partition_mut(n, f)` | `(usize, \|[MutableChunk<T>]\| -> R) -> R` | Scoped read-write partition |
-| `pool.snapshot()` | `Pool<T> -> (FrozenPool<T>, Pool<T>)` | Copy-on-write snapshot isolation |
+| `pool.snapshot()` | `Pool<T> -> (Pool<T>, Pool<T>)` | Returns `(snapshot, original)` — snapshot is an independent clone |
 
-```rask
-entities.with_partition(4, |chunks| {
-    parallel_for(chunks) { |chunk|
-        for (h, entity) in chunk.entries() {
-            analyze(entity)  // Zero generation checks (frozen iteration)
-        }
-    }
-})  // Auto-reunifies here
-```
-
-**Snapshot isolation** — frozen snapshot for readers while writer continues:
-
+<!-- test: skip -->
 ```rask
 let (snapshot, mut pool) = entities.snapshot()
 
-// Readers see frozen state (iterate for zero-check access)
-spawn(|| { render_frame(snapshot) }
+// Readers see frozen state
+spawn(|| { render_frame(snapshot) })
 
 // Writer can mutate concurrently
 try pool.insert(new_entity)
 pool.remove(dead_entity)
 ```
 
-First mutation after snapshot triggers O(n) copy-on-write.
+First mutation after `snapshot()` triggers an O(n) copy. The snapshot is a regular `Pool<T>` — use it with `using frozen Pool<T>` functions to enforce read-only access at the call site.
 
 ## Linear Types in Pools
 
@@ -382,9 +325,6 @@ ensure files.take_all_with(|f| { f.close(); })
 | `Pool<T>` | if `T: Send` | if `T: Sync` |
 | `Handle<T>` | Yes (Copy) | Yes |
 | `WeakHandle<T>` | Yes (Copy) | Yes |
-| `FrozenPool<T>` | if `T: Send` | Yes (immutable) |
-| `FrozenChunk<T>` | if `T: Send` | if `T: Sync` |
-| `MutableChunk<T>` | if `T: Send` | No |
 
 ## Capacity and Allocation
 
@@ -482,19 +422,10 @@ ERROR [mem.pools/PF5]: cannot write through handle in frozen context
    |                                     ------ context is frozen
 2  |      h.health -= 10
    |      ^^^^^^^^^^^^^^ cannot write in frozen context
-```
 
-**Frozen pool index access [PF6]:**
-```
-ERROR [mem.pools/PF6]: FrozenPool does not support index access
-   |
-3  |  const entity = frozen[h]
-   |                 ^^^^^^^^^ cannot index FrozenPool with handle
+FIX: Remove the frozen annotation if mutation is needed:
 
-FIX: Use get() for checked random access, or iterate:
-
-  if frozen.get(h) is Some(entity) { ... }
-  for (h, entity) in frozen.entries() { ... }
+  func bad(h: Handle<Entity>) using Pool<Entity> { ... }
 ```
 
 ## Edge Cases
@@ -511,12 +442,8 @@ FIX: Use get() for checked random access, or iterate:
 | Nested cursors | — | Compile error (pool already borrowed) |
 | Drop Pool<Resource> while non-empty | R5 | Runtime panic |
 | `clear()` on Pool<Resource> | — | Compile error (would abandon resources) |
-| `frozen[h]` index access | PF6 | Compile error (use `get()` or iterate) |
-| `frozen.get(h)` with stale handle | PF7 | Returns `None` |
+| Write in frozen context | PF5 | Compile error |
 | `get_unchecked` with stale handle | — | **Undefined behavior** |
-| `with_partition(0, f)` | — | Compile error (n must be > 0) |
-| Partition while borrowed | — | Compile error |
-| Drop snapshot while readers active | — | Safe (refcount keeps data alive) |
 
 ## Examples
 
@@ -561,19 +488,22 @@ func build_graph() -> Pool<Node> or Error {
 
 ### Rendering Pipeline
 
+<!-- test: skip -->
 ```rask
 func render_frame(world: World) {
-    // Physics update (mutable iteration — clean)
+    // Physics update (mutable iteration)
     for mutate entity in world.entities {
         entity.update_physics()
     }
 
-    // Render pass (read-only, zero-cost iteration)
-    const frozen = world.entities.freeze()
-    for entity in frozen.values() {
+    // Render pass (read-only via frozen context)
+    render_entities(world.entities)
+}
+
+func render_entities() using frozen entities: Pool<Entity> {
+    for entity in entities.values() {
         renderer.draw(entity)
     }
-    world.entities = frozen.thaw()
 }
 ```
 
@@ -587,7 +517,7 @@ func render_frame(world: World) {
 
 **PH3 (handle identity):** Handles are database primary keys. You can have 10 copies of the key `42` — they all access the same row. The keys aren't borrowed; only the access is.
 
-**PF5–PF7 (frozen pools):** Frozen pools don't support `frozen[h]` indexing — this prevents stale handle access from being possible in safe code. Zero-cost access is available through iteration (`values()`, `entries()`, `handles()`), which only yields occupied slots from an immutable pool. Random access with external handles uses `frozen.get(h)` which returns `Option<T>` with a generation check. The common pattern (iterate all entities for a render pass) is zero-cost; the uncommon pattern (follow stored handles) has a checked fallback.
+**PF5 (frozen context):** I considered making FrozenPool a separate type with freeze/thaw ownership ceremonies. That's the Rust approach — explicit state transitions. But it adds a whole type to learn, and `using frozen Pool<T>` already provides the compile-time guarantee. The `frozen` modifier is a context property, not a type.
 
 **PL9 (handle stability):** This is why handles exist — stable identifiers that don't break when memory moves. Pointers would become dangling; handles never do.
 
@@ -628,30 +558,10 @@ with pool[h1] as e1, pool[h2] as e2 {
 }
 ```
 
-**Pool partitioning — parallel physics:**
-```rask
-func physics_tick(mut entities: Pool<Entity>, dt: f32) {
-    // Phase 1: Parallel read (compute forces)
-    const forces = entities.with_partition(num_cpus(), |chunks| {
-        parallel_map(chunks) { |chunk|
-            chunk.entries().map(|(h, e)| {
-                (h, compute_forces(e.position, e.mass))
-            }).collect<Vec<_>>()
-        }
-    });
-
-    // Phase 2: Serial write (apply forces)
-    for (h, force) in forces.flatten() {
-        entities[h].velocity += force * dt
-        entities[h].position += entities[h].velocity * dt
-    }
-}
-```
-
 **Self-referential patterns:** Doubly-linked lists, trees with parent pointers, graphs with cycles, and arena-allocated ASTs all use the pool+handle pattern. Key guidance:
-- Use `freeze_ref()` for read-only traversal (zero-cost iteration via `values()`/`entries()`)
-- Follow stored handles across a frozen pool with `frozen.get(h)` (checked, returns Option)
-- ASTs: build once, then freeze for analysis passes
+- Use `pool.values()` or `pool.entries()` for read-only traversal
+- Follow stored handles with `pool.get(h)` (checked, returns Option)
+- Use `using frozen Pool<T>` functions for analysis passes that shouldn't mutate
 
 **Shared state:** Share handles, not data. Handles are 12-byte copyable values that can be sent anywhere. The pool stays in one thread; commands flow back to it.
 
@@ -688,14 +598,10 @@ func process_by_type(mut entities: Pool<Entity>) {
 |-----------|------|-------|
 | `pool[h]` | ~1 ns | Generation check + index |
 | `pool.get(h)` | ~1 ns | Same + Option wrap |
-| Frozen iteration | ~0 ns/element | No generation check (valid by construction) |
-| `frozen.get(h)` | ~1 ns | Generation check + Option wrap |
 | `insert()` | Amortized O(1) | May allocate (unbounded) |
 | `remove()` | O(1) | Bumps generation |
 | `cursor()` iteration | O(capacity) | Scans all slots |
-| `with_partition(n, f)` | O(1) setup/teardown | Auto-reunifies |
-| `snapshot()` | O(1) | CoW on first mutation |
-| First mutation after snapshot | O(n) | Triggers copy-on-write |
+| `snapshot()` | O(n) | Shallow clone |
 | Registry lookup | ~1-2 ns | Thread-local HashMap |
 
 ### IDE Integration


### PR DESCRIPTION
## Summary

This PR removes the `FrozenPool<T>` type and replaces it with a `frozen` modifier on context clauses (`using frozen Pool<T>`). The change simplifies the API surface while maintaining the same safety guarantees through compile-time effect checking.

## Key Changes

- **Remove FrozenPool type**: Eliminated `FrozenPool<T>`, `FrozenChunk<T>`, and `MutableChunk<T>` as separate types
- **Frozen context modifier**: Introduced `using frozen Pool<T>` syntax to declare read-only contexts at the function level
- **Simplified API**: Removed freeze/thaw ceremonies (`pool.freeze()`, `pool.freeze_ref()`, `pool.with_frozen()`, `frozen.get()`, `frozen.with_valid()`)
- **Unified access patterns**: All pools use the same `pool[h]`, `pool.get(h)`, `pool.values()`, `pool.entries()` methods regardless of mutability
- **Snapshot simplification**: Changed `snapshot()` to return `(Pool<T>, Pool<T>)` instead of `(FrozenPool<T>, Pool<T>)` — snapshot is now a regular pool clone
- **Removed partitioning API**: Deleted `pool.with_partition()` and `pool.with_partition_mut()` methods
- **Effect inference**: Private functions can infer `frozen` automatically; public functions must declare it explicitly
- **Compiler optimization**: Generation checks during frozen context iteration are now a compiler optimization (FZ1) rather than a type-level guarantee

## Implementation Details

- The `frozen` modifier is a **context property**, not a type-level distinction
- Writing through handles in a `frozen` context is a compile error (enforced by effect system)
- Generation checks still occur for `h.field` auto-resolution in frozen contexts (same as mutable)
- The compiler may eliminate generation checks during iteration in frozen contexts when it can prove no structural mutations occur
- Frozen contexts forbid: writes, inserts, removes, and clears
- Send/Sync trait bounds simplified: removed `FrozenPool<T>`, `FrozenChunk<T>`, `MutableChunk<T>` from the table

## Rationale

This design reduces cognitive load by eliminating a separate type while preserving safety. The `frozen` modifier on context clauses provides the same compile-time guarantees as a separate type would, but integrates naturally with Rask's existing effect system. Functions declare their mutability requirements upfront, making the contract explicit without requiring ownership ceremonies.

https://claude.ai/code/session_01TExMtCRhJAFLfkJb4VABxq