### PR TITLE
Document macro system rejection and compiler-known functions

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -46,7 +46,7 @@
 - [x] **`todo()` / `unreachable()`** — Development panic builtins returning `!` (Never). Interpreter + native codegen (desugars to `panic()` in MIR). See [error-types.md](specs/types/error-types.md)
 - [x] **Tuple spec** — Formalized existing tuple support. See [tuples.md](specs/types/tuples.md)
 - [x] **Destructuring spec** — Formalized existing destructuring. See [control-flow.md](specs/control/control-flow.md)
-- [ ] Macros / `format!`
+- [x] **Macros / `format!`** — `format()` is a compiler-known function (`std.fmt/CM1`, `struct.modules/BF2`). General macro system rejected (`rejected-features.md`)
 ## Design — Decided
 
 - [x] **Serialization / encoding** — `comptime for` + field access, auto-derived `Encode`/`Decode` marker traits, field annotations (`@rename`, `@skip`, `@default`). See [encoding.md](specs/stdlib/encoding.md)

--- a/specs/rejected-features.md
+++ b/specs/rejected-features.md
@@ -389,11 +389,41 @@ Rust programmers will find this backwards. I think it's clearer for everyone els
 
 ---
 
+## General Macro System
+
+**Looked at:** Rust (declarative + procedural macros), Zig (comptime), Nim (templates + macros)
+
+Rust macros solve real problems: variadic arguments (`format!`, `vec!`), conditional compilation (`cfg!`), code generation (`derive`), and domain-specific syntax. But they're a second language with their own syntax, error messages, and learning curve. `macro_rules!` is notoriously hard to read. Procedural macros require a separate crate. Both make code harder to analyze.
+
+I'm not adding a macro system. Here's what covers those use cases instead.
+
+### Variadic arguments
+
+`format()`, `println()`, and `print()` are compiler-known functions (`struct.modules/BF2`). The compiler parses templates, type-checks arguments, and generates specialized code. No variadic mechanism needed—the compiler handles these directly.
+
+For user-defined variadic functions: Rask doesn't have them. Pass a `Vec` or use generic overloads. Variadics complicate type checking and make call-site errors harder to diagnose.
+
+### Code generation
+
+`comptime for` + `std.reflect` handles serialization, encoding, and struct-walking patterns (`ctrl.comptime/CT48-CT54`). Build scripts handle external codegen (protobuf, schemas). `comptime if cfg.*` handles conditional compilation.
+
+### Domain-specific syntax
+
+Not supported. DSLs in macros look concise but break tooling—IDEs, formatters, linters all need macro expansion to understand the code. Write functions instead.
+
+### What I chose instead
+
+Compiler-known functions for the handful of variadic built-ins. Comptime for compile-time computation. Build scripts for complex codegen. No user-extensible syntax transformation.
+
+This means Rask can't express `vec![1, 2, 3]`—you write `Vec.from([1, 2, 3])`. I think that's fine.
+
+---
+
 ## Summary
 
 Common thread: I optimize for transparency and local reasoning, but not at the cost of ergonomics.
 
-**Rejected:** Exceptions, async/await keywords, lifetime annotations, automatic supervision, algebraic effects, implicit receivers.
+**Rejected:** Exceptions, async/await keywords, lifetime annotations, automatic supervision, algebraic effects, implicit receivers, general macro system.
 
 **Chose:** Result types, green tasks without coloring, block-scoped borrows, library patterns, explicit parameters.
 

--- a/specs/stdlib/fmt.md
+++ b/specs/stdlib/fmt.md
@@ -143,6 +143,19 @@ FIX: Use all auto ({}, {}) or all explicit ({0}, {1}).
 | Empty template | F1 | Returns empty string |
 | `format("{:?}", x)` on auto-derived type | G2 | Shows struct fields / enum variants |
 
