### PR TITLE
Implement W2a–W2d pool-aware structural mutation rules for `with` blocks

### DIFF
--- a/compiler/crates/rask-diagnostics/src/convert.rs
+++ b/compiler/crates/rask-diagnostics/src/convert.rs
@@ -713,6 +713,49 @@ impl ToDiagnostic for rask_ownership::OwnershipError {
                 .with_help("remove `frozen` from the context clause, or remove the mutation")
                 .with_why("frozen contexts guarantee no structural mutations — this enables safe iteration without generation checks")
             }
+
+            WithBlockStructuralMutation { collection, operation, binding_span } => {
+                Diagnostic::error(format!(
+                    "cannot {} `{}` inside `with` block",
+                    operation, collection
+                ))
+                .with_code("E0808")
+                .with_primary(self.span, format!("{} not allowed inside with block", operation))
+                .with_secondary(*binding_span, "element borrowed here")
+                .with_help("move the structural mutation outside the with block")
+                .with_fix("move the structural mutation outside the with block")
+                .with_why(format!(
+                    "{} can reallocate, invalidating the borrowed element. \
+                     Pool handles survive reallocation — use Pool if you need insert/remove inside with",
+                    collection
+                ))
+            }
+
+            WithBlockBoundHandleRemoved { handle, collection: _, binding_span } => {
+                Diagnostic::error(format!(
+                    "cannot remove `{}` inside `with` block — it's the bound element",
+                    handle
+                ))
+                .with_code("E0809")
+                .with_primary(self.span, "removing the element you're borrowing")
+                .with_secondary(*binding_span, "element borrowed here")
+                .with_help("move the removal outside the with block")
+                .with_fix("move the removal outside the with block")
+                .with_why("removing the bound element frees its memory — the binding would dangle")
+            }
+
+            WithBlockClear { collection, binding_span } => {
+                Diagnostic::error(format!(
+                    "cannot clear `{}` inside `with` block",
+                    collection
+                ))
+                .with_code("E0810")
+                .with_primary(self.span, "clear invalidates all elements")
+                .with_secondary(*binding_span, "element borrowed here")
+                .with_help("move the clear outside the with block")
+                .with_fix("move the clear outside the with block")
+                .with_why("clearing the collection frees all elements — the binding would dangle")
+            }
         }
     }
 }

--- a/compiler/crates/rask-mir/src/lower/expr.rs
+++ b/compiler/crates/rask-mir/src/lower/expr.rs
@@ -1065,9 +1065,27 @@ impl<'a> MirLowerer<'a> {
                 let result_local = self.builder.alloc_temp(ret_ty.clone());
                 self.builder.push_stmt(MirStmt::Call {
                     dst: Some(result_local),
-                    func: FunctionRef::internal(qualified_name),
+                    func: FunctionRef::internal(qualified_name.clone()),
                     args: all_args,
                 });
+
+                // W2a/W2b: Re-resolve pool bindings after pool mutators inside `with` blocks
+                if matches!(qualified_name.as_str(),
+                    "Pool_insert" | "Pool_remove" | "Pool_clear" | "Pool_drain" | "Pool_alloc"
+                ) {
+                    if let ExprKind::Ident(pool_var) = &object.kind {
+                        if let Some(bindings) = self.with_pool_bindings.get(pool_var) {
+                            for &(handle_local, binding_local, pool_local) in bindings {
+                                self.builder.push_stmt(MirStmt::PoolCheckedAccess {
+                                    dst: binding_local,
+                                    pool: pool_local,
+                                    handle: handle_local,
+                                });
+                            }
+                        }
+                    }
+                }
+
                 Ok((MirOperand::Local(result_local), ret_ty))
             }
 
@@ -1884,7 +1902,33 @@ impl<'a> MirLowerer<'a> {
                 }
 
                 // Default: simple alias binding (Pool, Cell, etc.)
