### PR TITLE
Add effect inference engine for IO, Async, and Mutation tracking

### DIFF
--- a/compiler/Cargo.lock
+++ b/compiler/Cargo.lock
@@ -1220,6 +1220,7 @@ dependencies = [
  "rask-describe",
  "rask-desugar",
  "rask-diagnostics",
+ "rask-effects",
  "rask-fmt",
  "rask-hidden-params",
  "rask-interp",
@@ -1295,6 +1296,13 @@ dependencies = [
  "rask-types",
  "serde",
  "serde_json",
+]
+
+[[package]]
+name = "rask-effects"
+version = "0.1.0"
+dependencies = [
+ "rask-ast",
 ]
 
 [[package]]

--- a/compiler/Cargo.toml
+++ b/compiler/Cargo.toml
@@ -24,6 +24,7 @@ members = [
     "crates/rask-lint",
     "crates/rask-hidden-params",
     "crates/rask-semantic-hash",
+    "crates/rask-effects",
 ]
 
 [workspace.package]

--- a/compiler/crates/rask-cli/Cargo.toml
+++ b/compiler/crates/rask-cli/Cargo.toml
@@ -28,4 +28,5 @@ rask-mir = { path = "../rask-mir" }
 rask-codegen = { path = "../rask-codegen" }
 rask-stdlib = { path = "../rask-stdlib" }
 rask-hidden-params = { path = "../rask-hidden-params" }
+rask-effects = { path = "../rask-effects" }
 colored = "3"

--- a/compiler/crates/rask-cli/src/commands/pipeline.rs
+++ b/compiler/crates/rask-cli/src/commands/pipeline.rs
@@ -23,7 +23,7 @@ pub struct PackageContext {
     pub all_decls: Vec<Decl>,
 }
 
-/// Result of the frontend pipeline (lex → parse → desugar → resolve → typecheck → ownership).
+/// Result of the frontend pipeline (lex → parse → desugar → resolve → typecheck → ownership → effects).
 pub struct FrontendResult {
     pub decls: Vec<Decl>,
     pub typed: rask_types::TypedProgram,
@@ -33,6 +33,10 @@ pub struct FrontendResult {
     pub package_names: Vec<String>,
     /// Per-file source text for multi-file diagnostics (path, source).
     pub source_files: Vec<(std::path::PathBuf, String)>,
+    /// Per-function effect metadata (comp.effects).
+    pub effects: rask_effects::EffectMap,
+    /// Effect warnings (CW1, CW2).
+    pub effect_warnings: Vec<rask_effects::EffectWarning>,
 }
 
 /// Run the frontend pipeline on a .rk file.
@@ -113,12 +117,25 @@ fn run_frontend_single(path: &str, format: Format) -> FrontendResult {
         process::exit(1);
     }
 
+    // Effect inference (comp.effects) — metadata only, no AST changes
+    let (effects, effect_warnings) = rask_effects::infer_effects(&parse_result.decls);
+
+    // Show effect warnings (non-blocking)
+    if !effect_warnings.is_empty() && format == Format::Human {
+        let diags: Vec<Diagnostic> = effect_warnings.iter()
+            .map(|w| effect_warning_to_diagnostic(w))
+            .collect();
+        show_diagnostics(&diags, &source, path, "effects", format);
+    }
+
     FrontendResult {
         decls: parse_result.decls,
         typed,
         source: Some(source),
         package_names: vec![],
         source_files: vec![],
+        effects,
+        effect_warnings,
     }
 }
 
@@ -248,13 +265,33 @@ fn run_frontend_package(pkg_ctx: &mut PackageContext, path: &str, format: Format
 
     let _ = path; // used for context only, not for reading in package mode
 
+    // Effect inference (comp.effects) — metadata only, no AST changes
+    let (effects, effect_warnings) = rask_effects::infer_effects(&pkg_ctx.all_decls);
+
+    // Show effect warnings (non-blocking)
+    if !effect_warnings.is_empty() && format == Format::Human {
+        let diags: Vec<Diagnostic> = effect_warnings.iter()
+            .map(|w| effect_warning_to_diagnostic(w))
+            .collect();
+        show_multifile_diagnostics(&diags, &source_files, format);
+    }
+
     FrontendResult {
         decls: std::mem::take(&mut pkg_ctx.all_decls),
         typed,
         source: None,
         package_names,
         source_files,
+        effects,
+        effect_warnings,
     }
+}
+
+/// Convert an effect warning to a Diagnostic for display.
+fn effect_warning_to_diagnostic(w: &rask_effects::EffectWarning) -> Diagnostic {
+    Diagnostic::warning(&w.message)
+        .with_code(w.code)
+        .with_primary(w.span, format!("`{}` has IO effect", w.callee_name))
 }
 
 /// Show diagnostics for multi-file packages.

--- a/compiler/crates/rask-effects/Cargo.toml
+++ b/compiler/crates/rask-effects/Cargo.toml
@@ -1,0 +1,7 @@
+[package]
+name = "rask-effects"
+version.workspace = true
+edition.workspace = true
+
+[dependencies]
+rask-ast = { path = "../rask-ast" }

--- a/compiler/crates/rask-effects/src/infer.rs
+++ b/compiler/crates/rask-effects/src/infer.rs
@@ -1,0 +1,715 @@
+// SPDX-License-Identifier: (MIT OR Apache-2.0)
+
+//! Effect inference engine (comp.effects INF1-INF5).
+//!
+//! Three phases:
+//! 1. Collect function declarations, classify direct effects from body
+//! 2. Build call graph from function bodies
+//! 3. Fixed-point propagation: union callee effects into callers until stable
+
+use std::collections::{HashMap, HashSet};
+
+use rask_ast::decl::{Decl, DeclKind, FnDecl};
+use rask_ast::expr::{Expr, ExprKind};
+use rask_ast::stmt::{Stmt, StmtKind};
+
+use crate::{Effects, EffectMap};
+use crate::sources;
+
+/// Qualified function name (plain name or "Type.method").
+type FuncName = String;
+
+/// Run effect inference on declarations.
+pub fn infer(decls: &[Decl]) -> EffectMap {
+    let mut pass = InferPass::new();
+    pass.run(decls);
+    pass.effects
+}
+
+struct InferPass {
+    /// Per-function direct effects (before transitive propagation).
+    effects: EffectMap,
+    /// Call graph: caller → callees.
+    call_graph: HashMap<FuncName, HashSet<FuncName>>,
+}
+
+impl InferPass {
+    fn new() -> Self {
+        Self {
+            effects: HashMap::new(),
+            call_graph: HashMap::new(),
+        }
+    }
+
+    fn run(&mut self, decls: &[Decl]) {
+        // Phase 1: Classify direct effects and build call graph
+        self.collect(decls);
+
+        // Phase 2: Mark extern functions conservatively (INF5)
+        self.mark_externs(decls);
+
+        // Phase 3: Fixed-point propagation (FX2)
+        self.propagate();
+    }
+
+    // ── Phase 1: Collect ────────────────────────────────────────────
+
+    fn collect(&mut self, decls: &[Decl]) {
+        for decl in decls {
+            match &decl.kind {
+                DeclKind::Fn(f) => {
+                    self.collect_fn(&f.name, f);
+                }
+                DeclKind::Struct(s) => {
+                    for method in &s.methods {
+                        let qname = format!("{}.{}", s.name, method.name);
+                        self.collect_fn(&qname, method);
+                    }
+                }
+                DeclKind::Enum(e) => {
+                    for method in &e.methods {
+                        let qname = format!("{}.{}", e.name, method.name);
+                        self.collect_fn(&qname, method);
+                    }
+                }
+                DeclKind::Impl(i) => {
+                    for method in &i.methods {
+                        let qname = format!("{}.{}", i.target_ty, method.name);
+                        self.collect_fn(&qname, method);
+                    }
+                }
+                DeclKind::Trait(t) => {
+                    for method in &t.methods {
+                        let qname = format!("{}.{}", t.name, method.name);
+                        self.collect_fn(&qname, method);
+                    }
+                }
+                _ => {}
+            }
+        }
+    }
+
+    fn collect_fn(&mut self, qname: &str, f: &FnDecl) {
+        // PU2: comptime functions are always pure
+        if f.is_comptime {
+            self.effects.insert(qname.to_string(), Effects::default());
+            return;
+        }
+
+        // Classify direct effects from function body
+        let mut direct = Effects::default();
+        let mut callees = HashSet::new();
+        classify_body(&f.body, &mut direct, &mut callees);
+
+        // @no_io suppresses conservative IO marking
+        let has_no_io = f.attrs.iter().any(|a| a == "no_io");
+        if has_no_io {
+            direct.io = false;
+        }
+
+        self.effects.insert(qname.to_string(), direct);
+
+        if !callees.is_empty() {
+            self.call_graph.insert(qname.to_string(), callees);
+        }
+    }
+
+    // ── Phase 2: Extern declarations ────────────────────────────────
+
+    /// INF5: extern functions are conservatively IO unless @no_io.
+    fn mark_externs(&mut self, decls: &[Decl]) {
+        for decl in decls {
+            if let DeclKind::Extern(e) = &decl.kind {
+                // Skip if already registered (shouldn't happen, but defensive)
+                if self.effects.contains_key(&e.name) {
+                    continue;
+                }
+                self.effects.insert(
+                    e.name.clone(),
+                    Effects { io: true, async_: false, mutation: false },
+                );
+            }
+        }
+    }
+
+    // ── Phase 3: Fixed-point propagation ────────────────────────────
+
+    fn propagate(&mut self) {
+        loop {
+            let mut changed = false;
+
+            let graph_snapshot: Vec<(FuncName, HashSet<FuncName>)> =
+                self.call_graph.iter().map(|(k, v)| (k.clone(), v.clone())).collect();
+
+            for (caller, callees) in &graph_snapshot {
+                for callee in callees {
+                    let callee_effects = self.effects.get(callee).copied()
+                        .unwrap_or_default();
+
+                    if callee_effects.is_pure() {
+                        continue;
+                    }
+
+                    let caller_effects = self.effects.entry(caller.clone())
+                        .or_default();
+
+                    let before = *caller_effects;
+                    caller_effects.union(callee_effects);
+
+                    if *caller_effects != before {
+                        changed = true;
+                    }
+                }
+            }
+
+            if !changed {
+                break;
+            }
+        }
+
+        // AS3: Async implies IO — enforce invariant after propagation
+        for effects in self.effects.values_mut() {
+            if effects.async_ {
+                effects.io = true;
+            }
+        }
+    }
+}
+
+// ── Body classification ──────────────────────────────────────────────
+
+/// Walk a function body, collecting direct effects and callee names.
+fn classify_body(stmts: &[Stmt], effects: &mut Effects, callees: &mut HashSet<String>) {
+    for stmt in stmts {
+        classify_stmt(stmt, effects, callees);
+    }
+}
+
+fn classify_stmt(stmt: &Stmt, effects: &mut Effects, callees: &mut HashSet<String>) {
+    match &stmt.kind {
+        StmtKind::Expr(e) => classify_expr(e, effects, callees),
+        StmtKind::Let { init, .. } | StmtKind::Const { init, .. } => {
+            classify_expr(init, effects, callees);
+        }
+        StmtKind::LetTuple { init, .. } | StmtKind::ConstTuple { init, .. } => {
+            classify_expr(init, effects, callees);
+        }
+        StmtKind::Assign { target, value } => {
+            classify_expr(target, effects, callees);
+            classify_expr(value, effects, callees);
+        }
+        StmtKind::Return(Some(e)) => classify_expr(e, effects, callees),
+        StmtKind::Return(None) => {}
+        StmtKind::Break { value: Some(v), .. } => classify_expr(v, effects, callees),
+        StmtKind::Break { value: None, .. } | StmtKind::Continue(_) => {}
+        StmtKind::While { cond, body } => {
+            classify_expr(cond, effects, callees);
+            classify_body(body, effects, callees);
+        }
+        StmtKind::WhileLet { expr, body, .. } => {
+            classify_expr(expr, effects, callees);
+            classify_body(body, effects, callees);
+        }
+        StmtKind::Loop { body, .. } => classify_body(body, effects, callees),
+        StmtKind::For { iter, body, .. } => {
+            classify_expr(iter, effects, callees);
+            classify_body(body, effects, callees);
+        }
+        StmtKind::Ensure { body, else_handler } => {
+            classify_body(body, effects, callees);
+            if let Some((_, handler)) = else_handler {
+                classify_body(handler, effects, callees);
+            }
+        }
+        StmtKind::Comptime(body) => classify_body(body, effects, callees),
+    }
+}
+
+fn classify_expr(expr: &Expr, effects: &mut Effects, callees: &mut HashSet<String>) {
+    match &expr.kind {
+        ExprKind::Call { func, args } => {
+            if let Some(name) = extract_callee_name(func) {
+                // Check if this is a known source function
+                let direct = sources::classify_call(&name);
+                effects.union(direct);
+                callees.insert(name);
+            }
+            classify_expr(func, effects, callees);
+            for arg in args {
+                classify_expr(&arg.expr, effects, callees);
+            }
+        }
+
+        ExprKind::MethodCall { object, method, args, .. } => {
+            // Method calls: record the method name for call graph.
+            // Also check qualified "Type.method" form when we can extract
+            // the receiver type name.
+            if let ExprKind::Ident(type_name) = &object.kind {
+                let qname = format!("{}.{}", type_name, method);
+                let direct = sources::classify_call(&qname);
+                effects.union(direct);
+                callees.insert(qname);
+            }
+            // Also record bare method name
+            let direct = sources::classify_call(method);
+            effects.union(direct);
+            callees.insert(method.clone());
+
+            classify_expr(object, effects, callees);
+            for arg in args {
+                classify_expr(&arg.expr, effects, callees);
+            }
+        }
+
+        // IO3: unsafe blocks conservatively get IO
+        ExprKind::Unsafe { body } => {
+            effects.io = true;
+            classify_body(body, effects, callees);
+        }
+
+        // Spawn is an async source (AS1)
+        ExprKind::Spawn { body } => {
+            effects.io = true;
+            effects.async_ = true;
+            classify_body(body, effects, callees);
+        }
+
+        // Recurse into all other expression kinds
+        ExprKind::Binary { left, right, .. } => {
+            classify_expr(left, effects, callees);
+            classify_expr(right, effects, callees);
+        }
+        ExprKind::Unary { operand, .. } => classify_expr(operand, effects, callees),
+        ExprKind::Field { object, .. } | ExprKind::OptionalField { object, .. } => {
+            classify_expr(object, effects, callees);
+        }
+        ExprKind::Index { object, index } => {
+            classify_expr(object, effects, callees);
+            classify_expr(index, effects, callees);
+        }
+        ExprKind::Block(stmts) => classify_body(stmts, effects, callees),
+        ExprKind::If { cond, then_branch, else_branch } => {
+            classify_expr(cond, effects, callees);
+            classify_expr(then_branch, effects, callees);
+            if let Some(e) = else_branch {
+                classify_expr(e, effects, callees);
+            }
+        }
+        ExprKind::IfLet { expr, then_branch, else_branch, .. } => {
+            classify_expr(expr, effects, callees);
+            classify_expr(then_branch, effects, callees);
+            if let Some(e) = else_branch {
+                classify_expr(e, effects, callees);
+            }
+        }
+        ExprKind::GuardPattern { expr, else_branch, .. } => {
+            classify_expr(expr, effects, callees);
+            classify_expr(else_branch, effects, callees);
+        }
+        ExprKind::IsPattern { expr, .. } => classify_expr(expr, effects, callees),
+        ExprKind::Match { scrutinee, arms } => {
+            classify_expr(scrutinee, effects, callees);
+            for arm in arms {
+                if let Some(g) = &arm.guard {
+                    classify_expr(g, effects, callees);
+                }
+                classify_expr(&arm.body, effects, callees);
+            }
+        }
+        ExprKind::Try { expr: e, else_clause } => {
+            classify_expr(e, effects, callees);
+            if let Some(ec) = else_clause {
+                classify_expr(&ec.body, effects, callees);
+            }
+        }
+        ExprKind::Unwrap { expr: e, .. } | ExprKind::Cast { expr: e, .. } => {
+            classify_expr(e, effects, callees);
+        }
+        ExprKind::NullCoalesce { value, default } => {
+            classify_expr(value, effects, callees);
+            classify_expr(default, effects, callees);
+        }
+        ExprKind::Range { start, end, .. } => {
+            if let Some(s) = start { classify_expr(s, effects, callees); }
+            if let Some(e) = end { classify_expr(e, effects, callees); }
+        }
+        ExprKind::StructLit { fields, spread, .. } => {
+            for f in fields {
+                classify_expr(&f.value, effects, callees);
+            }
+            if let Some(s) = spread {
+                classify_expr(s, effects, callees);
+            }
+        }
+        ExprKind::Array(elems) | ExprKind::Tuple(elems) => {
+            for e in elems {
+                classify_expr(e, effects, callees);
+            }
+        }
+        ExprKind::ArrayRepeat { value, count } => {
+            classify_expr(value, effects, callees);
+            classify_expr(count, effects, callees);
+        }
+        ExprKind::UsingBlock { args, body, .. } => {
+            for arg in args {
+                classify_expr(&arg.expr, effects, callees);
+            }
+            classify_body(body, effects, callees);
+        }
+        ExprKind::WithAs { bindings, body } => {
+            for binding in bindings {
+                classify_expr(&binding.source, effects, callees);
+            }
+            classify_body(body, effects, callees);
+        }
+        ExprKind::Closure { body, .. } => classify_expr(body, effects, callees),
+        ExprKind::Comptime { body } | ExprKind::BlockCall { body, .. } => {
+            classify_body(body, effects, callees);
+        }
+        ExprKind::Assert { condition, message } | ExprKind::Check { condition, message } => {
+            classify_expr(condition, effects, callees);
+            if let Some(m) = message {
+                classify_expr(m, effects, callees);
+            }
+        }
+        ExprKind::Select { arms, .. } => {
+            for arm in arms {
+                match &arm.kind {
+                    rask_ast::expr::SelectArmKind::Recv { channel, .. } => {
+                        classify_expr(channel, effects, callees);
+                    }
+                    rask_ast::expr::SelectArmKind::Send { channel, value } => {
+                        classify_expr(channel, effects, callees);
+                        classify_expr(value, effects, callees);
+                    }
+                    rask_ast::expr::SelectArmKind::Default => {}
+                }
+                classify_expr(&arm.body, effects, callees);
+            }
+        }
+        // Leaves
+        ExprKind::Int(_, _)
+        | ExprKind::Float(_, _)
+        | ExprKind::String(_)
+        | ExprKind::Char(_)
+        | ExprKind::Bool(_)
+        | ExprKind::Null
+        | ExprKind::Ident(_) => {}
+    }
+}
+
+/// Extract callee name from a Call expression's func field.
+fn extract_callee_name(func: &Expr) -> Option<String> {
+    match &func.kind {
+        ExprKind::Ident(name) => Some(name.clone()),
+        ExprKind::Field { object, field } => {
+            if let ExprKind::Ident(obj_name) = &object.kind {
+                Some(format!("{}.{}", obj_name, field))
+            } else {
+                None
+            }
+        }
+        _ => None,
+    }
+}
+
+// ── Tests ────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use rask_ast::decl::{Decl, DeclKind, FnDecl, ExternDecl};
+    use rask_ast::expr::{CallArg, ArgMode, Expr, ExprKind};
+    use rask_ast::stmt::{Stmt, StmtKind};
+    use rask_ast::{NodeId, Span};
+
+    fn sp() -> Span { Span::new(0, 0) }
+
+    fn ident(name: &str) -> Expr {
+        Expr { id: NodeId(0), kind: ExprKind::Ident(name.into()), span: sp() }
+    }
+
+    fn call(func_name: &str, args: Vec<Expr>) -> Expr {
+        Expr {
+            id: NodeId(0),
+            kind: ExprKind::Call {
+                func: Box::new(ident(func_name)),
+                args: args.into_iter().map(|e| CallArg {
+                    name: None,
+                    mode: ArgMode::Default,
+                    expr: e,
+                }).collect(),
+            },
+            span: sp(),
+        }
+    }
+
+    fn method_call(obj: &str, method: &str) -> Expr {
+        Expr {
+            id: NodeId(0),
+            kind: ExprKind::MethodCall {
+                object: Box::new(ident(obj)),
+                method: method.into(),
+                type_args: None,
+                args: vec![],
+            },
+            span: sp(),
+        }
+    }
+
+    fn field_call(obj: &str, field: &str) -> Expr {
+        // Represents Type.method() — Field access as callee
+        Expr {
+            id: NodeId(0),
+            kind: ExprKind::Call {
+                func: Box::new(Expr {
+                    id: NodeId(0),
+                    kind: ExprKind::Field {
+                        object: Box::new(ident(obj)),
+                        field: field.into(),
+                    },
+                    span: sp(),
+                }),
+                args: vec![],
+            },
+            span: sp(),
+        }
+    }
+
+    fn return_stmt(val: Option<Expr>) -> Stmt {
+        Stmt { id: NodeId(0), kind: StmtKind::Return(val), span: sp() }
+    }
+
+    fn expr_stmt(e: Expr) -> Stmt {
+        Stmt { id: NodeId(0), kind: StmtKind::Expr(e), span: sp() }
+    }
+
+    fn make_fn(name: &str, body: Vec<Stmt>) -> Decl {
+        Decl {
+            id: NodeId(0),
+            kind: DeclKind::Fn(FnDecl {
+                name: name.into(),
+                type_params: vec![],
+                params: vec![],
+                ret_ty: None,
+                context_clauses: vec![],
+                body,
+                is_pub: false,
+                is_comptime: false,
+                is_unsafe: false,
+                abi: None,
+                attrs: vec![],
+                doc: None,
+                span: sp(),
+            }),
+            span: sp(),
+        }
+    }
+
+    fn make_comptime_fn(name: &str) -> Decl {
+        Decl {
+            id: NodeId(0),
+            kind: DeclKind::Fn(FnDecl {
+                name: name.into(),
+                type_params: vec![],
+                params: vec![],
+                ret_ty: None,
+                context_clauses: vec![],
+                body: vec![expr_stmt(call("println", vec![]))],
+                is_pub: false,
+                is_comptime: true,
+                is_unsafe: false,
+                abi: None,
+                attrs: vec![],
+                doc: None,
+                span: sp(),
+            }),
+            span: sp(),
+        }
+    }
+
+    fn make_extern(name: &str) -> Decl {
+        Decl {
+            id: NodeId(0),
+            kind: DeclKind::Extern(ExternDecl {
+                abi: "C".into(),
+                name: name.into(),
+                params: vec![],
+                ret_ty: None,
+                doc: None,
+            }),
+            span: sp(),
+        }
+    }
+
+    #[test]
+    fn pure_function() {
+        let decls = vec![make_fn("add", vec![return_stmt(Some(ident("x")))])];
+        let effects = infer(&decls);
+        assert!(effects["add"].is_pure());
+    }
+
+    #[test]
+    fn direct_io_call() {
+        let decls = vec![make_fn("load", vec![
+            expr_stmt(call("println", vec![])),
+        ])];
+        let effects = infer(&decls);
+        assert!(effects["load"].io);
+        assert!(!effects["load"].async_);
+    }
+
+    #[test]
+    fn direct_async_call() {
+        let decls = vec![make_fn("run", vec![
+            expr_stmt(call("spawn", vec![])),
+        ])];
+        let effects = infer(&decls);
+        assert!(effects["run"].io, "AS3: Async implies IO");
+        assert!(effects["run"].async_);
+    }
+
+    #[test]
+    fn field_call_io_source() {
+        let decls = vec![make_fn("read", vec![
+            expr_stmt(field_call("File", "open")),
+        ])];
+        let effects = infer(&decls);
+        assert!(effects["read"].io);
+    }
+
+    #[test]
+    fn method_call_io_source() {
+        let decls = vec![make_fn("net", vec![
+            expr_stmt(method_call("Channel", "send")),
+        ])];
+        let effects = infer(&decls);
+        assert!(effects["net"].io);
+        assert!(effects["net"].async_);
+    }
+
+    #[test]
+    fn transitive_propagation() {
+        // load calls println (IO)
+        // process calls load → should inherit IO
+        let decls = vec![
+            make_fn("load", vec![expr_stmt(call("println", vec![]))]),
+            make_fn("process", vec![expr_stmt(call("load", vec![]))]),
+        ];
+        let effects = infer(&decls);
+        assert!(effects["load"].io);
+        assert!(effects["process"].io, "Transitive IO via call to load");
+    }
+
+    #[test]
+    fn deep_transitive() {
+        // c calls println, b calls c, a calls b
+        let decls = vec![
+            make_fn("c", vec![expr_stmt(call("println", vec![]))]),
+            make_fn("b", vec![expr_stmt(call("c", vec![]))]),
+            make_fn("a", vec![expr_stmt(call("b", vec![]))]),
+        ];
+        let effects = infer(&decls);
+        assert!(effects["a"].io);
+        assert!(effects["b"].io);
+        assert!(effects["c"].io);
+    }
+
+    #[test]
+    fn mutual_recursion_terminates() {
+        // a calls b, b calls a, a also calls println
+        let decls = vec![
+            make_fn("a", vec![
+                expr_stmt(call("println", vec![])),
+                expr_stmt(call("b", vec![])),
+            ]),
+            make_fn("b", vec![expr_stmt(call("a", vec![]))]),
+        ];
+        let effects = infer(&decls);
+        assert!(effects["a"].io);
+        assert!(effects["b"].io, "b inherits IO from a via mutual recursion");
+    }
+
+    #[test]
+    fn unsafe_block_conservative_io() {
+        let decls = vec![make_fn("ffi_call", vec![
+            Stmt {
+                id: NodeId(0),
+                kind: StmtKind::Expr(Expr {
+                    id: NodeId(0),
+                    kind: ExprKind::Unsafe { body: vec![] },
+                    span: sp(),
+                }),
+                span: sp(),
+            },
+        ])];
+        let effects = infer(&decls);
+        assert!(effects["ffi_call"].io, "IO3: unsafe blocks conservative IO");
+    }
+
+    #[test]
+    fn comptime_always_pure() {
+        let decls = vec![make_comptime_fn("table_gen")];
+        let effects = infer(&decls);
+        assert!(effects["table_gen"].is_pure(), "PU2: comptime is pure");
+    }
+
+    #[test]
+    fn extern_conservative_io() {
+        let decls = vec![make_extern("c_function")];
+        let effects = infer(&decls);
+        assert!(effects["c_function"].io, "INF5: extern is conservative IO");
+    }
+
+    #[test]
+    fn spawn_expr_is_async() {
+        let decls = vec![make_fn("run", vec![
+            Stmt {
+                id: NodeId(0),
+                kind: StmtKind::Expr(Expr {
+                    id: NodeId(0),
+                    kind: ExprKind::Spawn { body: vec![] },
+                    span: sp(),
+                }),
+                span: sp(),
+            },
+        ])];
+        let effects = infer(&decls);
+        assert!(effects["run"].async_);
+        assert!(effects["run"].io, "AS3: Async implies IO");
+    }
+
+    #[test]
+    fn mutation_effect() {
+        let decls = vec![make_fn("grow", vec![
+            expr_stmt(method_call("pool", "insert")),
+        ])];
+        let effects = infer(&decls);
+        assert!(effects["grow"].mutation);
+        assert!(!effects["grow"].io, "Mutation is orthogonal to IO");
+    }
+
+    #[test]
+    fn mixed_effects() {
+        let decls = vec![make_fn("complex", vec![
+            expr_stmt(call("println", vec![])),
+            expr_stmt(call("spawn", vec![])),
+            expr_stmt(method_call("pool", "insert")),
+        ])];
+        let effects = infer(&decls);
+        assert!(effects["complex"].io);
+        assert!(effects["complex"].async_);
+        assert!(effects["complex"].mutation);
+    }
+
+    #[test]
+    fn unknown_callee_is_pure() {
+        let decls = vec![make_fn("caller", vec![
+            expr_stmt(call("some_unknown_fn", vec![])),
+        ])];
+        let effects = infer(&decls);
+        // Unknown function isn't in our source table, and there's no
+        // declaration to propagate from → stays pure
+        assert!(effects["caller"].is_pure());
+    }
+}

