### PR TITLE
Add unsafe operation tracking and expression-form unsafe syntax

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -59,7 +59,8 @@
 - [ ] `pool.remove_with(h, |val| { ... })` — cascading @resource cleanup helper
 - [ ] Style guideline: max 3 context clauses per function
 - [ ] **Trait satisfaction on methods** — Instead of `extend Type with Trait { }`, annotate individual methods: `func compare(self, other: T) -> Ordering for Comparable`. One `extend` block per type, methods self-declare which `explicit trait` they satisfy. Needs design for: default method overrides, multiple trait satisfaction per method, interaction with structural matching
-- [ ] **Granular unsafe operations** — Replace blanket `unsafe { }` blocks with per-operation unsafe markers (functions or tags). Each unsafe operation individually marked instead of a block that enables everything. Needs design for: syntax (functions like `raw_deref(ptr)` vs tags like `@unsafe deref`), interaction with existing `unsafe func` declarations, FFI calling convention
+- [x] **Granular unsafe operations** — Decided: keep blanket unsafe blocks. Compiler tracks operation categories internally (UnsafeCategory enum). Added oversized-block lint + expression-form `unsafe <expr>`. See mem.unsafe appendix for rationale
+- [ ] **Unsafe report command** — CLI command to report all unsafe operations by category, using UnsafeCategory data the checker already collects. Name TBD (not `rask audit` — that's dependency auditing)
 
 ## Post-v1.0
 

--- a/compiler/crates/rask-lint/src/idiom.rs
+++ b/compiler/crates/rask-lint/src/idiom.rs
@@ -444,3 +444,108 @@ fn extract_ensure_receiver(body: &[Stmt]) -> Option<String> {
         _ => None,
     }
 }
+
+/// idiom/large-unsafe-block: Flag unsafe blocks with too many statements.
+/// Big unsafe blocks defeat the purpose — keep them minimal so each unsafe
+/// operation is visible and auditable (mem.unsafe/U4).
+pub fn check_large_unsafe_blocks(decls: &[Decl], source: &str) -> Vec<LintDiagnostic> {
+    const MAX_STMTS: usize = 10;
+    let mut diags = Vec::new();
+
+    for decl in decls {
+        match &decl.kind {
+            DeclKind::Fn(f) => walk_for_large_unsafe(&f.body, source, MAX_STMTS, &mut diags),
+            DeclKind::Struct(s) => {
+                for m in &s.methods {
+                    walk_for_large_unsafe(&m.body, source, MAX_STMTS, &mut diags);
+                }
+            }
+            DeclKind::Enum(e) => {
+                for m in &e.methods {
+                    walk_for_large_unsafe(&m.body, source, MAX_STMTS, &mut diags);
+                }
+            }
+            DeclKind::Impl(imp) => {
+                for m in &imp.methods {
+                    walk_for_large_unsafe(&m.body, source, MAX_STMTS, &mut diags);
+                }
+            }
+            DeclKind::Test(t) => walk_for_large_unsafe(&t.body, source, MAX_STMTS, &mut diags),
+            _ => {}
+        }
+    }
+
+    diags
+}
+
+fn walk_for_large_unsafe(stmts: &[Stmt], source: &str, max: usize, diags: &mut Vec<LintDiagnostic>) {
+    for stmt in stmts {
+        match &stmt.kind {
+            StmtKind::Expr(e) => check_expr_for_large_unsafe(e, source, max, diags),
+            StmtKind::Let { init, .. } | StmtKind::Const { init, .. } => {
+                check_expr_for_large_unsafe(init, source, max, diags);
+            }
+            StmtKind::While { cond, body } => {
+                check_expr_for_large_unsafe(cond, source, max, diags);
+                walk_for_large_unsafe(body, source, max, diags);
+            }
+            StmtKind::For { iter, body, .. } => {
+                check_expr_for_large_unsafe(iter, source, max, diags);
+                walk_for_large_unsafe(body, source, max, diags);
+            }
+            StmtKind::Loop { body, .. } => walk_for_large_unsafe(body, source, max, diags),
+            _ => {}
+        }
+    }
+}
+
+fn check_expr_for_large_unsafe(expr: &Expr, source: &str, max: usize, diags: &mut Vec<LintDiagnostic>) {
+    match &expr.kind {
+        ExprKind::Unsafe { body } => {
+            if body.len() > max {
+                let (line, col) = util::line_col(source, expr.span.start);
+                let source_line = util::get_source_line(source, line);
+                diags.push(LintDiagnostic {
+                    rule: "idiom/large-unsafe-block".to_string(),
+                    severity: Severity::Warning,
+                    message: format!(
+                        "unsafe block has {} statements — keep unsafe blocks minimal (mem.unsafe/U4)",
+                        body.len()
+                    ),
+                    location: LintLocation {
+                        line,
+                        column: col,
+                        source_line,
+                    },
+                    fix: "extract operations into small safe wrapper functions".to_string(),
+                });
+            }
+            // Still recurse into the body for nested unsafe blocks
+            walk_for_large_unsafe(body, source, max, diags);
+        }
+        ExprKind::Block(stmts)
+        | ExprKind::UsingBlock { body: stmts, .. }
+        | ExprKind::Spawn { body: stmts }
+        | ExprKind::Comptime { body: stmts }
+        | ExprKind::BlockCall { body: stmts, .. } => {
+            walk_for_large_unsafe(stmts, source, max, diags);
+        }
+        ExprKind::If { cond, then_branch, else_branch } => {
+            check_expr_for_large_unsafe(cond, source, max, diags);
+            check_expr_for_large_unsafe(then_branch, source, max, diags);
+            if let Some(e) = else_branch {
+                check_expr_for_large_unsafe(e, source, max, diags);
+            }
+        }
+        ExprKind::Match { scrutinee, arms } => {
+            check_expr_for_large_unsafe(scrutinee, source, max, diags);
+            for arm in arms {
+                check_expr_for_large_unsafe(&arm.body, source, max, diags);
+            }
+        }
+        ExprKind::Closure { body, .. } => {
+            check_expr_for_large_unsafe(body, source, max, diags);
+        }
+        _ => {}
+    }
+}