+                // W2a/W2b: Track pool bindings for re-resolution after pool mutators
+                let mut pool_binding_keys: Vec<String> = Vec::new();
                 for binding in bindings {
+                    // Before lowering, extract pool/handle info for re-resolution tracking
+                    let pool_info = if let ExprKind::Index { object, index } = &binding.source.kind {
+                        if let ExprKind::Ident(coll_name) = &object.kind {
+                            let is_pool = self.local_type_prefix.get(coll_name)
+                                .map(|p| p == "Pool")
+                                .unwrap_or(false);
+                            if is_pool {
+                                let pool_local = self.locals.get(coll_name).map(|(id, _)| *id);
+                                let handle_local = if let ExprKind::Ident(h) = &index.kind {
+                                    self.locals.get(h).map(|(id, _)| *id)
+                                } else {
+                                    None
+                                };
+                                pool_local.zip(handle_local).map(|(p, h)| (coll_name.clone(), p, h))
+                            } else {
+                                None
+                            }
+                        } else {
+                            None
+                        }
+                    } else {
+                        None
+                    };
+
                     let (val, val_ty) = self.lower_expr(&binding.source)?;
                     let local = self.builder.alloc_local(binding.name.clone(), val_ty.clone());
                     self.locals.insert(binding.name.clone(), (local, val_ty));
@@ -1892,8 +1936,26 @@ impl<'a> MirLowerer<'a> {
                         dst: local,
                         rvalue: MirRValue::Use(val),
                     });
+
+                    // Register pool binding for re-resolution
+                    if let Some((pool_name, pool_local, handle_local)) = pool_info {
+                        self.with_pool_bindings.entry(pool_name.clone())
+                            .or_default()
+                            .push((handle_local, local, pool_local));
+                        pool_binding_keys.push(pool_name);
+                    }
                 }
-                self.lower_block(body)
+                let result = self.lower_block(body);
+                // Clean up pool binding registrations
+                for key in &pool_binding_keys {
+                    if let Some(entries) = self.with_pool_bindings.get_mut(key) {
+                        entries.pop();
+                        if entries.is_empty() {
+                            self.with_pool_bindings.remove(key);
+                        }
+                    }
+                }
+                result
             }
 
             // Spawn — synthesize a closure function and call rask_closure_spawn

--- a/compiler/crates/rask-mir/src/lower/mod.rs
+++ b/compiler/crates/rask-mir/src/lower/mod.rs
@@ -461,6 +461,9 @@ pub struct MirLowerer<'a> {
     /// Full type annotation string: variable name → type annotation (e.g. "Shared<Database>").
     /// Used to resolve generic inner types when the type checker leaves types unresolved.
     local_full_type: HashMap<String, String>,
+    /// W2a/W2b: Active `with` pool bindings for re-resolution after pool mutators.
+    /// Maps pool variable name → Vec of (handle_local, binding_local, pool_local).
+    with_pool_bindings: HashMap<String, Vec<(LocalId, LocalId, LocalId)>>,
 }
 
 impl<'a> MirLowerer<'a> {
@@ -646,6 +649,7 @@ impl<'a> MirLowerer<'a> {
             local_type_prefix: HashMap::new(),
             channel_elem_sizes: HashMap::new(),
             local_full_type: HashMap::new(),
+            with_pool_bindings: HashMap::new(),
         };
 
         // Resolve Self type from function name: "Document_delete_line" → "Document"

--- a/compiler/crates/rask-ownership/src/error.rs
+++ b/compiler/crates/rask-ownership/src/error.rs
@@ -90,6 +90,29 @@ pub enum OwnershipErrorKind {
         context_ty: String,
         operation: String,
     },
+
+    /// Structural mutation inside `with` block on non-pool collection (W2).
+    #[error("cannot {operation} `{collection}` inside `with` block — {collection} can reallocate")]
+    WithBlockStructuralMutation {
+        collection: String,
+        operation: String,
+        binding_span: Span,
+    },
+
+    /// Removing the bound handle inside `with` block (W2c).
+    #[error("cannot remove `{handle}` inside `with` block — it's the bound element")]
+    WithBlockBoundHandleRemoved {
+        handle: String,
+        collection: String,
+        binding_span: Span,
+    },
+
+    /// Clearing pool inside `with` block (W2d).
+    #[error("cannot clear `{collection}` inside `with` block — invalidates all elements")]
+    WithBlockClear {
+        collection: String,
+        binding_span: Span,
+    },
 }
 
 /// User-friendly access kind for error messages.

