### PR TITLE
Implement implicit trait coercion (TR5) for function arguments

### DIFF
--- a/compiler/crates/rask-cli/src/commands/codegen.rs
+++ b/compiler/crates/rask-cli/src/commands/codegen.rs
@@ -299,6 +299,7 @@ pub fn cmd_mir(path: &str, format: Format) {
         source_file: Some(path),
         shared_elem_types: std::cell::RefCell::new(std::collections::HashMap::new()),
         comptime_interp: Some(std::cell::RefCell::new(mir_interp)),
+        trait_coercions: &typed.trait_coercions,
     };
 
     let mut mir_errors = 0;

--- a/compiler/crates/rask-cli/src/commands/compile.rs
+++ b/compiler/crates/rask-cli/src/commands/compile.rs
@@ -86,6 +86,7 @@ pub fn compile_to_object(
         shared_elem_types: std::cell::RefCell::new(std::collections::HashMap::new()),
         comptime_interp,
         trait_methods: trait_methods.clone(),
+        trait_coercions: &typed.trait_coercions,
     };
 
     // MIR lowering
@@ -397,6 +398,7 @@ pub fn compile_benchmarks_to_object(
         source_file,
         shared_elem_types: std::cell::RefCell::new(std::collections::HashMap::new()),
         comptime_interp: bench_interp,
+        trait_coercions: &typed.trait_coercions,
     };
 
     // MIR lowering — skip the synthetic main() since gen_benchmark_runner replaces it

--- a/compiler/crates/rask-diagnostics/src/convert.rs
+++ b/compiler/crates/rask-diagnostics/src/convert.rs
@@ -429,15 +429,6 @@ impl ToDiagnostic for rask_types::TypeError {
                     .with_primary(*span, "unsafe operation outside unsafe block")
             }
 
-            ImplicitTraitCoercion { trait_name, value_desc, span } => {
-                Diagnostic::error(format!("implicit trait coercion to `any {}`", trait_name))
-                    .with_code("E0331")
-                    .with_primary(*span, format!("pass `{} as any {}` — implicit coercion not allowed at call sites", value_desc, trait_name))
-                    .with_help(format!("add `as any {}` to make the coercion explicit", trait_name))
-                    .with_fix(format!("add `as any {}`", trait_name))
-                    .with_why("trait object coercion must be explicit at call sites to make boxing visible (TR8)")
-            }
-
             TraitObjectSelfReturn { trait_name, method, span } => {
                 Diagnostic::error(format!("method `{}` returns Self — cannot be called through `any {}`", method, trait_name))
                     .with_code("E0332")

--- a/compiler/crates/rask-mir/src/lower/expr.rs
+++ b/compiler/crates/rask-mir/src/lower/expr.rs
@@ -36,6 +36,33 @@ impl<'a> MirLowerer<'a> {
         }
     }
 
