### PR TITLE
Rename trait names for clarity: Clone→Cloneable, Display→Displayable, Ord→Comparable

### DIFF
--- a/specs/SYNTAX.md
+++ b/specs/SYNTAX.md
@@ -363,12 +363,12 @@ extend Option<T> {
 ### Traits
 
 ```rask
-trait Display {
-    func display(self) -> string
+trait Displayable {
+    func to_string(self) -> string
 }
 
-trait Iterator<T> {
-    func next(self) -> Option<T>
+trait Iterator {
+    func next(self) -> Option<Self.Item>
 }
 ```
 
@@ -381,17 +381,17 @@ struct Point {
 }
 
 extend Point {
-    func display(self) -> string {
+    func to_string(self) -> string {
         return "{self.x}, {self.y}"
     }
 }
-// Point satisfies Display automatically
+// Point satisfies Displayable automatically
 ```
 
 **Explicit trait implementation:** Use `extend Type with Trait` when you want to document intent:
 ```rask
-extend Point with Display {
-    func display(self) -> string {
+extend Point with Displayable {
+    func to_string(self) -> string {
         return "({self.x}, {self.y})"
     }
 }
@@ -479,7 +479,7 @@ func transfer(from: Handle<Player>, to: Handle<Player>, item: Handle<Item>)
 
 **Constraints with `where`:**
 ```rask
-func sort(items: Vec<T>) -> Vec<T> where T: Ord {
+func sort(items: Vec<T>) -> Vec<T> where T: Comparable {
     // ...
 }
 
@@ -488,7 +488,7 @@ func process(data: T) -> U where T: Input, U: Output {
 }
 
 // Multiple constraints on same type
-func debug_sort(items: Vec<T>) where T: Ord + Debug {
+func debug_sort(items: Vec<T>) where T: Comparable + Debug {
     // ...
 }
 ```

--- a/specs/compiler/name-mangling.md
+++ b/specs/compiler/name-mangling.md
@@ -176,9 +176,9 @@ func write(h: Handle<T>) using Pool<T>
 → `_R4core_F5write_GHandle[T]:Pool[T]`
 
 ```rask
-func sort(arr: Vec<T>) using Compare<T> using Clone<T>
+func sort(arr: Vec<T>) using Comparable using Cloneable
 ```
-→ `_R4core_F4sort_GVec[T]:Compare[T]:Clone[T]`
+→ `_R4core_F4sort_GVec[T]:Comparable:Cloneable`
 
 **Rule:** Type parameters, then colon-separated context clauses.
 

--- a/specs/control/control-flow.md
+++ b/specs/control/control-flow.md
@@ -551,7 +551,7 @@ const input = loop {
 **Search pattern:**
 <!-- test: skip -->
 ```rask
-func find_first<T: Eq>(items: Vec<T>, target: T) -> Option<usize> {
+func find_first<T: Equal>(items: Vec<T>, target: T) -> Option<usize> {
     let i = 0
     loop {
         if i >= items.len() {
@@ -567,7 +567,7 @@ func find_first<T: Eq>(items: Vec<T>, target: T) -> Option<usize> {
 
 **Labeled break with value:**
 ```rask
-func find_in_matrix<T: Eq>(matrix: Vec<Vec<T>>, target: T) -> Option<(usize, usize)> {
+func find_in_matrix<T: Equal>(matrix: Vec<Vec<T>>, target: T) -> Option<(usize, usize)> {
     search: loop {
         for i in 0..matrix.len() {
             for j in 0..matrix[i].len() {

--- a/specs/memory/owned.md
+++ b/specs/memory/owned.md
@@ -30,7 +30,7 @@ drop(ptr)                         // Consume (deallocate)
 |----------|-------|
 | Size | 8 bytes (pointer) |
 | Copy | No (linear) |
-| Clone | Yes, if T: Clone (explicit `.clone()` required) |
+| Cloneable | Yes, if T: Cloneable (explicit `.clone()` required) |
 | Default | No |
 
 ## Linearity Rules
@@ -163,9 +163,9 @@ func eval(take expr: Owned<Expr>) -> i32 {
 }
 ```
 
-## Clone
+## Cloneable
 
-If `T: Clone`, then `Owned<T>: Clone`. Cloning allocates a new heap value. Clone is explicit — no implicit copying.
+If `T: Cloneable`, then `Owned<T>: Cloneable`. Cloning allocates a new heap value. Clone is explicit — no implicit copying.
 
 <!-- test: skip -->
 ```rask

--- a/specs/memory/value-semantics.md
+++ b/specs/memory/value-semantics.md
@@ -47,7 +47,7 @@ All types are values with single ownership. Small types (≤16 bytes) copy impli
 | Rule | Description |
 |------|-------------|
 | **U1: No implicit copy** | Unique types MUST be explicitly cloned; assignment/passing moves |
-| **U2: Clone still available** | `.clone()` works if all fields implement Clone |
+| **U2: Clone still available** | `.clone()` works if all fields implement Cloneable |
 | **U3: Size independent** | Works for any size, but most useful for small types |
 | **U4: Transitive** | Structs containing unique fields are automatically unique |
 
@@ -117,9 +117,9 @@ func try_duplicate<T>(value: T) -> (T, T) {
 | Trait | Operation | When available | Cost |
 |-------|-----------|----------------|------|
 | `Copy` | Implicit copy on assign/pass | Structural: ≤16 bytes, no `@unique` | Bitwise copy (cheap) |
-| `Clone` | Explicit `.clone()` call | If all fields are Clone | May allocate (visible cost) |
+| `Cloneable` | Explicit `.clone()` call | If all fields are Cloneable | May allocate (visible cost) |
 
-All Copy types are also Clone. Not all Clone types are Copy.
+All Copy types are also Cloneable. Not all Cloneable types are Copy.
 
 **Generic constraint propagation:**
 

--- a/specs/stdlib/README.md
+++ b/specs/stdlib/README.md
@@ -128,11 +128,14 @@ Always available without import:
 | Trait | Description |
 |-------|-------------|
 | `Copy` | Implicitly copyable (≤16 bytes) |
-| `Clone` | Explicitly cloneable |
-| `Display` | Human-readable formatting |
+| `Cloneable` | Explicitly cloneable |
+| `Equal` | Equality (`==`, `!=`) |
+| `Comparable` | Ordering (`<`, `>`, `<=`, `>=`) |
+| `Hashable` | Hash-based collections |
+| `Displayable` | Human-readable formatting |
 | `Debug` | Debug formatting |
-| `Eq`, `Ord` | Equality, ordering |
-| `Hash` | Hashable |
+| `Default` | Default values |
+| `Numeric` | Arithmetic operations |
 | `Iterator` | Iteration protocol |
 
 ---

--- a/specs/stdlib/collections.md
+++ b/specs/stdlib/collections.md
@@ -83,7 +83,7 @@ const users = Map.from([
 | `vec[i]` | `T` | `T: Copy` | Yes (OOB) |
 | `vec[i].field` | inline access (expression-scoped) | None | Yes (OOB) |
 | `vec.get(i)` | `Option<T>` | `T: Copy` | No |
-| `vec.get_clone(i)` | `Option<T>` | `T: Clone` | No |
+| `vec.get_clone(i)` | `Option<T>` | `T: Cloneable` | No |
 | `with vec[i] as v { ... }` | block value (mutable) | None | Yes (OOB) |
 | `vec.insert(i, x)` | `Result<(), InsertError<T>>` | None | Yes (OOB) |
 | `vec.remove(i)` | `T` | None | Yes (OOB) |
@@ -127,7 +127,7 @@ const name = with vec[i] as v { v.name.clone() }
 | `map[k]` | `V` | Panics if missing (V: Copy) |
 | `map[k].field` | inline access (expression-scoped) | Panics if missing |
 | `map.get(k)` | `Option<V>` | Copy out (V: Copy) |
-| `map.get_clone(k)` | `Option<V>` | Clone out (V: Clone) |
+| `map.get_clone(k)` | `Option<V>` | Clone out (V: Cloneable) |
 | `with map[k] as v { ... }` | block value (mutable) | Panics if missing |
 | `map.remove(k)` | `Option<V>` | Remove and return |
 
@@ -200,6 +200,44 @@ scores.sort()
 let users = get_users()
 users.sort_by_key(|u| u.name)
 users.sort_by(|a, b| b.score.compare(a.score))  // descending
+```
+
+## Vec Convenience Methods
+
+| Method | Signature | Trait Required | Notes |
+|--------|-----------|----------------|-------|
+| `vec.contains(item)` | `(T) -> bool` | `T: Equal` | Linear scan |
+| `vec.first()` | `() -> T?` | `T: Copy` | First element or None |
+| `vec.last()` | `() -> T?` | `T: Copy` | Last element or None |
+| `vec.reverse()` | `(mutate self)` | None | In-place reversal |
+| `vec.dedup()` | `(mutate self)` | `T: Equal` | Remove consecutive duplicates |
+
+<!-- test: skip -->
+```rask
+let items = [3, 1, 4, 1, 5]
+items.contains(4)             // true
+items.first()                 // Some(3)
+items.last()                  // Some(5)
+items.reverse()               // [5, 1, 4, 1, 3]
+
+items.sort()                  // [1, 1, 3, 4, 5]
+items.dedup()                 // [1, 3, 4, 5]
+```
+
+## Map Convenience Methods
+
+| Method | Returns | Notes |
+|--------|---------|-------|
+| `map.contains_key(k)` | `bool` | Check key existence without copying value |
+| `map.keys()` | expression-scoped iterator | Iterate over keys |
+| `map.values()` | expression-scoped iterator | Iterate over values |
+
+<!-- test: skip -->
+```rask
+const scores = Map.from([["alice", 10], ["bob", 20]])
+scores.contains_key("alice")      // true
+for name in scores.keys() { println(name) }
+for score in scores.values() { println(format("{}", score)) }
 ```
 
 ## Shrinking

--- a/specs/stdlib/fmt.md
+++ b/specs/stdlib/fmt.md
@@ -1,10 +1,10 @@
 <!-- id: std.fmt -->
 <!-- status: decided -->
-<!-- summary: String formatting via format(), Display/Debug traits, println interpolation -->
+<!-- summary: String formatting via format(), Displayable/Debug traits, Error auto-bridge, println interpolation -->
 
 # Formatting
 
-`format(template, args...)` with `{}`, `{0}`, `{name}`, `{:spec}` placeholders. `Display` and `Debug` traits for type-to-string conversion. `println`/`print` do implicit `{name}` interpolation.
+`format(template, args...)` with `{}`, `{0}`, `{name}`, `{:spec}` placeholders. `Displayable` and `Debug` traits for type-to-string conversion. `println`/`print` do implicit `{name}` interpolation.
 
 ## format() Function
 
@@ -40,24 +40,47 @@ const hex = format("0x{:08X}", 0xDEAD)
 const table = format("{:<10} {:>8}", "Name", "Score")
 ```
 
-## Display Trait
+## Displayable Trait
 
 | Rule | Description |
 |------|-------------|
-| **D1: Trait** | `trait Display { func to_string(self) -> string }` |
-| **D2: Primitives** | All primitive types implement `Display` by default |
-| **D3: Structs opt-in** | Structs do NOT auto-implement `Display` — must add via `extend Type with Display` |
-| **D4: Required for {}** | `format("{}", x)` calls `to_string()`. Compile error if `Display` not implemented |
+| **D1: Trait** | `trait Displayable { func to_string(self) -> string }` |
+| **D2: Primitives** | All primitive types implement `Displayable` by default |
+| **D3: Structs opt-in** | Structs do NOT auto-implement `Displayable` — must add via `extend Type with Displayable` |
+| **D4: Required for {}** | `format("{}", x)` calls `to_string()`. Compile error if `Displayable` not implemented |
+| **D5: Error bridge** | Types satisfying `Error` (have `message(self) -> string`) auto-satisfy `Displayable` — `to_string()` calls `message()`. No boilerplate needed for error types in `format("{}", err)` |
 
 <!-- test: parse -->
 ```rask
 struct Point { x: f64, y: f64 }
 
-extend Point with Display {
+extend Point with Displayable {
     func to_string(self) -> string {
         return format("({}, {})", self.x, self.y)
     }
 }
+```
+
+**Error types are automatically Displayable (D5):**
+
+<!-- test: parse -->
+```rask
+enum AppError {
+    NotFound(path: string),
+    Timeout,
+}
+
+extend AppError {
+    func message(self) -> string {
+        match self {
+            NotFound(p) => format("not found: {}", p),
+            Timeout => "timed out",
+        }
+    }
+}
+
+// No extend with Displayable needed — Error types get it for free
+// format("{}", AppError.Timeout) → "timed out"
 ```
 
 ## Debug Trait
@@ -97,16 +120,23 @@ println("Position: {point.x}, {point.y}")
 ## Error Messages
 
 ```
-ERROR [std.fmt/D4]: type does not implement Display
+ERROR [std.fmt/D4]: type does not implement Displayable
    |
 5  |  println(format("{}", my_struct))
-   |                       ^^^^^^^^^ `MyStruct` does not implement Display
+   |                       ^^^^^^^^^ `MyStruct` does not implement Displayable
 
-WHY: {} calls to_string(), which requires the Display trait.
+WHY: {} calls to_string(), which requires the Displayable trait.
 
-FIX: Add Display implementation:
-  extend MyStruct with Display {
+FIX 1: Add Displayable implementation:
+
+  extend MyStruct with Displayable {
       func to_string(self) -> string { ... }
+  }
+
+FIX 2: If this is an error type, add message() instead (auto-bridges to Displayable):
+
+  extend MyStruct {
+      func message(self) -> string { ... }
   }
 ```
 
@@ -138,7 +168,8 @@ FIX: Use all auto ({}, {}) or all explicit ({0}, {1}).
 | Case | Rule | Handling |
 |------|------|----------|
 | Missing arg for `{2}` | F2 | Compile-time error (when possible) or runtime panic |
-| Type without Display in `{}` | D4 | Compile-time error |
+| Type without Displayable in `{}` | D4 | Compile-time error |
+| Error type in `{}` | D5 | Auto-bridges — calls `message()` |
 | `{{` in template | F4 | Literal `{` |
 | Empty template | F1 | Returns empty string |
 | `format("{:?}", x)` on auto-derived type | G2 | Shows struct fields / enum variants |
@@ -149,7 +180,7 @@ FIX: Use all auto ({}, {}) or all explicit ({0}, {1}).
 |------|-------------|
 | **CM1: Compiler-known** | `format()` is a compiler-known function, not a regular function. It accepts variable arguments through compiler support (`struct.modules/BF4`), not through a general variadic mechanism |
 | **CM2: Template parsing** | The compiler parses the template string at compile time, extracting placeholder positions, names, and format specifiers |
-| **CM3: Per-arg type check** | Each argument is type-checked against its placeholder: `{}` requires `Display`, `{:?}` requires `Debug`, `{:x}` requires integer type |
+| **CM3: Per-arg type check** | Each argument is type-checked against its placeholder: `{}` requires `Displayable`, `{:?}` requires `Debug`, `{:x}` requires integer type |
 | **CM4: Compile-time errors** | Missing arguments, type mismatches, and malformed specifiers are compile-time errors. No runtime formatting failures for static templates |
 | **CM5: Codegen** | The compiler generates specialized string-building code per call site. No runtime template parsing for static templates |
 | **CM6: Comptime folding** | When all arguments are comptime-known, the result is a static string |
@@ -162,7 +193,9 @@ FIX: Use all auto ({}, {}) or all explicit ({0}, {1}).
 
 ### Rationale
 
-**D3 (structs opt-in):** Auto-deriving Display would produce output that looks intentional but isn't. Debug auto-derives because it's for developers. Display is for users, so you write it.
+**D3 (structs opt-in):** Auto-deriving Displayable would produce output that looks intentional but isn't. Debug auto-derives because it's for developers. Displayable is for users, so you write it.
+
+**D5 (Error bridge):** Every error type already has `message()` — requiring a separate `to_string()` that just calls `message()` is pure boilerplate. The compiler auto-bridges: if a type has `message(self) -> string`, it satisfies `Displayable` with `to_string()` delegating to `message()`. If you want different Displayable output than the error message, override with an explicit `extend Type with Displayable`.
 
 **I3 (no expressions):** Expressions in string interpolation create hidden complexity. `format()` makes the formatting explicit. Keeps println simple.
 
@@ -176,13 +209,13 @@ println(format("{:<20} {:>10} {:>10}", "Item", "Qty", "Price"))
 println(format("{:<20} {:>10} {:>10.2}", "Widget", 5, 9.99))
 ```
 
-**Custom Display with hex:**
+**Custom Displayable with hex:**
 
 <!-- test: parse -->
 ```rask
 struct Color { r: u8, g: u8, b: u8 }
 
-extend Color with Display {
+extend Color with Displayable {
     func to_string(self) -> string {
         return format("#{:02X}{:02X}{:02X}", self.r, self.g, self.b)
     }
@@ -209,4 +242,5 @@ const report = b.build()
 ### See Also
 
 - `std.strings` — `format()` returns a `string`, uses `string_builder` internally
-- `type.traits` — Display and Debug are standard traits
+- `type.traits` — Displayable and Debug are standard traits
+- `type.errors` — Error types auto-bridge to Displayable (D5)

--- a/specs/stdlib/math.md
+++ b/specs/stdlib/math.md
@@ -44,6 +44,30 @@ Dedicated `math` module for functions that don't attach to a single value (trig,
 | **M1: hypot** | `math.hypot(x, y)` computes sqrt(x^2 + y^2) without overflow |
 | **M2: clamp** | `math.clamp(x, lo, hi)` clamps to [lo, hi]; generic over ordered numeric types |
 
+## Generic Comparison Functions (Prelude)
+
+These are always available — no import needed. They work on any `Comparable` type, not just numbers.
+
+| Rule | Description |
+|------|-------------|
+| **G1: min** | `min(a, b)` returns the smaller of two values. `T: Comparable` |
+| **G2: max** | `max(a, b)` returns the larger of two values. `T: Comparable` |
+| **G3: clamp** | `clamp(value, lo, hi)` restricts value to [lo, hi]. `T: Comparable` |
+
+<!-- test: skip -->
+```rask
+// Work on any Comparable type — prelude, no import needed
+const smaller = min(a, b)
+const larger = max(a, b)
+const bounded = clamp(score, 0, 100)
+
+// Also work on strings (lexicographic), custom types, etc.
+const first_name = min(name_a, name_b)
+const newest = max(version_a, version_b)
+```
+
+`math.clamp` remains for numeric-specific use. The prelude `clamp` is generic over all Comparable types.
+
 ## Conversion and Classification
 
 | Rule | Description |

--- a/specs/stdlib/reflect.md
+++ b/specs/stdlib/reflect.md
@@ -144,7 +144,7 @@ FIX: Wrap in comptime block:
 ```
 ERROR [std.reflect/R2]: cannot discover types not in scope
    |
-3  |  const impls = reflect.implementors<Display>()
+3  |  const impls = reflect.implementors<Displayable>()
    |                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ whole-program query
 
 WHY: Reflection operates on imported types only. Type discovery requires whole-program analysis.

--- a/specs/stdlib/strings.md
+++ b/specs/stdlib/strings.md
@@ -146,6 +146,19 @@ Iterators borrow for expression scope only. Cannot be stored.
 
 No `+` operator. Allocation must be visible via method name or interpolation.
 
+## Join
+
+| Operation | Return | Notes |
+|-----------|--------|-------|
+| `strings.join(sep)` | `string` | Join a `Vec<string>` with separator, allocates |
+
+<!-- test: skip -->
+```rask
+const names = ["Alice", "Bob", "Charlie"]
+const result = names.join(", ")    // "Alice, Bob, Charlie"
+const csv = headers.join(",")      // CSV header row
+```
+
 ## In-Place Mutation
 
 | Operation | Signature | Notes |
@@ -429,7 +442,7 @@ for (i, c) in text.char_indices() {
 
 ### Integration
 
-- `string` implements `Clone`, `Display`, `Hash`, `Ord` traits
+- `string` implements `Cloneable`, `Displayable`, `Hashable`, `Comparable` traits
 - All types (`string`, `string_view`, `string_builder`, `StringPool`, `StringSlice`) are in core prelude
 - String builders can contain linear resources; `build()` consumes builder to preserve linearity
 - String literals and interpolation at comptime produce static strings

--- a/specs/types/enums.md
+++ b/specs/types/enums.md
@@ -87,7 +87,7 @@ match event {
 | **E4: Copy eligibility** | Enum is Copy if total size ≤16 bytes AND all variants are Copy |
 | **E5: Move semantics** | Non-Copy enums move on assignment; source invalidated |
 
-Clone derived automatically if all variants implement Clone.
+Cloneable derived automatically if all variants implement Cloneable.
 
 **Copy vs Move in patterns:**
 

--- a/specs/types/error-types.md
+++ b/specs/types/error-types.md
@@ -13,6 +13,7 @@ Errors are values. Any type with `message()` can be an error. Composition uses u
 | Rule | Description |
 |------|-------------|
 | **ER1: Structural matching** | Any type with `func message(self) -> string` satisfies the Error trait |
+| **ER1a: Auto-Displayable** | Error types auto-satisfy `Displayable` — `to_string()` calls `message()`. See `std.fmt/D5` |
 
 <!-- test: parse -->
 ```rask
@@ -20,6 +21,8 @@ trait Error {
     func message(self) -> string
 }
 ```
+
+Error types work directly in `format("{}", err)` and string interpolation without implementing `Displayable` separately.
 
 ## Result Type
 

--- a/specs/types/generics.md
+++ b/specs/types/generics.md
@@ -1,6 +1,6 @@
 <!-- id: type.generics -->
 <!-- status: decided -->
-<!-- summary: Trait matching by shape, operator-to-method expansion, verified clone, code specialization per type -->
+<!-- summary: Trait matching by shape, operator-to-method expansion, verified clone/equal/comparable, code specialization per type -->
 <!-- depends: types/structs.md, types/enums.md, types/traits.md -->
 <!-- implemented-by: compiler/crates/rask-types/ -->
 
@@ -30,12 +30,12 @@ Traits match by shape — if your type has the right methods, it satisfies the t
 
 | Trait Form | Meaning |
 |------------|---------|
-| `trait Comparable<T>` | Structural matching allowed |
-| `explicit trait Serializable<T>` | Requires explicit `extend` (for library stability) |
-| `trait HashKey<T>: Hashable<T>` | Composition (requires all methods from Hashable plus HashKey's own) |
+| `trait Comparable` | Structural matching allowed |
+| `explicit trait Serializable` | Requires explicit `extend` (for library stability) |
+| `trait Hashable: Equal` | Composition (requires all methods from Equal plus Hashable's own) |
 
 ```rask
-trait Name<T> {
+trait Name {
     method_name(self, params...) -> ReturnType
     another_method(self) -> OtherType
 
@@ -104,37 +104,37 @@ The compiler expands operators into method calls before type checking (G4), then
 | `a == b` | `a.eq(b)` | `eq(self, other: T) -> bool` |
 | `a < b` | `a.compare(b) == Less` | `compare(self, other: T) -> Ordering` |
 
-## Compiler-Verified Clone
+## Compiler-Verified Cloneable
 
-The compiler auto-derives Clone where all fields implement Clone and no raw pointers exist (G5).
+The compiler auto-derives Cloneable where all fields implement Cloneable and no raw pointers exist (G5).
 
 | Rule | Description |
 |------|-------------|
-| **CL1: Auto-derive** | Primitives, structs with all Clone fields, arrays/Vec of Clone, handles: auto-derived |
-| **CL2: Pointer block** | Struct with raw pointer is NOT Clone unless `unsafe extend` |
+| **CL1: Auto-derive** | Primitives, structs with all Cloneable fields, arrays/Vec of Cloneable, handles: auto-derived |
+| **CL2: Pointer block** | Struct with raw pointer is NOT Cloneable unless `unsafe extend` |
 
 ```rask
-trait Clone<T> {
-    clone(self) -> T
+trait Cloneable {
+    clone(self) -> Self
 }
 ```
 
-| Type | Clone Status |
-|------|--------------|
+| Type | Cloneable Status |
+|------|------------------|
 | Primitives (i32, bool, f64) | Auto-derived (bitwise copy) |
-| Struct with all Clone fields | Auto-derived (deep copy) |
-| Struct with raw pointer | NOT Clone unless `unsafe extend` |
-| Array/Vec of Clone | Auto-derived (element-wise clone) |
+| Struct with all Cloneable fields | Auto-derived (deep copy) |
+| Struct with raw pointer | NOT Cloneable unless `unsafe extend` |
+| Array/Vec of Cloneable | Auto-derived (element-wise clone) |
 | Handle types | Auto-derived (handle copy, not referent) |
 
-## Compiler-Verified Equatable
+## Compiler-Verified Equal
 
-The compiler auto-derives Equatable where all fields implement Equatable — same pattern as Clone.
+The compiler auto-derives Equal where all fields implement Equal — same pattern as Cloneable.
 
 | Rule | Description |
 |------|-------------|
-| **EQ1: Auto-derive** | Primitives, structs with all Equatable fields, enums (tag + payload equality): auto-derived |
-| **EQ2: Override** | `extend Type with Equatable { ... }` overrides the auto-derived version |
+| **EQ1: Auto-derive** | Primitives, structs with all Equal fields, enums (tag + payload equality): auto-derived |
+| **EQ2: Override** | `extend Type with Equal { ... }` overrides the auto-derived version |
 | **EQ3: Enum equality** | Variants compared by tag, then field-wise payload equality |
 
 ```rask
@@ -143,23 +143,23 @@ struct Point {
     y: i32
 }
 
-// No extend block needed — Point is Equatable because i32 is Equatable
+// No extend block needed — Point is Equal because i32 is Equal
 const a = Point { x: 1, y: 2 }
 const b = Point { x: 1, y: 2 }
 // a == b → true (field-wise comparison)
 ```
 
-| Type | Equatable Status |
-|------|-----------------|
+| Type | Equal Status |
+|------|--------------|
 | Primitives (i32, bool, f64, string) | Auto-derived |
-| Struct with all Equatable fields | Auto-derived (field-wise) |
-| Enum with all Equatable payloads | Auto-derived (tag + payload) |
-| Struct with `any Trait` field | NOT Equatable unless manually implemented |
-| Struct with closure field | NOT Equatable (closures have no equality) |
+| Struct with all Equal fields | Auto-derived (field-wise) |
+| Enum with all Equal payloads | Auto-derived (tag + payload) |
+| Struct with `any Trait` field | NOT Equal unless manually implemented |
+| Struct with closure field | NOT Equal (closures have no equality) |
 
 ## Compiler-Verified Hashable
 
-The compiler auto-derives Hashable where all fields implement Hashable. Since Hashable requires Equatable, auto-derive applies only when both are satisfied.
+The compiler auto-derives Hashable where all fields implement Hashable. Since Hashable requires Equal (supertrait), auto-derive applies only when both are satisfied.
 
 | Rule | Description |
 |------|-------------|
@@ -175,6 +175,49 @@ The compiler auto-derives Hashable where all fields implement Hashable. Since Ha
 | Struct with all Hashable fields | Auto-derived (field-wise hash combine) |
 | Enum with all Hashable payloads | Auto-derived (tag + payload) |
 | Handle types | Auto-derived (hash of index + generation) |
+
+## Compiler-Verified Comparable
+
+The compiler auto-derives Comparable where all fields implement Comparable — lexicographic by declaration order. Since Comparable requires Equal (supertrait), auto-derive applies only when both are satisfied.
+
+| Rule | Description |
+|------|-------------|
+| **CO1: Auto-derive** | Primitives, structs with all Comparable fields, enums (variant order, then payload): auto-derived |
+| **CO2: Override** | `extend Type with Comparable { ... }` overrides the auto-derived version |
+| **CO3: Lexicographic** | Fields compared in declaration order — first field is most significant |
+| **CO4: Float exclusion** | `f32`/`f64` are NOT Comparable (NaN breaks totality); see `type.operators/ORD3` |
+
+```rask
+trait Comparable: Equal {
+    compare(self, other: Self) -> Ordering
+}
+
+enum Ordering { Less, Equal, Greater }
+```
+
+| Type | Comparable Status |
+|------|-------------------|
+| Integer primitives, bool, char, string | Auto-derived |
+| `f32`, `f64` | NOT Comparable (NaN breaks totality) |
+| Struct with all Comparable fields | Auto-derived (lexicographic by field order) |
+| Enum with all Comparable payloads | Auto-derived (variant order, then payload) |
+| Struct with float field | NOT Comparable unless manually implemented with `.total_cmp()` |
+
+<!-- test: skip -->
+```rask
+struct Version {
+    major: u32
+    minor: u32
+    patch: u32
+}
+
+// No extend block needed — Version is Comparable because u32 is Comparable
+// Compares major first, then minor, then patch (lexicographic)
+const a = Version { major: 1, minor: 2, patch: 0 }
+const b = Version { major: 1, minor: 3, patch: 0 }
+// a < b → true (minor field differs)
+// a.compare(b) → Ordering.Less
+```
 
 ## Compiler-Verified Default
 
@@ -235,17 +278,15 @@ Must-consume resource types (`@resource`) can be generic parameters. Pattern mat
 
 Composition via `:` is additive (TD3). `T: HashKey` requires `hash`, `eq`, AND `clone`.
 
-Compiler collects all methods, deduplicates identical requirements, errors on conflicts.
+Compiler collects all methods from the full supertrait chain, deduplicates identical requirements, errors on conflicts.
 
 ```rask
-trait Hashable<T> {
+trait Hashable: Equal {
     hash(self) -> u64
-    eq(self, other: T) -> bool
 }
 
-trait HashKey<T>: Hashable<T> {
-    clone(self) -> T
-}
+trait HashKey: Hashable + Cloneable {}
+// Requires: eq (from Equal), hash (from Hashable), clone (from Cloneable)
 ```
 
 ## Code Specialization (Monomorphization)
@@ -264,11 +305,11 @@ When you call `sort<i32>` and `sort<string>`, the compiler generates two separat
 Integer literals auto-coerce to T when `T: Numeric`. Compiler inserts `T.from_int()`. IDE shows ghost text.
 
 ```rask
-trait Numeric<T> {
-    add(self, other: T) -> T
-    zero() -> T
-    one() -> T
-    from_int(n: i64) -> T
+trait Numeric {
+    add(self, other: Self) -> Self
+    zero() -> Self
+    one() -> Self
+    from_int(n: i64) -> Self
 }
 
 func increment<T: Numeric>(val: T) -> T {
@@ -300,7 +341,7 @@ func increment<T: Numeric>(val: T) -> T {
 
 **G4 (operator expansion):** Makes numeric code ergonomic — `a + b` reads naturally while the trait system handles dispatch.
 
-**G5 (verified clone):** Compiler-verified clone prevents aliasing bugs. Types with raw pointers can't silently claim to be cloneable.
+**G5 (verified clone):** Compiler-verified Cloneable prevents aliasing bugs. Types with raw pointers can't silently claim to be cloneable.
 
 **G6 (code specialization):** Keeps costs transparent and compilation fast. Each usage generates specialized code — no hidden function-pointer overhead.
 
@@ -311,10 +352,6 @@ func increment<T: Numeric>(val: T) -> T {
 **Generic sorting:**
 
 ```rask
-trait Comparable<T> {
-    compare(self, other: T) -> Ordering
-}
-
 public func sort<T: Comparable>(items: []T) {
     for i in 1..items.len() {
         let j = i
@@ -329,7 +366,7 @@ public func sort<T: Comparable>(items: []T) {
 **HashMap with verified clone:**
 
 ```rask
-trait HashKey<T>: Hashable<T> + Clone<T> {}
+trait HashKey: Hashable + Cloneable {}
 
 public struct HashMap<K: HashKey, V> {
     buckets: []Bucket<K, V>
@@ -337,7 +374,7 @@ public struct HashMap<K: HashKey, V> {
 
 public func insert<K: HashKey, V>(map: HashMap<K, V>, key: K, val: V) {
     const idx = key.hash() % map.buckets.len()
-    map.buckets[idx].add(key.clone(), val)  // Clone is compiler-verified deep copy
+    map.buckets[idx].add(key.clone(), val)  // Cloneable is compiler-verified deep copy
 }
 ```
 
@@ -356,13 +393,15 @@ public func insert<K: HashKey, V>(map: HashMap<K, V>, key: K, val: V) {
 
 | Trait | Methods | Auto-Derived? |
 |-------|---------|---------------|
-| `Equatable<T>` | `eq(self, other: T) -> bool` | Yes — all Equatable fields (EQ1) |
-| `Hashable<T>` | `hash(self) -> u64; eq(self, other: T) -> bool` | Yes — all Hashable fields (HA1) |
-| `Clone<T>` | `clone(self) -> T` | Yes — all Clone fields, no raw pointers (CL1) |
-| `Default<T>` | `default() -> T` | Yes — all Default fields, structs only (DF1) |
-| `Comparable<T>` | `compare(self, other: T) -> Ordering` | No — ordering is domain-specific |
-| `Numeric<T>` | `add, sub, mul, div, neg, zero, one, from_int` | No |
-| `Convert<From, Into>` | `convert(self: From) -> Into` | No |
+| `Equal` | `eq(self, other: Self) -> bool` | Yes — all Equal fields (EQ1) |
+| `Comparable`: Equal | `compare(self, other: Self) -> Ordering` | Yes — all Comparable fields, lexicographic (CO1) |
+| `Hashable`: Equal | `hash(self) -> u64` | Yes — all Hashable fields, no floats (HA1) |
+| `Cloneable` | `clone(self) -> Self` | Yes — all Cloneable fields, no raw pointers (CL1) |
+| `Default` | `default() -> Self` | Yes — all Default fields, structs only (DF1) |
+| `Displayable` | `to_string(self) -> string` | No — opt-in (user-facing output is intentional) |
+| `Debug` | `debug_string(self) -> string` | Yes — all types |
+| `Numeric` | `add, sub, mul, div, neg, zero, one, from_int` | No |
+| `Convert<From, To>` | `convert(self: From) -> To` | No |
 | `Encode` | Marker — no methods | Yes — all-Encode public fields (`std.encoding/E12`) |
 | `Decode` | Marker — no methods | Yes — all-Decode public fields (`std.encoding/E12`) |
 

--- a/specs/types/gradual-constraints.md
+++ b/specs/types/gradual-constraints.md
@@ -245,7 +245,7 @@ Inference rules:
 
 1. **Prototype:** `func process(data, handler) { ... }` — all inferred
 2. **Solidify:** `func process(data: Vec<Record>, handler) { ... }` — partial
-3. **Publish:** `public func process<T: Ord>(data: Vec<T>, handler: Handler<T>) -> T` — explicit
+3. **Publish:** `public func process<T: Comparable>(data: Vec<T>, handler: Handler<T>) -> T` — explicit
 
 Fully statically checked at every stage. Not dynamic typing.
 

--- a/specs/types/iterator-protocol.md
+++ b/specs/types/iterator-protocol.md
@@ -104,11 +104,17 @@ const lookup: Map<string, User> = users.map(|u| (u.name, u)).collect()
 | `.count()` | Counts elements | `usize` |
 | `.min()` | Smallest item | `Option<Item>` (requires `Item: Comparable`) |
 | `.max()` | Largest item | `Option<Item>` (requires `Item: Comparable`) |
+| `.min_by(cmp)` | Smallest by custom comparator | `Option<Item>` |
+| `.max_by(cmp)` | Largest by custom comparator | `Option<Item>` |
+| `.min_by_key(f)` | Smallest by extracted key | `Option<Item>` (requires key: Comparable) |
+| `.max_by_key(f)` | Largest by extracted key | `Option<Item>` (requires key: Comparable) |
 
 <!-- test: skip -->
 ```rask
 const total = orders.map(|o| o.amount).sum()
 const biggest = scores.max()
+const cheapest = orders.min_by_key(|o| o.price)
+const oldest = users.max_by(|a, b| a.age.compare(b.age))
 
 const csv = names.fold(string.new(), |acc, name| {
     if acc.is_empty(): return name

--- a/specs/types/operators.md
+++ b/specs/types/operators.md
@@ -1,6 +1,6 @@
 <!-- id: type.operators -->
 <!-- status: decided -->
-<!-- summary: Operator precedence, comparison/equality traits, operator trait list -->
+<!-- summary: Operator precedence, Equal/Comparable traits, operator trait list -->
 <!-- depends: types/primitives.md, types/traits.md -->
 
 # Operators
@@ -62,18 +62,18 @@ trait Equal {
 
 **Programmer must ensure:** reflexive (`a == a`), symmetric (`a == b` implies `b == a`), transitive.
 
-## Ordering Trait
+## Comparable Trait
 
 | Rule | Description |
 |------|-------------|
-| **ORD1: Ordered trait** | `<`, `>`, `<=`, `>=` derived from `cmp()` returning `Ordering` |
-| **ORD2: Derivable** | Structs derive lexicographic ordering (first field, then second, etc.) |
-| **ORD3: Float exclusion** | `f32`/`f64` don't implement `Ordered` (NaN breaks totality); use `.total_cmp()` |
+| **ORD1: Comparable trait** | `<`, `>`, `<=`, `>=` derived from `compare()` returning `Ordering` |
+| **ORD2: Derivable** | Structs and enums auto-derive lexicographic ordering (first field, then second, etc.). Override with explicit `extend Type with Comparable` |
+| **ORD3: Float exclusion** | `f32`/`f64` don't implement `Comparable` (NaN breaks totality); use `.total_cmp()` |
 
 <!-- test: skip -->
 ```rask
-trait Ordered: Equal {
-    func cmp(self, other: Self) -> Ordering
+trait Comparable: Equal {
+    func compare(self, other: Self) -> Ordering
 }
 
 enum Ordering { Less, Equal, Greater }
@@ -83,8 +83,8 @@ enum Ordering { Less, Equal, Greater }
 
 ## Type Support Summary
 
-| Type | `Equal` | `Ordered` | Notes |
-|------|---------|-----------|-------|
+| Type | `Equal` | `Comparable` | Notes |
+|------|---------|--------------|-------|
 | Integers | Yes | Yes | Natural ordering |
 | `bool` | Yes | Yes | `false < true` |
 | `char` | Yes | Yes | Unicode scalar order |
@@ -101,10 +101,10 @@ Operator traits: `Add`, `Sub`, `Mul`, `Div`, `Rem`, `Neg`, `BitAnd`, `BitOr`, `B
 | Case | Rule | Behavior |
 |------|------|----------|
 | `NaN == NaN` | EQ3 | `false` (IEEE 754) |
-| `NaN < 1.0` | ORD3 | Compile error (floats don't implement `Ordered`) |
+| `NaN < 1.0` | ORD3 | Compile error (floats don't implement `Comparable`) |
 | Shift exceeding bit width | BW2 | Panic |
 | Comparison chaining | P2 | Compile error |
-| Struct with float field | ORD2 | Cannot auto-derive `Ordered`; implement manually with `.total_cmp()` |
+| Struct with float field | ORD2 | Cannot auto-derive `Comparable`; implement manually with `.total_cmp()` |
 
 ---
 
@@ -114,7 +114,7 @@ Operator traits: `Add`, `Sub`, `Mul`, `Div`, `Rem`, `Neg`, `BitAnd`, `BitOr`, `B
 
 **EQ3 (float semantics):** IEEE 754 compliance means `NaN == NaN` is false, breaking reflexivity. Rather than silently deviating from IEEE or forbidding equality on floats, we provide `.total_eq()` and `.total_cmp()` as explicit opt-ins for total ordering.
 
-**ORD3 (float exclusion):** Excluding floats from `Ordered` prevents subtle sorting bugs. If you need to sort floats, `.total_cmp()` makes the choice explicit.
+**ORD3 (float exclusion):** Excluding floats from `Comparable` prevents subtle sorting bugs. If you need to sort floats, `.total_cmp()` makes the choice explicit.
 
 **P2 (no chaining):** Chained comparisons (`a < b < c`) are ambiguous in most languages. Requiring `&&` is explicit and matches user expectation.
 

--- a/specs/types/structs.md
+++ b/specs/types/structs.md
@@ -60,7 +60,7 @@ match r {
 |----------|------|
 | Copy | Struct is Copy if: all fields Copy AND size <=16 bytes AND not `@unique` |
 | Move | Non-Copy structs move on assignment; source invalidated |
-| Clone | Auto-derived if all fields implement Clone |
+| Cloneable | Auto-derived if all fields implement Cloneable |
 
 <!-- test: parse -->
 ```rask
@@ -181,11 +181,11 @@ const p: Pair<i32, string> = Pair { first: 1, second: "hello" }
 
 <!-- test: skip -->
 ```rask
-struct SortedVec<T: Ord> {
+struct SortedVec<T: Comparable> {
     items: Vec<T>
 }
 
-extend SortedVec<T: Ord> {
+extend SortedVec<T: Comparable> {
     func insert(self, item: T) {
         // ... maintain sorted order
     }

--- a/specs/types/traits.md
+++ b/specs/types/traits.md
@@ -79,7 +79,7 @@ Creating an `any Trait` value heap-allocates the concrete data.
 |------|-------------|
 | **TR9: Heap allocation** | `any Trait` heap-allocates the concrete value and constructs a fat pointer (data pointer + vtable pointer) |
 | **TR10: Owned data** | `any Trait` owns its heap data — same ownership model as Vec or string |
-| **TR11: Move-only** | `any Trait` is never Copy; assignment moves. Clone only if the trait provides a clone method |
+| **TR11: Move-only** | `any Trait` is never Copy; assignment moves. Cloneable only if the trait provides a clone method |
 
 The `any` keyword in the type is the cost signal.
 
@@ -116,7 +116,7 @@ Overhead is one pointer indirection per call plus a heap allocation per value. N
 |------|------|----------|
 | Method returns `Self` | TR2 | Can't call through `any`; other methods still work |
 | Generic method | TR3 | Can't call through `any`; other methods still work |
-| Clone of `any` value | TR11 | Not automatic; requires explicit trait method |
+| Clone of `any` value | TR11 | Not automatic; requires explicit Cloneable trait method |
 | Assignment | TR11 | Moves (never copies) |
 | Concurrency | — | `any` values sendable if underlying type is sendable |
 | Pool element | — | Not supported; use `[]any Trait` for heterogeneous collections |
@@ -329,7 +329,7 @@ extend App {
 ### Integration Notes
 
 - **Ownership**: `any` values own their heap data — the data pointer is owned, not a reference (`mem.ownership`)
-- **Clone**: `any Trait` is NOT automatically cloneable — requires an explicit trait method
+- **Cloneable**: `any Trait` is NOT automatically cloneable — requires an explicit trait method
 - **Drop**: scope exit calls vtable `drop_fn` then frees the heap allocation (`TR14`)
 - **Concurrency**: `any` values can be sent between tasks if the underlying type is sendable (`conc.tasks`)
 

--- a/specs/types/tuples.md
+++ b/specs/types/tuples.md
@@ -46,7 +46,7 @@ const (x, y) = point
 | Rule | Description |
 |------|-------------|
 | **TU7: Copy** | Tuples are Copy when all elements are Copy |
-| **TU8: Clone** | Tuples are Clone when all elements are Clone |
+| **TU8: Cloneable** | Tuples are Cloneable when all elements are Cloneable |
 | **TU9: Equality** | `==` and `!=` work when all elements support equality |
 | **TU10: Layout** | Struct layout rules apply: elements in order, padded for alignment (see `comp.mem-layout`) |
 


### PR DESCRIPTION
This PR standardizes trait naming across the specification for improved clarity and consistency:

**Summary**
Renames three core traits to better reflect their purpose and avoid confusion with language keywords or common patterns:
- `Clone<T>` → `Cloneable` (emphasizes the capability, not the action)
- `Display<T>` → `Displayable` (consistent with other capability traits like `Hashable`)
- `Ordered<T>` / `Ord` → `Comparable` (clearer intent for ordering operations)

**Key Changes**

- **Trait signatures simplified**: Removed generic type parameters from trait definitions (e.g., `trait Clone<T>` becomes `trait Cloneable`), using `Self` in method signatures instead
- **Comparable trait**: Now properly documented as auto-derivable with lexicographic ordering for structs/enums, with explicit float exclusion (NaN breaks totality)
- **Error auto-bridging**: Error types with `message()` now automatically satisfy `Displayable` without boilerplate (D5 rule in fmt.md)
- **Trait composition**: Updated supertrait relationships (e.g., `Comparable: Equal`, `Hashable: Equal`)
- **Documentation updates**: All specs, examples, and error messages updated to use new names
- **Prelude additions**: Generic `min()`, `max()`, `clamp()` functions for any `Comparable` type
- **Collection convenience methods**: Added `Vec.contains()`, `Vec.dedup()`, `Map.contains_key()`, `strings.join()` with proper trait requirements

**Implementation Details**

- Trait method signatures now use `Self` return types (e.g., `clone(self) -> Self` instead of `clone(self) -> T`)
- `Comparable` auto-derives for all types except floats; structs/enums compare lexicographically by field declaration order
- Error types get automatic `Displayable` implementation via compiler bridge to `message()` method
- All trait tables in stdlib specs updated with new names and auto-derivation rules
- Iterator protocol extended with `min_by()`, `max_by()`, `min_by_key()`, `max_by_key()` methods

https://claude.ai/code/session_01SZKoBoM2uZG6WEpDv9x31H