--- a/compiler/crates/rask-ownership/src/lib.rs
+++ b/compiler/crates/rask-ownership/src/lib.rs
@@ -33,6 +33,19 @@ impl OwnershipResult {
     }
 }
 
+/// W2 tracking: active `with` block binding info.
+#[derive(Debug, Clone)]
+struct WithBindingInfo {
+    /// Collection variable name (e.g. "pool" from `with pool[h] as entity`)
+    collection_name: String,
+    /// Handle/key variable name (e.g. "h")
+    handle_name: String,
+    /// Whether the collection is a Pool (relaxed W2 rules) vs Vec/Map/string
+    is_pool: bool,
+    /// Span of the `with` binding for error messages
+    span: Span,
+}
+
 /// Ownership and borrow checker.
 pub struct OwnershipChecker<'a> {
     /// The typed program from type checking.
@@ -56,6 +69,10 @@ pub struct OwnershipChecker<'a> {
     in_ensure: bool,
     /// Pool type names with frozen context (CC3/PF5: no writes, inserts, removes, clears).
     frozen_contexts: HashSet<String>,
+    /// Active `with` block bindings for W2 checking.
+    active_with_bindings: Vec<WithBindingInfo>,
+    /// Parameter type strings: param name → type annotation (e.g. "Pool<Entity>").
+    param_type_strings: HashMap<String, String>,
     /// Errors accumulated during analysis.
     errors: Vec<OwnershipError>,
 }
@@ -73,6 +90,8 @@ impl<'a> OwnershipChecker<'a> {
             ensure_registered: HashSet::new(),
             in_ensure: false,
             frozen_contexts: HashSet::new(),
+            active_with_bindings: Vec::new(),
+            param_type_strings: HashMap::new(),
             errors: Vec::new(),
         }
     }
@@ -147,6 +166,12 @@ impl<'a> OwnershipChecker<'a> {
                     self.frozen_contexts.insert(name.clone());
                 }
             }
+        }
+
+        // Register parameter type strings for W2 pool detection
+        self.param_type_strings.clear();
+        for param in &fn_decl.params {
+            self.param_type_strings.insert(param.name.clone(), param.ty.clone());
         }
 
         // Register parameters as owned or borrowed bindings
@@ -374,6 +399,56 @@ impl<'a> OwnershipChecker<'a> {
                         }
                     }
                 }
