### PR TITLE
Add tuple field access syntax (expr.0, expr.1, etc.)

### DIFF
--- a/compiler/crates/rask-interp/src/interp/assign.rs
+++ b/compiler/crates/rask-interp/src/interp/assign.rs
@@ -66,6 +66,15 @@ impl Interpreter {
                         fields.insert(field.clone(), value);
                         return Ok(());
                     }
+                    Value::Vec(v) if field.parse::<usize>().is_ok() => {
+                        let idx = field.parse::<usize>().unwrap();
+                        let mut vec = v.lock().unwrap();
+                        if idx < vec.len() {
+                            vec[idx] = value;
+                            return Ok(());
+                        }
+                        return Err(RuntimeError::IndexOutOfBounds { index: idx as i64, len: vec.len() });
+                    }
                     _ => return Err(RuntimeError::TypeError(format!(
                         "cannot assign field '{}' on {}", field, current.type_name()
                     ))),

--- a/compiler/crates/rask-interp/src/interp/eval_expr.rs
+++ b/compiler/crates/rask-interp/src/interp/eval_expr.rs
@@ -471,6 +471,12 @@ impl Interpreter {
                     Value::Struct { fields, .. } => {
                         Ok(fields.get(field).cloned().unwrap_or(Value::Unit))
                     }
+                    // Tuple field access: tuple.0, tuple.1, ...
+                    Value::Vec(v) if field.parse::<usize>().is_ok() => {
+                        let idx = field.parse::<usize>().unwrap();
+                        let vec = v.lock().unwrap();
+                        Ok(vec.get(idx).cloned().unwrap_or(Value::Unit))
+                    }
                     Value::Module(ModuleKind::Time) => {
                         match field.as_str() {
                             "Instant" => Ok(Value::Type("Instant".to_string())),

--- a/compiler/crates/rask-mir/src/lower/expr.rs
+++ b/compiler/crates/rask-mir/src/lower/expr.rs
@@ -52,6 +52,34 @@ impl<'a> MirLowerer<'a> {
         }
     }
 
+    /// Resolve a numeric field name on a tuple type.
+    /// Returns (field_index, element_type, byte_offset, field_size).
+    pub(super) fn resolve_tuple_field(
+        ty: &MirType,
+        field: &str,
+    ) -> Option<(u32, MirType, Option<u32>, Option<u32>)> {
+        let fields = match ty {
+            MirType::Tuple(fields) => fields,
+            _ => return None,
+        };
+        let idx: usize = field.parse().ok()?;
+        if idx >= fields.len() {
+            return None;
+        }
+        let elem_ty = fields[idx].clone();
+        let mut offset = 0u32;
+        for (i, f) in fields.iter().enumerate() {
+            let align = f.align();
+            offset = (offset + align - 1) & !(align - 1);
+            if i == idx {
+                break;
+            }
+            offset += f.size();
+        }
+        let size = elem_ty.size();
+        Some((idx as u32, elem_ty, Some(offset), Some(size)))
+    }
+
     pub(super) fn lower_expr(&mut self, expr: &Expr) -> Result<TypedOperand, LoweringError> {
         match &expr.kind {
             // Literals
@@ -1054,6 +1082,8 @@ impl<'a> MirLowerer<'a> {
                     } else {
                         (0, MirType::I64, None, None)
                     }
+                } else if let Some(resolved) = Self::resolve_tuple_field(&obj_ty, field) {
+                    resolved
                 } else {
                     // Object isn't MirType::Struct — try the type checker to
                     // resolve struct info (e.g. pool[h] returns Ptr but the
@@ -1079,6 +1109,21 @@ impl<'a> MirLowerer<'a> {
                                     resolved = true;
                                 }
                             }
+                        } else if let Some(tuple_resolved) = Self::resolve_tuple_field(&obj_mir, field) {
+                            return {
+                                let (ti, trt, tbo, tfs) = tuple_resolved;
+                                let result_local = self.builder.alloc_temp(trt.clone());
+                                self.builder.push_stmt(MirStmt::Assign {
+                                    dst: result_local,
+                                    rvalue: MirRValue::Field {
+                                        base: obj_op,
+                                        field_index: ti,
+                                        byte_offset: tbo,
+                                        field_size: tfs,
+                                    },
+                                });
+                                Ok((MirOperand::Local(result_local), trt))
+                            };
                         }
                     }
 
@@ -1098,6 +1143,14 @@ impl<'a> MirLowerer<'a> {
                                             fs = Some(fl.size);
                                             resolved = true;
                                         }
+                                    }
+                                } else if let Some(MirType::Tuple(_)) = &local_ty {
+                                    if let Some(tuple_resolved) = Self::resolve_tuple_field(&local_ty.unwrap(), field) {
+                                        fi = tuple_resolved.0;
+                                        rt = tuple_resolved.1;
+                                        bo = tuple_resolved.2;
+                                        fs = tuple_resolved.3;
+                                        resolved = true;
                                     }
                                 }
                             }

--- a/compiler/crates/rask-mir/src/lower/stmt.rs
+++ b/compiler/crates/rask-mir/src/lower/stmt.rs
@@ -82,6 +82,8 @@ impl<'a> MirLowerer<'a> {
                                     .map(|f| f.offset)
                                     .unwrap_or(0)
                             } else { 0 }
