### PR TITLE
Add package manager example and HTTP client implementation

### DIFF
--- a/compiler/runtime/rask_runtime.h
+++ b/compiler/runtime/rask_runtime.h
@@ -239,6 +239,10 @@ int64_t rask_time_Instant_duration_since(int64_t self_ns, int64_t other_ns);
 // Basic TCP socket operations.
 
 int64_t rask_net_tcp_listen(const RaskString *addr);
+int64_t rask_net_tcp_connect(const RaskString *addr);
+
+// Response reading (reads until EOF for Connection: close pattern).
+RaskString *rask_io_read_until_close(int64_t fd, int64_t max_len);
 
 // ─── JSON module ────────────────────────────────────────────
 // Encode helpers — used by codegen-generated struct serialization.

--- a/compiler/runtime/runtime.c
+++ b/compiler/runtime/runtime.c
@@ -341,6 +341,7 @@ RaskVec *rask_file_lines(int64_t file) {
 #include <sys/socket.h>
 #include <netinet/in.h>
 #include <arpa/inet.h>
+#include <netdb.h>
 
 int64_t rask_net_tcp_listen(const RaskString *addr) {
     const char *a = addr ? rask_string_ptr(addr) : "0.0.0.0:0";
@@ -386,6 +387,50 @@ int64_t rask_net_tcp_accept(int64_t listen_fd) {
     return (int64_t)client;
 }
 
+int64_t rask_net_tcp_connect(const RaskString *addr) {
+    const char *a = addr ? rask_string_ptr(addr) : "127.0.0.1:80";
+
+    // Parse "host:port"
+    char host[256] = "127.0.0.1";
+    char port_str[16] = "80";
+    const char *colon = strrchr(a, ':');
+    if (colon) {
+        size_t hlen = (size_t)(colon - a);
+        if (hlen > 0 && hlen < sizeof(host)) {
+            memcpy(host, a, hlen);
+            host[hlen] = '\0';
+        }
+        size_t plen = strlen(colon + 1);
+        if (plen > 0 && plen < sizeof(port_str)) {
+            memcpy(port_str, colon + 1, plen + 1);
+        }
+    }
+
+    // Resolve hostname via getaddrinfo (handles both IPs and DNS names)
+    struct addrinfo hints, *result;
+    memset(&hints, 0, sizeof(hints));
+    hints.ai_family = AF_INET;
+    hints.ai_socktype = SOCK_STREAM;
+
+    int err = getaddrinfo(host, port_str, &hints, &result);
+    if (err != 0) return -1;
+
+    int fd = socket(result->ai_family, result->ai_socktype, result->ai_protocol);
+    if (fd < 0) {
+        freeaddrinfo(result);
+        return -1;
+    }
+
+    if (connect(fd, result->ai_addr, result->ai_addrlen) < 0) {
+        close(fd);
+        freeaddrinfo(result);
+        return -1;
+    }
+
+    freeaddrinfo(result);
+    return (int64_t)fd;
+}
+
 // ─── String-based socket I/O (used by Rask stdlib HTTP parser) ────
 
 // Read up to max_len bytes from fd, return as RaskString.
@@ -413,6 +458,22 @@ RaskString *rask_io_read_string(int64_t fd, int64_t max_len) {
         }
     }
 done:;
+    RaskString *s = rask_string_from_bytes(buf, total);
+    rask_free(buf);
+    return s;
+}
+
+// Read until connection closes or max_len reached. For HTTP client responses
+// where Connection: close is used.
+RaskString *rask_io_read_until_close(int64_t fd, int64_t max_len) {
+    if (max_len <= 0 || max_len > 4 * 1024 * 1024) max_len = 1048576;
+    char *buf = (char *)rask_alloc(max_len);
+    int64_t total = 0;
+    while (total < max_len) {
+        ssize_t n = read((int)fd, buf + total, (size_t)(max_len - total));
+        if (n <= 0) break;
+        total += n;
+    }
     RaskString *s = rask_string_from_bytes(buf, total);
     rask_free(buf);
     return s;

--- a/examples/package_manager.rk
+++ b/examples/package_manager.rk
@@ -67,12 +67,24 @@ extend Version {
         return 0
     }
 
-    func gte(self, other: Version) -> bool {
+    func lt(self, other: Version) -> bool {
+        return self.compare(other) < 0
+    }
+
+    func le(self, other: Version) -> bool {
+        return self.compare(other) <= 0
+    }
+
+    func gt(self, other: Version) -> bool {
+        return self.compare(other) > 0
+    }
+
+    func ge(self, other: Version) -> bool {
         return self.compare(other) >= 0
     }
 
-    func lt(self, other: Version) -> bool {
-        return self.compare(other) < 0
+    func eq(self, other: Version) -> bool {
+        return self.compare(other) == 0
     }
 }
 
@@ -115,29 +127,29 @@ extend Constraint {
         match self {
             Compatible(min) => {
                 // ^1.2.3 → >=1.2.3, <2.0.0
-                if v.lt(min) { return false }
+                if v < min { return false }
                 const next_major = Version {
                     major: min.major + 1,
                     minor: 0,
                     patch: 0,
                 }
-                return v.lt(next_major)
+                return v < next_major
             }
             Tilde(min) => {
                 // ~1.2.3 → >=1.2.3, <1.3.0
-                if v.lt(min) { return false }
+                if v < min { return false }
                 const next_minor = Version {
                     major: min.major,
                     minor: min.minor + 1,
                     patch: 0,
                 }
-                return v.lt(next_minor)
+                return v < next_minor
             }
             Exact(target) => {
-                return v.compare(target) == 0
+                return v == target
             }
             Minimum(min) => {
-                return v.gte(min)
+                return v >= min
             }
         }
     }
@@ -699,7 +711,7 @@ func resolve_one(
     for meta in versions {
         if constraint.satisfies(meta.version) {
             if best is Some(current) {
-                if meta.version.compare(current.version) > 0 {
+                if meta.version > current.version {
                     best = Some(meta)
                 }
             } else {

--- a/examples/package_manager.rk
+++ b/examples/package_manager.rk
@@ -1,0 +1,1208 @@
+// SPDX-License-Identifier: (MIT OR Apache-2.0)
+// Package Manager — Stress Test Application
+//
+// Implements a subset of `rask fetch`: manifest parsing, semver resolution,
+// dependency graph construction, lock file generation, and package fetching
+// from a local or HTTP registry.
+//
+// Demonstrates: Pool<T>/Handle<T> for dependency graphs, enum-based registry
+// dispatch, layered error types with cross-layer propagation, Map/Vec-heavy
+// algorithms, string parsing, file I/O with ensure cleanup, pattern matching
+// at scale.
+
+import fs
+import cli
+import std
+import http
+import json
+
+// ─── Semver ─────────────────────────────────────────────────────────
+
+struct Version {
+    major: i32
+    minor: i32
+    patch: i32
+}
+
+extend Version {
+    func parse(s: string) -> Version or VersionError {
+        const parts = s.split(".")
+        if parts.len() != 3 {
+            return Err(VersionError.InvalidFormat("expected MAJOR.MINOR.PATCH, got: {s}"))
+        }
+
+        const major = parts[0].trim().parse_int() is Ok(v) else {
+            return Err(VersionError.InvalidFormat("bad major version in: {s}"))
+        }
+        const minor = parts[1].trim().parse_int() is Ok(v) else {
+            return Err(VersionError.InvalidFormat("bad minor version in: {s}"))
+        }
+        const patch = parts[2].trim().parse_int() is Ok(v) else {
+            return Err(VersionError.InvalidFormat("bad patch version in: {s}"))
+        }
+
+        return Ok(Version {
+            major: major as i32,
+            minor: minor as i32,
+            patch: patch as i32,
+        })
+    }
+
+    func to_string(self) -> string {
+        return "{self.major}.{self.minor}.{self.patch}"
+    }
+
+    // -1, 0, or 1 for ordering
+    func compare(self, other: Version) -> i32 {
+        if self.major != other.major {
+            return if self.major < other.major: -1 else: 1
+        }
+        if self.minor != other.minor {
+            return if self.minor < other.minor: -1 else: 1
+        }
+        if self.patch != other.patch {
+            return if self.patch < other.patch: -1 else: 1
+        }
+        return 0
+    }
+
+    func gte(self, other: Version) -> bool {
+        return self.compare(other) >= 0
+    }
+
+    func lt(self, other: Version) -> bool {
+        return self.compare(other) < 0
+    }
+}
+
+// ─── Version Constraints ────────────────────────────────────────────
+
+enum Constraint {
+    Compatible(Version)     // ^1.2.3 → >=1.2.3, <2.0.0
+    Tilde(Version)          // ~1.2.3 → >=1.2.3, <1.3.0
+    Exact(Version)          // =1.2.3
+    Minimum(Version)        // >=1.2.3
+}
+
+extend Constraint {
+    func parse(s: string) -> Constraint or VersionError {
+        const trimmed = s.trim()
+
+        if trimmed.starts_with("^") {
+            const ver = try Version.parse(trimmed[1..].to_string())
+            return Ok(Constraint.Compatible(ver))
+        }
+        if trimmed.starts_with("~") {
+            const ver = try Version.parse(trimmed[1..].to_string())
+            return Ok(Constraint.Tilde(ver))
+        }
+        if trimmed.starts_with(">=") {
+            const ver = try Version.parse(trimmed[2..].to_string())
+            return Ok(Constraint.Minimum(ver))
+        }
+        if trimmed.starts_with("=") {
+            const ver = try Version.parse(trimmed[1..].to_string())
+            return Ok(Constraint.Exact(ver))
+        }
+
+        // Bare version string treated as compatible
+        const ver = try Version.parse(trimmed.to_string())
+        return Ok(Constraint.Compatible(ver))
+    }
+
+    func satisfies(self, v: Version) -> bool {
+        match self {
+            Compatible(min) => {
+                // ^1.2.3 → >=1.2.3, <2.0.0
+                if v.lt(min) { return false }
+                const next_major = Version {
+                    major: min.major + 1,
+                    minor: 0,
+                    patch: 0,
+                }
+                return v.lt(next_major)
+            }
+            Tilde(min) => {
+                // ~1.2.3 → >=1.2.3, <1.3.0
+                if v.lt(min) { return false }
+                const next_minor = Version {
+                    major: min.major,
+                    minor: min.minor + 1,
+                    patch: 0,
+                }
+                return v.lt(next_minor)
+            }
+            Exact(target) => {
+                return v.compare(target) == 0
+            }
+            Minimum(min) => {
+                return v.gte(min)
+            }
+        }
+    }
+
+    func to_string(self) -> string {
+        match self {
+            Compatible(v) => return "^{v.to_string()}",
+            Tilde(v) => return "~{v.to_string()}",
+            Exact(v) => return "={v.to_string()}",
+            Minimum(v) => return ">={v.to_string()}",
+        }
+    }
+}
+
+// ─── Error Types ────────────────────────────────────────────────────
+//
+// Five error types, one per layer. FetchError composes them at the top.
+
+enum VersionError {
+    InvalidFormat(string)
+}
+
+extend VersionError {
+    func message(self) -> string {
+        match self {
+            InvalidFormat(msg) => return "invalid version: {msg}",
+        }
+    }
+}
+
+enum ManifestError {
+    ParseError(i32, string)     // line, message
+    MissingField(string)
+    InvalidConstraint(string)
+}
+
+extend ManifestError {
+    func message(self) -> string {
+        match self {
+            ParseError(line, msg) => return "manifest line {line}: {msg}",
+            MissingField(field) => return "missing required field: {field}",
+            InvalidConstraint(msg) => return "bad constraint: {msg}",
+        }
+    }
+}
+
+enum RegistryError {
+    PackageNotFound(string)
+    NetworkError(string)
+    ChecksumMismatch(string, string, string)    // package, expected, got
+    IoError(string)
+}
+
+extend RegistryError {
+    func message(self) -> string {
+        match self {
+            PackageNotFound(name) => return "package not found: {name}",
+            NetworkError(msg) => return "network error: {msg}",
+            ChecksumMismatch(pkg, expected, got) => {
+                return "checksum mismatch for {pkg}: expected {expected}, got {got}"
+            }
+            IoError(msg) => return "I/O error: {msg}",
+        }
+    }
+}
+
+enum ResolveError {
+    Conflict(string, string, string)    // package, constraint_a, constraint_b
+    Cycle(string)
+    NoMatch(string, string)             // package, constraint
+}
+
+extend ResolveError {
+    func message(self) -> string {
+        match self {
+            Conflict(pkg, a, b) => {
+                return "version conflict for {pkg}: {a} vs {b}"
+            }
+            Cycle(chain) => return "dependency cycle: {chain}",
+            NoMatch(pkg, constraint) => {
+                return "no version of {pkg} satisfies {constraint}"
+            }
+        }
+    }
+}
+
+enum FetchError {
+    Manifest(ManifestError)
+    Version(VersionError)
+    Registry(RegistryError)
+    Resolve(ResolveError)
+    Io(string)
+}
+
+extend FetchError {
+    func message(self) -> string {
+        match self {
+            Manifest(e) => return e.message(),
+            Version(e) => return e.message(),
+            Registry(e) => return e.message(),
+            Resolve(e) => return e.message(),
+            Io(msg) => return "I/O error: {msg}",
+        }
+    }
+}
+
+// ─── Package Types ──────────────────────────────────────────────────
+
+struct Dependency {
+    name: string
+    constraint: Constraint
+}
+
+struct Manifest {
+    name: string
+    version: Version
+    deps: Vec<Dependency>
+}
+
+struct PackageMeta {
+    name: string
+    version: Version
+    checksum: string
+    deps: Vec<Dependency>
+}
+
+struct ResolvedPkg {
+    meta: PackageMeta
+    deps: Vec<Handle<ResolvedPkg>>
+}
+
+struct DepGraph {
+    packages: Pool<ResolvedPkg>
+    root: Handle<ResolvedPkg>
+    by_name: Map<string, Handle<ResolvedPkg>>
+}
+
+// ─── Lock File Types ────────────────────────────────────────────────
+
+struct LockedPackage {
+    name: string
+    version: string
+    checksum: string
+}
+
+// ─── Manifest Parser ────────────────────────────────────────────────
+//
+// Parses simplified build.rk format:
+//   package "name" "version" {
+//       dep "http" "^2.0"
+//       dep "json" "^1.5"
+//   }
+
+func load_manifest(path: string) -> Manifest or FetchError {
+    const content = try fs.read_file(path) else |e| FetchError.Io("cannot read {path}: {e}")
+    return try parse_manifest(content) else |e| FetchError.Manifest(e)
+}
+
+func parse_manifest(content: string) -> Manifest or ManifestError {
+    const lines = content.lines()
+    let name = ""
+    let version_str = ""
+    let deps = Vec.new()
+    let in_block = false
+    let line_num = 0
+
+    for line in lines {
+        line_num += 1
+        const trimmed = line.trim()
+
+        // Skip empty lines and comments
+        if trimmed.is_empty() { continue }
+        if trimmed.starts_with("//") { continue }
+
+        if trimmed.starts_with("package") {
+            // Parse: package "name" "version" {
+            const (parsed_name, parsed_ver) = try parse_package_line(trimmed, line_num)
+            name = parsed_name
+            version_str = parsed_ver
+            in_block = true
+            continue
+        }
+
+        if trimmed == "}" {
+            in_block = false
+            continue
+        }
+
+        if in_block && trimmed.starts_with("dep ") {
+            const d = try parse_dep_line(trimmed, line_num)
+            deps.push(d)
+            continue
+        }
+
+        if in_block {
+            // Unknown directive inside package block — skip for now
+            continue
+        }
+    }
+
+    if name.is_empty() {
+        return Err(ManifestError.MissingField("package name"))
+    }
+
+    const version = Version.parse(version_str) is Ok(v) else {
+        return Err(ManifestError.InvalidConstraint("bad package version: {version_str}"))
+    }
+
+    return Ok(Manifest { name: name, version: version, deps: deps })
+}
+
+// Extract name and version from: package "name" "version" {
+func parse_package_line(line: string, line_num: i32) -> (string, string) or ManifestError {
+    // Find first quoted string (package name)
+    const first_quote = line.find("\"") is Some(pos) else {
+        return Err(ManifestError.ParseError(line_num, "expected quoted package name"))
+    }
+    const after_first = first_quote + 1
+    const end_first = line[after_first..].find("\"") is Some(pos) else {
+        return Err(ManifestError.ParseError(line_num, "unterminated package name"))
+    }
+    const name = line[after_first..after_first + end_first].to_string()
+
+    // Find second quoted string (version)
+    const rest_start = after_first + end_first + 1
+    const second_quote = line[rest_start..].find("\"") is Some(pos) else {
+        return Err(ManifestError.ParseError(line_num, "expected quoted version"))
+    }
+    const ver_start = rest_start + second_quote + 1
+    const end_second = line[ver_start..].find("\"") is Some(pos) else {
+        return Err(ManifestError.ParseError(line_num, "unterminated version"))
+    }
+    const version = line[ver_start..ver_start + end_second].to_string()
+
+    return Ok((name, version))
+}
+
+// Extract dependency from: dep "name" "constraint"
+func parse_dep_line(line: string, line_num: i32) -> Dependency or ManifestError {
+    const first_quote = line.find("\"") is Some(pos) else {
+        return Err(ManifestError.ParseError(line_num, "expected quoted dep name"))
+    }
+    const after_first = first_quote + 1
+    const end_first = line[after_first..].find("\"") is Some(pos) else {
+        return Err(ManifestError.ParseError(line_num, "unterminated dep name"))
+    }
+    const name = line[after_first..after_first + end_first].to_string()
+
+    const rest_start = after_first + end_first + 1
+    const second_quote = line[rest_start..].find("\"") is Some(pos) else {
+        return Err(ManifestError.ParseError(line_num, "expected quoted constraint"))
+    }
+    const con_start = rest_start + second_quote + 1
+    const end_second = line[con_start..].find("\"") is Some(pos) else {
+        return Err(ManifestError.ParseError(line_num, "unterminated constraint"))
+    }
+    const constraint_str = line[con_start..con_start + end_second].to_string()
+
+    const constraint = Constraint.parse(constraint_str) is Ok(c) else {
+        return Err(ManifestError.InvalidConstraint(constraint_str))
+    }
+
+    return Ok(Dependency { name: name, constraint: constraint })
+}
+
+// ─── Registry ───────────────────────────────────────────────────────
+//
+// Enum-based dispatch: local filesystem for testing, HTTP for real registries.
+// Using enum rather than `any Trait` for explicit dispatch.
+
+enum RegistrySource {
+    Local(string)       // root path
+    Http(string)        // base URL
+}
+
+// Local registry layout:
+//   root/<pkg>/index.json   → ["1.0.0", "1.1.0"]
+//   root/<pkg>/1.0.0/meta.json
+
+func registry_available(source: RegistrySource, name: string) -> Vec<PackageMeta> or RegistryError {
+    match source {
+        Local(root) => return local_available(root, name),
+        Http(base_url) => return http_available(base_url, name),
+    }
+}
+
+func registry_fetch(source: RegistrySource, name: string, version: Version) -> string or RegistryError {
+    match source {
+        Local(root) => return local_fetch(root, name, version),
+        Http(base_url) => return http_fetch(base_url, name, version),
+    }
+}
+
+// ─── Local Registry ─────────────────────────────────────────────────
+
+func local_available(root: string, name: string) -> Vec<PackageMeta> or RegistryError {
+    // Read index file listing available versions
+    const index_path = "{root}/{name}/index.json"
+    const index_content = fs.read_file(index_path) is Ok(c) else {
+        return Err(RegistryError.PackageNotFound(name))
+    }
+
+    const parsed = json.parse(index_content) is Ok(v) else {
+        return Err(RegistryError.IoError("invalid JSON in {index_path}"))
+    }
+    const version_list = parsed.as_array() is Some(arr) else {
+        return Err(RegistryError.IoError("expected array in {index_path}"))
+    }
+
+    let versions = Vec.new()
+    for entry in version_list {
+        const ver_str = entry.as_string() is Some(s) else { continue }
+        const meta_path = "{root}/{name}/{ver_str}/meta.json"
+        const meta = load_package_meta(meta_path) is Ok(m) else { continue }
+        versions.push(meta)
+    }
+
+    if versions.is_empty() {
+        return Err(RegistryError.PackageNotFound(name))
+    }
+    return Ok(versions)
+}
+
+func local_fetch(root: string, name: string, version: Version) -> string or RegistryError {
+    const ver_str = version.to_string()
+    const pkg_path = "{root}/{name}/{ver_str}"
+    if !fs.exists(pkg_path) {
+        return Err(RegistryError.PackageNotFound("{name}@{ver_str}"))
+    }
+    return Ok(pkg_path)
+}
+
+// ─── Package Meta Loader ────────────────────────────────────────────
+
+func load_package_meta(path: string) -> PackageMeta or RegistryError {
+    const content = fs.read_file(path) is Ok(c) else {
+        return Err(RegistryError.IoError("cannot read {path}"))
+    }
+
+    const parsed = json.parse(content) is Ok(v) else {
+        return Err(RegistryError.IoError("invalid JSON in {path}"))
+    }
+    const obj = parsed.as_object() is Some(m) else {
+        return Err(RegistryError.IoError("expected object in {path}"))
+    }
+
+    const name_val = obj.get("name") is Some(v) else {
+        return Err(RegistryError.IoError("missing 'name' in {path}"))
+    }
+    const name = name_val.as_string() is Some(s) else {
+        return Err(RegistryError.IoError("'name' not a string in {path}"))
+    }
+
+    const ver_val = obj.get("version") is Some(v) else {
+        return Err(RegistryError.IoError("missing 'version' in {path}"))
+    }
+    const ver_str = ver_val.as_string() is Some(s) else {
+        return Err(RegistryError.IoError("'version' not a string in {path}"))
+    }
+
+    const check_val = obj.get("checksum") is Some(v) else {
+        return Err(RegistryError.IoError("missing 'checksum' in {path}"))
+    }
+    const checksum = check_val.as_string() is Some(s) else {
+        return Err(RegistryError.IoError("'checksum' not a string in {path}"))
+    }
+
+    const version = Version.parse(ver_str) is Ok(v) else {
+        return Err(RegistryError.IoError("bad version in {path}: {ver_str}"))
+    }
+
+    let deps = Vec.new()
+    const deps_val = obj.get("deps")
+    if deps_val is Some(dv) {
+        const dep_arr = dv.as_array() is Some(arr) else {
+            return Err(RegistryError.IoError("'deps' not an array in {path}"))
+        }
+        for d_val in dep_arr {
+            const d_obj = d_val.as_object() is Some(dm) else { continue }
+            const dn_val = d_obj.get("name") is Some(v) else { continue }
+            const dn = dn_val.as_string() is Some(s) else { continue }
+            const dc_val = d_obj.get("constraint") is Some(v) else { continue }
+            const dc = dc_val.as_string() is Some(s) else { continue }
+            const constraint = Constraint.parse(dc) is Ok(c) else { continue }
+            deps.push(Dependency { name: dn, constraint: constraint })
+        }
+    }
+
+    return Ok(PackageMeta {
+        name: name,
+        version: version,
+        checksum: checksum,
+        deps: deps,
+    })
+}
+
+// ─── HTTP Registry ──────────────────────────────────────────────────
+
+func http_available(base_url: string, name: string) -> Vec<PackageMeta> or RegistryError {
+    const url = "{base_url}/packages/{name}"
+    const resp = http.get(url) is Ok(r) else {
+        return Err(RegistryError.NetworkError("failed to fetch {url}"))
+    }
+
+    if resp.status == 404 {
+        return Err(RegistryError.PackageNotFound(name))
+    }
+    if !resp.is_ok() {
+        return Err(RegistryError.NetworkError("registry returned {resp.status} for {name}"))
+    }
+
+    const parsed = json.parse(resp.body) is Ok(v) else {
+        return Err(RegistryError.NetworkError("invalid JSON from registry for {name}"))
+    }
+    const arr = parsed.as_array() is Some(a) else {
+        return Err(RegistryError.NetworkError("expected array from registry for {name}"))
+    }
+
+    let versions = Vec.new()
+    for entry in arr {
+        const obj = entry.as_object() is Some(m) else { continue }
+
+        const n_val = obj.get("name") is Some(v) else { continue }
+        const pkg_name = n_val.as_string() is Some(s) else { continue }
+        const v_val = obj.get("version") is Some(v) else { continue }
+        const ver_str = v_val.as_string() is Some(s) else { continue }
+        const c_val = obj.get("checksum") is Some(v) else { continue }
+        const checksum = c_val.as_string() is Some(s) else { continue }
+
+        const version = Version.parse(ver_str) is Ok(v) else { continue }
+
+        let deps = Vec.new()
+        const deps_val = obj.get("deps")
+        if deps_val is Some(dv) {
+            const dep_arr = dv.as_array() is Some(a) else { continue }
+            for d_val in dep_arr {
+                const d_obj = d_val.as_object() is Some(dm) else { continue }
+                const dn_val = d_obj.get("name") is Some(v) else { continue }
+                const dn = dn_val.as_string() is Some(s) else { continue }
+                const dc_val = d_obj.get("constraint") is Some(v) else { continue }
+                const dc = dc_val.as_string() is Some(s) else { continue }
+                const constraint = Constraint.parse(dc) is Ok(c) else { continue }
+                deps.push(Dependency { name: dn, constraint: constraint })
+            }
+        }
+
+        versions.push(PackageMeta {
+            name: pkg_name,
+            version: version,
+            checksum: checksum,
+            deps: deps,
+        })
+    }
+
+    if versions.is_empty() {
+        return Err(RegistryError.PackageNotFound(name))
+    }
+    return Ok(versions)
+}
+
+func http_fetch(base_url: string, name: string, version: Version) -> string or RegistryError {
+    const ver_str = version.to_string()
+    const url = "{base_url}/packages/{name}/{ver_str}/download"
+    const resp = http.get(url) is Ok(r) else {
+        return Err(RegistryError.NetworkError("failed to download {name}@{ver_str}"))
+    }
+
+    if !resp.is_ok() {
+        return Err(RegistryError.NetworkError("download failed: {resp.status} for {name}@{ver_str}"))
+    }
+
+    // Write to cache
+    const cache_dir = "/tmp/rask-cache/{name}-{ver_str}"
+    fs.create_dir_all(cache_dir)
+    fs.write_file("{cache_dir}/package.tar", resp.body)
+    return Ok(cache_dir)
+}
+
+// ─── Dependency Resolver ────────────────────────────────────────────
+//
+// Greedy resolver: for each dependency, pick the newest version that
+// satisfies the constraint. Detect conflicts when two constraints
+// for the same package are incompatible. Detect cycles via a visited set.
+
+// Bundle resolver working state into a struct to avoid nested generics
+// in function signatures (Map<string, Handle<T>> triggers parser >> ambiguity).
+struct ResolveState {
+    packages: Pool<ResolvedPkg>
+    by_name: Map<string, Handle<ResolvedPkg>>
+    visiting: Vec<string>
+}
+
+func resolve(manifest: Manifest, source: RegistrySource) -> DepGraph or FetchError {
+    let state = ResolveState {
+        packages: Pool.new(),
+        by_name: Map.new(),
+        visiting: Vec.new(),
+    }
+
+    // Insert root package
+    const root_meta = PackageMeta {
+        name: manifest.name.clone(),
+        version: manifest.version,
+        checksum: "",
+        deps: Vec.new(),
+    }
+    const root = try state.packages.insert(ResolvedPkg {
+        meta: root_meta,
+        deps: Vec.new(),
+    }) else |e| FetchError.Io("pool insert failed")
+
+    // Resolve each dependency
+    for d in manifest.deps {
+        const handle = try resolve_one(d.name.clone(), d.constraint, source, mutate state)
+        with state.packages[root] as root_pkg {
+            root_pkg.deps.push(handle)
+        }
+    }
+
+    return Ok(DepGraph {
+        packages: state.packages,
+        root: root,
+        by_name: state.by_name,
+    })
+}
+
+func resolve_one(name: string, constraint: Constraint, source: RegistrySource, mutate state: ResolveState) -> Handle<ResolvedPkg> or FetchError {
+    // Check for circular dependency
+    for v in state.visiting {
+        if v == name {
+            const chain = format_cycle(state.visiting, name)
+            return Err(FetchError.Resolve(ResolveError.Cycle(chain)))
+        }
+    }
+
+    // Already resolved? Check compatibility.
+    if state.by_name.contains_key(name) {
+        const existing_handle = state.by_name.get(name) is Some(h) else {
+            return Err(FetchError.Io("impossible: key exists but get failed"))
+        }
+        const existing_handle = existing_handle.clone()
+
+        with state.packages[existing_handle] as existing {
+            if constraint.satisfies(existing.meta.version) {
+                return Ok(existing_handle)
+            }
+            const con_str = constraint.to_string()
+            const ver_str = existing.meta.version.to_string()
+            return Err(FetchError.Resolve(ResolveError.Conflict(
+                name.clone(),
+                ver_str,
+                con_str,
+            )))
+        }
+    }
+
+    // Query registry for available versions
+    const versions = try registry_available(source, name) else |e| FetchError.Registry(e)
+
+    // Pick newest version satisfying constraint (maximal compatible)
+    let best: PackageMeta? = None
+    for meta in versions {
+        if constraint.satisfies(meta.version) {
+            if best is Some(current) {
+                if meta.version.compare(current.version) > 0 {
+                    best = Some(meta)
+                }
+            } else {
+                best = Some(meta)
+            }
+        }
+    }
+
+    const meta = best is Some else {
+        const con_str = constraint.to_string()
+        return Err(FetchError.Resolve(ResolveError.NoMatch(name.clone(), con_str)))
+    }
+
+    // Insert into pool
+    const handle = try state.packages.insert(ResolvedPkg {
+        meta: PackageMeta {
+            name: meta.name.clone(),
+            version: meta.version,
+            checksum: meta.checksum.clone(),
+            deps: Vec.new(),
+        },
+        deps: Vec.new(),
+    }) else |e| FetchError.Io("pool insert failed")
+
+    state.by_name.insert(name.clone(), handle)
+
+    // Recursively resolve transitive deps
+    state.visiting.push(name.clone())
+    for d in meta.deps {
+        const dep_handle = try resolve_one(d.name.clone(), d.constraint, source, mutate state)
+        with state.packages[handle] as pkg {
+            pkg.deps.push(dep_handle)
+        }
+    }
+    state.visiting.pop()
+
+    return Ok(handle)
+}
+
+func format_cycle(chain: Vec<string>, name: string) -> string {
+    let out = string.new()
+    for pkg in chain {
+        out.push_str(pkg)
+        out.push_str(" -> ")
+    }
+    out.push_str(name)
+    return out
+}
+
+// ─── Fetch Packages ─────────────────────────────────────────────────
+
+func fetch_packages(graph: DepGraph, source: RegistrySource, cache_dir: string) -> () or FetchError {
+    const handles = graph.packages.handles()
+    let fetched = 0
+
+    for handle in handles {
+        with graph.packages[handle] as pkg {
+            // Skip root package
+            if pkg.meta.checksum.is_empty() { continue }
+
+            const name = pkg.meta.name.clone()
+            const version = pkg.meta.version
+            const ver_str = version.to_string()
+
+            // Check if already cached
+            const cached_path = "{cache_dir}/{name}-{ver_str}"
+            if fs.exists(cached_path) {
+                println("  cached  {name}@{ver_str}")
+                continue
+            }
+
+            // Fetch from registry
+            println("  fetch   {name}@{ver_str}")
+            const pkg_path = try registry_fetch(source, name, version) else |e| FetchError.Registry(e)
+
+            // Verify checksum (placeholder — real impl would SHA-256)
+            // For now, just record that we fetched it
+            fetched += 1
+        }
+    }
+
+    println("Fetched {fetched} packages")
+    return Ok(())
+}
+
+// ─── Lock File ──────────────────────────────────────────────────────
+//
+// Format:
+//   lockfile-version = 1
+//
+//   [[package]]
+//   name = "http"
+//   version = "2.1.0"
+//   checksum = "sha256:a1b2..."
+
+func write_lockfile(graph: DepGraph, path: string) -> () or FetchError {
+    let out = string.new()
+    out.push_str("lockfile-version = 1\n\n")
+
+    // Collect packages in topological order
+    const order = topo_sort(graph)
+
+    for handle in order {
+        with graph.packages[handle] as pkg {
+            // Skip root
+            if pkg.meta.checksum.is_empty() { continue }
+
+            out.push_str("[[package]]\n")
+            out.push_str("name = \"{pkg.meta.name}\"\n")
+            const ver_str = pkg.meta.version.to_string()
+            out.push_str("version = \"{ver_str}\"\n")
+            out.push_str("checksum = \"{pkg.meta.checksum}\"\n")
+
+            // Record direct deps
+            if !pkg.deps.is_empty() {
+                out.push_str("deps = [")
+                let first = true
+                for dep_handle in pkg.deps {
+                    with graph.packages[dep_handle] as dep_pkg {
+                        if !first { out.push_str(", ") }
+                        out.push_str("\"{dep_pkg.meta.name}\"")
+                        first = false
+                    }
+                }
+                out.push_str("]\n")
+            }
+
+            out.push_str("\n")
+        }
+    }
+
+    try fs.write_file(path, out) else |e| FetchError.Io("cannot write lock file: {e}")
+
+    return Ok(())
+}
+
+func read_lockfile(path: string) -> Map<string, LockedPackage> or FetchError {
+    let packages = Map.new()
+
+    const content = fs.read_file(path) is Ok(c) else {
+        // No lock file yet — that's fine
+        return Ok(packages)
+    }
+
+    let current_name = ""
+    let current_version = ""
+    let current_checksum = ""
+
+    for line in content.lines() {
+        const trimmed = line.trim()
+
+        if trimmed == "[[package]]" {
+            // Flush previous
+            if !current_name.is_empty() {
+                packages.insert(current_name.clone(), LockedPackage {
+                    name: current_name.clone(),
+                    version: current_version.clone(),
+                    checksum: current_checksum.clone(),
+                })
+            }
+            current_name = ""
+            current_version = ""
+            current_checksum = ""
+            continue
+        }
+
+        if trimmed.starts_with("name = ") {
+            current_name = extract_quoted_value(trimmed)
+            continue
+        }
+        if trimmed.starts_with("version = ") {
+            current_version = extract_quoted_value(trimmed)
+            continue
+        }
+        if trimmed.starts_with("checksum = ") {
+            current_checksum = extract_quoted_value(trimmed)
+            continue
+        }
+    }
+
+    // Flush last
+    if !current_name.is_empty() {
+        packages.insert(current_name.clone(), LockedPackage {
+            name: current_name.clone(),
+            version: current_version.clone(),
+            checksum: current_checksum.clone(),
+        })
+    }
+
+    return Ok(packages)
+}
+
+func extract_quoted_value(line: string) -> string {
+    const first = line.find("\"") is Some(pos) else { return "" }
+    const rest = first + 1
+    const second = line[rest..].find("\"") is Some(pos) else { return "" }
+    return line[rest..rest + second].to_string()
+}
+
+// ─── Topological Sort ───────────────────────────────────────────────
+//
+// Post-order DFS: deps appear before their dependents.
+
+func topo_sort(graph: DepGraph) -> Vec<Handle<ResolvedPkg>> {
+    let visited = Map.new()
+    let order = Vec.new()
+
+    topo_visit(graph, graph.root, mutate visited, mutate order)
+
+    return order
+}
+
+func topo_visit(graph: DepGraph, handle: Handle<ResolvedPkg>, mutate visited: Map<i64, bool>, mutate order: Vec<Handle<ResolvedPkg>>) {
+    const key = handle as i64
+    if visited.contains_key(key) { return }
+    visited.insert(key, true)
+
+    with graph.packages[handle] as pkg {
+        for dep_handle in pkg.deps {
+            topo_visit(graph, dep_handle, mutate visited, mutate order)
+        }
+    }
+
+    order.push(handle)
+}
+
+// ─── Display ────────────────────────────────────────────────────────
+
+func print_dep_graph(graph: DepGraph) {
+    println("Dependency graph:")
+    print_node(graph, graph.root, 0)
+}
+
+func print_node(graph: DepGraph, handle: Handle<ResolvedPkg>, depth: i32) {
+    let indent = string.new()
+    let i = 0
+    while i < depth {
+        indent.push_str("  ")
+        i += 1
+    }
+
+    with graph.packages[handle] as pkg {
+        const ver = pkg.meta.version.to_string()
+        if depth == 0 {
+            println("{indent}{pkg.meta.name}@{ver} (root)")
+        } else {
+            println("{indent}{pkg.meta.name}@{ver}")
+        }
+
+        for child in pkg.deps {
+            print_node(graph, child, depth + 1)
+        }
+    }
+}
+
+func print_lock_diff(old_lock: Map<string, LockedPackage>, graph: DepGraph) {
+    const handles = graph.packages.handles()
+    let added = 0
+    let updated = 0
+    let unchanged = 0
+
+    for handle in handles {
+        with graph.packages[handle] as pkg {
+            if pkg.meta.checksum.is_empty() { continue }
+            const ver = pkg.meta.version.to_string()
+
+            if old_lock.contains_key(pkg.meta.name) {
+                const locked = old_lock.get(pkg.meta.name) is Some(l) else { continue }
+                if locked.version == ver {
+                    unchanged += 1
+                } else {
+                    println("  updated {pkg.meta.name}: {locked.version} -> {ver}")
+                    updated += 1
+                }
+            } else {
+                println("  added   {pkg.meta.name}@{ver}")
+                added += 1
+            }
+        }
+    }
+
+    if added == 0 && updated == 0 {
+        println("Lock file is up to date ({unchanged} packages)")
+    } else {
+        println("{added} added, {updated} updated, {unchanged} unchanged")
+    }
+}
+
+// ─── CLI ────────────────────────────────────────────────────────────
+
+struct CliArgs {
+    command: string
+    manifest_path: string
+    registry_type: string       // "local" or "http"
+    registry_path: string       // for local registry
+    registry_url: string        // for http registry
+    cache_dir: string
+    lock_path: string
+}
+
+func parse_cli_args(args: Vec<string>) -> CliArgs or FetchError {
+    let result = CliArgs {
+        command: "",
+        manifest_path: "build.rk",
+        registry_type: "local",
+        registry_path: "./registry",
+        registry_url: "http://packages.rask-lang.dev",
+        cache_dir: "/tmp/rask-cache",
+        lock_path: "rask.lock",
+    }
+
+    let positional = Vec.new()
+    let i = 1  // skip program name
+
+    while i < args.len() {
+        const arg = args[i]
+
+        match arg {
+            "--registry" => {
+                i += 1
+                if i < args.len() {
+                    result.registry_type = args[i].to_string()
+                }
+            }
+            "--registry-path" => {
+                i += 1
+                if i < args.len() {
+                    result.registry_path = args[i].to_string()
+                }
+            }
+            "--registry-url" => {
+                i += 1
+                if i < args.len() {
+                    result.registry_url = args[i].to_string()
+                }
+            }
+            "--cache" => {
+                i += 1
+                if i < args.len() {
+                    result.cache_dir = args[i].to_string()
+                }
+            }
+            "--manifest" => {
+                i += 1
+                if i < args.len() {
+                    result.manifest_path = args[i].to_string()
+                }
+            }
+            "--lock" => {
+                i += 1
+                if i < args.len() {
+                    result.lock_path = args[i].to_string()
+                }
+            }
+            "-h" | "--help" => {
+                print_usage()
+                std.exit(0)
+            }
+            _ => positional.push(arg.to_string()),
+        }
+        i += 1
+    }
+
+    if positional.is_empty() {
+        return Err(FetchError.Io("no command specified"))
+    }
+    result.command = positional[0].to_string()
+
+    return Ok(result)
+}
+
+func print_usage() {
+    println("rask-fetch: dependency resolver and package fetcher")
+    println("")
+    println("Usage: package_manager [OPTIONS] <command>")
+    println("")
+    println("Commands:")
+    println("  resolve     Resolve dependencies and print the graph")
+    println("  fetch       Resolve + download packages to cache")
+    println("  lock        Generate/update rask.lock")
+    println("  check       Verify lock file is in sync with manifest")
+    println("")
+    println("Options:")
+    println("  --manifest PATH       Path to build.rk (default: build.rk)")
+    println("  --registry local|http Registry type (default: local)")
+    println("  --registry-path PATH  Local registry directory")
+    println("  --registry-url URL    HTTP registry base URL")
+    println("  --cache PATH          Cache directory (default: /tmp/rask-cache)")
+    println("  --lock PATH           Lock file path (default: rask.lock)")
+    println("  -h, --help            Show this help")
+}
+
+// ─── Main ───────────────────────────────────────────────────────────
+
+func create_registry(args: CliArgs) -> RegistrySource {
+    if args.registry_type == "http" {
+        return RegistrySource.Http(args.registry_url)
+    }
+    return RegistrySource.Local(args.registry_path)
+}
+
+func run(args: CliArgs) -> () or FetchError {
+    const source = create_registry(args)
+
+    println("Loading manifest: {args.manifest_path}")
+    const manifest = try load_manifest(args.manifest_path)
+    println("Package: {manifest.name}@{manifest.version.to_string()}")
+    println("Dependencies: {manifest.deps.len()}")
+    println("")
+
+    match args.command {
+        "resolve" => {
+            println("Resolving dependencies...")
+            const graph = try resolve(manifest, source)
+            print_dep_graph(graph)
+        }
+        "fetch" => {
+            println("Resolving dependencies...")
+            const graph = try resolve(manifest, source)
+            print_dep_graph(graph)
+            println("")
+            println("Fetching packages to {args.cache_dir}...")
+            try fetch_packages(graph, source, args.cache_dir)
+        }
+        "lock" => {
+            println("Resolving dependencies...")
+            const graph = try resolve(manifest, source)
+
+            // Check against existing lock
+            const old_lock = try read_lockfile(args.lock_path)
+            print_lock_diff(old_lock, graph)
+
+            println("Writing lock file: {args.lock_path}")
+            try write_lockfile(graph, args.lock_path)
+            println("Done.")
+        }
+        "check" => {
+            const old_lock = try read_lockfile(args.lock_path)
+            if old_lock.is_empty() {
+                println("No lock file found. Run 'lock' first.")
+                std.exit(1)
+            }
+
+            println("Resolving dependencies...")
+            const graph = try resolve(manifest, source)
+
+            let drift = false
+            const handles = graph.packages.handles()
+            for handle in handles {
+                with graph.packages[handle] as pkg {
+                    if pkg.meta.checksum.is_empty() { continue }
+                    const ver = pkg.meta.version.to_string()
+
+                    if old_lock.contains_key(pkg.meta.name) {
+                        const locked = old_lock.get(pkg.meta.name) is Some(l) else {
+                            continue
+                        }
+                        if locked.version != ver {
+                            println("  DRIFT {pkg.meta.name}: locked={locked.version}, resolved={ver}")
+                            drift = true
+                        }
+                    } else {
+                        println("  NEW   {pkg.meta.name}@{ver} (not in lock file)")
+                        drift = true
+                    }
+                }
+            }
+
+            if drift {
+                println("Lock file is out of date. Run 'lock' to update.")
+                std.exit(1)
+            } else {
+                println("Lock file is up to date.")
+            }
+        }
+        _ => {
+            println("Unknown command: {args.command}")
+            print_usage()
+            std.exit(1)
+        }
+    }
+
+    return Ok(())
+}
+
+func main() {
+    const args = cli.args()
+    const cli_args = match parse_cli_args(args) {
+        Ok(a) => a,
+        Err(e) => {
+            println("rask-fetch: {e.message()}")
+            print_usage()
+            std.exit(1)
+        }
+    }
+
+    match run(cli_args) {
+        Ok(()) => {}
+        Err(e) => {
+            println("error: {e.message()}")
+            std.exit(1)
+        }
+    }
+}

--- a/examples/package_manager.rk
+++ b/examples/package_manager.rk
@@ -5,9 +5,10 @@
 // dependency graph construction, lock file generation, and package fetching
 // from a local or HTTP registry.
 //
-// Demonstrates: Pool<T>/Handle<T> for dependency graphs, enum-based registry
-// dispatch, layered error types with cross-layer propagation, Map/Vec-heavy
-// algorithms, string parsing, file I/O with ensure cleanup, pattern matching
+// Demonstrates: Pool<T>/Handle<T> for dependency graphs, trait-based registry
+// dispatch with implicit `any Trait` coercion, layered error types with
+// cross-layer propagation, Map/Vec-heavy algorithms, string parsing, file I/O,
+// multi-line function signatures, try/else across lines, pattern matching
 // at scale.
 
 import fs
@@ -326,8 +327,8 @@ func parse_manifest(content: string) -> Manifest or ManifestError {
         }
 
         if in_block && trimmed.starts_with("dep ") {
-            const d = try parse_dep_line(trimmed, line_num)
-            deps.push(d)
+            const dep = try parse_dep_line(trimmed, line_num)
+            deps.push(dep)
             continue
         }
 
@@ -404,33 +405,33 @@ func parse_dep_line(line: string, line_num: i32) -> Dependency or ManifestError 
 
 // ─── Registry ───────────────────────────────────────────────────────
 //
-// Enum-based dispatch: local filesystem for testing, HTTP for real registries.
-// Using enum rather than `any Trait` for explicit dispatch.
+// Trait-based dispatch with implicit coercion (TR5). Functions accept
+// `any Registry`; concrete types coerce automatically at call sites.
 
-enum RegistrySource {
-    Local(string)       // root path
-    Http(string)        // base URL
-}
-
-// Local registry layout:
-//   root/<pkg>/index.json   → ["1.0.0", "1.1.0"]
-//   root/<pkg>/1.0.0/meta.json
-
-func registry_available(source: RegistrySource, name: string) -> Vec<PackageMeta> or RegistryError {
-    match source {
-        Local(root) => return local_available(root, name),
-        Http(base_url) => return http_available(base_url, name),
-    }
-}
-
-func registry_fetch(source: RegistrySource, name: string, version: Version) -> string or RegistryError {
-    match source {
-        Local(root) => return local_fetch(root, name, version),
-        Http(base_url) => return http_fetch(base_url, name, version),
-    }
+trait Registry {
+    func available(self, name: string) -> Vec<PackageMeta> or RegistryError
+    func fetch_package(self, name: string, version: Version) -> string or RegistryError
 }
 
 // ─── Local Registry ─────────────────────────────────────────────────
+//
+// Layout:
+//   root/<pkg>/index.json   → ["1.0.0", "1.1.0"]
+//   root/<pkg>/1.0.0/meta.json
+
+struct LocalRegistry {
+    root: string
+}
+
+extend LocalRegistry with Registry {
+    func available(self, name: string) -> Vec<PackageMeta> or RegistryError {
+        return local_available(self.root, name)
+    }
+
+    func fetch_package(self, name: string, version: Version) -> string or RegistryError {
+        return local_fetch(self.root, name, version)
+    }
+}
 
 func local_available(root: string, name: string) -> Vec<PackageMeta> or RegistryError {
     // Read index file listing available versions
@@ -519,6 +520,20 @@ func load_package_meta(path: string) -> PackageMeta or RegistryError {
 
 // ─── HTTP Registry ──────────────────────────────────────────────────
 
+struct HttpRegistry {
+    base_url: string
+}
+
+extend HttpRegistry with Registry {
+    func available(self, name: string) -> Vec<PackageMeta> or RegistryError {
+        return http_available(self.base_url, name)
+    }
+
+    func fetch_package(self, name: string, version: Version) -> string or RegistryError {
+        return http_fetch(self.base_url, name, version)
+    }
+}
+
 func http_available(base_url: string, name: string) -> Vec<PackageMeta> or RegistryError {
     const url = "{base_url}/packages/{name}"
     const resp = http.get(url) is Ok(r) else {
@@ -599,15 +614,14 @@ func http_fetch(base_url: string, name: string, version: Version) -> string or R
 // satisfies the constraint. Detect conflicts when two constraints
 // for the same package are incompatible. Detect cycles via a visited set.
 
-// Bundle resolver working state into a struct to avoid nested generics
-// in function signatures (Map<string, Handle<T>> triggers parser >> ambiguity).
+// Bundle resolver working state: pool, name→handle map, and cycle-detection stack.
 struct ResolveState {
     packages: Pool<ResolvedPkg>
     by_name: Map<string, Handle<ResolvedPkg>>
     visiting: Vec<string>
 }
 
-func resolve(manifest: Manifest, source: RegistrySource) -> DepGraph or FetchError {
+func resolve(manifest: Manifest, registry: any Registry) -> DepGraph or FetchError {
     let state = ResolveState {
         packages: Pool.new(),
         by_name: Map.new(),
@@ -627,8 +641,8 @@ func resolve(manifest: Manifest, source: RegistrySource) -> DepGraph or FetchErr
     }) else |e| FetchError.Io("pool insert failed")
 
     // Resolve each dependency
-    for d in manifest.deps {
-        const handle = try resolve_one(d.name.clone(), d.constraint, source, mutate state)
+    for dep in manifest.deps {
+        const handle = try resolve_one(dep.name.clone(), dep.constraint, registry, mutate state)
         with state.packages[root] as root_pkg {
             root_pkg.deps.push(handle)
         }
@@ -641,7 +655,12 @@ func resolve(manifest: Manifest, source: RegistrySource) -> DepGraph or FetchErr
     })
 }
 
-func resolve_one(name: string, constraint: Constraint, source: RegistrySource, mutate state: ResolveState) -> Handle<ResolvedPkg> or FetchError {
+func resolve_one(
+    name: string,
+    constraint: Constraint,
+    registry: any Registry,
+    mutate state: ResolveState,
+) -> Handle<ResolvedPkg> or FetchError {
     // Check for circular dependency
     for v in state.visiting {
         if v == name {
@@ -672,7 +691,8 @@ func resolve_one(name: string, constraint: Constraint, source: RegistrySource, m
     }
 
     // Query registry for available versions
-    const versions = try registry_available(source, name) else |e| FetchError.Registry(e)
+    const versions = try registry.available(name)
+        else |e| FetchError.Registry(e)
 
     // Pick newest version satisfying constraint (maximal compatible)
     let best: PackageMeta? = None
@@ -708,8 +728,8 @@ func resolve_one(name: string, constraint: Constraint, source: RegistrySource, m
 
     // Recursively resolve transitive deps
     state.visiting.push(name.clone())
-    for d in meta.deps {
-        const dep_handle = try resolve_one(d.name.clone(), d.constraint, source, mutate state)
+    for dep in meta.deps {
+        const dep_handle = try resolve_one(dep.name.clone(), dep.constraint, registry, mutate state)
         with state.packages[handle] as pkg {
             pkg.deps.push(dep_handle)
         }
@@ -731,7 +751,11 @@ func format_cycle(chain: Vec<string>, name: string) -> string {
 
 // ─── Fetch Packages ─────────────────────────────────────────────────
 
-func fetch_packages(graph: DepGraph, source: RegistrySource, cache_dir: string) -> () or FetchError {
+func fetch_packages(
+    graph: DepGraph,
+    registry: any Registry,
+    cache_dir: string,
+) -> () or FetchError {
     const handles = graph.packages.handles()
     let fetched = 0
 
@@ -753,7 +777,8 @@ func fetch_packages(graph: DepGraph, source: RegistrySource, cache_dir: string) 
 
             // Fetch from registry
             println("  fetch   {name}@{ver_str}")
-            const pkg_path = try registry_fetch(source, name, version) else |e| FetchError.Registry(e)
+            const pkg_path = try registry.fetch_package(name, version)
+                else |e| FetchError.Registry(e)
 
             // Verify checksum (placeholder — real impl would SHA-256)
             // For now, just record that we fetched it
@@ -892,7 +917,12 @@ func topo_sort(graph: DepGraph) -> Vec<Handle<ResolvedPkg>> {
     return order
 }
 
-func topo_visit(graph: DepGraph, handle: Handle<ResolvedPkg>, mutate visited: Map<i64, bool>, mutate order: Vec<Handle<ResolvedPkg>>) {
+func topo_visit(
+    graph: DepGraph,
+    handle: Handle<ResolvedPkg>,
+    mutate visited: Map<i64, bool>,
+    mutate order: Vec<Handle<ResolvedPkg>>,
+) {
     const key = handle as i64
     if visited.contains_key(key) { return }
     visited.insert(key, true)
@@ -1074,15 +1104,15 @@ func print_usage() {
 
 // ─── Main ───────────────────────────────────────────────────────────
 
-func create_registry(args: CliArgs) -> RegistrySource {
+func create_registry(args: CliArgs) -> any Registry {
     if args.registry_type == "http" {
-        return RegistrySource.Http(args.registry_url)
+        return HttpRegistry { base_url: args.registry_url }
     }
-    return RegistrySource.Local(args.registry_path)
+    return LocalRegistry { root: args.registry_path }
 }
 
 func run(args: CliArgs) -> () or FetchError {
-    const source = create_registry(args)
+    const registry = create_registry(args)
 
     println("Loading manifest: {args.manifest_path}")
     const manifest = try load_manifest(args.manifest_path)
@@ -1093,20 +1123,20 @@ func run(args: CliArgs) -> () or FetchError {
     match args.command {
         "resolve" => {
             println("Resolving dependencies...")
-            const graph = try resolve(manifest, source)
+            const graph = try resolve(manifest, registry)
             print_dep_graph(graph)
         }
         "fetch" => {
             println("Resolving dependencies...")
-            const graph = try resolve(manifest, source)
+            const graph = try resolve(manifest, registry)
             print_dep_graph(graph)
             println("")
             println("Fetching packages to {args.cache_dir}...")
-            try fetch_packages(graph, source, args.cache_dir)
+            try fetch_packages(graph, registry, args.cache_dir)
         }
         "lock" => {
             println("Resolving dependencies...")
-            const graph = try resolve(manifest, source)
+            const graph = try resolve(manifest, registry)
 
             // Check against existing lock
             const old_lock = try read_lockfile(args.lock_path)
@@ -1124,7 +1154,7 @@ func run(args: CliArgs) -> () or FetchError {
             }
 
             println("Resolving dependencies...")
-            const graph = try resolve(manifest, source)
+            const graph = try resolve(manifest, registry)
 
             let drift = false
             const handles = graph.packages.handles()

--- a/examples/package_manager.rk
+++ b/examples/package_manager.rk
@@ -483,25 +483,14 @@ func load_package_meta(path: string) -> PackageMeta or RegistryError {
         return Err(RegistryError.IoError("expected object in {path}"))
     }
 
-    const name_val = obj.get("name") is Some(v) else {
+    const name = obj.get("name")?.as_string() is Some else {
         return Err(RegistryError.IoError("missing 'name' in {path}"))
     }
-    const name = name_val.as_string() is Some(s) else {
-        return Err(RegistryError.IoError("'name' not a string in {path}"))
-    }
-
-    const ver_val = obj.get("version") is Some(v) else {
+    const ver_str = obj.get("version")?.as_string() is Some else {
         return Err(RegistryError.IoError("missing 'version' in {path}"))
     }
-    const ver_str = ver_val.as_string() is Some(s) else {
-        return Err(RegistryError.IoError("'version' not a string in {path}"))
-    }
-
-    const check_val = obj.get("checksum") is Some(v) else {
+    const checksum = obj.get("checksum")?.as_string() is Some else {
         return Err(RegistryError.IoError("missing 'checksum' in {path}"))
-    }
-    const checksum = check_val.as_string() is Some(s) else {
-        return Err(RegistryError.IoError("'checksum' not a string in {path}"))
     }
 
     const version = Version.parse(ver_str) is Ok(v) else {
@@ -509,17 +498,12 @@ func load_package_meta(path: string) -> PackageMeta or RegistryError {
     }
 
     let deps = Vec.new()
-    const deps_val = obj.get("deps")
-    if deps_val is Some(dv) {
-        const dep_arr = dv.as_array() is Some(arr) else {
-            return Err(RegistryError.IoError("'deps' not an array in {path}"))
-        }
+    if obj.get("deps")?.as_array() is Some(dep_arr) {
         for d_val in dep_arr {
             const d_obj = d_val.as_object() is Some(dm) else { continue }
-            const dn_val = d_obj.get("name") is Some(v) else { continue }
-            const dn = dn_val.as_string() is Some(s) else { continue }
-            const dc_val = d_obj.get("constraint") is Some(v) else { continue }
-            const dc = dc_val.as_string() is Some(s) else { continue }
+            const dn = d_obj.get("name")?.as_string() ?? ""
+            const dc = d_obj.get("constraint")?.as_string() ?? ""
+            if dn.is_empty() || dc.is_empty() { continue }
             const constraint = Constraint.parse(dc) is Ok(c) else { continue }
             deps.push(Dependency { name: dn, constraint: constraint })
         }
@@ -558,26 +542,20 @@ func http_available(base_url: string, name: string) -> Vec<PackageMeta> or Regis
     let versions = Vec.new()
     for entry in arr {
         const obj = entry.as_object() is Some(m) else { continue }
-
-        const n_val = obj.get("name") is Some(v) else { continue }
-        const pkg_name = n_val.as_string() is Some(s) else { continue }
-        const v_val = obj.get("version") is Some(v) else { continue }
-        const ver_str = v_val.as_string() is Some(s) else { continue }
-        const c_val = obj.get("checksum") is Some(v) else { continue }
-        const checksum = c_val.as_string() is Some(s) else { continue }
+        const pkg_name = obj.get("name")?.as_string() ?? ""
+        const ver_str = obj.get("version")?.as_string() ?? ""
+        const checksum = obj.get("checksum")?.as_string() ?? ""
+        if pkg_name.is_empty() || ver_str.is_empty() { continue }
 
         const version = Version.parse(ver_str) is Ok(v) else { continue }
 
         let deps = Vec.new()
-        const deps_val = obj.get("deps")
-        if deps_val is Some(dv) {
-            const dep_arr = dv.as_array() is Some(a) else { continue }
+        if obj.get("deps")?.as_array() is Some(dep_arr) {
             for d_val in dep_arr {
                 const d_obj = d_val.as_object() is Some(dm) else { continue }
-                const dn_val = d_obj.get("name") is Some(v) else { continue }
-                const dn = dn_val.as_string() is Some(s) else { continue }
-                const dc_val = d_obj.get("constraint") is Some(v) else { continue }
-                const dc = dc_val.as_string() is Some(s) else { continue }
+                const dn = d_obj.get("name")?.as_string() ?? ""
+                const dc = d_obj.get("constraint")?.as_string() ?? ""
+                if dn.is_empty() || dc.is_empty() { continue }
                 const constraint = Constraint.parse(dc) is Ok(c) else { continue }
                 deps.push(Dependency { name: dn, constraint: constraint })
             }

--- a/examples/package_manager.rk
+++ b/examples/package_manager.rk
@@ -52,40 +52,6 @@ extend Version {
     func to_string(self) -> string {
         return "{self.major}.{self.minor}.{self.patch}"
     }
-
-    // -1, 0, or 1 for ordering
-    func compare(self, other: Version) -> i32 {
-        if self.major != other.major {
-            return if self.major < other.major: -1 else: 1
-        }
-        if self.minor != other.minor {
-            return if self.minor < other.minor: -1 else: 1
-        }
-        if self.patch != other.patch {
-            return if self.patch < other.patch: -1 else: 1
-        }
-        return 0
-    }
-
-    func lt(self, other: Version) -> bool {
-        return self.compare(other) < 0
-    }
-
-    func le(self, other: Version) -> bool {
-        return self.compare(other) <= 0
-    }
-
-    func gt(self, other: Version) -> bool {
-        return self.compare(other) > 0
-    }
-
-    func ge(self, other: Version) -> bool {
-        return self.compare(other) >= 0
-    }
-
-    func eq(self, other: Version) -> bool {
-        return self.compare(other) == 0
-    }
 }
 
 // ─── Version Constraints ────────────────────────────────────────────

--- a/stdlib/http.rk
+++ b/stdlib/http.rk
@@ -407,6 +407,9 @@ func format_http_response(resp: Response) -> string {
 extern "C" {
     func rask_io_read_string(fd: i64, max: i64) -> i64
     func rask_io_write_string(fd: i64, s: i64) -> i64
+    func rask_io_read_until_close(fd: i64, max: i64) -> i64
+    func rask_net_tcp_connect(addr: i64) -> i64
+    func rask_io_close_fd(fd: i64) -> ()
 }
 
 // Read raw bytes from a TCP connection (up to max_bytes).
@@ -418,6 +421,196 @@ func read_raw(conn_fd: i64, max_bytes: i64) -> string {
 // Write a string to a TCP connection.
 func write_raw(conn_fd: i64, data: string) {
     unsafe { rask_io_write_string(conn_fd, data as i64) }
+}
+
+// ─── Client Helpers ──────────────────────────────────────────────
+
+// Parse "http://host:port/path" into (host, port, path).
+func parse_url(url: string) -> (string, string, string) or HttpError {
+    let rest = url.clone()
+
+    // Strip scheme
+    if rest.starts_with("http://") {
+        rest = rest[7..].to_string()
+    } else if rest.starts_with("https://") {
+        return Err(HttpError.InvalidUrl("HTTPS not supported yet"))
+    }
+
+    // Split host+port from path at first /
+    let host_port = rest.clone()
+    let path = "/"
+    const slash = rest.find("/")
+    if slash is Some(pos) {
+        host_port = rest[0..pos].to_string()
+        path = rest[pos..].to_string()
+    }
+
+    // Split host from port at last :
+    let host = host_port.clone()
+    let port = "80"
+    const colon = host_port.find(":")
+    if colon is Some(cpos) {
+        host = host_port[0..cpos].to_string()
+        port = host_port[cpos + 1..].to_string()
+    }
+
+    if host.is_empty() {
+        return Err(HttpError.InvalidUrl("empty host in URL: {url}"))
+    }
+
+    return Ok((host, port, path))
+}
+
+// Format an HTTP/1.1 request for the wire.
+func format_http_request(req: Request, host: string) -> string {
+    let out = string.new()
+
+    // Request line
+    out.push_str(req.method.to_string())
+    out.push_str(" ")
+    out.push_str(req.url)
+    out.push_str(" HTTP/1.1\r\n")
+
+    // Host header
+    out.push_str("Host: ")
+    out.push_str(host)
+    out.push_str("\r\n")
+
+    // User headers
+    for (name, value) in req.headers.entries.iter() {
+        out.push_str(name)
+        out.push_str(": ")
+        out.push_str(value)
+        out.push_str("\r\n")
+    }
+
+    // Connection: close so the server closes after response
+    out.push_str("Connection: close\r\n")
+
+    // Content-Length for bodies
+    if req.body.len() > 0 {
+        out.push_str("Content-Length: ")
+        out.push_str("{req.body.len()}")
+        out.push_str("\r\n")
+    }
+
+    out.push_str("\r\n")
+    out.push_str(req.body)
+
+    return out
+}
+
+// Parse raw HTTP/1.1 response bytes into a Response.
+func parse_http_response(raw: string) -> Response or HttpError {
+    const len = raw.len()
+    if len == 0 {
+        return Err(HttpError.InvalidResponse("empty response"))
+    }
+
+    // Find end of status line
+    let line_end: usize = 0
+    while line_end + 1 < len {
+        if raw.byte_at(line_end) == 13 && raw.byte_at(line_end + 1) == 10 {
+            break
+        }
+        line_end += 1
+    }
+
+    // Parse status line: "HTTP/1.1 200 OK"
+    const status_line = raw[0..line_end]
+    let first_sp: usize = 0
+    while first_sp < line_end && raw.byte_at(first_sp) != 32 {
+        first_sp += 1
+    }
+    let second_sp = first_sp + 1
+    while second_sp < line_end && raw.byte_at(second_sp) != 32 {
+        second_sp += 1
+    }
+
+    const status_str = raw[first_sp + 1..second_sp]
+    const status_val = status_str.parse_int() is Ok(v) else {
+        return Err(HttpError.InvalidResponse("bad status code: {status_str}"))
+    }
+    const status = status_val as u16
+
+    // Parse headers
+    let headers = Headers.new()
+    let pos = line_end + 2
+    while pos + 1 < len {
+        if raw.byte_at(pos) == 13 && raw.byte_at(pos + 1) == 10 {
+            pos += 2
+            break
+        }
+
+        let hline_end = pos
+        while hline_end + 1 < len {
+            if raw.byte_at(hline_end) == 13 && raw.byte_at(hline_end + 1) == 10 {
+                break
+            }
+            hline_end += 1
+        }
+
+        let colon = pos
+        while colon < hline_end {
+            if raw.byte_at(colon) == 58 && colon + 1 < hline_end && raw.byte_at(colon + 1) == 32 {
+                break
+            }
+            colon += 1
+        }
+
+        if colon < hline_end {
+            const hname = raw[pos..colon]
+            const hvalue = raw[colon + 2..hline_end]
+            headers.set(hname, hvalue)
+        }
+
+        pos = hline_end + 2
+    }
+
+    // Body is everything after headers
+    const body = if pos < len {
+        raw[pos..].to_string()
+    } else {
+        string.new()
+    }
+
+    return Ok(Response {
+        status: status,
+        headers: headers,
+        body: body,
+    })
+}
+
+// Connect, send request, read response, close connection.
+func send_request(method: Method, url: string, body: string, extra_headers: Headers) -> Response or HttpError {
+    const (host, port, path) = try parse_url(url)
+    const addr = "{host}:{port}"
+
+    // Connect
+    const conn_fd = unsafe { rask_net_tcp_connect(addr as i64) }
+    if conn_fd < 0 {
+        return Err(HttpError.ConnectionFailed("cannot connect to {addr}"))
+    }
+
+    // Build and send request
+    let req = Request.new(method, path)
+    for (name, value) in extra_headers.entries.iter() {
+        req = req.with_header(name, value)
+    }
+    if body.len() > 0 {
+        req = req.with_body(body)
+    }
+    const raw_req = format_http_request(req, host)
+    write_raw(conn_fd, raw_req)
+
+    // Read response (reads until server closes connection)
+    const raw_resp_ptr = unsafe { rask_io_read_until_close(conn_fd, 1048576) }
+    const raw_resp = raw_resp_ptr as string
+
+    // Close connection
+    unsafe { rask_io_close_fd(conn_fd) }
+
+    return parse_http_response(raw_resp)
 }
 
 // ─── Server Integration ──────────────────────────────────────────
@@ -521,44 +714,70 @@ extend http {
         }
     }
 
-    /// Simple GET request using a shared internal client.
-    public func get(url: string) -> Response or HttpError { }
+    public func get(url: string) -> Response or HttpError {
+        return send_request(Method.Get, url, "", Headers.new())
+    }
 
-    /// Simple POST request.
-    public func post(url: string, body: string) -> Response or HttpError { }
+    public func post(url: string, body: string) -> Response or HttpError {
+        return send_request(Method.Post, url, body, Headers.new())
+    }
 
-    /// Simple PUT request.
-    public func put(url: string, body: string) -> Response or HttpError { }
+    public func put(url: string, body: string) -> Response or HttpError {
+        return send_request(Method.Put, url, body, Headers.new())
+    }
 
-    /// Simple DELETE request.
-    public func delete(url: string) -> Response or HttpError { }
+    public func delete(url: string) -> Response or HttpError {
+        return send_request(Method.Delete, url, "", Headers.new())
+    }
 
-    /// Send a custom request.
-    public func request(request: Request) -> Response or HttpError { }
+    public func request(request: Request) -> Response or HttpError {
+        return send_request(request.method, request.url, request.body, request.headers)
+    }
 }
 
 // ─── HttpClient ──────────────────────────────────────────────────
 
-struct HttpClient { }
+struct HttpClient {
+    default_headers: Headers
+}
 
 extend HttpClient {
-    public func new() -> HttpClient { return HttpClient {} }
+    public func new() -> HttpClient {
+        return HttpClient { default_headers: Headers.new() }
+    }
 
     public func with_timeout(take self, timeout: Duration) -> HttpClient {
+        // Timeout not yet wired to socket options
         return self
     }
 
     public func with_header(take self, name: string, value: string) -> HttpClient {
+        self.default_headers.set(name, value)
         return self
     }
 
     public func with_max_redirects(take self, n: u32) -> HttpClient {
+        // Redirect following not yet implemented
         return self
     }
 
-    public func get(self, url: string) -> Response or HttpError { }
-    public func post(self, url: string, body: string) -> Response or HttpError { }
-    public func put(self, url: string, body: string) -> Response or HttpError { }
-    public func delete(self, url: string) -> Response or HttpError { }
-    public func request(self, request: Request) -> Response or HttpError { }
+    public func get(self, url: string) -> Response or HttpError {
+        return send_request(Method.Get, url, "", self.default_headers)
+    }
+
+    public func post(self, url: string, body: string) -> Response or HttpError {
+        return send_request(Method.Post, url, body, self.default_headers)
+    }
+
+    public func put(self, url: string, body: string) -> Response or HttpError {
+        return send_request(Method.Put, url, body, self.default_headers)
+    }
+
+    public func delete(self, url: string) -> Response or HttpError {
+        return send_request(Method.Delete, url, "", self.default_headers)
+    }
+
+    public func request(self, request: Request) -> Response or HttpError {
+        return send_request(request.method, request.url, request.body, self.default_headers)
+    }
 }

--- a/stdlib/net.rk
+++ b/stdlib/net.rk
@@ -6,4 +6,7 @@ struct net { }
 extend net {
     /// Listen for TCP connections on the given address.
     public func tcp_listen(addr: string) -> TcpListener or Error { }
+
+    /// Connect to a remote TCP address. Returns a connection or error.
+    public func tcp_connect(addr: string) -> TcpConnection or Error { }
 }


### PR DESCRIPTION
## Summary

This PR adds a comprehensive package manager example application (`examples/package_manager.rk`) that demonstrates advanced Rask language features, along with completing the HTTP client implementation in the standard library to support it.

## Key Changes

### New Example: Package Manager (`examples/package_manager.rk`)
A 1194-line stress test application implementing a subset of `rask fetch` with:
- **Semantic versioning**: `Version` struct with parsing and comparison, `Constraint` enum supporting `^`, `~`, `>=`, and exact version matching
- **Manifest parsing**: Custom parser for simplified `build.rk` format with line-by-line error tracking
- **Layered error types**: Five specialized error enums (`VersionError`, `ManifestError`, `RegistryError`, `ResolveError`, `FetchError`) with cross-layer composition and message formatting
- **Trait-based registry dispatch**: `Registry` trait with implicit `any Registry` coercion, supporting both `LocalRegistry` and `HttpRegistry` implementations
- **Dependency resolution**: Greedy resolver with conflict detection, cycle detection via visited stack, and topological sorting for lock file generation
- **Lock file management**: TOML-like format parsing/generation with diff reporting
- **CLI argument parsing**: Multi-option command-line interface with help text

Demonstrates language features: `Pool<T>`/`Handle<T>` for dependency graphs, pattern matching at scale, `try/else` across lines, multi-line function signatures, `Map`/`Vec`-heavy algorithms, string parsing, and file I/O.

### HTTP Client Implementation (`stdlib/http.rk`)
Completed the HTTP client API with working implementations:
- `parse_url()`: Parses HTTP URLs into (host, port, path) components
- `format_http_request()`: Builds HTTP/1.1 request wire format with headers and body
- `parse_http_response()`: Parses raw HTTP/1.1 responses into `Response` objects with status, headers, and body
- `send_request()`: End-to-end client: connects, sends request, reads response, closes connection
- Public API methods: `http.get()`, `http.post()`, `http.put()`, `http.delete()`, `http.request()`
- `HttpClient` struct with builder pattern for default headers

### Runtime Support (`compiler/runtime/runtime.c` and `rask_runtime.h`)
- `rask_net_tcp_connect()`: Establishes TCP connections using `getaddrinfo()` for DNS resolution and hostname/port parsing
- `rask_io_read_until_close()`: Reads from socket until server closes or max bytes reached (for HTTP response bodies)
- `rask_io_close_fd()`: Closes file descriptors

### Standard Library Stubs (`stdlib/net.rk`)
Added placeholder for `net.tcp_connect()` public API.

## Notable Implementation Details

- HTTP parsing handles CRLF line endings and header parsing with byte-level inspection
- Registry trait enables polymorphic dispatch without runtime overhead via implicit coercion
- Error propagation uses `try/else` chains across multiple layers
- Dependency graph uses `Pool<T>` with `Handle<T>` for efficient memory management and cycle detection
- Lock file format is human-readable TOML-like syntax with topological ordering

https://claude.ai/code/session_01VYYd12gPAyndhpwKbaTyie