### PR TITLE
Implement stdlib redesign in compiler: traits, comparison, prelude fu…

### DIFF
--- a/compiler/crates/rask-interp/src/builtins/collections.rs
+++ b/compiler/crates/rask-interp/src/builtins/collections.rs
@@ -317,11 +317,33 @@ impl Interpreter {
             "sort_by" => {
                 let closure = args.into_iter().next().unwrap_or(Value::Unit);
                 let mut vec = v.lock().unwrap();
-                // Custom comparison via closure
+                // Custom comparison via closure — accepts Ordering enum or Int
                 vec.sort_by(|a, b| {
                     match self.call_value(closure.clone(), vec![a.clone(), b.clone()]) {
+                        Ok(Value::Enum { name, variant, .. }) if name == "Ordering" => {
+                            match variant.as_str() {
+                                "Less" => std::cmp::Ordering::Less,
+                                "Greater" => std::cmp::Ordering::Greater,
+                                _ => std::cmp::Ordering::Equal,
+                            }
+                        }
                         Ok(Value::Int(n)) if n < 0 => std::cmp::Ordering::Less,
                         Ok(Value::Int(n)) if n > 0 => std::cmp::Ordering::Greater,
+                        _ => std::cmp::Ordering::Equal,
+                    }
+                });
+                Ok(Value::Unit)
+            }
+            "sort_by_key" => {
+                let closure = args.into_iter().next().unwrap_or(Value::Unit);
+                let mut vec = v.lock().unwrap();
+                vec.sort_by(|a, b| {
+                    let ka = self.call_value(closure.clone(), vec![a.clone()]).ok();
+                    let kb = self.call_value(closure.clone(), vec![b.clone()]).ok();
+                    match (ka, kb) {
+                        (Some(ref va), Some(ref vb)) => {
+                            Self::value_cmp(va, vb).unwrap_or(std::cmp::Ordering::Equal)
+                        }
                         _ => std::cmp::Ordering::Equal,
                     }
                 });

--- a/compiler/crates/rask-interp/src/builtins/iterators.rs
+++ b/compiler/crates/rask-interp/src/builtins/iterators.rs
@@ -400,6 +400,206 @@ impl Interpreter {
                 }
                 Ok(Value::Vec(Arc::new(Mutex::new(result))))
             }
+            "min" => {
+                let mut best: Option<Value> = None;
+                loop {
+                    match self.iter_next(iter)? {
+                        Some(item) => {
+                            best = Some(match best.take() {
+                                None => item,
+                                Some(b) => {
+                                    if Self::value_cmp(&item, &b) == Some(std::cmp::Ordering::Less) {
+                                        item
+                                    } else {
+                                        b
+                                    }
+                                }
+                            });
+                        }
+                        None => break,
+                    }
+                }
+                match best {
+                    Some(v) => Ok(Value::Enum {
+                        name: "Option".to_string(),
+                        variant: "Some".to_string(),
+                        fields: vec![v],
+                    }),
+                    None => Ok(Value::Enum {
+                        name: "Option".to_string(),
+                        variant: "None".to_string(),
+                        fields: vec![],
+                    }),
+                }
+            }
+            "max" => {
+                let mut best: Option<Value> = None;
+                loop {
+                    match self.iter_next(iter)? {
+                        Some(item) => {
+                            best = Some(match best.take() {
+                                None => item,
+                                Some(b) => {
+                                    if Self::value_cmp(&item, &b) == Some(std::cmp::Ordering::Greater) {
+                                        item
+                                    } else {
+                                        b
+                                    }
+                                }
+                            });
+                        }
+                        None => break,
+                    }
+                }
+                match best {
+                    Some(v) => Ok(Value::Enum {
+                        name: "Option".to_string(),
+                        variant: "Some".to_string(),
+                        fields: vec![v],
+                    }),
+                    None => Ok(Value::Enum {
+                        name: "Option".to_string(),
+                        variant: "None".to_string(),
+                        fields: vec![],
+                    }),
+                }
+            }
+            "min_by" => {
+                let cmp_fn = args.into_iter().next().unwrap_or(Value::Unit);
+                let mut best: Option<Value> = None;
+                loop {
+                    match self.iter_next(iter)? {
+                        Some(item) => {
+                            best = Some(match best.take() {
+                                None => item,
+                                Some(b) => {
+                                    let ord = self.call_value(cmp_fn.clone(), vec![item.clone(), b.clone()])?;
+                                    match ord {
+                                        Value::Enum { ref name, ref variant, .. } if name == "Ordering" && variant == "Less" => item,
+                                        Value::Int(n) if n < 0 => item,
+                                        _ => b,
+                                    }
+                                }
+                            });
+                        }
+                        None => break,
+                    }
+                }
+                match best {
+                    Some(v) => Ok(Value::Enum {
+                        name: "Option".to_string(),
+                        variant: "Some".to_string(),
+                        fields: vec![v],
+                    }),
+                    None => Ok(Value::Enum {
+                        name: "Option".to_string(),
+                        variant: "None".to_string(),
+                        fields: vec![],
+                    }),
+                }
+            }
+            "max_by" => {
+                let cmp_fn = args.into_iter().next().unwrap_or(Value::Unit);
+                let mut best: Option<Value> = None;
+                loop {
+                    match self.iter_next(iter)? {
+                        Some(item) => {
+                            best = Some(match best.take() {
+                                None => item,
+                                Some(b) => {
+                                    let ord = self.call_value(cmp_fn.clone(), vec![item.clone(), b.clone()])?;
+                                    match ord {
+                                        Value::Enum { ref name, ref variant, .. } if name == "Ordering" && variant == "Greater" => item,
+                                        Value::Int(n) if n > 0 => item,
+                                        _ => b,
+                                    }
+                                }
+                            });
+                        }
+                        None => break,
+                    }
+                }
+                match best {
+                    Some(v) => Ok(Value::Enum {
+                        name: "Option".to_string(),
+                        variant: "Some".to_string(),
+                        fields: vec![v],
+                    }),
+                    None => Ok(Value::Enum {
+                        name: "Option".to_string(),
+                        variant: "None".to_string(),
+                        fields: vec![],
+                    }),
+                }
+            }
+            "min_by_key" => {
+                let key_fn = args.into_iter().next().unwrap_or(Value::Unit);
+                let mut best: Option<(Value, Value)> = None;
+                loop {
+                    match self.iter_next(iter)? {
+                        Some(item) => {
+                            let key = self.call_value(key_fn.clone(), vec![item.clone()])?;
+                            best = Some(match best.take() {
+                                None => (item, key),
+                                Some((bi, bk)) => {
+                                    if Self::value_cmp(&key, &bk) == Some(std::cmp::Ordering::Less) {
+                                        (item, key)
+                                    } else {
+                                        (bi, bk)
+                                    }
+                                }
+                            });
+                        }
+                        None => break,
+                    }
+                }
+                match best {
+                    Some((v, _)) => Ok(Value::Enum {
+                        name: "Option".to_string(),
+                        variant: "Some".to_string(),
+                        fields: vec![v],
+                    }),
+                    None => Ok(Value::Enum {
+                        name: "Option".to_string(),
+                        variant: "None".to_string(),
+                        fields: vec![],
+                    }),
+                }
+            }
+            "max_by_key" => {
+                let key_fn = args.into_iter().next().unwrap_or(Value::Unit);
+                let mut best: Option<(Value, Value)> = None;
+                loop {
+                    match self.iter_next(iter)? {
+                        Some(item) => {
+                            let key = self.call_value(key_fn.clone(), vec![item.clone()])?;
+                            best = Some(match best.take() {
+                                None => (item, key),
+                                Some((bi, bk)) => {
+                                    if Self::value_cmp(&key, &bk) == Some(std::cmp::Ordering::Greater) {
+                                        (item, key)
+                                    } else {
+                                        (bi, bk)
+                                    }
+                                }
+                            });
+                        }
+                        None => break,
+                    }
+                }
+                match best {
+                    Some((v, _)) => Ok(Value::Enum {
+                        name: "Option".to_string(),
+                        variant: "Some".to_string(),
+                        fields: vec![v],
+                    }),
+                    None => Ok(Value::Enum {
+                        name: "Option".to_string(),
+                        variant: "None".to_string(),
+                        fields: vec![],
+                    }),
+                }
+            }
             _ => Err(RuntimeError::NoSuchMethod {
                 ty: "Iterator".to_string(),
                 method: method.to_string(),

--- a/compiler/crates/rask-interp/src/builtins/mod.rs
+++ b/compiler/crates/rask-interp/src/builtins/mod.rs
@@ -109,13 +109,75 @@ impl Interpreter {
             Value::Enum { .. } if method == "hash" => {
                 return Ok(Value::Int(Self::value_hash(&receiver) as i64));
             }
+            Value::Struct { .. } if method == "compare" => {
+                if let Some(other) = args.first() {
+                    let ord = Self::value_cmp(&receiver, other).unwrap_or(std::cmp::Ordering::Equal);
+                    return Ok(Value::Enum {
+                        name: "Ordering".to_string(),
+                        variant: match ord {
+                            std::cmp::Ordering::Less => "Less".to_string(),
+                            std::cmp::Ordering::Equal => "Equal".to_string(),
+                            std::cmp::Ordering::Greater => "Greater".to_string(),
+                        },
+                        fields: vec![],
+                    });
+                }
+                return Ok(Value::Enum {
+                    name: "Ordering".to_string(),
+                    variant: "Equal".to_string(),
+                    fields: vec![],
+                });
+            }
+            Value::Enum { .. } if method == "compare" => {
+                if let Some(other) = args.first() {
+                    let ord = Self::value_cmp(&receiver, other).unwrap_or(std::cmp::Ordering::Equal);
+                    return Ok(Value::Enum {
+                        name: "Ordering".to_string(),
+                        variant: match ord {
+                            std::cmp::Ordering::Less => "Less".to_string(),
+                            std::cmp::Ordering::Equal => "Equal".to_string(),
+                            std::cmp::Ordering::Greater => "Greater".to_string(),
+                        },
+                        fields: vec![],
+                    });
+                }
+                return Ok(Value::Enum {
+                    name: "Ordering".to_string(),
+                    variant: "Equal".to_string(),
+                    fields: vec![],
+                });
+            }
             Value::Struct { .. } if method == "clone" => return Ok(receiver.deep_clone()),
             Value::Enum { .. } if method == "clone" => return Ok(receiver.deep_clone()),
             _ => {}
         }
 
-        // Generic to_string fallback
+        // Generic to_string fallback — Error→Displayable bridge (D5):
+        // If the type has a user-defined message() method, use it for to_string().
         if method == "to_string" {
+            let type_name = match &receiver {
+                Value::Struct { name, .. } => Some(name.clone()),
+                Value::Enum { name, .. } => Some(name.clone()),
+                _ => None,
+            };
+            if let Some(ref tn) = type_name {
+                // Check for user-defined to_string first, then message (Error bridge)
+                let base_name = tn.find('.').map_or(tn.as_str(), |pos| &tn[..pos]);
+                let has_to_string = self.methods.get(tn)
+                    .and_then(|m| m.get("to_string"))
+                    .or_else(|| self.methods.get(base_name).and_then(|m| m.get("to_string")));
+                if let Some(method_fn) = has_to_string {
+                    let method_fn = method_fn.clone();
+                    return self.call_function(&method_fn, vec![receiver]).map_err(|diag| diag.error);
+                }
+                let has_message = self.methods.get(tn)
+                    .and_then(|m| m.get("message"))
+                    .or_else(|| self.methods.get(base_name).and_then(|m| m.get("message")));
+                if let Some(method_fn) = has_message {
+                    let method_fn = method_fn.clone();
+                    return self.call_function(&method_fn, vec![receiver]).map_err(|diag| diag.error);
+                }
+            }
             return Ok(Value::String(Arc::new(Mutex::new(format!("{}", receiver)))));
         }
 

--- a/compiler/crates/rask-interp/src/builtins/primitives.rs
+++ b/compiler/crates/rask-interp/src/builtins/primitives.rs
@@ -8,6 +8,19 @@ use std::sync::{Arc, Mutex};
 use crate::interp::{Interpreter, RuntimeError};
 use crate::value::Value;
 
+/// Create an Ordering enum value from a std::cmp::Ordering.
+fn ordering_value(ord: std::cmp::Ordering) -> Value {
+    Value::Enum {
+        name: "Ordering".to_string(),
+        variant: match ord {
+            std::cmp::Ordering::Less => "Less".to_string(),
+            std::cmp::Ordering::Equal => "Equal".to_string(),
+            std::cmp::Ordering::Greater => "Greater".to_string(),
+        },
+        fields: vec![],
+    }
+}
+
 impl Interpreter {
     /// Handle integer method calls.
     pub(crate) fn call_int_method(
@@ -36,6 +49,7 @@ impl Interpreter {
             "le" => { let b = self.expect_int(args, 0)?; Ok(Value::Bool(a <= b)) }
             "gt" => { let b = self.expect_int(args, 0)?; Ok(Value::Bool(a > b)) }
             "ge" => { let b = self.expect_int(args, 0)?; Ok(Value::Bool(a >= b)) }
+            "compare" => { let b = self.expect_int(args, 0)?; Ok(ordering_value(a.cmp(&b))) }
             "bit_and" => { let b = self.expect_int(args, 0)?; Ok(Value::Int(a & b)) }
             "bit_or" => { let b = self.expect_int(args, 0)?; Ok(Value::Int(a | b)) }
             "bit_xor" => { let b = self.expect_int(args, 0)?; Ok(Value::Int(a ^ b)) }
@@ -81,6 +95,7 @@ impl Interpreter {
             "le" => { let b = self.expect_int128(args, 0)?; Ok(Value::Bool(a <= b)) }
             "gt" => { let b = self.expect_int128(args, 0)?; Ok(Value::Bool(a > b)) }
             "ge" => { let b = self.expect_int128(args, 0)?; Ok(Value::Bool(a >= b)) }
+            "compare" => { let b = self.expect_int128(args, 0)?; Ok(ordering_value(a.cmp(&b))) }
             "bit_and" => { let b = self.expect_int128(args, 0)?; Ok(Value::Int128(a & b)) }
             "bit_or" => { let b = self.expect_int128(args, 0)?; Ok(Value::Int128(a | b)) }
             "bit_xor" => { let b = self.expect_int128(args, 0)?; Ok(Value::Int128(a ^ b)) }
@@ -124,6 +139,7 @@ impl Interpreter {
             "le" => { let b = self.expect_uint128(args, 0)?; Ok(Value::Bool(a <= b)) }
             "gt" => { let b = self.expect_uint128(args, 0)?; Ok(Value::Bool(a > b)) }
             "ge" => { let b = self.expect_uint128(args, 0)?; Ok(Value::Bool(a >= b)) }
+            "compare" => { let b = self.expect_uint128(args, 0)?; Ok(ordering_value(a.cmp(&b))) }
             "bit_and" => { let b = self.expect_uint128(args, 0)?; Ok(Value::Uint128(a & b)) }
             "bit_or" => { let b = self.expect_uint128(args, 0)?; Ok(Value::Uint128(a | b)) }
             "bit_xor" => { let b = self.expect_uint128(args, 0)?; Ok(Value::Uint128(a ^ b)) }
@@ -158,6 +174,10 @@ impl Interpreter {
             "le" => { let b = self.expect_float(args, 0)?; Ok(Value::Bool(a <= b)) }
             "gt" => { let b = self.expect_float(args, 0)?; Ok(Value::Bool(a > b)) }
             "ge" => { let b = self.expect_float(args, 0)?; Ok(Value::Bool(a >= b)) }
+            "compare" => {
+                let b = self.expect_float(args, 0)?;
+                Ok(ordering_value(a.partial_cmp(&b).unwrap_or(std::cmp::Ordering::Equal)))
+            }
             "abs" => Ok(Value::Float(a.abs())),
             "floor" => Ok(Value::Float(a.floor())),
             "ceil" => Ok(Value::Float(a.ceil())),
@@ -184,6 +204,7 @@ impl Interpreter {
     ) -> Result<Value, RuntimeError> {
         match method {
             "eq" => { let b = self.expect_bool(args, 0)?; Ok(Value::Bool(a == b)) }
+            "compare" => { let b = self.expect_bool(args, 0)?; Ok(ordering_value(a.cmp(&b))) }
             "to_string" => Ok(Value::String(Arc::new(Mutex::new(if a { "true" } else { "false" }.to_string())))),
             _ => Err(RuntimeError::NoSuchMethod {
                 ty: "bool".to_string(),
@@ -209,6 +230,7 @@ impl Interpreter {
             "to_uppercase" => Ok(Value::Char(c.to_uppercase().next().unwrap_or(c))),
             "to_lowercase" => Ok(Value::Char(c.to_lowercase().next().unwrap_or(c))),
             "eq" => { let other = self.expect_char(args, 0)?; Ok(Value::Bool(c == other)) }
+            "compare" => { let other = self.expect_char(args, 0)?; Ok(ordering_value(c.cmp(&other))) }
             _ => Err(RuntimeError::NoSuchMethod {
                 ty: "char".to_string(),
                 method: method.to_string(),

--- a/compiler/crates/rask-interp/src/builtins/strings.rs
+++ b/compiler/crates/rask-interp/src/builtins/strings.rs
@@ -208,6 +208,35 @@ impl Interpreter {
                 let b = self.expect_string(&args, 0)?;
                 Ok(Value::Bool(*s.lock().unwrap() != b))
             }
+            "lt" => {
+                let b = self.expect_string(&args, 0)?;
+                Ok(Value::Bool(*s.lock().unwrap() < b))
+            }
+            "le" => {
+                let b = self.expect_string(&args, 0)?;
+                Ok(Value::Bool(*s.lock().unwrap() <= b))
+            }
+            "gt" => {
+                let b = self.expect_string(&args, 0)?;
+                Ok(Value::Bool(*s.lock().unwrap() > b))
+            }
+            "ge" => {
+                let b = self.expect_string(&args, 0)?;
+                Ok(Value::Bool(*s.lock().unwrap() >= b))
+            }
+            "compare" => {
+                let b = self.expect_string(&args, 0)?;
+                let ord = s.lock().unwrap().cmp(&b);
+                Ok(Value::Enum {
+                    name: "Ordering".to_string(),
+                    variant: match ord {
+                        std::cmp::Ordering::Less => "Less".to_string(),
+                        std::cmp::Ordering::Equal => "Equal".to_string(),
+                        std::cmp::Ordering::Greater => "Greater".to_string(),
+                    },
+                    fields: vec![],
+                })
+            }
             _ => Err(RuntimeError::NoSuchMethod {
                 ty: "string".to_string(),
                 method: method.to_string(),

--- a/compiler/crates/rask-interp/src/interp/dispatch.rs
+++ b/compiler/crates/rask-interp/src/interp/dispatch.rs
@@ -136,6 +136,39 @@ impl Interpreter {
                     )),
                 }
             }
+            BuiltinKind::Min => {
+                if args.len() != 2 {
+                    return Err(RuntimeError::ArityMismatch { expected: 2, got: args.len() });
+                }
+                match Self::value_cmp(&args[0], &args[1]) {
+                    Some(std::cmp::Ordering::Greater) => Ok(args.into_iter().nth(1).unwrap()),
+                    _ => Ok(args.into_iter().next().unwrap()),
+                }
+            }
+            BuiltinKind::Max => {
+                if args.len() != 2 {
+                    return Err(RuntimeError::ArityMismatch { expected: 2, got: args.len() });
+                }
+                match Self::value_cmp(&args[0], &args[1]) {
+                    Some(std::cmp::Ordering::Less) => Ok(args.into_iter().nth(1).unwrap()),
+                    _ => Ok(args.into_iter().next().unwrap()),
+                }
+            }
+            BuiltinKind::Clamp => {
+                if args.len() != 3 {
+                    return Err(RuntimeError::ArityMismatch { expected: 3, got: args.len() });
+                }
+                let value = &args[0];
+                let lo = &args[1];
+                let hi = &args[2];
+                if Self::value_cmp(value, lo) == Some(std::cmp::Ordering::Less) {
+                    Ok(args.into_iter().nth(1).unwrap())
+                } else if Self::value_cmp(value, hi) == Some(std::cmp::Ordering::Greater) {
+                    Ok(args.into_iter().nth(2).unwrap())
+                } else {
+                    Ok(args.into_iter().next().unwrap())
+                }
+            }
         }
     }
 

--- a/compiler/crates/rask-interp/src/interp/register.rs
+++ b/compiler/crates/rask-interp/src/interp/register.rs
@@ -161,6 +161,12 @@ impl Interpreter {
             .define("todo".to_string(), Value::Builtin(BuiltinKind::Todo));
         self.env
             .define("unreachable".to_string(), Value::Builtin(BuiltinKind::Unreachable));
+        self.env
+            .define("min".to_string(), Value::Builtin(BuiltinKind::Min));
+        self.env
+            .define("max".to_string(), Value::Builtin(BuiltinKind::Max));
+        self.env
+            .define("clamp".to_string(), Value::Builtin(BuiltinKind::Clamp));
 
         // Builtin types (always in scope, matching resolver builtins)
         self.env

--- a/compiler/crates/rask-interp/src/value.rs
+++ b/compiler/crates/rask-interp/src/value.rs
@@ -127,6 +127,9 @@ pub enum BuiltinKind {
     AsyncSpawn, // spawn(|| {}) from async module
     Todo,
     Unreachable,
+    Min,   // generic min(a, b) — prelude
+    Max,   // generic max(a, b) — prelude
+    Clamp, // generic clamp(value, lo, hi) — prelude
 }
 
 /// Type constructor kinds (for static method calls like Vec.new()).

--- a/compiler/crates/rask-resolve/src/resolver.rs
+++ b/compiler/crates/rask-resolve/src/resolver.rs
@@ -65,6 +65,9 @@ impl Resolver {
             ("transmute", BuiltinFunctionKind::Transmute, None),
             ("todo", BuiltinFunctionKind::Todo, Some("!")),
             ("unreachable", BuiltinFunctionKind::Unreachable, Some("!")),
+            ("min", BuiltinFunctionKind::Min, None),
+            ("max", BuiltinFunctionKind::Max, None),
+            ("clamp", BuiltinFunctionKind::Clamp, None),
         ];
 
         for (name, builtin, ret_ty) in builtin_fns {

--- a/compiler/crates/rask-resolve/src/symbol.rs
+++ b/compiler/crates/rask-resolve/src/symbol.rs
@@ -150,6 +150,12 @@ pub enum BuiltinFunctionKind {
     Todo,
     /// unreachable - panic with "entered unreachable code"
     Unreachable,
+    /// min - generic minimum of two comparable values
+    Min,
+    /// max - generic maximum of two comparable values
+    Max,
+    /// clamp - constrain value between lo and hi
+    Clamp,
 }
 
 /// Built-in module kinds (stdlib modules).

--- a/compiler/crates/rask-types/src/traits.rs
+++ b/compiler/crates/rask-types/src/traits.rs
@@ -255,6 +255,13 @@ impl<'a> TraitChecker<'a> {
             }]),
             "Comparable" | "Ord" => Some(vec![
                 MethodSig {
+                    name: "compare".to_string(),
+                    self_param: SelfParam::Value,
+                    params: vec![(Type::Var(crate::types::TypeVarId(0)), ParamMode::Default)],
+                    // Returns Ordering enum — use Var as placeholder (structural check)
+                    ret: Type::Var(crate::types::TypeVarId(0)),
+                },
+                MethodSig {
                     name: "lt".to_string(),
                     self_param: SelfParam::Value,
                     params: vec![(Type::Var(crate::types::TypeVarId(0)), ParamMode::Default)],
@@ -279,7 +286,7 @@ impl<'a> TraitChecker<'a> {
                     ret: Type::Bool,
                 },
             ]),
-            "Clone" => Some(vec![MethodSig {
+            "Clone" | "Cloneable" => Some(vec![MethodSig {
                 name: "clone".to_string(),
                 self_param: SelfParam::Value,
                 params: vec![],
@@ -305,6 +312,18 @@ impl<'a> TraitChecker<'a> {
                     ret: Type::Bool,
                 },
             ]),
+            "Displayable" => Some(vec![MethodSig {
+                name: "to_string".to_string(),
+                self_param: SelfParam::Value,
+                params: vec![],
+                ret: Type::String,
+            }]),
+            "Debug" => Some(vec![MethodSig {
+                name: "debug_string".to_string(),
+                self_param: SelfParam::Value,
+                params: vec![],
+                ret: Type::String,
+            }]),
             _ => None,
         }
     }
@@ -332,33 +351,33 @@ impl<'a> TraitChecker<'a> {
     /// Check if a primitive type has a builtin method.
     fn has_builtin_method(&self, ty: &Type, method: &str) -> bool {
         match ty {
-            // Integer types: eq, hash, clone, default, arithmetic
+            // Integer types: eq, hash, clone, default, arithmetic, compare, to_string
             Type::I8 | Type::I16 | Type::I32 | Type::I64 | Type::I128 |
             Type::U8 | Type::U16 | Type::U32 | Type::U64 | Type::U128 => {
                 matches!(method,
                     "add" | "sub" | "mul" | "div" | "rem" |
-                    "neg" | "eq" | "lt" | "le" | "gt" | "ge" |
+                    "neg" | "eq" | "lt" | "le" | "gt" | "ge" | "compare" |
                     "bit_and" | "bit_or" | "bit_xor" | "shl" | "shr" | "bit_not" |
-                    "hash" | "clone" | "default"
+                    "hash" | "clone" | "default" | "to_string" | "debug_string"
                 )
             }
             // Floats: eq, clone, default, but NOT hash (HA4)
             Type::F32 | Type::F64 => {
                 matches!(method,
                     "add" | "sub" | "mul" | "div" | "rem" |
-                    "neg" | "eq" | "lt" | "le" | "gt" | "ge" |
+                    "neg" | "eq" | "lt" | "le" | "gt" | "ge" | "compare" |
                     "bit_and" | "bit_or" | "bit_xor" | "shl" | "shr" | "bit_not" |
-                    "clone" | "default"
+                    "clone" | "default" | "to_string" | "debug_string"
                 )
             }
-            // Bool: eq, hash, clone, default
-            Type::Bool => matches!(method, "eq" | "hash" | "clone" | "default"),
-            // Char: eq, hash, clone, default, comparison
-            Type::Char => matches!(method, "eq" | "lt" | "le" | "gt" | "ge" | "hash" | "clone" | "default"),
-            // String: eq, hash, clone, default, len
-            Type::String => matches!(method, "eq" | "len" | "clone" | "hash" | "default"),
+            // Bool: eq, hash, clone, default, compare, to_string
+            Type::Bool => matches!(method, "eq" | "compare" | "hash" | "clone" | "default" | "to_string" | "debug_string"),
+            // Char: eq, hash, clone, default, comparison, to_string
+            Type::Char => matches!(method, "eq" | "lt" | "le" | "gt" | "ge" | "compare" | "hash" | "clone" | "default" | "to_string" | "debug_string"),
+            // String: eq, hash, clone, default, len, comparison, to_string
+            Type::String => matches!(method, "eq" | "lt" | "le" | "gt" | "ge" | "compare" | "len" | "clone" | "hash" | "default" | "to_string" | "debug_string"),
             // Unit: eq, hash, clone, default
-            Type::Unit => matches!(method, "eq" | "hash" | "clone" | "default"),
+            Type::Unit => matches!(method, "eq" | "hash" | "clone" | "default" | "to_string" | "debug_string"),
             _ => false,
         }
     }
@@ -482,7 +501,8 @@ pub fn implemented_traits(types: &TypeTable, ty: &Type) -> Vec<String> {
     let known_traits = [
         "Add", "Sub", "Mul", "Div", "Rem", "Neg",
         "Equal", "Eq", "Comparable", "Ord",
-        "Clone", "Default", "Hashable",
+        "Clone", "Cloneable", "Default", "Hashable",
+        "Displayable", "Debug",
     ];
 
     for trait_name in known_traits {


### PR DESCRIPTION
…nctions

Compiler implementation matching the spec changes from the previous commit:

- Trait system: Add Cloneable alias for Clone, Displayable trait (to_string), Debug trait (debug_string), compare() method to Comparable trait
- Primitives: Add compare() returning Ordering enum to int, float, bool, char, string types. Add comparison operators (lt/le/gt/ge) to strings
- Collections: sort_by now accepts Ordering enum values (not just Int), add sort_by_key method to Vec
- Iterators: Add min, max, min_by, max_by, min_by_key, max_by_key terminals
- Prelude: Add generic min(a,b), max(a,b), clamp(val,lo,hi) functions using value_cmp for any Comparable type
- Error bridge (D5): to_string fallback checks for user-defined message() method, enabling Error types to auto-satisfy Displayable
- Type checker: Update has_builtin_method for compare/to_string/debug_string, update implemented_traits list with new trait names
- Resolver: Register min/max/clamp as builtin prelude functions

https://claude.ai/code/session_01SZKoBoM2uZG6WEpDv9x31H