+                        } else if let Some((_, _, Some(bo), _)) = Self::resolve_tuple_field(&obj_ty, field) {
+                            bo
                         } else { 0 };
                         let base_local = match obj_op {
                             MirOperand::Local(id) => id,

--- a/compiler/crates/rask-parser/src/parser.rs
+++ b/compiler/crates/rask-parser/src/parser.rs
@@ -2989,6 +2989,22 @@ impl Parser {
 
             TokenKind::Dot => {
                 self.advance();
+
+                // Tuple field access: expr.0, expr.1, ...
+                if let TokenKind::Int(n, None) = self.current_kind().clone() {
+                    if n < 0 {
+                        return Err(ParseError::expected(
+                            "a non-negative index",
+                            self.current_kind(),
+                            self.current().span,
+                        ));
+                    }
+                    let field = n.to_string();
+                    self.advance();
+                    let end = self.tokens[self.pos - 1].span.end;
+                    return Ok(Expr { id: self.next_id(), kind: ExprKind::Field { object: Box::new(lhs), field }, span: Span::new(start, end) });
+                }
+
                 let field = self.expect_ident_or_keyword()?;
 
                 let type_args = if self.check(&TokenKind::Lt) && self.looks_like_generic_method_call() {
@@ -3045,7 +3061,19 @@ impl Parser {
             // Optional chaining
             TokenKind::QuestionDot => {
                 self.advance();
-                let field = self.expect_ident_or_keyword()?;
+                let field = if let TokenKind::Int(n, None) = self.current_kind().clone() {
+                    if n < 0 {
+                        return Err(ParseError::expected(
+                            "a non-negative index",
+                            self.current_kind(),
+                            self.current().span,
+                        ));
+                    }
+                    self.advance();
+                    n.to_string()
+                } else {
+                    self.expect_ident_or_keyword()?
+                };
                 let end = self.tokens[self.pos - 1].span.end;
                 Ok(Expr { id: self.next_id(), kind: ExprKind::OptionalField { object: Box::new(lhs), field }, span: Span::new(start, end) })
             }
@@ -3458,6 +3486,27 @@ impl Parser {
                 };
             } else if self.check(&TokenKind::Dot) {
                 self.advance();
+
+                // Tuple field access: expr.0, expr.1, ...
+                if let TokenKind::Int(n, None) = self.current_kind().clone() {
+                    if n < 0 {
+                        return Err(ParseError::expected(
+                            "a non-negative index",
+                            self.current_kind(),
+                            self.current().span,
+                        ));
+                    }
+                    let field = n.to_string();
+                    self.advance();
+                    let end = self.tokens[self.pos - 1].span.end;
+                    expr = Expr {
+                        id: self.next_id(),
+                        kind: ExprKind::Field { object: Box::new(expr), field },
+                        span: Span::new(start, end),
+                    };
+                    continue;
+                }
+
                 let field = self.expect_ident_or_keyword()?;
                 // Method call: .field(args...)
                 if self.check(&TokenKind::LParen) {

--- a/specs/types/tuples.md
+++ b/specs/types/tuples.md
@@ -33,7 +33,14 @@ Single-element tuple with trailing comma (`(i32,)`) — not yet implemented in p
 | **TU5: Positional access** | `.0`, `.1`, `.2`, etc. access tuple elements by position |
 | **TU6: Bounds checked** | Accessing beyond tuple length is a compile error |
 
-Positional access (`.0`, `.1`) — not yet implemented in parser. Destructure instead:
+<!-- test: parse -->
+```rask
+const point = (10, 20)
+const x = point.0
+const y = point.1
+```
+
+Destructuring also works:
 
 <!-- test: parse -->
 ```rask


### PR DESCRIPTION
## Summary
This PR implements tuple field access using positional syntax (`.0`, `.1`, etc.) across the parser, MIR lowering, and interpreter layers. Previously, tuples could only be accessed through destructuring; now they support direct positional field access like `tuple.0`.

## Key Changes

- **Parser (`rask-parser`)**: Added support for parsing numeric field access after `.` and `?.` operators. The parser now recognizes integer literals following dots and converts them to field names, with validation to reject negative indices.

- **MIR Lowering (`rask-mir`)**: 
  - Added `resolve_tuple_field()` helper function that resolves numeric field names on tuple types, computing field index, type, byte offset, and size
  - Integrated tuple field resolution into field access expression lowering for both direct tuple types and local variables containing tuples
  - Updated statement lowering to handle byte offset calculation for tuple field assignments

- **Interpreter (`rask-interp`)**: 
  - Added tuple field access support in expression evaluation by parsing numeric field names as vector indices
  - Added tuple field assignment support in the assignment handler

- **Documentation (`specs/types/tuples.md`)**: Updated specification to show that positional access is now implemented with working examples

## Implementation Details

The `resolve_tuple_field()` function handles the core logic:
- Validates that the field name is a valid non-negative integer index
- Computes proper byte offsets accounting for alignment requirements
- Returns field index, element type, byte offset, and field size for code generation

The implementation correctly handles struct alignment when calculating byte offsets for tuple fields, ensuring proper memory layout for code generation.

https://claude.ai/code/session_01WScyYihnNiNFBXRBnwFoJi