--- a/compiler/crates/rask-lint/src/rules.rs
+++ b/compiler/crates/rask-lint/src/rules.rs
@@ -28,6 +28,7 @@ fn all_rules() -> Vec<Rule> {
         Rule { id: "idiom/unwrap-production", check: idiom::check_unwrap_production },
         Rule { id: "idiom/missing-ensure", check: idiom::check_missing_ensure },
         Rule { id: "idiom/ensure-ordering", check: idiom::check_ensure_ordering },
+        Rule { id: "idiom/large-unsafe-block", check: idiom::check_large_unsafe_blocks },
         // Style
         Rule { id: "style/snake-case-func", check: style::check_snake_case_func },
         Rule { id: "style/pascal-case-type", check: style::check_pascal_case_type },

--- a/compiler/crates/rask-parser/src/parser.rs
+++ b/compiler/crates/rask-parser/src/parser.rs
@@ -2675,8 +2675,13 @@ impl Parser {
             TokenKind::Unsafe => {
                 self.advance();
                 self.skip_newlines();
-                let body = self.parse_block_body()?;
-                let end = self.tokens[self.pos - 1].span.end;
+                let body = if self.check(&TokenKind::LBrace) {
+                    self.parse_block_body()?
+                } else {
+                    let expr = self.parse_expr()?;
+                    vec![Stmt { id: self.next_id(), kind: StmtKind::Expr(expr.clone()), span: expr.span }]
+                };
+                let end = body.last().map(|s| s.span.end).unwrap_or(start);
                 Ok(Expr { id: self.next_id(), kind: ExprKind::Unsafe { body }, span: Span::new(start, end) })
             }
 

--- a/compiler/crates/rask-types/src/checker/check_expr.rs
+++ b/compiler/crates/rask-types/src/checker/check_expr.rs
@@ -99,6 +99,7 @@ impl TypeChecker {
                 let operand_ty = self.infer_expr(operand);
                 match op {
                     rask_ast::expr::UnaryOp::Deref => {
+                        self.unsafe_ops.push((expr.span, super::UnsafeCategory::PointerDeref));
                         if !self.in_unsafe {
                             self.errors.push(TypeError::UnsafeRequired {
                                 operation: "pointer dereference".to_string(),
@@ -871,6 +872,7 @@ impl TypeChecker {
         if let ExprKind::Ident(name) = &func.kind {
             // transmute(val) — reinterpret bits, requires unsafe
             if name == "transmute" {
+                self.unsafe_ops.push((span, super::UnsafeCategory::Transmute));
                 if !self.in_unsafe {
                     self.errors.push(TypeError::UnsafeRequired {
                         operation: "transmute".to_string(),
@@ -906,20 +908,23 @@ impl TypeChecker {
         if let ExprKind::Ident(_) = &func.kind {
             if let Some(&sym_id) = self.resolved.resolutions.get(&func.id) {
                 if let Some(sym) = self.resolved.symbols.get(sym_id) {
-                    let requires_unsafe = match &sym.kind {
-                        SymbolKind::ExternFunction { .. } => true,
-                        SymbolKind::Function { is_unsafe: true, .. } => true,
-                        _ => false,
+                    let unsafe_category = match &sym.kind {
+                        SymbolKind::ExternFunction { .. } => Some(super::UnsafeCategory::ExternCall),
+                        SymbolKind::Function { is_unsafe: true, .. } => Some(super::UnsafeCategory::UnsafeFuncCall),
+                        _ => None,
                     };
-                    if requires_unsafe && !self.in_unsafe {
-                        let operation = match &sym.kind {
-                            SymbolKind::ExternFunction { .. } => "extern function call",
-                            _ => "unsafe function call",
-                        };
-                        self.errors.push(TypeError::UnsafeRequired {
-                            operation: operation.to_string(),
-                            span,
-                        });
+                    if let Some(category) = unsafe_category {
+                        self.unsafe_ops.push((span, category));
+                        if !self.in_unsafe {
+                            let operation = match category {
+                                super::UnsafeCategory::ExternCall => "extern function call",
+                                _ => "unsafe function call",
+                            };
+                            self.errors.push(TypeError::UnsafeRequired {
+                                operation: operation.to_string(),
+                                span,
+                            });
+                        }
                     }
                 }
             }
@@ -1202,11 +1207,18 @@ impl TypeChecker {
         span: Span,
     ) -> Option<Type> {
         let requires_unsafe = method != "is_null";
-        if requires_unsafe && !self.in_unsafe {
-            self.errors.push(TypeError::UnsafeRequired {
-                operation: format!("pointer method .{}()", method),
-                span,
-            });
+        if requires_unsafe {
+            let category = match method {
+                "add" | "sub" | "offset" => super::UnsafeCategory::PointerArithmetic,
+                _ => super::UnsafeCategory::PointerMethod,
+            };
+            self.unsafe_ops.push((span, category));
+            if !self.in_unsafe {
+                self.errors.push(TypeError::UnsafeRequired {
+                    operation: format!("pointer method .{}()", method),
+                    span,
+                });
+            }
         }
 
         match method {
@@ -1328,6 +1340,7 @@ impl TypeChecker {
         if !self.in_assign_target {
             if let Type::Named(type_id) = &obj_ty {
                 if let Some(TypeDef::Union { .. }) = self.types.get(*type_id) {
+                    self.unsafe_ops.push((span, super::UnsafeCategory::UnionFieldAccess));
                     if !self.in_unsafe {
                         self.errors.push(TypeError::UnsafeRequired {
                             operation: "union field access".to_string(),

--- a/compiler/crates/rask-types/src/checker/check_stmt.rs
+++ b/compiler/crates/rask-types/src/checker/check_stmt.rs
@@ -68,11 +68,14 @@ impl TypeChecker {
             }
             StmtKind::Assign { target, value } => {
                 // Deref write (*ptr = value) requires unsafe
-                if matches!(&target.kind, rask_ast::expr::ExprKind::Unary { op: rask_ast::expr::UnaryOp::Deref, .. }) && !self.in_unsafe {
-                    self.errors.push(TypeError::UnsafeRequired {
-                        operation: "pointer dereference write".to_string(),
-                        span: stmt.span,
-                    });
+                if matches!(&target.kind, rask_ast::expr::ExprKind::Unary { op: rask_ast::expr::UnaryOp::Deref, .. }) {
+                    self.unsafe_ops.push((stmt.span, super::UnsafeCategory::PointerDerefWrite));
+                    if !self.in_unsafe {
+                        self.errors.push(TypeError::UnsafeRequired {
+                            operation: "pointer dereference write".to_string(),
+                            span: stmt.span,
+                        });
+                    }
                 }
                 // Reject mutation of read-only parameters (default params are read-only)
                 if let Some(root) = Self::root_ident_name(target) {

--- a/compiler/crates/rask-types/src/checker/mod.rs
+++ b/compiler/crates/rask-types/src/checker/mod.rs
@@ -33,6 +33,19 @@ pub use parse_type::parse_type_string;
 
 use borrow::{ActiveBorrow, PersistentBorrow};
 
+/// Classification of unsafe operations for auditing and tooling.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum UnsafeCategory {
+    PointerDeref,
+    PointerDerefWrite,
+    PointerArithmetic,
+    PointerMethod,
+    ExternCall,
+    UnsafeFuncCall,
+    Transmute,
+    UnionFieldAccess,
+}
+
 pub struct TypeChecker {
     /// Symbol table from resolution.
     pub(super) resolved: ResolvedProgram,
@@ -66,6 +79,8 @@ pub struct TypeChecker {
     pub(super) fn_type_params: HashMap<SymbolId, Vec<String>>,
     /// Whether we're inside an `unsafe {}` block (for validating pointer ops and extern calls).
     pub(super) in_unsafe: bool,
+    /// Collected unsafe operations with their locations (for tooling/auditing).
+    pub(super) unsafe_ops: Vec<(rask_ast::Span, UnsafeCategory)>,
     /// Whether we're inferring an assignment target (union field writes are safe per UN3).
     pub(super) in_assign_target: bool,
     /// GC1/GC2: Pre-created type vars for functions with inferred params/return.
@@ -91,6 +106,7 @@ impl TypeChecker {
             pending_call_type_args: Vec::new(),
             fn_type_params: HashMap::new(),
             in_unsafe: false,
+            unsafe_ops: Vec::new(),
             inferred_fn_types: HashMap::new(),
             in_assign_target: false,
         }

--- a/examples/19_unsafe.rk
+++ b/examples/19_unsafe.rk
@@ -11,12 +11,10 @@ extern "C" func memcpy(dest: *u8, src: *u8, n: i32)
 extern "C" func malloc(size: i32) -> *u8
 extern "C" func free(ptr: *u8)
 
-// Wrapper for C strlen
+// Wrapper for C strlen — expression form for single operations
 func c_string_length(s: string) -> i32 {
-    unsafe {
-        const ptr = s.as_ptr()
-        return strlen(ptr)
-    }
+    const ptr = s.as_ptr()
+    return unsafe strlen(ptr)
 }
 
 // Safe wrapper for raw pointer operations
@@ -111,6 +109,15 @@ func main() {
         print(second)
         print("\n")
     }
+
+    // Expression form — no braces needed for single operations
+    print("\n=== Expression-Form Unsafe ===\n")
+    const x = 42
+    let ptr: *i32 = &x as *i32
+    const value = unsafe *ptr
+    print("Read via expression-form unsafe: ")
+    print(value)
+    print("\n")
 
     print("\n=== When to Use Unsafe ===\n")
     print("1. FFI - calling C/C++ libraries\n")

--- a/specs/memory/unsafe.md
+++ b/specs/memory/unsafe.md
@@ -14,7 +14,7 @@ Explicit `unsafe` blocks quarantine operations that bypass safety checks. Debug 
 |------|-------------|
 | **U1: Explicit scope** | Unsafe operations are ONLY valid inside `unsafe {}` blocks |
 | **U2: Local scope** | Unsafe does not propagate; calling a safe function from unsafe is safe |
-| **U3: Expression result** | Unsafe block can return a value: `const x = unsafe { ptr.read() }` |
+| **U3: Expression result** | Unsafe block/expression can return a value: `const x = unsafe ptr.read()` |
 | **U4: Minimal scope** | Unsafe blocks SHOULD be as small as possible |
 
 <!-- test: skip -->
@@ -361,9 +361,10 @@ ERROR [mem.unsafe/U1]: unsafe operation outside unsafe block
 
 WHY: Unsafe operations must be explicitly scoped so safety boundaries are visible.
 
-FIX: Wrap in an unsafe block:
+FIX: Wrap in unsafe:
 
-  const x = unsafe { *ptr }
+  const x = unsafe *ptr
+  const x = unsafe { *ptr }  // block form also works
 ```
 
 **Calling unsafe function without block [U1]:**
@@ -374,7 +375,8 @@ ERROR [mem.unsafe/U1]: call to unsafe function outside unsafe block
    |  ^^^^^^^^^^^^^^^^^^^^^^^ requires unsafe
 
 FIX:
-  unsafe { dangerous_operation(ptr) }
+  unsafe dangerous_operation(ptr)
+  unsafe { dangerous_operation(ptr) }  // block form also works
 ```
 
 **Missing clobber declaration [ASM2]:**
@@ -566,6 +568,42 @@ IDE SHOULD highlight unsafe blocks distinctly. Lints SHOULD warn about large uns
 | Unsafe highlighting | `unsafe {}` blocks shown with distinct background |
 | Hover on `unsafe` | Shows which operations inside require unsafe |
 | Large block warning | Lint when unsafe block exceeds ~20 lines |
+
+### Expression Form
+
+`unsafe` supports both block and expression forms. The expression form is shorthand for a single-operation unsafe block:
+
+<!-- test: parse -->
+```rask
+extern "C" func get_ptr() -> *i32
+
+func example() {
+    const ptr = unsafe get_ptr()
+
+    // Block form
+    const a = unsafe { *ptr }
+
+    // Expression form (equivalent)
+    const b = unsafe *ptr
+}
+```
+
+The expression form encourages minimal unsafe scope — one operation, no ceremony. For multiple operations, use the block form.
+
+### Design Decision: Granular Unsafe
+
+I considered replacing blanket `unsafe {}` blocks with per-operation markers — syntax like `@unsafe deref` or specialized functions like `raw_deref(ptr)` that would tag each operation individually.
+
+I decided against it. Per-operation syntax doesn't catch real bugs. The bugs in unsafe code are logic errors *within* correctly-identified operations (dangling pointer, wrong offset), not accidentally using the wrong *category* of operation. Adding per-operation markers increases ceremony without safety benefit — exactly the kind of abstraction tax the language tries to eliminate.
+
+The compiler already classifies every unsafe operation internally (`UnsafeCategory` enum: pointer deref, deref write, arithmetic, extern call, unsafe func call, transmute, union field access). This data enables tooling — a future CLI command can report all unsafe operations by category across a codebase, providing auditability without syntax cost.
+
+What I added instead:
+- **Expression-form `unsafe <expr>`** — minimal syntax for single operations
+- **`idiom/large-unsafe-block` lint** — warns when an unsafe block exceeds 10 statements, enforcing U4 (minimal scope)
+- **Operation classification infrastructure** — compiler tracks categories for future tooling
+
+This is "information without enforcement" — the data exists for tools that want it, but the language doesn't force developers to annotate what the compiler already knows.
 
 ### See Also
 


### PR DESCRIPTION
## Summary

This PR adds comprehensive unsafe operation tracking to the compiler and introduces expression-form `unsafe` syntax for minimal unsafe scopes. It also implements a new lint to flag excessively large unsafe blocks.

## Key Changes

- **Expression-form unsafe syntax**: Parser now supports `unsafe <expr>` in addition to `unsafe { ... }` blocks, enabling minimal syntax for single unsafe operations
- **Unsafe operation classification**: Compiler now tracks all unsafe operations with categorization (`UnsafeCategory` enum) including pointer dereference, arithmetic, extern calls, transmute, and union field access
- **Large unsafe block lint**: New `idiom/large-unsafe-block` rule warns when unsafe blocks exceed 10 statements, enforcing the U4 principle (minimal scope)
- **Comprehensive operation tracking**: All unsafe operations (deref, deref write, pointer arithmetic, pointer methods, extern calls, unsafe function calls, transmute, union field access) are now recorded with their locations for future tooling and auditing

## Implementation Details

- **Parser changes** (`rask-parser`): Modified unsafe expression parsing to accept either block form `unsafe { ... }` or expression form `unsafe <expr>`
- **Type checker changes** (`rask-types`): Added `unsafe_ops` vector to track all unsafe operations with their spans and categories; updated all unsafe operation checks to record operations before validation
- **Lint implementation** (`rask-lint`): New `check_large_unsafe_blocks()` function recursively walks AST to find unsafe blocks exceeding the statement threshold
- **Documentation updates**: Clarified U3 principle to reflect expression-form support; added design rationale explaining why per-operation markers were rejected in favor of compiler-tracked categories for tooling

The changes maintain backward compatibility — existing `unsafe { ... }` blocks continue to work unchanged, while the new expression form provides a more ergonomic alternative for single operations.

https://claude.ai/code/session_01B2FWuDcz1BMcy9p3n8q3WD