### PR TITLE
Add unsafe report command to analyze unsafe operations

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -48,7 +48,7 @@ Ownership checking works for common patterns but has gaps in error reporting and
 Single-file compilation works. Multi-file packages have symbol visibility issues.
 
 - [ ] **Cross-package public symbol export** — `public` types/funcs not visible via `import pkg` in workspace path deps. `lsm.DbError` resolves to `no such field on __module_lsm`. Blocks multi-package examples.
-- [ ] **Parser: empty guard else block** — `expr is Ok else {}` with empty braces causes brace mismatch.
+- [x] **Parser: empty guard else block** — `expr is Ok else {}` with empty braces causes brace mismatch.
 
 ## 8. Build Infrastructure & Security
 
@@ -57,7 +57,7 @@ Hardening for the package ecosystem. Not blocking any examples.
 - [ ] **Build script sandbox** — Cross-platform sandbox for dep build scripts (SB1-SB7).
 - [ ] **Package signing** — Ed25519 TOFU signing on publish/fetch (SG1-SG7, KM1-KM3, LK8).
 - [ ] **Build exec gating** — `exec()`/`exec_output()` require `build_exec` capability (PM9-PM10).
-- [ ] **Unsafe report command** — CLI command to report all unsafe operations by category.
+- [x] **Unsafe report command** — CLI command to report all unsafe operations by category.
 
 ---
 
@@ -148,5 +148,11 @@ Hardening for the package ecosystem. Not blocking any examples.
 - [x] Serialization / encoding spec
 - [x] Granular unsafe operations — keep blanket unsafe blocks
 - [x] Capability-based security for dependencies
+
+### Build Infrastructure
+- [x] Unsafe report command — `rask unsafe <file>` reports operations by category
+
+### Parser
+- [x] Empty guard else block — `expr is Ok else {}` already works correctly
 
 </details>

--- a/compiler/crates/rask-cli/src/commands/analysis.rs
+++ b/compiler/crates/rask-cli/src/commands/analysis.rs
@@ -1,8 +1,11 @@
 // SPDX-License-Identifier: (MIT OR Apache-2.0)
-//! Analysis commands: typecheck, ownership, comptime.
+//! Analysis commands: typecheck, ownership, comptime, unsafe report.
 
 use colored::Colorize;
 use rask_diagnostics::{Diagnostic, ToDiagnostic};
+use rask_types::UnsafeCategory;
+use std::collections::BTreeMap;
+use std::fmt::Write as _;
 use std::fs;
 use std::process;
 
@@ -154,4 +157,80 @@ pub fn cmd_comptime(path: &str, format: Format) {
             process::exit(1);
         }
     }