+## Compiler Mechanism
+
+| Rule | Description |
+|------|-------------|
+| **CM1: Compiler-known** | `format()` is a compiler-known function, not a regular function. It accepts variable arguments through compiler support (`struct.modules/BF4`), not through a general variadic mechanism |
+| **CM2: Template parsing** | The compiler parses the template string at compile time, extracting placeholder positions, names, and format specifiers |
+| **CM3: Per-arg type check** | Each argument is type-checked against its placeholder: `{}` requires `Display`, `{:?}` requires `Debug`, `{:x}` requires integer type |
+| **CM4: Compile-time errors** | Missing arguments, type mismatches, and malformed specifiers are compile-time errors. No runtime formatting failures for static templates |
+| **CM5: Codegen** | The compiler generates specialized string-building code per call site. No runtime template parsing for static templates |
+| **CM6: Comptime folding** | When all arguments are comptime-known, the result is a static string |
+
+`println` and `print` use the same mechanism for interpolation: the compiler rewrites `println("Hello, {name}!")` into string-building code at compile time.
+
 ---
 
 ## Appendix (non-normative)

--- a/specs/structure/modules.md
+++ b/specs/structure/modules.md
@@ -29,6 +29,15 @@ Package-visible default with explicit `public`, fixed built-in types, simple pat
 | **BI3: No shadowing** | Defining local type with built-in name is a compile error |
 | **BI4: Qualified fallback** | `core.Result` always works regardless of local names |
 
+## Built-in Functions
+
+| Rule | Description |
+|------|-------------|
+| **BF1: Always available** | `println`, `print`, `format`, `panic`, `todo`, `unreachable`, `spawn`, `transmute` |
+| **BF2: Compiler-known** | Not regular functions. The compiler knows their signatures, validates arguments, and generates specialized code per call site |
+| **BF3: No shadowing** | Defining a function with a built-in name is a compile error |
+| **BF4: No variadics** | `format`, `println`, `print` accept variable arguments through compiler support, not through a general variadic mechanism. The compiler parses template strings at compile time and type-checks each argument against its placeholder |
+
 ## Package Organization
 
 | Rule | Description |


### PR DESCRIPTION
## Summary

This PR documents the decision to reject a general macro system in Rask and instead use compiler-known functions for variadic built-ins like `format()`, `println()`, and `print()`. It formalizes how these functions work at the compiler level.

## Key Changes

- **Added "General Macro System" section to rejected features** — Explains why Rask doesn't implement macros (Rust-style or otherwise) and what alternatives are used instead:
  - Variadic arguments handled via compiler-known functions, not a general variadic mechanism
  - Code generation via `comptime for` + `std.reflect` and build scripts
  - Domain-specific syntax explicitly not supported to preserve tooling compatibility

- **Formalized compiler mechanism for `format()` in stdlib/fmt.md** — Added "Compiler Mechanism" section documenting:
  - `format()` is compiler-known, not a regular function (CM1)
  - Template parsing happens at compile time (CM2)
  - Per-argument type checking against placeholders (CM3)
  - Compile-time error reporting (CM4)
  - Specialized code generation per call site (CM5)
  - Comptime folding when arguments are known (CM6)

- **Added "Built-in Functions" section to structure/modules.md** — Defines rules for compiler-known functions:
  - Lists always-available built-ins: `println`, `print`, `format`, `panic`, `todo`, `unreachable`, `spawn`, `transmute`
  - Clarifies they are not regular functions and cannot be shadowed
  - Explicitly states variable arguments are compiler-supported, not via a general variadic mechanism

- **Updated TODO.md** — Marked "Macros / `format!`" as complete with reference to the new documentation

## Notable Details

The design choice trades off some ergonomics (e.g., `Vec.from([1, 2, 3])` instead of `vec![1, 2, 3]`) for transparency and tooling compatibility. Compiler-known functions are limited to essential built-ins, avoiding the complexity and analysis burden of a full macro system.

https://claude.ai/code/session_015C12k1sjFt9pXjBvS4CuaE