+                // W2: Check structural mutations inside `with` blocks
+                if matches!(method.as_str(), "insert" | "remove" | "clear" | "push" | "pop") {
+                    if let ExprKind::Ident(coll_name) = &object.kind {
+                        for wb in &self.active_with_bindings {
+                            if wb.collection_name == *coll_name {
+                                if wb.is_pool {
+                                    // W2d: clear is always forbidden
+                                    if method == "clear" {
+                                        self.errors.push(OwnershipError {
+                                            kind: OwnershipErrorKind::WithBlockClear {
+                                                collection: coll_name.clone(),
+                                                binding_span: wb.span,
+                                            },
+                                            span: expr.span,
+                                        });
+                                    }
+                                    // W2c: remove(bound_handle) is forbidden
+                                    else if method == "remove" {
+                                        if let Some(first_arg) = args.first() {
+                                            if let ExprKind::Ident(arg_name) = &first_arg.expr.kind {
+                                                if *arg_name == wb.handle_name {
+                                                    self.errors.push(OwnershipError {
+                                                        kind: OwnershipErrorKind::WithBlockBoundHandleRemoved {
+                                                            handle: arg_name.clone(),
+                                                            collection: coll_name.clone(),
+                                                            binding_span: wb.span,
+                                                        },
+                                                        span: expr.span,
+                                                    });
+                                                }
+                                            }
+                                        }
+                                    }
+                                    // W2a/W2b: insert and remove(other) are allowed for Pool
+                                } else {
+                                    // W2: non-pool collections — all structural mutations forbidden
+                                    self.errors.push(OwnershipError {
+                                        kind: OwnershipErrorKind::WithBlockStructuralMutation {
+                                            collection: coll_name.clone(),
+                                            operation: method.clone(),
+                                            binding_span: wb.span,
+                                        },
+                                        span: expr.span,
+                                    });
+                                }
+                                break;
+                            }
+                        }
+                    }
+                }
                 // If this is a `take self` method, mark the object as moved
                 // (skip in ensure bodies — ensure defers execution)
                 if !self.in_ensure && self.is_take_self_method(object, method) {
@@ -510,10 +585,28 @@ impl<'a> OwnershipChecker<'a> {
                 self.check_block(body);
             }
             ExprKind::WithAs { bindings, body } => {
+                let prev_count = self.active_with_bindings.len();
                 for binding in bindings {
                     self.check_expr(&binding.source);
+                    // W2: Track binding info for structural mutation checking
+                    if let ExprKind::Index { object, index } = &binding.source.kind {
+                        if let ExprKind::Ident(coll_name) = &object.kind {
+                            let handle_name = if let ExprKind::Ident(h) = &index.kind {
+                                h.clone()
+                            } else {
+                                String::new()
+                            };
+                            self.active_with_bindings.push(WithBindingInfo {
+                                collection_name: coll_name.clone(),
+                                handle_name,
+                                is_pool: self.is_pool_type(coll_name),
+                                span: binding.source.span,
+                            });
+                        }
+                    }
                 }
                 self.check_block(body);
+                self.active_with_bindings.truncate(prev_count);
             }
             ExprKind::Spawn { body } => {
                 self.check_block(body);
@@ -888,6 +981,27 @@ impl<'a> OwnershipChecker<'a> {
                 }
             }
         }
+    }
+
+    /// Check if a binding's type is Pool (for W2 pool-aware rules).
+    fn is_pool_type(&self, name: &str) -> bool {
+        // Check resolved types from type checker
+        if let Some(ty) = self.binding_types.get(name) {
+            if let Type::Generic { base, .. } = ty {
+                if let Some(def) = self.program.types.get(*base) {
+                    return matches!(def,
+                        rask_types::TypeDef::Struct { name, .. }
+                        | rask_types::TypeDef::Enum { name, .. }
+                        if name == "Pool"
+                    );
+                }
+            }
+        }
+        // Fallback: check parameter type strings (e.g. "Pool<Entity>")
+        if let Some(ty_str) = self.param_type_strings.get(name) {
+            return ty_str.starts_with("Pool<") || ty_str == "Pool";
+        }
+        false
     }
 
     /// Look up the move reason for a binding by name.