--- a/compiler/crates/rask-effects/src/lib.rs
+++ b/compiler/crates/rask-effects/src/lib.rs
@@ -1,0 +1,116 @@
+// SPDX-License-Identifier: (MIT OR Apache-2.0)
+
+//! Effect tracking for Rask (comp.effects).
+//!
+//! Infers IO, Async, and Mutation effects per function via transitive
+//! call graph analysis. Effects are metadata — visible through IDE ghost
+//! text and linter warnings, not enforced in the type system.
+//!
+//! Three categories (FX1):
+//! - IO: syscalls, file/network/stdio operations
+//! - Async: spawn, sleep, channel ops
+//! - Mutation: pool structural changes (Grow/Shrink)
+//!
+//! Run after type checking. No AST modifications — annotation only.
+
+pub mod infer;
+pub mod sources;
+pub mod warnings;
+
+use std::collections::HashMap;
+
+use rask_ast::Span;
+use rask_ast::decl::Decl;
+
+/// 3-bit effect mask per function (FX1).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub struct Effects {
+    pub io: bool,
+    pub async_: bool,
+    pub mutation: bool,
+}
+
+impl Effects {
+    /// PU1: A function is pure if it has no effects.
+    pub fn is_pure(&self) -> bool {
+        !self.io && !self.async_ && !self.mutation
+    }
+
+    /// Merge another effect set into this one.
+    pub fn union(&mut self, other: Effects) {
+        self.io |= other.io;
+        self.async_ |= other.async_;
+        self.mutation |= other.mutation;
+    }
+
+    /// Ghost text label for IDE display (IDE1).
+    pub fn label(&self) -> &'static str {
+        match (self.io, self.async_, self.mutation) {
+            (false, false, false) => "[pure]",
+            (true, false, false) => "[io]",
+            (true, true, false) => "[io, async]",
+            (false, false, true) => "[mutation]",
+            (true, false, true) => "[io, mutation]",
+            (true, true, true) => "[io, async, mutation]",
+            // AS3: Async implies IO, so async without io shouldn't happen.
+            // Handle defensively anyway.
+            (false, true, false) => "[async]",
+            (false, true, true) => "[async, mutation]",
+        }
+    }
+}
+
+/// Per-function effect results keyed by qualified function name.
+pub type EffectMap = HashMap<String, Effects>;
+
+/// A warning from effect analysis (CW1, CW2).
+#[derive(Debug, Clone)]
+pub struct EffectWarning {
+    /// Spec rule: "comp.effects/CW1" or "comp.effects/CW2".
+    pub code: &'static str,
+    pub message: String,
+    /// Location of the problematic call site.
+    pub span: Span,
+    /// Name of the function that introduces the effect.
+    pub callee_name: String,
+}
+
+/// Run effect inference on a set of declarations.
+///
+/// Returns the per-function effect map and any warnings (CW1/CW2).
+/// Call after type checking — no AST modifications.
+pub fn infer_effects(decls: &[Decl]) -> (EffectMap, Vec<EffectWarning>) {
+    let effects = infer::infer(decls);
+    let warnings = warnings::detect(decls, &effects);
+    (effects, warnings)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn effects_union() {
+        let mut a = Effects { io: true, async_: false, mutation: false };
+        let b = Effects { io: false, async_: true, mutation: true };
+        a.union(b);
+        assert!(a.io);
+        assert!(a.async_);
+        assert!(a.mutation);
+    }
+
+    #[test]
+    fn pure_detection() {
+        assert!(Effects::default().is_pure());
+        assert!(!Effects { io: true, ..Default::default() }.is_pure());
+    }
+
+    #[test]
+    fn label_format() {
+        assert_eq!(Effects::default().label(), "[pure]");
+        assert_eq!(Effects { io: true, async_: false, mutation: false }.label(), "[io]");
+        assert_eq!(Effects { io: true, async_: true, mutation: false }.label(), "[io, async]");
+        assert_eq!(Effects { io: false, async_: false, mutation: true }.label(), "[mutation]");
+        assert_eq!(Effects { io: true, async_: false, mutation: true }.label(), "[io, mutation]");
+    }
+}

