### PR TITLE
Add derive method generation and stdlib runtime enhancements

### DIFF
--- a/compiler/crates/rask-cli/src/commands/codegen.rs
+++ b/compiler/crates/rask-cli/src/commands/codegen.rs
@@ -16,6 +16,9 @@ fn run_pipeline(path: &str, format: Format) -> (MonoProgram, rask_types::TypedPr
     // Hidden parameter pass — desugar `using` clauses into explicit params
     rask_hidden_params::desugar_hidden_params(&mut result.decls);
 
+    // Generate synthetic function bodies for auto-derived methods (compare, etc.)
+    super::derive::generate_derived_methods(&mut result.decls, &result.typed);
+
     // Inject compiled stdlib functions + struct defs AFTER typechecking.
     // Type signatures come from BuiltinModule stubs during resolve/typecheck.
     // Function bodies and struct layouts are only needed at mono/codegen time.

--- a/compiler/crates/rask-cli/src/commands/derive.rs
+++ b/compiler/crates/rask-cli/src/commands/derive.rs
@@ -1,0 +1,172 @@
+// SPDX-License-Identifier: (MIT OR Apache-2.0)
+//! Synthetic function body generation for auto-derived trait methods.
+//!
+//! After typechecking confirms which methods are auto-derived (compare, eq,
+//! hash, clone), this pass generates actual AST function bodies so they
+//! compile through the normal pipeline (mono → MIR → codegen).
+
+use rask_ast::decl::{Decl, DeclKind, FnDecl, ImplDecl, Param};
+use rask_ast::expr::{BinOp, Expr, ExprKind};
+use rask_ast::stmt::{Stmt, StmtKind};
+use rask_ast::{NodeId, Span};
+use rask_types::TypedProgram;
+
+const DUMMY: Span = Span { start: 0, end: 0 };
+
+fn expr(kind: ExprKind) -> Expr {
+    Expr { id: NodeId(0), kind, span: DUMMY }
+}
+
+fn stmt(kind: StmtKind) -> Stmt {
+    Stmt { id: NodeId(0), kind, span: DUMMY }
+}
+
+/// Generate synthetic function bodies for auto-derived methods on structs.
+///
+/// Currently handles:
+/// - `compare`: lexicographic field-by-field comparison returning i64 (-1, 0, 1)
+///
+/// The generated functions are added as Impl declarations to `decls`.
+pub fn generate_derived_methods(decls: &mut Vec<Decl>, typed: &TypedProgram) {
+    let mut new_impls = Vec::new();
+
+    for type_def in typed.types.iter() {
+        match type_def {
+            rask_types::TypeDef::Struct { name, fields, methods, .. } => {
+                // Check for user-provided compare
+                let has_user_compare = decls.iter().any(|d| match &d.kind {
+                    DeclKind::Impl(imp) if imp.target_ty == *name => {
+                        imp.methods.iter().any(|m| m.name == "compare")
+                    }
+                    _ => false,
+                });
+
+                // Only generate if type checker derived it and no user impl exists
+                if !has_user_compare && methods.iter().any(|m| m.name == "compare") {
+                    if let Some(fn_decl) = gen_struct_compare(&name, &fields) {
+                        new_impls.push(Decl {
+                            id: NodeId(0),
+                            kind: DeclKind::Impl(ImplDecl {
+                                trait_name: None,
+                                target_ty: name.clone(),
+                                methods: vec![fn_decl],
+                                is_unsafe: false,
+                                doc: None,
+                            }),
+                            span: DUMMY,
+                        });
+                    }
+                }
+            }
+            _ => {}
+        }
+    }
+
+    decls.extend(new_impls);
+}
+
+/// Generate a `compare` function body for a struct with the given fields.
+///
+/// Produces:
+/// ```text
+/// func compare(self, other: TypeName) -> i64 {
+///     if self.f1 < other.f1 { return -1 }
+///     if self.f1 > other.f1 { return 1 }
+///     if self.f2 < other.f2 { return -1 }
+///     if self.f2 > other.f2 { return 1 }
+///     ...
+///     return 0
+/// }
+/// ```
+///
+/// Uses raw i64 return (-1/0/1) rather than Ordering enum because the
+/// runtime (sort_by, etc.) operates on i64 values directly.
+fn gen_struct_compare(
+    type_name: &str,
+    fields: &[(String, rask_types::Type)],
+) -> Option<FnDecl> {
+    // Only generate for structs with comparable fields
+    if fields.is_empty() {
+        return None;
+    }
+
+    let mut body = Vec::new();
+
+    for (field_name, _field_ty) in fields {
+        // self.field
+        let self_field = expr(ExprKind::Field {
+            object: Box::new(expr(ExprKind::Ident("self".to_string()))),
+            field: field_name.clone(),
+        });
+        // other.field
+        let other_field = expr(ExprKind::Field {
+            object: Box::new(expr(ExprKind::Ident("other".to_string()))),
+            field: field_name.clone(),
+        });
+
+        // if self.field < other.field { return -1 }
+        body.push(stmt(StmtKind::Expr(expr(ExprKind::If {
+            cond: Box::new(expr(ExprKind::Binary {
+                op: BinOp::Lt,
+                left: Box::new(self_field.clone()),
+                right: Box::new(other_field.clone()),
+            })),
+            then_branch: Box::new(expr(ExprKind::Block(vec![
+                stmt(StmtKind::Return(Some(expr(ExprKind::Unary {
+                    op: rask_ast::expr::UnaryOp::Neg,
+                    operand: Box::new(expr(ExprKind::Int(1, None))),
+                })))),
+            ]))),
+            else_branch: None,
+        }))));
+
+        // if self.field > other.field { return 1 }
+        body.push(stmt(StmtKind::Expr(expr(ExprKind::If {
+            cond: Box::new(expr(ExprKind::Binary {
+                op: BinOp::Gt,
+                left: Box::new(self_field),
+                right: Box::new(other_field),
+            })),
+            then_branch: Box::new(expr(ExprKind::Block(vec![
+                stmt(StmtKind::Return(Some(expr(ExprKind::Int(1, None))))),
+            ]))),
+            else_branch: None,
+        }))));
+    }
+
+    // return 0
+    body.push(stmt(StmtKind::Return(Some(expr(ExprKind::Int(0, None))))));
+
+    Some(FnDecl {
+        name: "compare".to_string(),
+        type_params: vec![],
+        params: vec![
+            Param {
+                name: "self".to_string(),
+                name_span: DUMMY,
+                ty: type_name.to_string(),
+                is_take: false,
+                is_mutate: false,
+                default: None,
+            },
+            Param {
+                name: "other".to_string(),
+                name_span: DUMMY,
+                ty: type_name.to_string(),
+                is_take: false,
+                is_mutate: false,
+                default: None,
+            },
+        ],
+        ret_ty: Some("i64".to_string()),
+        context_clauses: vec![],
+        body,
+        is_pub: false,
+        is_comptime: false,
+        is_unsafe: false,
+        abi: None,
+        attrs: vec![],
+        doc: None,
+        span: DUMMY,
+    })
+}

--- a/compiler/crates/rask-cli/src/commands/mod.rs
+++ b/compiler/crates/rask-cli/src/commands/mod.rs
@@ -19,3 +19,4 @@ pub mod fetch;
 pub mod vendor;
 pub mod publish;
 pub mod audit;
+pub mod derive;

--- a/compiler/crates/rask-codegen/src/dispatch.rs
+++ b/compiler/crates/rask-codegen/src/dispatch.rs
@@ -662,6 +662,14 @@ pub fn stdlib_entries() -> Vec<StdlibEntry> {
             ret_ty: None,
             can_panic: false,
         },
+        // Alias: .push() on string → push_char (char is the natural element type)
+        StdlibEntry {
+            mir_name: "string_push",
+            c_name: "rask_string_push_char",
+            params: &[types::I64, types::I32],
+            ret_ty: None,
+            can_panic: false,
+        },
         StdlibEntry {
             mir_name: "string_chars",
             c_name: "rask_string_chars",
@@ -1008,6 +1016,13 @@ pub fn stdlib_entries() -> Vec<StdlibEntry> {
         StdlibEntry {
             mir_name: "File_write",
             c_name: "rask_file_write",
+            params: &[types::I64, types::I64],
+            ret_ty: None,
+            can_panic: false,
+        },
+        StdlibEntry {
+            mir_name: "File_write_all",
+            c_name: "rask_file_write_all",
             params: &[types::I64, types::I64],
             ret_ty: None,
             can_panic: false,
@@ -1901,6 +1916,13 @@ pub fn stdlib_entries() -> Vec<StdlibEntry> {
             can_panic: false,
         },
         StdlibEntry {
+            mir_name: "Mutex_clone",
+            c_name: "rask_mutex_clone",
+            params: &[types::I64],
+            ret_ty: Some(types::I64),
+            can_panic: false,
+        },
+        StdlibEntry {
             mir_name: "Mutex_drop",
             c_name: "rask_mutex_drop",
             params: &[types::I64],
@@ -1961,6 +1983,13 @@ pub fn stdlib_entries() -> Vec<StdlibEntry> {
         StdlibEntry {
             mir_name: "char_is_lowercase",
             c_name: "rask_char_is_lowercase",
+            params: &[types::I32],
+            ret_ty: Some(types::I64),
+            can_panic: false,
+        },
+        StdlibEntry {
+            mir_name: "char_to_int",
+            c_name: "rask_char_to_int",
             params: &[types::I32],
             ret_ty: Some(types::I64),
             can_panic: false,

--- a/compiler/crates/rask-mir/src/lower/expr.rs
+++ b/compiler/crates/rask-mir/src/lower/expr.rs
@@ -1050,7 +1050,9 @@ impl<'a> MirLowerer<'a> {
                         "to_vec" | "chunks" | "skip"
                         | "map" | "filter" | "collect"
                         | "enumerate" | "any" | "all" | "find" | "fold"
-                        | "for_each" | "flat_map" | "take" | "zip" => Some("Vec".to_string()),
+                        | "for_each" | "flat_map" | "take" | "zip"
+                        | "sort_by" | "sort" | "dedup"
+                        | "first" | "last" => Some("Vec".to_string()),
                         "join" if all_args.len() == 2 => Some("Vec".to_string()),
                         // Map (Vec uses index syntax for element access, so .get()/.insert()/.remove()
                         // as method calls are effectively Map-only in practice)

--- a/compiler/crates/rask-mir/src/lower/mod.rs
+++ b/compiler/crates/rask-mir/src/lower/mod.rs
@@ -339,6 +339,7 @@ impl<'a> MirContext<'a> {
         match ty {
             Type::String => Some("string"),
             Type::UnresolvedNamed(name) => match name.as_str() {
+                "string" => Some("string"),
                 "Vec" => Some("Vec"),
                 "Map" => Some("Map"),
                 "Pool" => Some("Pool"),

--- a/compiler/crates/rask-mir/src/lower/stmt.rs
+++ b/compiler/crates/rask-mir/src/lower/stmt.rs
@@ -375,12 +375,14 @@ impl<'a> MirLowerer<'a> {
                 if super::is_type_constructor_name(obj_name) {
                     // Type.method() → prefix is the type name.
                     // Covers stdlib (Vec, Map, string) and user types (Person, Document).
+                    // Strip generic args: Map<string, JsonValue> → Map
+                    let base_name = obj_name.split('<').next().unwrap_or(obj_name);
                     if super::MirContext::stdlib_type_prefix(
-                        &rask_types::Type::UnresolvedNamed(obj_name.clone())
+                        &rask_types::Type::UnresolvedNamed(base_name.to_string())
                     ).is_some()
-                        || obj_name.chars().next().map_or(false, |c| c.is_uppercase())
+                        || base_name.chars().next().map_or(false, |c| c.is_uppercase())
                     {
-                        self.local_type_prefix.insert(name.to_string(), obj_name.clone());
+                        self.local_type_prefix.insert(name.to_string(), base_name.to_string());
                     } else {
                         // Module function (fs.open) → check return type prefix
                         let func_name = format!("{}_{}", obj_name, method);

--- a/compiler/runtime/rask_runtime.h
+++ b/compiler/runtime/rask_runtime.h
@@ -135,6 +135,7 @@ int64_t rask_char_is_alphanumeric(int32_t c);
 int64_t rask_char_is_whitespace(int32_t c);
 int64_t rask_char_is_uppercase(int32_t c);
 int64_t rask_char_is_lowercase(int32_t c);
+int64_t rask_char_to_int(int32_t c);
 int64_t rask_char_to_uppercase(int32_t c);
 int64_t rask_char_to_lowercase(int32_t c);
 int64_t rask_char_len_utf8(int32_t c);
@@ -250,6 +251,7 @@ void        rask_fs_append_file(const RaskString *path, const RaskString *conten
 void        rask_file_close(int64_t file);
 RaskString *rask_file_read_all(int64_t file);
 void        rask_file_write(int64_t file, const RaskString *content);
+void        rask_file_write_all(int64_t file, const RaskString *content);
 void        rask_file_write_line(int64_t file, const RaskString *content);
 RaskVec    *rask_file_lines(int64_t file);
 
@@ -507,6 +509,7 @@ int64_t rask_mutex_try_lock(RaskMutex *m, RaskAccessFn f, void *ctx);
 int64_t rask_mutex_new_ptr(int64_t data_ptr, int64_t data_size);
 int64_t rask_mutex_lock_ptr(int64_t mutex, int64_t closure);
 int64_t rask_mutex_try_lock_ptr(int64_t mutex, int64_t closure);
+int64_t rask_mutex_clone(int64_t mutex);
 void    rask_mutex_drop(int64_t mutex);
 
 // ─── Shared (RwLock) ───────────────────────────────────────

--- a/compiler/runtime/runtime.c
+++ b/compiler/runtime/runtime.c
@@ -310,6 +310,20 @@ void rask_file_write(int64_t file, const RaskString *content) {
     fwrite(rask_string_ptr(content), 1, (size_t)rask_string_len(content), f);
 }
 
+void rask_file_write_all(int64_t file, const RaskString *content) {
+    FILE *f = (FILE *)(uintptr_t)file;
+    if (!f || !content) return;
+    const char *ptr = rask_string_ptr(content);
+    size_t remaining = (size_t)rask_string_len(content);
+    while (remaining > 0) {
+        size_t written = fwrite(ptr, 1, remaining, f);
+        if (written == 0) break;
+        ptr += written;
+        remaining -= written;
+    }
+    fflush(f);
+}
+
 void rask_file_write_line(int64_t file, const RaskString *content) {
     FILE *f = (FILE *)(uintptr_t)file;
     if (!f) return;

--- a/compiler/runtime/string.c
+++ b/compiler/runtime/string.c
@@ -411,6 +411,10 @@ int64_t rask_char_is_lowercase(int32_t c) {
     return (c >= 'a' && c <= 'z') ? 1 : 0;
 }
 
+int64_t rask_char_to_int(int32_t c) {
+    return (int64_t)c;
+}
+
 int64_t rask_char_to_uppercase(int32_t c) {
     if (c >= 'a' && c <= 'z') return c - 32;
     return c;

--- a/compiler/runtime/sync.c
+++ b/compiler/runtime/sync.c
@@ -23,6 +23,7 @@ struct RaskMutex {
     pthread_mutex_t lock;
     void           *data;
     int64_t         data_size;
+    _Atomic int64_t refcount;
 };
 
 RaskMutex *rask_mutex_new(const void *initial_data, int64_t data_size) {
@@ -36,12 +37,14 @@ RaskMutex *rask_mutex_new(const void *initial_data, int64_t data_size) {
     m->data_size = data_size;
     m->data = rask_alloc(data_size);
 
+    atomic_store(&m->refcount, 1);
     memcpy(m->data, initial_data, (size_t)data_size);
     return m;
 }
 
 void rask_mutex_free(RaskMutex *m) {
     if (!m) return;
+    if (atomic_fetch_sub(&m->refcount, 1) > 1) return;
     pthread_mutex_destroy(&m->lock);
     rask_free(m->data);
     rask_free(m);
@@ -204,6 +207,12 @@ int64_t rask_mutex_try_lock_ptr(int64_t mutex, int64_t closure) {
         return result;
     }
     return 0; // lock not acquired
+}
+
+int64_t rask_mutex_clone(int64_t mutex) {
+    RaskMutex *m = (RaskMutex *)(intptr_t)mutex;
+    atomic_fetch_add(&m->refcount, 1);
+    return mutex;
 }
 
 void rask_mutex_drop(int64_t mutex) {


### PR DESCRIPTION
## Summary
This PR adds support for auto-generating synthetic function bodies for derived trait methods (starting with `compare`), along with several stdlib runtime enhancements for file I/O, synchronization primitives, and character operations.

## Key Changes

### Derive Method Generation
- **New module**: `rask-cli/src/commands/derive.rs` - Generates synthetic AST function bodies for auto-derived methods after typechecking
  - Implements `compare` method generation for structs with lexicographic field-by-field comparison
  - Returns i64 values (-1, 0, 1) for use by runtime sort operations
  - Only generates when type checker marks method as derived and no user implementation exists
- Integrated into codegen pipeline to run after hidden parameter desugaring

### Runtime & Stdlib Additions
- **File I/O**: Added `rask_file_write_all()` with retry loop to ensure complete writes and flush
- **Synchronization**: Enhanced `RaskMutex` with atomic reference counting for proper clone/drop semantics
  - Added `rask_mutex_clone()` to increment refcount
  - Modified `rask_mutex_free()` to only deallocate when refcount reaches zero
- **Character operations**: Added `rask_char_to_int()` for char-to-i64 conversion
- **Dispatch entries**: Registered new stdlib functions in codegen dispatch table

### MIR Lowering Fixes
- Fixed generic type handling in method call lowering: strip generic arguments (e.g., `Map<string, JsonValue>` → `Map`) before type prefix lookup
- Extended Vec method recognition to include `sort_by`, `sort`, `dedup`, `first`, `last`
- Added "string" as recognized stdlib type prefix in MIR context

## Implementation Details
- Derived `compare` generates nested if-statements for each field, returning early on inequality
- Mutex refcounting uses C11 atomics (`_Atomic`, `atomic_fetch_add`, `atomic_fetch_sub`)
- Generic type stripping uses simple string split on `<` to handle parameterized types in method resolution

https://claude.ai/code/session_01MEnGYfH3HXi9BycrR64EmM