--- a/specs/memory/borrowing.md
+++ b/specs/memory/borrowing.md
@@ -136,7 +136,11 @@ For non-Copy types, `const x = collection[key]` is a compile error. Use `.clone(
 | Rule | Description |
 |------|-------------|
 | **W1: First-class block** | `with` is a real scope — `return` exits the function, `try` propagates to the enclosing function, `break`/`continue` work for surrounding loops |
-| **W2: No structural mutation** | Source collection cannot be structurally mutated inside the `with` block (no insert, remove, clear). Reading and writing other elements via inline access is allowed |
+| **W2: No structural mutation (Vec/Map/string)** | Source collection cannot be structurally mutated inside the `with` block (no insert, remove, push, pop, clear). Reading and writing other elements via inline access is allowed |
+| **W2a: Pool insert allowed** | `pool.insert()` is allowed inside `with pool[h]` — compiler re-resolves bindings after insert (handles survive reallocation per `mem.pools/PL9`) |
+| **W2b: Pool remove(other) allowed** | `pool.remove(other_h)` is allowed if `other_h` is not the bound handle variable — compiler re-resolves; runtime panic if aliased (same semantics as W3) |
+| **W2c: Pool remove(bound) forbidden** | `pool.remove(h)` where `h` is the bound handle is a compile error — you can't remove the element you're borrowing |
+| **W2d: Pool clear forbidden** | `pool.clear()` is always a compile error inside `with` — invalidates everything |
 | **W3: Aliasing check** | Multiple bindings from same collection: runtime panic if same key/handle |
 | **W4: Error semantics** | Panics on invalid handle/OOB (matches direct indexing) |
 | **W5: Mutable binding** | `with` bindings are always mutable. Read-only access is enforced by the source (e.g., `shared.read()` prevents mutation). Compiler warns when binding is never mutated |
@@ -190,26 +194,49 @@ func apply_buff(pool: Pool<Entity>, h: Handle<Entity>) -> () or Error {
 
 ### Structural mutation restriction (W2)
 
-Structural mutations on the source collection are forbidden inside the `with` block — operations that add, remove, or reallocate elements (insert, remove, push, pop, clear). Reading and writing other elements via inline access works normally.
+For Vec, Map, and string: structural mutations are forbidden inside the `with` block — operations that add, remove, or reallocate elements (insert, remove, push, pop, clear). Reading and writing other elements via inline access works normally.
 
 <!-- test: compile-fail -->
 ```rask