+    /// Emit a TraitBox instruction: heap-allocate `value` and produce a trait object.
+    /// Used for both explicit `as any Trait` casts and implicit TR5 coercions.
+    fn emit_trait_box(
+        &mut self,
+        val: MirOperand,
+        concrete_mir_ty: &MirType,
+        trait_name: &str,
+    ) -> (MirOperand, MirType) {
+        let concrete_type = self.mir_type_name(concrete_mir_ty)
+            .unwrap_or_else(|| "unknown".to_string());
+        let concrete_size = self.elem_size_for_type(concrete_mir_ty) as u32;
+        let vtable_name = format!(".vtable.{}__{}", concrete_type, trait_name);
+        let trait_obj_ty = MirType::TraitObject { trait_name: trait_name.to_string() };
+        let result_local = self.builder.alloc_temp(trait_obj_ty.clone());
+
+        self.builder.push_stmt(MirStmt::TraitBox {
+            dst: result_local,
+            value: val,
+            concrete_type,
+            trait_name: trait_name.to_string(),
+            concrete_size,
+            vtable_name,
+        });
+
+        (MirOperand::Local(result_local), trait_obj_ty)
+    }
+
     /// Derive a tracking key for Vec element type inference.
     /// Returns `"v"` for `v.push(x)` and `"self.field"` for `self.field.push(x)`.
     fn vec_tracking_key(object: &Expr) -> Option<String> {
@@ -157,8 +184,14 @@ impl<'a> MirLowerer<'a> {
             ExprKind::Call { func, args } => {
                 let mut arg_operands = Vec::new();
                 for a in args {
-                    let (op, _) = self.lower_expr(&a.expr)?;
-                    arg_operands.push(op);
+                    let (op, mir_ty) = self.lower_expr(&a.expr)?;
+                    // TR5: implicit trait coercion — emit TraitBox if type checker flagged this arg
+                    if let Some(trait_name) = self.ctx.trait_coercions.get(&a.expr.id) {
+                        let (boxed_op, _) = self.emit_trait_box(op, &mir_ty, trait_name);
+                        arg_operands.push(boxed_op);
+                    } else {
+                        arg_operands.push(op);
+                    }
                 }
 
                 // Non-ident callees: field access, returned functions, etc.
@@ -1694,28 +1727,7 @@ impl<'a> MirLowerer<'a> {
                 // Trait object boxing: `value as any Trait`
                 if let Some(trait_name) = ty.strip_prefix("any ") {
                     let (val, concrete_mir_ty) = self.lower_expr(expr)?;
-
-                    // Determine concrete type name for vtable lookup.
-                    // Prefer MIR-level struct layout name ("Dog") over raw Type
-                    // which formats as "<type#N>" for Named types.
-                    let concrete_type = self.mir_type_name(&concrete_mir_ty)
-                        .unwrap_or_else(|| "unknown".to_string());
-
-                    let concrete_size = self.elem_size_for_type(&concrete_mir_ty) as u32;
-                    let vtable_name = format!(".vtable.{}__{}", concrete_type, trait_name);
-                    let trait_obj_ty = MirType::TraitObject { trait_name: trait_name.to_string() };
-                    let result_local = self.builder.alloc_temp(trait_obj_ty.clone());
-
-                    self.builder.push_stmt(MirStmt::TraitBox {
-                        dst: result_local,
-                        value: val,
-                        concrete_type: concrete_type.clone(),
-                        trait_name: trait_name.to_string(),
-                        concrete_size,
-                        vtable_name,
-                    });
-
-                    return Ok((MirOperand::Local(result_local), trait_obj_ty));
+                    return Ok(self.emit_trait_box(val, &concrete_mir_ty, trait_name));
                 }
 
                 let (val, _) = self.lower_expr(expr)?;

--- a/compiler/crates/rask-mir/src/lower/mod.rs
+++ b/compiler/crates/rask-mir/src/lower/mod.rs
@@ -111,6 +111,8 @@ pub struct MirContext<'a> {
     /// Trait method lists for trait object dispatch.
     /// Key: trait name, Value: method names in declaration order.
     pub trait_methods: HashMap<String, Vec<String>>,
+    /// TR5: implicit trait coercion sites. NodeId of expression → trait name.
+    pub trait_coercions: &'a HashMap<NodeId, String>,
 }
 
 impl<'a> MirContext<'a> {
@@ -121,6 +123,8 @@ impl<'a> MirContext<'a> {
         static EMPTY_EXTERNS: std::sync::LazyLock<std::collections::HashSet<String>> =
             std::sync::LazyLock::new(std::collections::HashSet::new);
         static EMPTY_TYPE_NAMES: std::sync::LazyLock<HashMap<rask_types::TypeId, String>> =
+            std::sync::LazyLock::new(HashMap::new);
+        static EMPTY_COERCIONS: std::sync::LazyLock<HashMap<NodeId, String>> =
             std::sync::LazyLock::new(HashMap::new);
         MirContext {
             struct_layouts: &[],
@@ -134,6 +138,7 @@ impl<'a> MirContext<'a> {
             shared_elem_types: std::cell::RefCell::new(HashMap::new()),
             comptime_interp: None,
             trait_methods: HashMap::new(),
+            trait_coercions: &EMPTY_COERCIONS,
         }
     }
 
@@ -2372,6 +2377,7 @@ mod tests {
         let comptime_globals = HashMap::new();
         let extern_funcs = std::collections::HashSet::new();
         let type_names = HashMap::new();
+        let empty_coercions = HashMap::new();
         let ctx = MirContext {
             struct_layouts: &[],
             enum_layouts: &enum_layouts,
@@ -2384,6 +2390,7 @@ mod tests {
             source_file: None,
             comptime_interp: None,
             trait_methods: HashMap::new(),
+            trait_coercions: &empty_coercions,
         };
 
         let decl = make_fn("f", vec![], None, vec![
@@ -2421,6 +2428,7 @@ mod tests {
         let comptime_globals = HashMap::new();
         let extern_funcs = std::collections::HashSet::new();
         let type_names = HashMap::new();
+        let empty_coercions = HashMap::new();
         let ctx = MirContext {
             struct_layouts: &[],
             enum_layouts: &enum_layouts,
@@ -2433,6 +2441,7 @@ mod tests {
             source_file: None,
             comptime_interp: None,
             trait_methods: HashMap::new(),
+            trait_coercions: &empty_coercions,
         };
 
         let decl = make_fn("f", vec![], None, vec![
@@ -2476,6 +2485,7 @@ mod tests {
         let comptime_globals = HashMap::new();
         let extern_funcs = std::collections::HashSet::new();
         let type_names = HashMap::new();
+        let empty_coercions = HashMap::new();
         let ctx = MirContext {
             struct_layouts: &[],
             enum_layouts: &enum_layouts,
@@ -2488,6 +2498,7 @@ mod tests {
             source_file: None,
             comptime_interp: None,
             trait_methods: HashMap::new(),
+            trait_coercions: &empty_coercions,
         };
 
         let decl = make_fn("f", vec![], None, vec![

--- a/compiler/crates/rask-mono/src/lib.rs
+++ b/compiler/crates/rask-mono/src/lib.rs
@@ -247,6 +247,7 @@ mod tests {
             types: rask_types::TypeTable::new(),
             node_types: std::collections::HashMap::new(),
             call_type_args: std::collections::HashMap::new(),
+            trait_coercions: std::collections::HashMap::new(),
         }
     }
 

--- a/compiler/crates/rask-types/src/checker/check_expr.rs
+++ b/compiler/crates/rask-types/src/checker/check_expr.rs
@@ -989,7 +989,7 @@ impl TypeChecker {
                 // Propagate expected param types to arguments
                 let ret = *ret.clone();
                 for (param, arg) in params.clone().iter().zip(args.iter()) {
-                    // TR8: require explicit `as any Trait` at call sites
+                    // TR5: record implicit trait coercion for MIR boxing
                     if let Type::TraitObject { ref trait_name } = param {
                         let is_explicit_cast = matches!(
                             &arg.expr.kind,
@@ -998,15 +998,10 @@ impl TypeChecker {
                         if !is_explicit_cast {
                             let arg_ty = self.infer_expr(&arg.expr);
                             if !matches!(arg_ty, Type::TraitObject { .. } | Type::Error) {
-                                let desc = match &arg_ty {
-                                    Type::Named(id) => self.types.type_name(*id),
-                                    other => format!("{}", other),
-                                };
-                                self.errors.push(TypeError::ImplicitTraitCoercion {
-                                    trait_name: trait_name.clone(),
-                                    value_desc: desc,
-                                    span: arg.expr.span,
-                                });
+                                self.trait_coercions.insert(
+                                    arg.expr.id,
+                                    trait_name.clone(),
+                                );
                             }
                         }
                     }

--- a/compiler/crates/rask-types/src/checker/errors.rs
+++ b/compiler/crates/rask-types/src/checker/errors.rs
@@ -115,12 +115,6 @@ pub enum TypeError {
         operation: String,
         span: Span,
     },
-    #[error("pass `{value_desc} as any {trait_name}` — implicit trait coercion is not allowed at call sites")]
-    ImplicitTraitCoercion {
-        trait_name: String,
-        value_desc: String,
-        span: Span,
-    },
     #[error("method `{method}` returns Self and cannot be called through `any {trait_name}`")]
     TraitObjectSelfReturn {
         trait_name: String,

--- a/compiler/crates/rask-types/src/checker/mod.rs
+++ b/compiler/crates/rask-types/src/checker/mod.rs
@@ -86,6 +86,9 @@ pub struct TypeChecker {
     /// GC1/GC2: Pre-created type vars for functions with inferred params/return.
     /// Key is function name, value is (param_type_vars, return_type_var).
     pub(super) inferred_fn_types: HashMap<String, (Vec<(String, Type)>, Type)>,
+    /// TR5: implicit trait coercion sites. NodeId of expression → trait name.
+    /// MIR lowering uses this to emit TraitBox instructions at coercion sites.
+    pub(super) trait_coercions: HashMap<NodeId, String>,
 }
 
 impl TypeChecker {
@@ -109,6 +112,7 @@ impl TypeChecker {
             unsafe_ops: Vec::new(),
             inferred_fn_types: HashMap::new(),
             in_assign_target: false,
+            trait_coercions: HashMap::new(),
         }
     }
 
@@ -143,6 +147,8 @@ impl TypeChecker {
             })
             .collect();
 
+        let trait_coercions = self.trait_coercions.clone();
+
         if self.errors.is_empty() {
             Ok(TypedProgram {
                 symbols: self.resolved.symbols,
@@ -150,6 +156,7 @@ impl TypeChecker {
                 types: self.types,
                 node_types,
                 call_type_args,
+                trait_coercions,
             })
         } else {
             let ctx = &self.ctx;
@@ -167,6 +174,7 @@ impl TypeChecker {
                     types: self.types,
                     node_types,
                     call_type_args,
+                    trait_coercions,
                 })
             } else {
                 Err(errors)

--- a/compiler/crates/rask-types/src/checker/type_defs.rs
+++ b/compiler/crates/rask-types/src/checker/type_defs.rs
@@ -86,4 +86,6 @@ pub struct TypedProgram {
     /// Resolved type arguments for each generic call site.
     /// Key is the Call/MethodCall expression's NodeId.
     pub call_type_args: HashMap<NodeId, Vec<Type>>,
+    /// TR5: implicit trait coercion sites. NodeId of expression → trait name.
+    pub trait_coercions: HashMap<NodeId, String>,
 }

--- a/compiler/crates/rask-types/src/checker/unify.rs
+++ b/compiler/crates/rask-types/src/checker/unify.rs
@@ -326,6 +326,22 @@ impl TypeChecker {
                 Ok(false)
             }
 
+            // Trait object coercion: concrete → any Trait (TR5)
+            (concrete, Type::TraitObject { ref trait_name })
+            | (Type::TraitObject { ref trait_name }, concrete)
+                if !matches!(concrete, Type::TraitObject { .. }) =>
+            {
+                if crate::traits::implements_trait(&self.types, concrete, trait_name) {
+                    Ok(false)
+                } else {
+                    Err(TypeError::Mismatch {
+                        expected: t1,
+                        found: t2,
+                        span,
+                    })
+                }
+            }
+
             _ => Err(TypeError::Mismatch {
                 expected: t1,
                 found: t2,

--- a/specs/types/traits.md
+++ b/specs/types/traits.md
@@ -53,7 +53,7 @@ func render_all(widgets: []any Widget) {
 
 The `any` keyword in the target type is the cost signal. Conversion is implicit when the target type is known to be `any Trait`:
 
-<!-- test: skip -->
+<!-- test: parse -->
 ```rask
 const button = Button { label: "OK" }
 
@@ -211,7 +211,7 @@ extend Container {
 
 **TR1–TR4 (per-method restrictions):** Rust rejects entire traits from `dyn` if any method is incompatible — "trait is not object-safe." I think that's too coarse. A trait with nine compatible methods and one `Self`-returning method should work with `any` — you just can't call that one method. The error appears at the call site where the problem is, not at the coercion site where it isn't.
 
-**TR5 (implicit when target is `any`):** Originally I required explicit `as any Trait` at call sites (the old TR8). The rationale was cost visibility — `render(button)` hides a heap allocation. But in practice, the `any` keyword is already visible in the function signature, the collection type, or the struct field type. Requiring `as any Widget` on every handler registration, every collection element, every callback — it's ceremony that doesn't help readability. The `any` keyword in the *type system* is the cost signal, not the conversion at each use site. If you see `[]any Widget`, you know there's allocation. You don't need `[button as any Widget, slider as any Widget]` to remind you.
+**TR5 (implicit when target is `any`):** The `any` keyword is already visible in the function signature, the collection type, or the struct field type. Requiring `as any Widget` on every handler registration, every collection element, every callback — it's ceremony that doesn't help readability. The `any` keyword in the *type system* is the cost signal, not the conversion at each use site. If you see `[]any Widget`, you know there's allocation. You don't need `[button as any Widget, slider as any Widget]` to remind you.
 
 **TR9 (heap allocation):** I chose owned heap allocation over alternatives. The `any` keyword is the cost signal — you see it in the type, you know there's indirection and allocation. This is a deliberate tradeoff: ergonomic for the use cases where you need it (handlers, plugins, UI), explicit enough that you won't accidentally use it in hot paths.
 


### PR DESCRIPTION
## Summary
This PR implements TR5 (implicit trait coercion) to allow automatic boxing of concrete types to trait objects at function call sites, eliminating the need for explicit `as any Trait` casts in argument lists. The coercion is implicit when the target parameter type is known to be `any Trait`, with the cost signal provided by the `any` keyword in the type signature rather than at each use site.

## Key Changes

- **Type Checker (check_expr.rs):** Changed from rejecting implicit trait coercions with an error to recording them in a `trait_coercions` map indexed by expression NodeId. This allows MIR lowering to emit `TraitBox` instructions at coercion sites.

- **Type Unification (unify.rs):** Added trait object coercion rule to allow unification between concrete types and `any Trait` when the concrete type implements the trait.

- **MIR Lowering (expr.rs):** 
  - Extracted trait boxing logic into a new `emit_trait_box()` helper method to avoid duplication
  - Modified call expression lowering to check `trait_coercions` map and emit `TraitBox` instructions for implicit coercions
  - Simplified explicit `as any Trait` cast handling to use the new helper

- **Type System (type_defs.rs, mod.rs):** Added `trait_coercions` field to `TypedProgram` and `TypeChecker` to propagate coercion information from type checking to MIR lowering.

- **Diagnostics (convert.rs):** Removed `ImplicitTraitCoercion` error variant and its diagnostic handler, as implicit coercions are now allowed.

- **Documentation (traits.md):** Updated TR5 specification to reflect that implicit coercion is now allowed at call sites, with the `any` keyword in type signatures serving as the cost signal.

- **Test Updates:** Updated all test contexts to include the new `trait_coercions` field.

## Implementation Details

The coercion mechanism works in two phases:
1. **Type Checking:** When a function parameter expects `any Trait` but receives a concrete type, the type checker records this in `trait_coercions` instead of reporting an error
2. **MIR Lowering:** When lowering call expressions, the lowerer checks if each argument has a recorded coercion and emits a `TraitBox` instruction to perform the heap allocation and vtable setup

This approach maintains visibility of the allocation cost through the function signature while eliminating redundant syntax at call sites.

https://claude.ai/code/session_014MovLimsnrvTcQu4mvKXap