+}
+
+fn category_label(cat: UnsafeCategory) -> &'static str {
+    match cat {
+        UnsafeCategory::PointerDeref => "Pointer Dereference",
+        UnsafeCategory::PointerDerefWrite => "Pointer Dereference (write)",
+        UnsafeCategory::PointerArithmetic => "Pointer Arithmetic",
+        UnsafeCategory::PointerMethod => "Pointer Method",
+        UnsafeCategory::ExternCall => "Extern Call",
+        UnsafeCategory::UnsafeFuncCall => "Unsafe Function Call",
+        UnsafeCategory::Transmute => "Transmute",
+        UnsafeCategory::UnionFieldAccess => "Union Field Access",
+    }
+}
+
+pub fn cmd_unsafe_report(path: &str, format: Format) {
+    let result = super::pipeline::run_frontend(path, format);
+
+    let ops = &result.typed.unsafe_ops;
+
+    if format == Format::Json {
+        let mut json = String::from("{\n  \"unsafe_ops\": [");
+        for (i, (span, cat)) in ops.iter().enumerate() {
+            if i > 0 { json.push(','); }
+            let _ = write!(json,
+                "\n    {{\"category\": \"{:?}\", \"start\": {}, \"end\": {}}}",
+                cat, span.start, span.end
+            );
+        }
+        let _ = write!(json, "\n  ],\n  \"total\": {}\n}}", ops.len());
+        println!("{}", json);
+        return;
+    }
+
+    // Human format
+    if ops.is_empty() {
+        println!("{}", output::banner_ok("Unsafe Report"));
+        println!();
+        println!("No unsafe operations found.");
+        return;
+    }
+
+    // Build line map from source (single-file) or source_files (multi-file)
+    let line_map = result.source.as_ref().map(|s| rask_ast::LineMap::new(s));
+
+    // Group by category, preserving order via BTreeMap on discriminant
+    let mut grouped: BTreeMap<u8, (UnsafeCategory, Vec<&rask_ast::Span>)> = BTreeMap::new();
+    for (span, cat) in ops {
+        let key = *cat as u8;
+        grouped.entry(key).or_insert_with(|| (*cat, Vec::new())).1.push(span);
+    }
+
+    println!("{} Unsafe Report {}\n", "===".dimmed(), "===".dimmed());
+
+    let mut total_categories = 0;
+    for (_key, (cat, spans)) in &grouped {
+        total_categories += 1;
+        println!("{} ({})", category_label(*cat).yellow(), spans.len());
+        for span in spans {
+            if let Some(ref lm) = line_map {
+                let (line, col) = lm.offset_to_line_col(span.start);
+                println!("  {}:{}:{}", output::file_path(path), line, col);
+            } else {
+                println!("  offset {}..{}", span.start, span.end);
+            }
+        }
+        println!();
+    }
+
+    println!("{} {} unsafe operation(s) across {} categor{} {}",
+        "===".dimmed(),
+        ops.len(),
+        total_categories,
+        if total_categories == 1 { "y" } else { "ies" },
+        "===".dimmed(),
+    );
 }

