### PR TITLE
Add string and char utility methods for iteration and searching

### DIFF
--- a/compiler/crates/rask-interp/src/builtins/primitives.rs
+++ b/compiler/crates/rask-interp/src/builtins/primitives.rs
@@ -230,6 +230,8 @@ impl Interpreter {
             "is_lowercase" => Ok(Value::Bool(c.is_lowercase())),
             "to_uppercase" => Ok(Value::Char(c.to_uppercase().next().unwrap_or(c))),
             "to_lowercase" => Ok(Value::Char(c.to_lowercase().next().unwrap_or(c))),
+            "len_utf8" => Ok(Value::Int(c.len_utf8() as i64)),
+            "to_string" => Ok(Value::String(Arc::new(Mutex::new(c.to_string())))),
             "eq" => { let other = self.expect_char(args, 0)?; Ok(Value::Bool(c == other)) }
             "compare" => { let other = self.expect_char(args, 0)?; Ok(ordering_value(c.cmp(&other))) }
             "debug_string" => Ok(Value::String(Arc::new(Mutex::new(format!("'{}'", c))))),

--- a/compiler/crates/rask-interp/src/builtins/strings.rs
+++ b/compiler/crates/rask-interp/src/builtins/strings.rs
@@ -51,6 +51,13 @@ impl Interpreter {
             "trim_end" => {
                 Ok(Value::String(Arc::new(Mutex::new(s.lock().unwrap().trim_end().to_string()))))
             }
+            "trim_bounds" => {
+                let guard = s.lock().unwrap();
+                let trimmed = guard.trim();
+                let start = trimmed.as_ptr() as usize - guard.as_ptr() as usize;
+                let end = start + trimmed.len();
+                Ok(Value::Vec(Arc::new(Mutex::new(vec![Value::Int(start as i64), Value::Int(end as i64)]))))
+            }
             "to_string" => Ok(Value::String(Arc::clone(s))),
             "debug_string" => {
                 let val = s.lock().unwrap();
@@ -91,6 +98,18 @@ impl Interpreter {
             "chars" => {
                 let chars: Vec<Value> = s.lock().unwrap().chars().map(Value::Char).collect();
                 Ok(Value::Vec(Arc::new(Mutex::new(chars))))
+            }
+            "char_indices" => {
+                let pairs: Vec<Value> = s.lock().unwrap().char_indices()
+                    .map(|(i, c)| Value::Vec(Arc::new(Mutex::new(vec![Value::Int(i as i64), Value::Char(c)]))))
+                    .collect();
+                Ok(Value::Vec(Arc::new(Mutex::new(pairs))))
+            }
+            "bytes" => {
+                let bytes: Vec<Value> = s.lock().unwrap().bytes()
+                    .map(|b| Value::Int(b as i64))
+                    .collect();
+                Ok(Value::Vec(Arc::new(Mutex::new(bytes))))
             }
             "lines" => {
                 let lines: Vec<Value> = s
@@ -188,9 +207,26 @@ impl Interpreter {
                     }),
                 }
             }
-            "index_of" => {
+            "index_of" | "find" => {
                 let pattern = self.expect_string(&args, 0)?;
                 match s.lock().unwrap().find(&pattern) {
+                    Some(idx) => Ok(Value::Enum {
+                        name: "Option".to_string(),
+                        variant: "Some".to_string(),
+                        fields: vec![Value::Int(idx as i64)],
+                        variant_index: 0,
+                    }),
+                    None => Ok(Value::Enum {
+                        name: "Option".to_string(),
+                        variant: "None".to_string(),
+                        fields: vec![],
+                        variant_index: 0,
+                    }),
+                }
+            }
+            "rfind" => {
+                let pattern = self.expect_string(&args, 0)?;
+                match s.lock().unwrap().rfind(&pattern) {
                     Some(idx) => Ok(Value::Enum {
                         name: "Option".to_string(),
                         variant: "Some".to_string(),

--- a/compiler/crates/rask-stdlib/src/registry.rs
+++ b/compiler/crates/rask-stdlib/src/registry.rs
@@ -91,16 +91,17 @@ const BOOL_METHODS: &[&str] = &["eq"];
 const CHAR_METHODS: &[&str] = &[
     "is_whitespace", "is_alphabetic", "is_alphanumeric",
     "is_digit", "is_uppercase", "is_lowercase",
-    "to_uppercase", "to_lowercase", "eq",
+    "to_uppercase", "to_lowercase", "len_utf8",
+    "to_string", "eq",
 ];
 
 const STRING_METHODS: &[&str] = &[
     "len", "is_empty", "clone", "starts_with", "ends_with", "contains",
-    "push", "push_str", "trim", "trim_start", "trim_end",
+    "push", "push_str", "trim", "trim_start", "trim_end", "trim_bounds",
     "to_string", "to_owned", "to_uppercase", "to_lowercase",
-    "split", "split_whitespace", "chars", "lines",
+    "split", "split_whitespace", "chars", "char_indices", "bytes", "lines",
     "replace", "substring", "parse_int", "parse",
-    "char_at", "byte_at", "parse_float", "index_of",
+    "char_at", "byte_at", "parse_float", "find", "index_of", "rfind",
     "repeat", "reverse", "eq", "ne",
 ];
 

--- a/stdlib/char.rk
+++ b/stdlib/char.rk
@@ -1,0 +1,33 @@
+// SPDX-License-Identifier: (MIT OR Apache-2.0)
+
+extend char {
+    /// Number of bytes needed to encode this char in UTF-8 (1–4).
+    public func len_utf8(self) -> usize { }
+
+    /// True if this is an ASCII character (0x00–0x7F).
+    public func is_ascii(self) -> bool { }
+
+    /// True if this is a Unicode alphabetic character.
+    public func is_alphabetic(self) -> bool { }
+
+    /// True if this is a Unicode numeric character.
+    public func is_numeric(self) -> bool { }
+
+    /// True if this is a Unicode alphanumeric character.
+    public func is_alphanumeric(self) -> bool { }
+
+    /// True if this is a Unicode whitespace character.
+    public func is_whitespace(self) -> bool { }
+
+    /// True if this is an uppercase character.
+    public func is_uppercase(self) -> bool { }
+
+    /// True if this is a lowercase character.
+    public func is_lowercase(self) -> bool { }
+
+    /// Simple 1:1 lowercase mapping.
+    public func to_lowercase(self) -> char { }
+
+    /// Simple 1:1 uppercase mapping.
+    public func to_uppercase(self) -> char { }
+}

--- a/stdlib/string.rk
+++ b/stdlib/string.rk
@@ -46,6 +46,9 @@ extend string {
     /// Remove trailing whitespace.
     public func trim_end(self) -> string { }
 
+    /// Byte indices of trimmed content: (start, end).
+    public func trim_bounds(self) -> (usize, usize) { }
+
     /// Append a character.
     public func push(mutate self, c: char) { }
 
@@ -63,6 +66,9 @@ extend string {
 
     /// Iterate over characters.
     public func chars(self) -> Iterator<char> { }
+
+    /// Iterate over (byte_index, char) pairs.
+    public func char_indices(self) -> Iterator<(usize, char)> { }
 
     /// Iterate over bytes.
     public func bytes(self) -> Iterator<u8> { }


### PR DESCRIPTION
## Summary
This PR extends the string and char standard library with additional utility methods for character iteration, byte operations, and pattern searching. These additions provide more comprehensive string manipulation capabilities aligned with common string APIs.

## Key Changes

**String Methods:**
- `trim_bounds()` - Returns byte indices (start, end) of trimmed content as a tuple
- `char_indices()` - Iterates over (byte_index, char) pairs for character-aware indexing
- `bytes()` - Iterates over individual bytes in the string
- `find()` - Added as an alias for `index_of()` for pattern searching
- `rfind()` - Searches for a pattern from the right, returning an Option with the byte index

**Char Methods:**
- `len_utf8()` - Returns the number of bytes needed to encode the character in UTF-8 (1–4)
- `to_string()` - Converts a char to a string

**Standard Library Updates:**
- Updated `stdlib/string.rk` with signatures for new string methods
- Added new `stdlib/char.rk` file with comprehensive char method signatures including predicates (`is_ascii`, `is_alphabetic`, `is_numeric`, etc.)
- Updated method registry in `compiler/crates/rask-stdlib/src/registry.rs` to include all new methods

## Implementation Details

- String search methods (`find`, `rfind`) return `Option<usize>` using the existing enum representation
- `char_indices()` returns an iterator of tuples represented as vectors containing index and character pairs
- `trim_bounds()` uses pointer arithmetic to calculate byte offsets of trimmed content relative to the original string
- All new methods follow existing patterns for string/char method implementation in the interpreter

https://claude.ai/code/session_01MfgbBVaHy9fn2Ja7VuCXus