--- a/compiler/crates/rask-effects/src/sources.rs
+++ b/compiler/crates/rask-effects/src/sources.rs
@@ -1,0 +1,131 @@
+// SPDX-License-Identifier: (MIT OR Apache-2.0)
+
+//! Ground-truth effect classification for known source functions.
+//!
+//! Maps function names to their direct effects based on the tables
+//! in `comp.effects` and `conc.io-context` specs.
+
+use crate::Effects;
+
+/// Classify a call target by its known effects.
+///
+/// Returns non-empty effects only for known source functions (stdlib IO,
+/// async primitives, pool structural mutations). Unknown functions return
+/// `Effects::default()` — their effects come from transitive propagation.
+pub fn classify_call(callee: &str) -> Effects {
+    // IO sources (conc.io-context table)
+    if is_io_source(callee) {
+        // Some IO sources are also Async (AS3: Async implies IO)
+        if is_async_source(callee) {
+            return Effects { io: true, async_: true, mutation: false };
+        }
+        return Effects { io: true, async_: false, mutation: false };
+    }
+
+    // Async-only sources (also get IO via AS3)
+    if is_async_source(callee) {
+        return Effects { io: true, async_: true, mutation: false };
+    }
+
+    // Pool structural mutation sources
+    if is_mutation_source(callee) {
+        return Effects { io: false, async_: false, mutation: true };
+    }
+
+    Effects::default()
+}
+
+fn is_io_source(callee: &str) -> bool {
+    matches!(callee,
+        // fs module
+        "File.open" | "File.read" | "File.write" | "File.close"
+        | "open" | "read_file" | "write_file" | "exists"
+        | "fs.read_file" | "fs.write_file" | "fs.exists"
+        // net module
+        | "TcpListener.bind" | "TcpListener.accept"
+        | "TcpConnection.read" | "TcpConnection.write"
+        | "UdpSocket.send" | "UdpSocket.recv"
+        // io module (stdio)
+        | "Stdin.read" | "Stdout.write" | "Stderr.write"
+        | "print" | "println" | "eprint" | "eprintln"
+        // async sources that are also IO (AS3)
+        | "sleep" | "timeout"
+        | "spawn" | "Channel.send" | "Channel.recv" | "TaskHandle.join"
+    )
+}
+
+fn is_async_source(callee: &str) -> bool {
+    matches!(callee,
+        "spawn" | "sleep" | "timeout"
+        | "Channel.send" | "Channel.recv"
+        | "TaskHandle.join"
+    )
+}
+
+fn is_mutation_source(callee: &str) -> bool {
+    // Pool structural operations (Grow/Shrink from comp.advanced/EF1-EF6).
+    // Method calls like `pool.insert(x)` arrive as callee "insert" or
+    // "pool.insert" depending on resolution. Match both forms.
+    matches!(callee,
+        "insert" | "remove"
+        | "pool.insert" | "pool.remove"
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn io_sources_classified() {
+        let e = classify_call("File.open");
+        assert!(e.io);
+        assert!(!e.async_);
+        assert!(!e.mutation);
+
+        assert!(classify_call("println").io);
+        assert!(classify_call("fs.read_file").io);
+        assert!(classify_call("TcpListener.accept").io);
+    }
+
+    #[test]
+    fn async_sources_also_io() {
+        let e = classify_call("spawn");
+        assert!(e.io, "AS3: Async implies IO");
+        assert!(e.async_);
+
+        let e = classify_call("Channel.send");
+        assert!(e.io);
+        assert!(e.async_);
+    }
+
+    #[test]
+    fn mutation_sources_classified() {
+        let e = classify_call("pool.insert");
+        assert!(e.mutation);
+        assert!(!e.io);
+
+        let e = classify_call("remove");
+        assert!(e.mutation);
+    }
+
+    #[test]
+    fn unknown_function_is_pure() {
+        let e = classify_call("add");
+        assert!(e.is_pure());
+
+        let e = classify_call("json.decode");
+        assert!(e.is_pure());
+
+        let e = classify_call("Vec.push");
+        assert!(e.is_pure());
+    }
+
+    #[test]
+    fn sleep_is_both_io_and_async() {
+        let e = classify_call("sleep");
+        assert!(e.io);
+        assert!(e.async_);
+        assert!(!e.mutation);
+    }
+}

--- a/compiler/crates/rask-effects/src/warnings.rs
+++ b/compiler/crates/rask-effects/src/warnings.rs
@@ -1,0 +1,528 @@
+// SPDX-License-Identifier: (MIT OR Apache-2.0)
+
+//! Effect-based compiler warnings (comp.effects/CW1, CW2).
+//!
+//! CW1: IO function called inside ThreadPool.spawn — blocks pool thread
+//! CW2: IO function called in a loop without `using Multitasking` context
+
+use rask_ast::decl::{Decl, DeclKind, FnDecl};
+use rask_ast::expr::{Expr, ExprKind};
+use rask_ast::stmt::{Stmt, StmtKind};
+
+use crate::{EffectMap, EffectWarning};
+
+/// Detect CW1 and CW2 warnings from declarations.
+pub fn detect(decls: &[Decl], effects: &EffectMap) -> Vec<EffectWarning> {
+    let mut warnings = Vec::new();
+    let mut ctx = WarnContext { effects, in_thread_pool: false, in_loop: false, in_multitasking: false };
+
+    for decl in decls {
+        match &decl.kind {
+            DeclKind::Fn(f) => ctx.check_fn(f, &mut warnings),
+            DeclKind::Struct(s) => {
+                for m in &s.methods { ctx.check_fn(m, &mut warnings); }
+            }
+            DeclKind::Enum(e) => {
+                for m in &e.methods { ctx.check_fn(m, &mut warnings); }
+            }
+            DeclKind::Impl(i) => {
+                for m in &i.methods { ctx.check_fn(m, &mut warnings); }
+            }
+            DeclKind::Trait(t) => {
+                for m in &t.methods { ctx.check_fn(m, &mut warnings); }
+            }
+            _ => {}
+        }
+    }
+
+    warnings
+}
+
+struct WarnContext<'a> {
+    effects: &'a EffectMap,
+    in_thread_pool: bool,
+    in_loop: bool,
+    in_multitasking: bool,
+}
+
+impl<'a> WarnContext<'a> {
+    fn check_fn(&mut self, f: &FnDecl, warnings: &mut Vec<EffectWarning>) {
+        // Reset context per function
+        self.in_thread_pool = false;
+        self.in_loop = false;
+        self.in_multitasking = false;
+        self.check_stmts(&f.body, warnings);
+    }
+
+    fn check_stmts(&mut self, stmts: &[Stmt], warnings: &mut Vec<EffectWarning>) {
+        for stmt in stmts {
+            self.check_stmt(stmt, warnings);
+        }
+    }
+
+    fn check_stmt(&mut self, stmt: &Stmt, warnings: &mut Vec<EffectWarning>) {
+        match &stmt.kind {
+            StmtKind::Expr(e) => self.check_expr(e, warnings),
+            StmtKind::Let { init, .. } | StmtKind::Const { init, .. } => {
+                self.check_expr(init, warnings);
+            }
+            StmtKind::LetTuple { init, .. } | StmtKind::ConstTuple { init, .. } => {
+                self.check_expr(init, warnings);
+            }
+            StmtKind::Assign { target, value } => {
+                self.check_expr(target, warnings);
+                self.check_expr(value, warnings);
+            }
+            StmtKind::Return(Some(e)) => self.check_expr(e, warnings),
+            StmtKind::Return(None) => {}
+            StmtKind::Break { value: Some(v), .. } => self.check_expr(v, warnings),
+            StmtKind::Break { value: None, .. } | StmtKind::Continue(_) => {}
+
+            // CW2: Track loop context
+            StmtKind::While { cond, body } => {
+                self.check_expr(cond, warnings);
+                let was_in_loop = self.in_loop;
+                self.in_loop = true;
+                self.check_stmts(body, warnings);
+                self.in_loop = was_in_loop;
+            }
+            StmtKind::WhileLet { expr, body, .. } => {
+                self.check_expr(expr, warnings);
+                let was_in_loop = self.in_loop;
+                self.in_loop = true;
+                self.check_stmts(body, warnings);
+                self.in_loop = was_in_loop;
+            }
+            StmtKind::Loop { body, .. } => {
+                let was_in_loop = self.in_loop;
+                self.in_loop = true;
+                self.check_stmts(body, warnings);
+                self.in_loop = was_in_loop;
+            }
+            StmtKind::For { iter, body, .. } => {
+                self.check_expr(iter, warnings);
+                let was_in_loop = self.in_loop;
+                self.in_loop = true;
+                self.check_stmts(body, warnings);
+                self.in_loop = was_in_loop;
+            }
+
+            StmtKind::Ensure { body, else_handler } => {
+                self.check_stmts(body, warnings);
+                if let Some((_, handler)) = else_handler {
+                    self.check_stmts(handler, warnings);
+                }
+            }
+            StmtKind::Comptime(body) => self.check_stmts(body, warnings),
+        }
+    }
+
+    fn check_expr(&mut self, expr: &Expr, warnings: &mut Vec<EffectWarning>) {
+        match &expr.kind {
+            ExprKind::Call { func, args } => {
+                let callee_name = extract_callee_name(func);
+                if let Some(ref name) = callee_name {
+                    self.maybe_warn_io_call(name, expr.span, warnings);
+                }
+                self.check_expr(func, warnings);
+                for arg in args {
+                    self.check_expr(&arg.expr, warnings);
+                }
+            }
+
+            ExprKind::MethodCall { object, method, args, .. } => {
+                // Check qualified form
+                if let ExprKind::Ident(type_name) = &object.kind {
+                    let qname = format!("{}.{}", type_name, method);
+                    self.maybe_warn_io_call(&qname, expr.span, warnings);
+                }
+                self.maybe_warn_io_call(method, expr.span, warnings);
+                self.check_expr(object, warnings);
+                for arg in args {
+                    self.check_expr(&arg.expr, warnings);
+                }
+            }
+
+            // CW1: ThreadPool.spawn — track context for body
+            ExprKind::UsingBlock { name, args, body } if is_thread_pool(name) => {
+                for arg in args {
+                    self.check_expr(&arg.expr, warnings);
+                }
+                let was_in_tp = self.in_thread_pool;
+                self.in_thread_pool = true;
+                self.check_stmts(body, warnings);
+                self.in_thread_pool = was_in_tp;
+            }
+
+            // Track Multitasking context (suppresses CW2)
+            ExprKind::UsingBlock { name, args, body } if is_multitasking(name) => {
+                for arg in args {
+                    self.check_expr(&arg.expr, warnings);
+                }
+                let was_mt = self.in_multitasking;
+                self.in_multitasking = true;
+                self.check_stmts(body, warnings);
+                self.in_multitasking = was_mt;
+            }
+
+            ExprKind::UsingBlock { args, body, .. } => {
+                for arg in args {
+                    self.check_expr(&arg.expr, warnings);
+                }
+                self.check_stmts(body, warnings);
+            }
+
+            // BlockCall: ThreadPool.spawn(|| { ... }) parsed as BlockCall
+            ExprKind::BlockCall { name, body } if is_thread_pool(name) => {
+                let was_in_tp = self.in_thread_pool;
+                self.in_thread_pool = true;
+                self.check_stmts(body, warnings);
+                self.in_thread_pool = was_in_tp;
+            }
+
+            ExprKind::Spawn { body } => self.check_stmts(body, warnings),
+
+            // Recurse into other expressions
+            ExprKind::Binary { left, right, .. } => {
+                self.check_expr(left, warnings);
+                self.check_expr(right, warnings);
+            }
+            ExprKind::Unary { operand, .. } => self.check_expr(operand, warnings),
+            ExprKind::Field { object, .. } | ExprKind::OptionalField { object, .. } => {
+                self.check_expr(object, warnings);
+            }
+            ExprKind::Index { object, index } => {
+                self.check_expr(object, warnings);
+                self.check_expr(index, warnings);
+            }
+            ExprKind::Block(stmts) => self.check_stmts(stmts, warnings),
+            ExprKind::If { cond, then_branch, else_branch } => {
+                self.check_expr(cond, warnings);
+                self.check_expr(then_branch, warnings);
+                if let Some(e) = else_branch { self.check_expr(e, warnings); }
+            }
+            ExprKind::IfLet { expr, then_branch, else_branch, .. } => {
+                self.check_expr(expr, warnings);
+                self.check_expr(then_branch, warnings);
+                if let Some(e) = else_branch { self.check_expr(e, warnings); }
+            }
+            ExprKind::GuardPattern { expr, else_branch, .. } => {
+                self.check_expr(expr, warnings);
+                self.check_expr(else_branch, warnings);
+            }
+            ExprKind::IsPattern { expr, .. } => self.check_expr(expr, warnings),
+            ExprKind::Match { scrutinee, arms } => {
+                self.check_expr(scrutinee, warnings);
+                for arm in arms {
+                    if let Some(g) = &arm.guard { self.check_expr(g, warnings); }
+                    self.check_expr(&arm.body, warnings);
+                }
+            }
+            ExprKind::Try { expr: e, else_clause } => {
+                self.check_expr(e, warnings);
+                if let Some(ec) = else_clause {
+                    self.check_expr(&ec.body, warnings);
+                }
+            }
+            ExprKind::Unwrap { expr: e, .. } | ExprKind::Cast { expr: e, .. } => {
+                self.check_expr(e, warnings);
+            }
+            ExprKind::NullCoalesce { value, default } => {
+                self.check_expr(value, warnings);
+                self.check_expr(default, warnings);
+            }
+            ExprKind::Range { start, end, .. } => {
+                if let Some(s) = start { self.check_expr(s, warnings); }
+                if let Some(e) = end { self.check_expr(e, warnings); }
+            }
+            ExprKind::StructLit { fields, spread, .. } => {
+                for f in fields { self.check_expr(&f.value, warnings); }
+                if let Some(s) = spread { self.check_expr(s, warnings); }
+            }
+            ExprKind::Array(elems) | ExprKind::Tuple(elems) => {
+                for e in elems { self.check_expr(e, warnings); }
+            }
+            ExprKind::ArrayRepeat { value, count } => {
+                self.check_expr(value, warnings);
+                self.check_expr(count, warnings);
+            }
+            ExprKind::WithAs { bindings, body } => {
+                for b in bindings { self.check_expr(&b.source, warnings); }
+                self.check_stmts(body, warnings);
+            }
+            ExprKind::Closure { body, .. } => self.check_expr(body, warnings),
+            ExprKind::Unsafe { body } | ExprKind::Comptime { body }
+            | ExprKind::BlockCall { body, .. } => {
+                self.check_stmts(body, warnings);
+            }
+            ExprKind::Assert { condition, message } | ExprKind::Check { condition, message } => {
+                self.check_expr(condition, warnings);
+                if let Some(m) = message { self.check_expr(m, warnings); }
+            }
+            ExprKind::Select { arms, .. } => {
+                for arm in arms {
+                    match &arm.kind {
+                        rask_ast::expr::SelectArmKind::Recv { channel, .. } => {
+                            self.check_expr(channel, warnings);
+                        }
+                        rask_ast::expr::SelectArmKind::Send { channel, value } => {
+                            self.check_expr(channel, warnings);
+                            self.check_expr(value, warnings);
+                        }
+                        rask_ast::expr::SelectArmKind::Default => {}
+                    }
+                    self.check_expr(&arm.body, warnings);
+                }
+            }
+            // Leaves
+            ExprKind::Int(_, _) | ExprKind::Float(_, _) | ExprKind::String(_)
+            | ExprKind::Char(_) | ExprKind::Bool(_) | ExprKind::Null
+            | ExprKind::Ident(_) => {}
+        }
+    }
+
+    /// Check if a callee has IO effects and we're in a warning context.
+    fn maybe_warn_io_call(
+        &self,
+        callee: &str,
+        span: rask_ast::Span,
+        warnings: &mut Vec<EffectWarning>,
+    ) {
+        let has_io = self.effects.get(callee)
+            .map_or(false, |e| e.io)
+            || crate::sources::classify_call(callee).io;
+
+        if !has_io {
+            return;
+        }
+
+        // CW1: IO in ThreadPool context
+        if self.in_thread_pool {
+            warnings.push(EffectWarning {
+                code: "comp.effects/CW1",
+                message: format!(
+                    "I/O function `{}` called in thread pool context — blocks pool thread",
+                    callee,
+                ),
+                span,
+                callee_name: callee.to_string(),
+            });
+        }
+
+        // CW2: IO in loop without Multitasking
+        if self.in_loop && !self.in_multitasking {
+            warnings.push(EffectWarning {
+                code: "comp.effects/CW2",
+                message: format!(
+                    "I/O function `{}` in loop without `using Multitasking` — blocks thread on each iteration",
+                    callee,
+                ),
+                span,
+                callee_name: callee.to_string(),
+            });
+        }
+    }
+}
+
+fn is_thread_pool(name: &str) -> bool {
+    name == "ThreadPool" || name == "thread_pool"
+}
+
+fn is_multitasking(name: &str) -> bool {
+    name == "Multitasking" || name == "multitasking"
+}
+
+fn extract_callee_name(func: &Expr) -> Option<String> {
+    match &func.kind {
+        ExprKind::Ident(name) => Some(name.clone()),
+        ExprKind::Field { object, field } => {
+            if let ExprKind::Ident(obj_name) = &object.kind {
+                Some(format!("{}.{}", obj_name, field))
+            } else {
+                None
+            }
+        }
+        _ => None,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use rask_ast::decl::{Decl, DeclKind, FnDecl};
+    use rask_ast::expr::{Expr, ExprKind};
+    use rask_ast::stmt::{Stmt, StmtKind, ForBinding};
+    use rask_ast::{NodeId, Span};
+    use std::collections::HashMap;
+
+    fn sp() -> Span { Span::new(0, 0) }
+
+    fn ident(name: &str) -> Expr {
+        Expr { id: NodeId(0), kind: ExprKind::Ident(name.into()), span: sp() }
+    }
+
+    fn call(func_name: &str) -> Expr {
+        Expr {
+            id: NodeId(0),
+            kind: ExprKind::Call {
+                func: Box::new(ident(func_name)),
+                args: vec![],
+            },
+            span: sp(),
+        }
+    }
+
+    fn field_call(obj: &str, field: &str) -> Expr {
+        Expr {
+            id: NodeId(0),
+            kind: ExprKind::Call {
+                func: Box::new(Expr {
+                    id: NodeId(0),
+                    kind: ExprKind::Field {
+                        object: Box::new(ident(obj)),
+                        field: field.into(),
+                    },
+                    span: sp(),
+                }),
+                args: vec![],
+            },
+            span: sp(),
+        }
+    }
+
+    fn expr_stmt(e: Expr) -> Stmt {
+        Stmt { id: NodeId(0), kind: StmtKind::Expr(e), span: sp() }
+    }
+
+    fn make_fn(name: &str, body: Vec<Stmt>) -> Decl {
+        Decl {
+            id: NodeId(0),
+            kind: DeclKind::Fn(FnDecl {
+                name: name.into(),
+                type_params: vec![],
+                params: vec![],
+                ret_ty: None,
+                context_clauses: vec![],
+                body,
+                is_pub: false,
+                is_comptime: false,
+                is_unsafe: false,
+                abi: None,
+                attrs: vec![],
+                doc: None,
+                span: sp(),
+            }),
+            span: sp(),
+        }
+    }
+
+    fn effects_with_io(name: &str) -> EffectMap {
+        let mut m = HashMap::new();
+        m.insert(name.into(), crate::Effects { io: true, async_: false, mutation: false });
+        m
+    }
+
+    #[test]
+    fn cw1_io_in_thread_pool() {
+        // ThreadPool.spawn { println() }
+        let body = vec![expr_stmt(Expr {
+            id: NodeId(0),
+            kind: ExprKind::UsingBlock {
+                name: "ThreadPool".into(),
+                args: vec![],
+                body: vec![expr_stmt(call("println"))],
+            },
+            span: sp(),
+        })];
+        let decls = vec![make_fn("worker", body)];
+        let effects = effects_with_io("println");
+        let warnings = detect(&decls, &effects);
+        assert_eq!(warnings.len(), 1);
+        assert_eq!(warnings[0].code, "comp.effects/CW1");
+        assert!(warnings[0].message.contains("println"));
+    }
+
+    #[test]
+    fn cw2_io_in_loop_without_multitasking() {
+        // for x in items { println() }
+        let body = vec![Stmt {
+            id: NodeId(0),
+            kind: StmtKind::For {
+                label: None,
+                binding: ForBinding::Single("x".into()),
+                iter: ident("items"),
+                body: vec![expr_stmt(call("println"))],
+            },
+            span: sp(),
+        }];
+        let decls = vec![make_fn("process", body)];
+        let effects = effects_with_io("println");
+        let warnings = detect(&decls, &effects);
+        assert_eq!(warnings.len(), 1);
+        assert_eq!(warnings[0].code, "comp.effects/CW2");
+    }
+
+    #[test]
+    fn no_cw2_with_multitasking_context() {
+        // using Multitasking { for x in items { println() } }
+        let loop_body = vec![Stmt {
+            id: NodeId(0),
+            kind: StmtKind::For {
+                label: None,
+                binding: ForBinding::Single("x".into()),
+                iter: ident("items"),
+                body: vec![expr_stmt(call("println"))],
+            },
+            span: sp(),
+        }];
+        let body = vec![expr_stmt(Expr {
+            id: NodeId(0),
+            kind: ExprKind::UsingBlock {
+                name: "Multitasking".into(),
+                args: vec![],
+                body: loop_body,
+            },
+            span: sp(),
+        })];
+        let decls = vec![make_fn("process", body)];
+        let effects = effects_with_io("println");
+        let warnings = detect(&decls, &effects);
+        assert!(warnings.is_empty(), "No CW2 inside Multitasking context");
+    }
+
+    #[test]
+    fn no_warning_for_pure_call_in_loop() {
+        let body = vec![Stmt {
+            id: NodeId(0),
+            kind: StmtKind::For {
+                label: None,
+                binding: ForBinding::Single("x".into()),
+                iter: ident("items"),
+                body: vec![expr_stmt(call("add"))],
+            },
+            span: sp(),
+        }];
+        let decls = vec![make_fn("process", body)];
+        let effects = HashMap::new(); // add has no effects
+        let warnings = detect(&decls, &effects);
+        assert!(warnings.is_empty());
+    }
+
+    #[test]
+    fn cw1_with_file_read() {
+        let body = vec![expr_stmt(Expr {
+            id: NodeId(0),
+            kind: ExprKind::UsingBlock {
+                name: "ThreadPool".into(),
+                args: vec![],
+                body: vec![expr_stmt(field_call("File", "read"))],
+            },
+            span: sp(),
+        })];
+        let decls = vec![make_fn("bad", body)];
+        let effects = effects_with_io("File.read");
+        let warnings = detect(&decls, &effects);
+        assert_eq!(warnings.len(), 1);
+        assert_eq!(warnings[0].code, "comp.effects/CW1");
+    }
+}


### PR DESCRIPTION
## Summary

Implements the effect tracking system (comp.effects) for Rask, enabling inference and reporting of IO, Async, and Mutation effects across function call graphs. Effects are tracked as metadata for IDE display and linter warnings, not enforced in the type system.

## Key Changes

- **New `rask-effects` crate** with three main modules:
  - `infer.rs`: Three-phase effect inference engine
    - Phase 1: Collect function declarations and classify direct effects from function bodies
    - Phase 2: Mark extern functions conservatively as IO (INF5)
    - Phase 3: Fixed-point propagation to union callee effects into callers until stable
  - `sources.rs`: Ground-truth classification for known source functions (stdlib IO, async primitives, pool mutations)
  - `warnings.rs`: Detection of effect-based compiler warnings
    - CW1: IO function called inside ThreadPool.spawn (blocks pool thread)
    - CW2: IO function called in loop without `using Multitasking` context

- **Effect system (FX1)**: Three-bit effect mask per function
  - `io`: syscalls, file/network/stdio operations
  - `async_`: spawn, sleep, channel operations
  - `mutation`: pool structural changes (Grow/Shrink)

- **Integration into pipeline**:
  - Effect inference runs after type checking as a post-processing pass
  - Results stored in `FrontendResult` for IDE and diagnostic use
  - No AST modifications — annotation only

- **Comprehensive test coverage** for:
  - Pure function detection (PU1, PU2)
  - Direct effect classification (IO3, AS1)
  - Transitive propagation including mutual recursion
  - Extern function conservative marking (INF5)
  - Async implies IO invariant (AS3)
  - Warning detection (CW1, CW2)

## Implementation Details

- Uses call graph analysis with fixed-point iteration for transitive effect propagation
- Handles comptime functions as always pure (PU2)
- Supports `@no_io` attribute to suppress conservative IO marking
- Tracks context (ThreadPool, Multitasking, loops) for warning detection
- Extracts callee names from both direct calls and qualified method calls (Type.method)
- Defensive handling of unknown functions (default to pure, inherit via propagation)

https://claude.ai/code/session_011rkT47v9s6gwhpXoEy13wr