--- a/compiler/crates/rask-cli/src/help.rs
+++ b/compiler/crates/rask-cli/src/help.rs
@@ -61,6 +61,7 @@ pub fn print_usage() {
     println!("{}", output::section_header("Debugging and Exploration:"));
     println!("  {} {}  Lint source files for conventions", output::command("lint"), output::arg("<file|dir>"));
     println!("  {} {}       Show a module's public API", output::command("api"), output::arg("<file>"));
+    println!("  {} {}    Report all unsafe operations by category", output::command("unsafe"), output::arg("<file>"));
 
     println!();
     println!("{}", output::section_header("Compilation Phases:"));
@@ -571,6 +572,24 @@ pub fn print_comptime_help() {
     println!();
     println!("{}", output::section_header("Options:"));
     println!("  {}  Output comptime results as structured JSON", output::arg("--json"));
+}
+
+pub fn print_unsafe_help() {
+    println!("{}", output::section_header("Unsafe Report"));
+    println!();
+    println!("Report all unsafe operations in a Rask source file, grouped by category.");
+    println!();
+    println!("{}: {} {} {}", "Usage".yellow(),
+        output::command("rask"),
+        output::command("unsafe"),
+        output::arg("<file.rk>"));
+    println!();
+    println!("{}", output::section_header("Categories:"));
+    println!("  Pointer Dereference, Pointer Dereference (write), Pointer Arithmetic,");
+    println!("  Pointer Method, Extern Call, Unsafe Function Call, Transmute, Union Field Access");
+    println!();
+    println!("{}", output::section_header("Options:"));
+    println!("  {}  Output unsafe report as structured JSON", output::arg("--json"));
 }
 
 pub fn print_mono_help() {

--- a/compiler/crates/rask-cli/src/main.rs
+++ b/compiler/crates/rask-cli/src/main.rs
@@ -178,6 +178,18 @@ fn main() {
             }
             commands::analysis::cmd_comptime(cmd_args[2], format);
         }
+        "unsafe" => {
+            if cmd_args.contains(&"--help") || cmd_args.contains(&"-h") {
+                help::print_unsafe_help();
+                return;
+            }
+            if cmd_args.len() < 3 {
+                eprintln!("{}: missing file argument", output::error_label());
+                eprintln!("{}: {} {} {}", "Usage".yellow(), output::command("rask"), output::command("unsafe"), output::arg("<file.rk>"));
+                process::exit(1);
+            }
+            commands::analysis::cmd_unsafe_report(cmd_args[2], format);
+        }
         "run" => {
             if cmd_args.contains(&"--help") || cmd_args.contains(&"-h") {
                 help::print_run_help();

--- a/compiler/crates/rask-mono/src/lib.rs
+++ b/compiler/crates/rask-mono/src/lib.rs
@@ -253,6 +253,7 @@ mod tests {
             node_types: std::collections::HashMap::new(),
             call_type_args: std::collections::HashMap::new(),
             trait_coercions: std::collections::HashMap::new(),
+            unsafe_ops: Vec::new(),
         }
     }
 

--- a/compiler/crates/rask-types/src/checker/mod.rs
+++ b/compiler/crates/rask-types/src/checker/mod.rs
@@ -159,6 +159,8 @@ impl TypeChecker {
 
         let trait_coercions = self.trait_coercions.clone();
 
+        let unsafe_ops = self.unsafe_ops;
+
         if self.errors.is_empty() {
             Ok(TypedProgram {
                 symbols: self.resolved.symbols,
@@ -167,6 +169,7 @@ impl TypeChecker {
                 node_types,
                 call_type_args,
                 trait_coercions,
+                unsafe_ops,
             })
         } else {
             let ctx = &self.ctx;
@@ -185,6 +188,7 @@ impl TypeChecker {
                     node_types,
                     call_type_args,
                     trait_coercions,
+                    unsafe_ops,
                 })
             } else {
                 Err(errors)

--- a/compiler/crates/rask-types/src/checker/type_defs.rs
+++ b/compiler/crates/rask-types/src/checker/type_defs.rs
@@ -88,4 +88,6 @@ pub struct TypedProgram {
     pub call_type_args: HashMap<NodeId, Vec<Type>>,
     /// TR5: implicit trait coercion sites. NodeId of expression → trait name.
     pub trait_coercions: HashMap<NodeId, String>,
+    /// Unsafe operations recorded during type checking (span + category).
+    pub unsafe_ops: Vec<(rask_ast::Span, super::UnsafeCategory)>,
 }

--- a/compiler/crates/rask-types/src/lib.rs
+++ b/compiler/crates/rask-types/src/lib.rs
@@ -11,7 +11,7 @@ pub use types::{GenericArg, Type, TypeId, TypeVarId};
 pub use checker::{
     typecheck, TypeChecker, TypedProgram, TypeTable, TypeDef,
     TypeError, InferenceContext, TypeConstraint, MethodSig, SelfParam,
-    parse_type_string,
+    parse_type_string, UnsafeCategory,
 };
 pub use traits::{
     TraitBound, TraitChecker, TraitError,


### PR DESCRIPTION
## Summary
This PR adds a new `rask unsafe <file>` CLI command that reports all unsafe operations found in a Rask source file, grouped by category. This enables developers to audit unsafe code usage in their projects.

## Key Changes

- **New CLI command**: Added `unsafe` subcommand to report unsafe operations by category
  - Supports both human-readable and JSON output formats
  - Groups unsafe operations by category (pointer dereference, extern calls, transmute, etc.)
  - Shows file location (line:column) for each unsafe operation

- **Type system integration**: 
  - Exported `UnsafeCategory` from `rask_types` for use in CLI
  - Added `unsafe_ops` field to `TypedProgram` to carry unsafe operation data from type checking through to CLI
  - Updated `TypeChecker` to propagate unsafe operations in both success and error paths

- **Help documentation**: Added `print_unsafe_help()` function documenting the new command and its categories

- **Updated TODO tracking**: Marked two items as complete:
  - Parser: empty guard else block (already working)
  - Unsafe report command (now implemented)

## Implementation Details

- The `cmd_unsafe_report()` function processes the typed program and formats unsafe operations
- Uses `BTreeMap` to group operations by category while preserving order
- Leverages existing `LineMap` infrastructure to convert byte offsets to line:column positions
- JSON output includes category (as debug format) and byte span offsets
- Human-readable output shows category counts and formatted file locations

https://claude.ai/code/session_0172uayQqDJCPDLoaFBPQZpW