-with pool[h] as entity {
-    entity.health -= 10
-    pool.remove(other_h)     // ERROR: structural mutation inside with block
+with vec[i] as item {
+    item.count += 1
+    vec.push(new_item)       // ERROR: structural mutation inside with block
 }
 ```
 
-Reading and writing other elements is allowed:
+**Pool exception (W2a–W2d):** Pool handles survive reallocation (`mem.pools/PL9`). The compiler exploits this — `insert` and `remove(other)` are allowed inside `with pool[h]` blocks. After each structural mutation, the compiler re-resolves the binding by re-validating the handle (~1ns generation check).
 
 <!-- test: skip -->
 ```rask
 with pool[h] as entity {
     entity.health -= pool[other_h].bonus    // OK: inline read of other element
     pool[other_h].last_attacker = Some(h)   // OK: inline write to other element
-    pool.insert(new_entity)                 // ERROR: structural mutation (insert)
+
+    // Pool-specific: insert and remove(other) are allowed
+    const ally = try pool.insert(new_ally)  // OK: re-resolves entity binding  [re-resolved]
+    entity.allies.push(ally)                // entity still valid after insert
+    pool.remove(expired_h)                  // OK: re-resolves  [re-resolved]
 }
 ```
+
+Removing the bound handle or clearing the pool remain compile errors:
+
+<!-- test: compile-fail -->
+```rask
+with pool[h] as entity {
+    entity.health -= 10
+    pool.remove(h)           // ERROR: removing the bound element (W2c)
+}
+```
+
+<!-- test: compile-fail -->
+```rask
+with pool[h] as entity {
+    pool.clear()             // ERROR: clears everything (W2d)
+}
+```
+
+If `remove(other_h)` happens to alias the bound handle at runtime, the re-resolution panics with "stale handle" — same aliasing semantics as W3.
 
 For multi-statement access to multiple elements, the comma syntax is still preferred:
 <!-- test: skip -->
@@ -376,25 +403,41 @@ FIX 2: Store indices:
   process(line[view])
 ```
 
-**Structural mutation inside with [W2]:**
+**Structural mutation inside with — Vec/Map/string [W2]:**
 ```
-ERROR [mem.borrowing/W2]: cannot structurally mutate collection inside with block
+ERROR [mem.borrowing/W2]: cannot push to `vec` inside with block — vec can reallocate
+   |
+5  |  with vec[i] as item {
+   |  ---- element borrowed here
+6  |      item.count += 1
+7  |      vec.push(new_item)
+   |      ^^^^^^^^^^^^^^^^^^ structural mutation not allowed inside with block
+
+WHY: Vec/Map/string can reallocate, invalidating the borrowed element.
+     Pool handles survive reallocation — use Pool if you need insert/remove inside with.
+
+FIX: Move the structural mutation outside the with block:
+
+  with vec[i] as item { item.count += 1 }
+  vec.push(new_item)
+```
+
+**Removing bound handle inside with — Pool [W2c]:**
+```
+ERROR [mem.borrowing/W2c]: cannot remove `h` inside with block — it's the bound element
    |
 5  |  with pool[h] as entity {
    |  ---- element borrowed here
 6  |      entity.health -= 10
-7  |      pool.remove(other)
-   |      ^^^^^^^^^^^^^^^^^ structural mutation not allowed inside with block
+7  |      pool.remove(h)
+   |      ^^^^^^^^^^^^^^ removing the element you're borrowing
 
-WHY: insert, remove, and clear can invalidate the borrowed element.
-     Reading and writing other elements is fine.
+WHY: Removing the bound element frees its memory. The binding would dangle.
 
-FIX: Move the structural mutation outside the with block:
+FIX: Move the removal outside the with block:
 
-  const should_remove = pool[h].health <= 0
-  if should_remove {
-      pool.remove(other)
-  }
+  const should_remove = with pool[h] as e { e.health -= 10; e.health <= 0 }
+  if should_remove { pool.remove(h) }
 ```
 
 ## Edge Cases
@@ -417,7 +460,11 @@ FIX: Move the structural mutation outside the with block:
 | Nested `with` same collection | W2 | Compile error (use comma syntax) |
 | Inline read of other element inside `with` | W2 | Allowed |
 | Inline write of other element inside `with` | W2 | Allowed (runtime panic if same handle) |
-| Structural mutation inside `with` | W2 | Compile error |
+| Structural mutation inside `with` (Vec/Map/string) | W2 | Compile error |
+| `pool.insert()` inside `with pool[h]` | W2a | Allowed — re-resolves binding |
+| `pool.remove(other_h)` inside `with pool[h]` | W2b | Allowed — re-resolves; runtime panic if aliased |
+| `pool.remove(h)` inside `with pool[h]` (bound handle) | W2c | Compile error |
+| `pool.clear()` inside `with pool[h]` | W2d | Compile error |
 | Disjoint field borrows | F2 | Non-overlapping fields can be borrowed simultaneously |
 | Field borrow + whole-struct borrow | F3 | Compile error: struct already borrowed |
 | Same field borrowed twice | F2 | Compile error: field already borrowed |
@@ -486,7 +533,9 @@ func apply_buff(pool: Pool<Entity>, h: Handle<Entity>) -> () or Error {
 
 **W1 (with as first-class block):** The biggest concrete win over the old closure-based `modify()`. Closures can't propagate `return`/`try`/`break` to the enclosing function — `with` can. One access pattern for every container type.
 
-**W2 (no structural mutation):** The compiler categorizes each collection method as structural (changes element count or triggers reallocation: insert, remove, push, pop, clear) or non-structural (reads/writes existing elements). Structural mutations are forbidden inside `with` — they could invalidate the borrowed element. Non-structural access to other elements is allowed because it doesn't affect the held element's memory. This pushes complexity into the compiler (method categorization) to give the user natural access patterns.
+**W2 (structural mutation):** The compiler categorizes each collection method as structural (changes element count or triggers reallocation: insert, remove, push, pop, clear) or non-structural (reads/writes existing elements). For Vec/Map/string, structural mutations are forbidden inside `with` — they could invalidate the borrowed element.
+
+**W2a–W2d (pool exception):** Pool handles survive reallocation (PL9) — that's the entire point of handles. I decided to exploit this inside `with` blocks rather than apply the same restriction as Vec/Map. After `pool.insert()` or `pool.remove(other)`, the compiler re-resolves the binding by re-validating the handle (~1ns generation check). If a `remove(other_h)` aliased the bound handle at runtime, the re-resolution panics "stale handle" — same aliasing semantics as W3. The cost is per-type rules in the compiler, but pools already have their own rules (context clauses, generation coalescing, frozen modifiers). One more isn't conceptual overhead — it's the handle abstraction doing what it was designed for.
 
 **W5 (always mutable):** `with` exists for multi-statement access — and the overwhelming majority of cases involve mutation. If you just need to read, inline access often suffices. Making bindings always mutable eliminates the `const` keyword from `with` entirely, removing a concept that caused confusion: for `Shared<T>`, `const` previously changed the lock type (shared vs exclusive), while for everything else it only controlled binding mutability. With explicit `.read()`/`.write()` on Shared, there's no need for `const` on `with` bindings. The compiler warns when a `with` binding is never mutated.
 
@@ -559,6 +608,7 @@ The IDE makes access patterns visible through ghost annotations.
 | Inline access | `[inline access]` |
 | `with` block | `[bound: lines N-M]` |
 | Conflict site | `[conflict: viewed on line N]` |
+| Pool re-resolution (W2a/W2b) | `[re-resolved]` |
 
 <!-- test: skip -->
 ```rask

--- a/specs/memory/pools.md
+++ b/specs/memory/pools.md
@@ -111,12 +111,22 @@ with pool[h] as entity {
 with pool[h] as e: e.health -= damage
 ```
 
-Structural mutations are forbidden inside the `with` block — but reading and writing other elements is fine (`mem.borrowing/W2`):
-<!-- test: compile-fail -->
+Pool handles survive reallocation (PL9), so `insert` and `remove(other)` are allowed inside `with` blocks — the compiler re-resolves bindings after each structural mutation (`mem.borrowing/W2a`, `W2b`). Removing the bound handle or clearing the pool remain compile errors (`W2c`, `W2d`):
+
+<!-- test: skip -->
 ```rask
 with pool[h] as entity {
     entity.health -= pool[other_h].bonus    // OK: read other element
-    pool.remove(h)    // ERROR: structural mutation inside with block
+    const ally = try pool.insert(new_ally)  // OK: re-resolves entity  [re-resolved]
+    entity.allies.push(ally)                // entity still valid
+    pool.remove(expired_h)                  // OK: re-resolves  [re-resolved]
+}
+```
+
+<!-- test: compile-fail -->
+```rask
+with pool[h] as entity {
+    pool.remove(h)    // ERROR: removing the bound element (W2c)
 }
 ```
 
@@ -519,7 +529,7 @@ func render_entities() using frozen entities: Pool<Entity> {
 
 **PF5 (frozen context):** I considered making FrozenPool a separate type with freeze/thaw ownership ceremonies. That's the Rust approach — explicit state transitions. But it adds a whole type to learn, and `using frozen Pool<T>` already provides the compile-time guarantee. The `frozen` modifier is a context property, not a type.
 
-**PL9 (handle stability):** This is why handles exist — stable identifiers that don't break when memory moves. Pointers would become dangling; handles never do.
+**PL9 (handle stability):** This is why handles exist — stable identifiers that don't break when memory moves. Pointers would become dangling; handles never do. This stability is what allows `insert` and `remove(other)` inside `with` blocks (W2a/W2b) — the compiler re-resolves the binding via the still-valid handle after each structural mutation. Vec/Map can't do this (indices shift, keys rehash), but pools can because handle stability is a structural guarantee.
 
 ### Patterns & Guidance
 
@@ -546,13 +556,20 @@ with entities[h] as e {
     events.insert(Event.Died(h))    // OK: different collection
 }
 
-// Pattern 2: Restructure logic
+// Pattern 2: Insert/remove other inside with (W2a/W2b)
+with pool[h] as entity {
+    const ally = try pool.insert(new_ally)   // OK: re-resolves
+    entity.allies.push(ally)
+    pool.remove(expired_h)                   // OK: re-resolves
+}
+
+// Pattern 3: Remove bound handle — restructure outside with
 const should_remove = pool[h].health <= 0
 if should_remove {
     pool.remove(h)    // OK: not inside with block
 }
 
-// Pattern 3: Multi-element access
+// Pattern 4: Multi-element access
 with pool[h1] as e1, pool[h2] as e2 {
     e1.health -= e2.attack
 }


### PR DESCRIPTION
## Summary

This PR implements fine-grained structural mutation checking for `with` blocks that distinguishes between Pool collections and other container types (Vec, Map, string). Pool handles survive reallocation, enabling safe `insert` and `remove(other)` operations inside `with` blocks with automatic binding re-resolution, while non-pool collections remain fully restricted.

## Key Changes

**Ownership Checker (rask-ownership)**
- Added `WithBindingInfo` struct to track active `with` block bindings with collection name, handle name, pool type flag, and span
- Added `active_with_bindings` stack and `param_type_strings` map to the `OwnershipChecker` to enable W2 rule enforcement
- Implemented `is_pool_type()` method to detect Pool types via resolved types or parameter type strings
- Added structural mutation detection in method call checking that enforces:
  - **W2**: All structural mutations (insert, remove, clear, push, pop) forbidden for Vec/Map/string
  - **W2a**: `pool.insert()` allowed — re-resolves binding after insertion
  - **W2b**: `pool.remove(other_h)` allowed — re-resolves binding after removal
  - **W2c**: `pool.remove(h)` forbidden when `h` is the bound handle
  - **W2d**: `pool.clear()` always forbidden inside `with` blocks
- Updated `WithAs` expression handling to track binding info on entry and clean up on exit

**MIR Lowerer (rask-mir)**
- Added `with_pool_bindings` map to track pool bindings requiring re-resolution
- Implemented automatic `PoolCheckedAccess` MIR statement generation after pool mutator calls (insert, remove, clear, drain, alloc) to re-validate handles
- Pool binding tracking is scoped to `with` block lifetime with proper cleanup

**Error Handling (rask-diagnostics)**
- Added three new error variants with distinct error codes:
  - `E0808`: WithBlockStructuralMutation (Vec/Map/string mutations)
  - `E0809`: WithBlockBoundHandleRemoved (removing bound handle from pool)
  - `E0810`: WithBlockClear (clearing pool inside with block)
- Each error includes helpful context about why the operation is forbidden and how to fix it

**Documentation (specs/memory/borrowing.md, specs/memory/pools.md)**
- Clarified W2 rule applies only to Vec/Map/string
- Added W2a–W2d rules explaining pool-specific exceptions
- Updated examples showing allowed insert/remove patterns with `[re-resolved]` annotations
- Added error message examples for each violation type
- Updated edge cases table with pool-specific scenarios
- Explained rationale: pool handles survive reallocation, enabling compiler-driven re-resolution

## Implementation Details

- Pool detection uses both resolved type information from the type checker and fallback string matching on parameter type annotations
- Binding re-resolution is implemented as `PoolCheckedAccess` MIR statements that perform ~1ns generation checks
- Runtime aliasing detection for `remove(other_h)` follows W3 semantics — panics with "stale handle" if the removed handle matches the bound handle
- The implementation maintains backward compatibility — non-pool collections continue to forbid all structural mutations

https://claude.ai/code/session_01FC9pLM7BvJw9h3LpiEu7hS