### PR TITLE
Implement conditional compilation with dead branch elimination

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -27,7 +27,7 @@ Returning or passing structs through function boundaries sometimes generates wro
 
 The interpreter-based comptime system works for simple cases but doesn't bridge into native codegen.
 
-- [ ] **MIR: comptime module constants** — `comptime { ... }` at module level doesn't inject results into MIR scope. `SQUARES`, `PRIMES` etc. unresolved. Blocks 17_comptime.
+- [x] **MIR: comptime module constants** — `comptime { ... }` at module level doesn't inject results into MIR scope. `SQUARES`, `PRIMES` etc. unresolved. Blocks 17_comptime.
 - [ ] **Conditional compilation** — `comptime if cfg.os/arch/features` (CC1-CC2).
 
 ## 5. Collection Iteration & Runtime Crashes
@@ -114,6 +114,7 @@ Hardening for the package ecosystem. Not blocking any examples.
 - [x] Module-level constants
 - [x] `i64.MAX` / `i32.MIN` type-associated constants
 - [x] For-loop tuple destructuring
+- [x] Comptime module constants — MIR resolves globals, scalar deref, branch quota reset
 
 ### Type Checker
 - [x] Vec.len() returned i64 instead of u64

--- a/TODO.md
+++ b/TODO.md
@@ -40,8 +40,8 @@ Several examples compile and link but crash at runtime with no output.
 
 Ownership checking works for common patterns but has gaps in error reporting and explicit `own` handling.
 
-- [ ] **Ownership error messages lack source location** — `rask-cli/src/commands/build.rs:628` prints `error.kind` only, no file/line/span. The `OwnershipError` struct has a `span` field but it's never rendered. Needs file-to-span mapping like the type checker has.
-- [ ] **Ownership checker ignores `own` at call sites** — `ArgMode::Own` is parsed but `rask-ownership` never inspects it. Call sites with `own kv` don't mark `kv` as moved.
+- [x] **Ownership error messages lack source location** — `rask-cli/src/commands/build.rs:628` prints `error.kind` only, no file/line/span. The `OwnershipError` struct has a `span` field but it's never rendered. Needs file-to-span mapping like the type checker has.
+- [x] **Ownership checker ignores `own` at call sites** — `ArgMode::Own` is parsed but `rask-ownership` never inspects it. Call sites with `own kv` don't mark `kv` as moved.
 
 ## 7. Multi-Package / Build System
 
@@ -122,6 +122,8 @@ Hardening for the package ecosystem. Not blocking any examples.
 ### Ownership
 - [x] `mutate self` treated as borrowed
 - [x] if/else branches don't save/restore state
+- [x] Ownership error messages lack source location in `rask build`
+- [x] `own` at call sites marks variable as moved
 
 ### Build System
 - [x] Build pipeline end-to-end

--- a/TODO.md
+++ b/TODO.md
@@ -28,7 +28,7 @@ Returning or passing structs through function boundaries sometimes generates wro
 The interpreter-based comptime system works for simple cases but doesn't bridge into native codegen.
 
 - [x] **MIR: comptime module constants** — `comptime { ... }` at module level doesn't inject results into MIR scope. `SQUARES`, `PRIMES` etc. unresolved. Blocks 17_comptime.
-- [ ] **Conditional compilation** — `comptime if cfg.os/arch/features` (CC1-CC2).
+- [x] **Conditional compilation** — `comptime if cfg.os/arch/features` (CC1-CC2). Dead branch elimination via AST rewrite before desugar; resolver also has cfg-aware fallback.
 
 ## 5. Collection Iteration & Runtime Crashes
 

--- a/compiler/crates/rask-cli/src/commands/build.rs
+++ b/compiler/crates/rask-cli/src/commands/build.rs
@@ -7,6 +7,9 @@ use std::path::{Path, PathBuf};
 use std::process;
 use std::time::Instant;
 
+use rask_diagnostics::formatter::DiagnosticFormatter;
+use rask_diagnostics::ToDiagnostic;
+
 use crate::output;
 
 /// Build options parsed from CLI flags.
@@ -625,7 +628,24 @@ pub fn cmd_build(path: &str, opts: BuildOptions) {
                             let ownership_result = rask_ownership::check_ownership(&typed, &all_decls);
                             if !ownership_result.is_ok() {
                                 for error in &ownership_result.errors {
-                                    eprintln!("error: {}", error.kind);
+                                    let d = error.to_diagnostic();
+                                    let primary_end = d.labels.iter()
+                                        .find(|l| l.style == rask_diagnostics::LabelStyle::Primary)
+                                        .map(|l| l.span.end);
+                                    let matched = primary_end.and_then(|end| {
+                                        let candidates: Vec<_> = source_files.iter()
+                                            .filter(|(_, src)| end <= src.len() && !src.is_empty())
+                                            .collect();
+                                        if candidates.len() == 1 { Some(candidates[0]) } else { None }
+                                    });
+                                    if let Some((path, source)) = matched {
+                                        let file_name = path.to_string_lossy();
+                                        let fmt = DiagnosticFormatter::new(source)
+                                            .with_file_name(&file_name);
+                                        eprintln!("{}", fmt.format(&d));
+                                    } else {
+                                        eprintln!("{}: {}", output::error_label(), d.message);
+                                    }
                                 }
                                 total_errors += ownership_result.errors.len();
                             } else {

--- a/compiler/crates/rask-cli/src/commands/codegen.rs
+++ b/compiler/crates/rask-cli/src/commands/codegen.rs
@@ -88,6 +88,7 @@ pub fn evaluate_comptime_globals(
     }
 
     for (name, init) in comptime_consts {
+        comptime_interp.reset_branch_count();
         match comptime_interp.eval_expr(init) {
             Ok(val) => {
                 let type_prefix = val.type_prefix().to_string();

--- a/compiler/crates/rask-cli/src/commands/pipeline.rs
+++ b/compiler/crates/rask-cli/src/commands/pipeline.rs
@@ -80,10 +80,14 @@ fn run_frontend_single(path: &str, format: Format) -> FrontendResult {
         process::exit(1);
     }
 
+    // Eliminate dead branches in `comptime if cfg.*` before any other pass (CC1)
+    let cfg = rask_comptime::CfgConfig::from_host("debug", vec![]);
+    rask_comptime::eliminate_comptime_if(&mut parse_result.decls, &cfg);
+
     rask_desugar::desugar(&mut parse_result.decls);
     rask_desugar::desugar_default_args(&mut parse_result.decls);
 
-    let resolved = match rask_resolve::resolve(&parse_result.decls) {
+    let resolved = match rask_resolve::resolve_with_cfg(&parse_result.decls, cfg.to_cfg_values()) {
         Ok(r) => r,
         Err(errors) => {
             let diags: Vec<Diagnostic> = errors.iter().map(|e| e.to_diagnostic()).collect();
@@ -148,15 +152,17 @@ fn run_frontend_package(pkg_ctx: &mut PackageContext, path: &str, format: Format
         .map(|f| (f.path.clone(), f.source.clone()))
         .collect();
 
+    // Eliminate dead branches in `comptime if cfg.*` before any other pass (CC1)
+    let cfg = rask_comptime::CfgConfig::from_host("debug", vec![]);
+    rask_comptime::eliminate_comptime_if(&mut pkg_ctx.all_decls, &cfg);
+
     rask_desugar::desugar(&mut pkg_ctx.all_decls);
     rask_desugar::desugar_default_args(&mut pkg_ctx.all_decls);
-
-    // Resolver handles external packages via collect_package_exports —
-    // only pass root package decls here to avoid double registration.
-    let resolved = match rask_resolve::resolve_package(
+    let resolved = match rask_resolve::resolve_package_with_cfg(
         &pkg_ctx.all_decls,
         &pkg_ctx.registry,
         pkg_ctx.root_id,
+        cfg.to_cfg_values(),
     ) {
         Ok(r) => r,
         Err(errors) => {

--- a/compiler/crates/rask-comptime/src/lib.rs
+++ b/compiler/crates/rask-comptime/src/lib.rs
@@ -59,6 +59,17 @@ impl CfgConfig {
         }
     }
 
+    /// Convert to a flat map of field name → value for the resolver's
+    /// dead branch elimination in `comptime if`.
+    pub fn to_cfg_values(&self) -> HashMap<String, String> {
+        let mut m = HashMap::new();
+        m.insert("os".to_string(), self.os.clone());
+        m.insert("arch".to_string(), self.arch.clone());
+        m.insert("env".to_string(), self.env.clone());
+        m.insert("profile".to_string(), self.profile.clone());
+        m
+    }
+
     /// Convert to a `ComptimeValue::Struct` for injection into the comptime environment.
     pub fn to_comptime_value(&self) -> ComptimeValue {
         let mut fields = HashMap::new();
@@ -90,6 +101,229 @@ fn detect_env() -> String {
     } else {
         "unknown".to_string()
     }
+}
+
+// ============================================================================
+// Conditional Compilation — Dead Branch Elimination (CC1)
+// ============================================================================
+
+/// Eliminate dead branches in `comptime if cfg.*` blocks.
+///
+/// Walks the AST and replaces `comptime { if cfg.field == "value" { A } else { B } }`
+/// with either `A` or `B` statements. Runs before desugar so `==` is still `Binary { Eq }`.
+pub fn eliminate_comptime_if(decls: &mut [Decl], cfg: &CfgConfig) {
+    let cfg_values = cfg.to_cfg_values();
+    for decl in decls {
+        eliminate_in_decl(decl, &cfg_values);
+    }
+}
+
+fn eliminate_in_decl(decl: &mut Decl, cfg_values: &HashMap<String, String>) {
+    match &mut decl.kind {
+        DeclKind::Fn(f) => eliminate_in_fn_body(&mut f.body, cfg_values),
+        DeclKind::Struct(s) => {
+            for m in &mut s.methods { eliminate_in_fn_body(&mut m.body, cfg_values); }
+        }
+        DeclKind::Enum(e) => {
+            for m in &mut e.methods { eliminate_in_fn_body(&mut m.body, cfg_values); }
+        }
+        DeclKind::Trait(t) => {
+            for m in &mut t.methods { eliminate_in_fn_body(&mut m.body, cfg_values); }
+        }
+        DeclKind::Impl(i) => {
+            for m in &mut i.methods { eliminate_in_fn_body(&mut m.body, cfg_values); }
+        }
+        DeclKind::Const(c) => eliminate_in_expr(&mut c.init, cfg_values),
+        DeclKind::Test(t) => eliminate_in_stmts(&mut t.body, cfg_values),
+        DeclKind::Benchmark(b) => eliminate_in_stmts(&mut b.body, cfg_values),
+        _ => {}
+    }
+}
+
+fn eliminate_in_fn_body(body: &mut Vec<Stmt>, cfg_values: &HashMap<String, String>) {
+    eliminate_in_stmts(body, cfg_values);
+}
+
+fn eliminate_in_stmts(stmts: &mut Vec<Stmt>, cfg_values: &HashMap<String, String>) {
+    let mut i = 0;
+    while i < stmts.len() {
+        if let StmtKind::Comptime(body) = &stmts[i].kind {
+            if let Some(replacement) = try_eval_comptime_if_stmts(body, cfg_values) {
+                // Replace the comptime stmt with the taken branch's stmts
+                stmts.splice(i..=i, replacement);
+                continue; // Re-check at same index (new stmts may contain comptime)
+            }
+        }
+        // Recurse into the statement
+        eliminate_in_stmt(&mut stmts[i], cfg_values);
+        i += 1;
+    }
+}
+
+fn eliminate_in_stmt(stmt: &mut Stmt, cfg_values: &HashMap<String, String>) {
+    match &mut stmt.kind {
+        StmtKind::Expr(e) => eliminate_in_expr(e, cfg_values),
+        StmtKind::Let { init, .. } | StmtKind::Const { init, .. } => eliminate_in_expr(init, cfg_values),
+        StmtKind::LetTuple { init, .. } | StmtKind::ConstTuple { init, .. } => eliminate_in_expr(init, cfg_values),
+        StmtKind::Assign { target, value } => {
+            eliminate_in_expr(target, cfg_values);
+            eliminate_in_expr(value, cfg_values);
+        }
+        StmtKind::Return(Some(e)) => eliminate_in_expr(e, cfg_values),
+        StmtKind::While { cond, body } => {
+            eliminate_in_expr(cond, cfg_values);
+            eliminate_in_stmts(body, cfg_values);
+        }
+        StmtKind::WhileLet { expr, body, .. } => {
+            eliminate_in_expr(expr, cfg_values);
+            eliminate_in_stmts(body, cfg_values);
+        }
+        StmtKind::Loop { body, .. } => eliminate_in_stmts(body, cfg_values),
+        StmtKind::For { iter, body, .. } => {
+            eliminate_in_expr(iter, cfg_values);
+            eliminate_in_stmts(body, cfg_values);
+        }
+        StmtKind::Ensure { body, else_handler } => {
+            eliminate_in_stmts(body, cfg_values);
+            if let Some((_, handler)) = else_handler {
+                eliminate_in_stmts(handler, cfg_values);
+            }
+        }
+        StmtKind::Comptime(body) => eliminate_in_stmts(body, cfg_values),
+        _ => {}
+    }
+}
+
+fn eliminate_in_expr(expr: &mut Expr, cfg_values: &HashMap<String, String>) {
+    match &mut expr.kind {
+        ExprKind::Binary { left, right, .. } => {
+            eliminate_in_expr(left, cfg_values);
+            eliminate_in_expr(right, cfg_values);
+        }
+        ExprKind::Unary { operand, .. } => eliminate_in_expr(operand, cfg_values),
+        ExprKind::Call { func, args } => {
+            eliminate_in_expr(func, cfg_values);
+            for arg in args { eliminate_in_expr(&mut arg.expr, cfg_values); }
+        }
+        ExprKind::MethodCall { object, args, .. } => {
+            eliminate_in_expr(object, cfg_values);
+            for arg in args { eliminate_in_expr(&mut arg.expr, cfg_values); }
+        }
+        ExprKind::Field { object, .. } => eliminate_in_expr(object, cfg_values),
+        ExprKind::Index { object, index } => {
+            eliminate_in_expr(object, cfg_values);
+            eliminate_in_expr(index, cfg_values);
+        }
+        ExprKind::Block(stmts) => eliminate_in_stmts(stmts, cfg_values),
+        ExprKind::If { cond, then_branch, else_branch } => {
+            eliminate_in_expr(cond, cfg_values);
+            eliminate_in_expr(then_branch, cfg_values);
+            if let Some(e) = else_branch { eliminate_in_expr(e, cfg_values); }
+        }
+        ExprKind::Match { scrutinee, arms } => {
+            eliminate_in_expr(scrutinee, cfg_values);
+            for arm in arms { eliminate_in_expr(&mut arm.body, cfg_values); }
+        }
+        ExprKind::Closure { body, .. } => eliminate_in_expr(body, cfg_values),
+        ExprKind::Comptime { body } => {
+            // Check if this is `comptime if cfg.* { ... } else { ... }` in expression context
+            if let Some(replacement) = try_eval_comptime_if_stmts(body, cfg_values) {
+                // Replace the comptime expression with a block containing the taken branch
+                expr.kind = ExprKind::Block(replacement);
+                return;
+            }
+            eliminate_in_stmts(body, cfg_values);
+        }
+        ExprKind::Unsafe { body } => eliminate_in_stmts(body, cfg_values),
+        ExprKind::Spawn { body } => eliminate_in_stmts(body, cfg_values),
+        ExprKind::StructLit { fields, .. } => {
+            for f in fields { eliminate_in_expr(&mut f.value, cfg_values); }
+        }
+        ExprKind::Array(elems) | ExprKind::Tuple(elems) => {
+            for e in elems { eliminate_in_expr(e, cfg_values); }
+        }
+        _ => {}
+    }
+}
+
+/// Try to evaluate a comptime if cfg condition and return the taken branch.
+fn try_eval_comptime_if_stmts(stmts: &[Stmt], cfg_values: &HashMap<String, String>) -> Option<Vec<Stmt>> {
+    if stmts.len() != 1 {
+        return None;
+    }
+    let inner = match &stmts[0].kind {
+        StmtKind::Expr(e) => e,
+        _ => return None,
+    };
+    let (cond, then_branch, else_branch) = match &inner.kind {
+        ExprKind::If { cond, then_branch, else_branch } => (cond, then_branch, else_branch),
+        _ => return None,
+    };
+
+    let taken = eval_cfg_condition(cond, cfg_values)?;
+    if taken {
+        if let ExprKind::Block(block_stmts) = &then_branch.kind {
+            Some(block_stmts.clone())
+        } else {
+            None
+        }
+    } else if let Some(else_br) = else_branch {
+        if let ExprKind::Block(block_stmts) = &else_br.kind {
+            Some(block_stmts.clone())
+        } else {
+            None
+        }
+    } else {
+        Some(vec![])
+    }
+}
+
+/// Evaluate a cfg condition at compile time.
+/// Supports: `cfg.field == "value"`, `cfg.field != "value"`,
+/// `!expr`, `expr && expr`, `expr || expr`.
+fn eval_cfg_condition(expr: &Expr, cfg_values: &HashMap<String, String>) -> Option<bool> {
+    match &expr.kind {
+        ExprKind::Binary { op, left, right } => {
+            match op {
+                BinOp::Eq | BinOp::Ne => {
+                    let (field, value) = extract_cfg_comparison(left, right)?;
+                    let cfg_val = cfg_values.get(field)?;
+                    let result = cfg_val.as_str() == value;
+                    Some(if *op == BinOp::Eq { result } else { !result })
+                }
+                BinOp::And => {
+                    Some(eval_cfg_condition(left, cfg_values)? && eval_cfg_condition(right, cfg_values)?)
+                }
+                BinOp::Or => {
+                    Some(eval_cfg_condition(left, cfg_values)? || eval_cfg_condition(right, cfg_values)?)
+                }
+                _ => None,
+            }
+        }
+        ExprKind::Unary { op: UnaryOp::Not, operand } => {
+            Some(!eval_cfg_condition(operand, cfg_values)?)
+        }
+        _ => None,
+    }
+}
+
+fn extract_cfg_comparison<'a>(left: &'a Expr, right: &'a Expr) -> Option<(&'a str, &'a str)> {
+    if let Some(field) = extract_cfg_field(left) {
+        if let ExprKind::String(val) = &right.kind { return Some((field, val)); }
+    }
+    if let Some(field) = extract_cfg_field(right) {
+        if let ExprKind::String(val) = &left.kind { return Some((field, val)); }
+    }
+    None
+}
+
+fn extract_cfg_field(expr: &Expr) -> Option<&str> {
+    if let ExprKind::Field { object, field } = &expr.kind {
+        if let ExprKind::Ident(name) = &object.kind {
+            if name == "cfg" { return Some(field); }
+        }
+    }
+    None
 }
 
 // ============================================================================

--- a/compiler/crates/rask-comptime/src/lib.rs
+++ b/compiler/crates/rask-comptime/src/lib.rs
@@ -377,7 +377,7 @@ impl ComptimeEnv {
             scopes: vec![HashMap::new()],
             functions: HashMap::new(),
             branch_count: 0,
-            branch_quota: 1000, // Default
+            branch_quota: 10_000, // Default
         }
     }
 
@@ -388,6 +388,11 @@ impl ComptimeEnv {
             branch_count: 0,
             branch_quota: quota,
         }
+    }
+
+    /// Reset branch counter between independent comptime evaluations.
+    pub fn reset_branch_count(&mut self) {
+        self.branch_count = 0;
     }
 
     fn push_scope(&mut self) {
@@ -488,6 +493,11 @@ impl ComptimeInterpreter {
         Self {
             env: ComptimeEnv::with_quota(quota),
         }
+    }
+
+    /// Reset branch counter between independent comptime evaluations.
+    pub fn reset_branch_count(&mut self) {
+        self.env.reset_branch_count();
     }
 
     /// Inject the `cfg` build configuration into the comptime environment.
@@ -1754,6 +1764,6 @@ mod tests {
 
         // We'd need to construct AST nodes for proper testing
         // For now, just verify the interpreter can be created
-        assert_eq!(interp.env.branch_quota, 1000);
+        assert_eq!(interp.env.branch_quota, 10_000);
     }
 }

--- a/compiler/crates/rask-mir/src/lower/expr.rs
+++ b/compiler/crates/rask-mir/src/lower/expr.rs
@@ -184,6 +184,44 @@ impl<'a> MirLowerer<'a> {
                         });
                         Ok((MirOperand::Local(result_local), option_ty))
                     }
+                } else if let Some(meta) = self.ctx.comptime_globals.get(name) {
+                    // Module-level comptime global reference
+                    let global_local = self.builder.alloc_temp(MirType::Ptr);
+                    self.builder.push_stmt(MirStmt::GlobalRef {
+                        dst: global_local,
+                        name: name.clone(),
+                    });
+
+                    if meta.type_prefix == "Vec" {
+                        // Array global: wrap raw data into a Vec
+                        let vec_local = self.builder.alloc_temp(MirType::I64);
+                        self.builder.push_stmt(MirStmt::Call {
+                            dst: Some(vec_local),
+                            func: FunctionRef::internal("rask_vec_from_static".to_string()),
+                            args: vec![
+                                MirOperand::Local(global_local),
+                                MirOperand::Constant(MirConst::Int(meta.elem_count as i64)),
+                            ],
+                        });
+                        self.local_type_prefix.insert(name.to_string(), "Vec".to_string());
+                        Ok((MirOperand::Local(vec_local), MirType::I64))
+                    } else {
+                        // Scalar global: load value from the data pointer
+                        let mir_ty = match meta.type_prefix.as_str() {
+                            "bool" => MirType::Bool,
+                            "i32" => MirType::I32,
+                            "i64" => MirType::I64,
+                            "f32" => MirType::F32,
+                            "f64" => MirType::F64,
+                            _ => MirType::I64,
+                        };
+                        let result_local = self.builder.alloc_temp(mir_ty.clone());
+                        self.builder.push_stmt(MirStmt::Assign {
+                            dst: result_local,
+                            rvalue: MirRValue::Deref(MirOperand::Local(global_local)),
+                        });
+                        Ok((MirOperand::Local(result_local), mir_ty))
+                    }
                 } else {
                     Err(LoweringError::UnresolvedVariable(name.clone()))
                 }

--- a/compiler/crates/rask-mir/src/lower/stmt.rs
+++ b/compiler/crates/rask-mir/src/lower/stmt.rs
@@ -29,18 +29,45 @@ impl<'a> MirLowerer<'a> {
             StmtKind::Const { name, ty, init, .. } => {
                 // If this const was evaluated at compile time, emit a global reference
                 if let Some(meta) = self.ctx.comptime_globals.get(name) {
-                    let mir_ty = if let Some(ty_str) = ty.as_deref() {
-                        self.ctx.resolve_type_str(ty_str)
+                    if meta.type_prefix == "Vec" {
+                        // Array: store pointer for later Vec wrapping
+                        let mir_ty = if let Some(ty_str) = ty.as_deref() {
+                            self.ctx.resolve_type_str(ty_str)
+                        } else {
+                            MirType::Ptr
+                        };
+                        let local_id = self.builder.alloc_local(name.to_string(), mir_ty.clone());
+                        self.locals.insert(name.to_string(), (local_id, mir_ty));
+                        self.builder.push_stmt(MirStmt::GlobalRef {
+                            dst: local_id,
+                            name: name.clone(),
+                        });
                     } else {
-                        MirType::Ptr
-                    };
-                    let local_id = self.builder.alloc_local(name.to_string(), mir_ty.clone());
-                    self.locals.insert(name.to_string(), (local_id, mir_ty));
-                    self.builder.push_stmt(MirStmt::GlobalRef {
-                        dst: local_id,
-                        name: name.clone(),
-                    });
-                    // Track type prefix for method dispatch
+                        // Scalar: load the data pointer, then deref to get the value
+                        let mir_ty = match meta.type_prefix.as_str() {
+                            "bool" => MirType::Bool,
+                            "i32" => MirType::I32,
+                            "i64" => MirType::I64,
+                            "f32" => MirType::F32,
+                            "f64" => MirType::F64,
+                            _ => if let Some(ty_str) = ty.as_deref() {
+                                self.ctx.resolve_type_str(ty_str)
+                            } else {
+                                MirType::I64
+                            },
+                        };
+                        let ptr_local = self.builder.alloc_temp(MirType::Ptr);
+                        self.builder.push_stmt(MirStmt::GlobalRef {
+                            dst: ptr_local,
+                            name: name.clone(),
+                        });
+                        let local_id = self.builder.alloc_local(name.to_string(), mir_ty.clone());
+                        self.builder.push_stmt(MirStmt::Assign {
+                            dst: local_id,
+                            rvalue: MirRValue::Deref(MirOperand::Local(ptr_local)),
+                        });
+                        self.locals.insert(name.to_string(), (local_id, mir_ty));
+                    }
                     self.local_type_prefix.insert(name.to_string(), meta.type_prefix.clone());
                     return Ok(());
                 }

--- a/compiler/crates/rask-ownership/src/lib.rs
+++ b/compiler/crates/rask-ownership/src/lib.rs
@@ -15,7 +15,7 @@ pub use error::{OwnershipError, OwnershipErrorKind, AccessKind, MoveReason};
 use std::collections::{HashMap, HashSet};
 
 use rask_ast::decl::{Decl, DeclKind, FnDecl};
-use rask_ast::expr::{Expr, ExprKind, Pattern};
+use rask_ast::expr::{ArgMode, Expr, ExprKind, Pattern};
 use rask_ast::stmt::{ForBinding, Stmt, StmtKind};
 use rask_ast::Span;
 use rask_types::{Type, TypedProgram};
@@ -382,12 +382,22 @@ impl<'a> OwnershipChecker<'a> {
                 self.check_expr(func);
                 for arg in args {
                     self.check_expr(&arg.expr);
+                    if arg.mode == ArgMode::Own {
+                        if let ExprKind::Ident(name) = &arg.expr.kind {
+                            self.bindings.insert(name.clone(), BindingState::Moved { at: arg.expr.span });
+                        }
+                    }
                 }
             }
             ExprKind::MethodCall { object, method, type_args: _, args } => {
                 self.check_expr(object);
                 for arg in args {
                     self.check_expr(&arg.expr);
+                    if arg.mode == ArgMode::Own {
+                        if let ExprKind::Ident(name) = &arg.expr.kind {
+                            self.bindings.insert(name.clone(), BindingState::Moved { at: arg.expr.span });
+                        }
+                    }
                 }
                 // CC3/PF5: Check for mutations on frozen pool contexts
                 if matches!(method.as_str(), "insert" | "remove" | "clear") {

--- a/compiler/crates/rask-resolve/src/lib.rs
+++ b/compiler/crates/rask-resolve/src/lib.rs
@@ -49,6 +49,14 @@ pub fn resolve(decls: &[Decl]) -> Result<ResolvedProgram, Vec<ResolveError>> {
     Resolver::resolve(decls)
 }
 
+/// Resolve with cfg values for dead branch elimination in `comptime if`.
+pub fn resolve_with_cfg(
+    decls: &[Decl],
+    cfg_values: HashMap<String, String>,
+) -> Result<ResolvedProgram, Vec<ResolveError>> {
+    Resolver::resolve_with_cfg(decls, cfg_values)
+}
+
 /// Resolve stdlib definition files — skips E0209 builtin shadowing checks.
 pub fn resolve_stdlib(decls: &[Decl]) -> Result<ResolvedProgram, Vec<ResolveError>> {
     Resolver::resolve_stdlib(decls)
@@ -63,6 +71,16 @@ pub fn resolve_package(
     Resolver::resolve_package(decls, registry, current_package)
 }
 
+/// Resolve a package with cfg values for dead branch elimination.
+pub fn resolve_package_with_cfg(
+    decls: &[Decl],
+    registry: &PackageRegistry,
+    current_package: PackageId,
+    cfg_values: HashMap<String, String>,
+) -> Result<ResolvedProgram, Vec<ResolveError>> {
+    Resolver::resolve_package_with_cfg(decls, registry, current_package, cfg_values)
+}
+
 /// Resolve a package with separate stdlib declarations. Stdlib decls are
 /// processed in stdlib_mode (bypasses builtin-shadowing checks).
 pub fn resolve_package_with_stdlib(
@@ -72,4 +90,16 @@ pub fn resolve_package_with_stdlib(
     stdlib_decls: &[Decl],
 ) -> Result<ResolvedProgram, Vec<ResolveError>> {
     Resolver::resolve_package_with_stdlib(decls, registry, current_package, stdlib_decls)
+}
+
+/// Resolve a package with stdlib declarations and cfg values for
+/// dead branch elimination in `comptime if`.
+pub fn resolve_package_with_stdlib_and_cfg(
+    decls: &[Decl],
+    registry: &PackageRegistry,
+    current_package: PackageId,
+    stdlib_decls: &[Decl],
+    cfg_values: HashMap<String, String>,
+) -> Result<ResolvedProgram, Vec<ResolveError>> {
+    Resolver::resolve_package_with_stdlib_and_cfg(decls, registry, current_package, stdlib_decls, cfg_values)
 }

--- a/compiler/crates/rask-resolve/src/resolver.rs
+++ b/compiler/crates/rask-resolve/src/resolver.rs
@@ -4,7 +4,7 @@
 use std::collections::{HashMap, HashSet};
 use rask_ast::decl::{Decl, DeclKind, FnDecl, StructDecl, EnumDecl, TraitDecl, ImplDecl, ImportDecl, ExportDecl, TypeParam, UnionDecl};
 use rask_ast::stmt::{ForBinding, Stmt, StmtKind};
-use rask_ast::expr::{Expr, ExprKind, Pattern};
+use rask_ast::expr::{BinOp, Expr, ExprKind, Pattern, UnaryOp};
 use rask_ast::{NodeId, Span};
 
 use crate::error::ResolveError;
@@ -30,6 +30,9 @@ pub struct Resolver {
     package_exports: HashMap<PackageId, HashMap<String, SymbolId>>,
     /// When true, declarations can shadow builtin names without E0209.
     stdlib_mode: bool,
+    /// Compile-time cfg values for dead branch elimination in `comptime if`.
+    /// Maps field names (os, arch, env, profile) to their values.
+    cfg_values: HashMap<String, String>,
 }
 
 impl Resolver {
@@ -47,6 +50,7 @@ impl Resolver {
             type_param_map: HashMap::new(),
             package_exports: HashMap::new(),
             stdlib_mode: false,
+            cfg_values: HashMap::new(),
         };
 
         resolver.register_builtins();
@@ -287,6 +291,25 @@ impl Resolver {
         Self::resolve_inner(decls, false)
     }
 
+    /// Resolve with cfg values for dead branch elimination in `comptime if`.
+    pub fn resolve_with_cfg(
+        decls: &[Decl],
+        cfg_values: HashMap<String, String>,
+    ) -> Result<ResolvedProgram, Vec<ResolveError>> {
+        let mut resolver = Resolver::new();
+        resolver.cfg_values = cfg_values;
+        resolver.collect_declarations(decls);
+        resolver.resolve_bodies(decls);
+        if resolver.errors.is_empty() {
+            Ok(ResolvedProgram {
+                symbols: resolver.symbols,
+                resolutions: resolver.resolutions,
+            })
+        } else {
+            Err(resolver.errors)
+        }
+    }
+
     /// Resolve stdlib definition files — skips E0209 builtin shadowing checks.
     pub fn resolve_stdlib(decls: &[Decl]) -> Result<ResolvedProgram, Vec<ResolveError>> {
         Self::resolve_inner(decls, true)
@@ -300,6 +323,15 @@ impl Resolver {
         Self::resolve_package_with_stdlib(decls, registry, current_package, &[])
     }
 
+    pub fn resolve_package_with_cfg(
+        decls: &[Decl],
+        registry: &crate::PackageRegistry,
+        current_package: crate::PackageId,
+        cfg_values: HashMap<String, String>,
+    ) -> Result<ResolvedProgram, Vec<ResolveError>> {
+        Self::resolve_package_with_stdlib_and_cfg(decls, registry, current_package, &[], cfg_values)
+    }
+
     /// Resolve a package with separate stdlib declarations processed in
     /// stdlib_mode (bypasses builtin-shadowing checks). Stdlib decls are
     /// collected and resolved first, then user decls on top.
@@ -309,7 +341,20 @@ impl Resolver {
         current_package: crate::PackageId,
         stdlib_decls: &[Decl],
     ) -> Result<ResolvedProgram, Vec<ResolveError>> {
+        Self::resolve_package_with_stdlib_and_cfg(decls, registry, current_package, stdlib_decls, HashMap::new())
+    }
+
+    /// Resolve a package with stdlib declarations and cfg values for
+    /// dead branch elimination in `comptime if`.
+    pub fn resolve_package_with_stdlib_and_cfg(
+        decls: &[Decl],
+        registry: &crate::PackageRegistry,
+        current_package: crate::PackageId,
+        stdlib_decls: &[Decl],
+        cfg_values: HashMap<String, String>,
+    ) -> Result<ResolvedProgram, Vec<ResolveError>> {
         let mut resolver = Resolver::new();
+        resolver.cfg_values = cfg_values;
 
         resolver.current_package = Some(current_package);
 
@@ -1214,12 +1259,127 @@ impl Resolver {
             }
             StmtKind::Comptime(body) => {
                 self.scopes.push(ScopeKind::Block);
-                for s in body {
-                    self.resolve_stmt(s);
+                if let Some(taken) = self.try_resolve_comptime_if(body) {
+                    for s in taken {
+                        self.resolve_stmt(s);
+                    }
+                } else {
+                    for s in body {
+                        self.resolve_stmt(s);
+                    }
                 }
                 self.scopes.pop();
             }
         }
+    }
+
+    /// Try to evaluate a `comptime if cfg.field == "value"` condition statically.
+    /// Returns the taken branch's statements if the pattern matches and
+    /// the condition can be evaluated, or None to fall through to normal resolution.
+    fn try_resolve_comptime_if<'b>(&self, stmts: &'b [Stmt]) -> Option<&'b [Stmt]> {
+        if self.cfg_values.is_empty() || stmts.len() != 1 {
+            return None;
+        }
+        let inner = match &stmts[0].kind {
+            StmtKind::Expr(e) => e,
+            _ => return None,
+        };
+        let (cond, then_branch, else_branch) = match &inner.kind {
+            ExprKind::If { cond, then_branch, else_branch } => (cond, then_branch, else_branch),
+            _ => return None,
+        };
+
+        let taken = self.eval_cfg_condition(cond)?;
+        if taken {
+            if let ExprKind::Block(block_stmts) = &then_branch.kind {
+                Some(block_stmts)
+            } else {
+                None
+            }
+        } else if let Some(else_br) = else_branch {
+            if let ExprKind::Block(block_stmts) = &else_br.kind {
+                Some(block_stmts)
+            } else {
+                None
+            }
+        } else {
+            Some(&[])
+        }
+    }
+
+    /// Evaluate a cfg condition expression statically.
+    /// Handles both pre-desugar (`Binary { Eq, .. }`) and post-desugar
+    /// (`MethodCall { method: "eq", .. }`) forms, plus `!`, `&&`, `||`.
+    fn eval_cfg_condition(&self, expr: &Expr) -> Option<bool> {
+        match &expr.kind {
+            // Pre-desugar: cfg.field == "value"
+            ExprKind::Binary { op, left, right } => {
+                match op {
+                    BinOp::Eq | BinOp::Ne => {
+                        let (field, value) = self.extract_cfg_comparison(left, right)?;
+                        let cfg_val = self.cfg_values.get(field)?;
+                        let result = cfg_val == value;
+                        Some(if *op == BinOp::Eq { result } else { !result })
+                    }
+                    BinOp::And => {
+                        let l = self.eval_cfg_condition(left)?;
+                        let r = self.eval_cfg_condition(right)?;
+                        Some(l && r)
+                    }
+                    BinOp::Or => {
+                        let l = self.eval_cfg_condition(left)?;
+                        let r = self.eval_cfg_condition(right)?;
+                        Some(l || r)
+                    }
+                    _ => None,
+                }
+            }
+            // Post-desugar: cfg.field.eq("value") — `==` desugars to `.eq()` method call
+            ExprKind::MethodCall { object, method, args, .. } if method == "eq" => {
+                let field = self.extract_cfg_field(object)?;
+                let value = match args.first() {
+                    Some(arg) => match &arg.expr.kind {
+                        ExprKind::String(s) => s.as_str(),
+                        _ => return None,
+                    },
+                    None => return None,
+                };
+                let cfg_val = self.cfg_values.get(field)?;
+                Some(cfg_val == value)
+            }
+            // Post-desugar: !(cfg.field.eq("value")) — `!=` desugars to `!(.eq())`
+            ExprKind::Unary { op: UnaryOp::Not, operand } => {
+                Some(!self.eval_cfg_condition(operand)?)
+            }
+            _ => None,
+        }
+    }
+
+    /// Extract (field_name, string_value) from `cfg.field == "value"` (pre-desugar).
+    fn extract_cfg_comparison<'b>(&self, left: &'b Expr, right: &'b Expr) -> Option<(&'b str, &'b str)> {
+        if let Some(field) = self.extract_cfg_field(left) {
+            if let ExprKind::String(val) = &right.kind {
+                return Some((field, val));
+            }
+        }
+        if let Some(field) = self.extract_cfg_field(right) {
+            if let ExprKind::String(val) = &left.kind {
+                return Some((field, val));
+            }
+        }
+        None
+    }
+
+    /// Extract the field name from a `cfg.field` expression.
+    fn extract_cfg_field<'b>(&self, expr: &'b Expr) -> Option<&'b str> {
+        if let ExprKind::Field { object, field } = &expr.kind {
+            if let ExprKind::Ident(name) = &object.kind {
+                if name == "cfg" {
+                    return Some(field);
+                }
+            }
+        }
+        None
     }
 
     // =========================================================================
@@ -1538,8 +1698,14 @@ impl Resolver {
             }
             ExprKind::Comptime { body } => {
                 self.scopes.push(ScopeKind::Block);
-                for stmt in body {
-                    self.resolve_stmt(stmt);
+                if let Some(taken) = self.try_resolve_comptime_if(body) {
+                    for s in taken {
+                        self.resolve_stmt(s);
+                    }
+                } else {
+                    for stmt in body {
+                        self.resolve_stmt(stmt);
+                    }
                 }
                 self.scopes.pop();
             }


### PR DESCRIPTION
## Summary

This PR implements conditional compilation support for the Rask compiler through dead branch elimination in `comptime if cfg.*` blocks. The feature allows developers to write platform-specific code that is eliminated at compile time based on build configuration (OS, architecture, environment, profile).

## Key Changes

- **Dead Branch Elimination (CC1)**: Added `eliminate_comptime_if()` function in `rask-comptime` that walks the AST before desugaring and replaces `comptime { if cfg.field == "value" { A } else { B } }` with either branch A or B based on the current build configuration.

- **Resolver Integration**: Extended `rask-resolve` with cfg-aware condition evaluation in `try_resolve_comptime_if()` and `eval_cfg_condition()`. The resolver can now statically evaluate cfg conditions during name resolution, supporting both pre-desugar (`Binary { Eq }`) and post-desugar (`MethodCall { eq }`) forms.

- **Configuration API**: Added `CfgConfig::to_cfg_values()` to convert build configuration into a flat `HashMap<String, String>` for use by both the AST rewriter and resolver. Supports `os`, `arch`, `env`, and `profile` fields.

- **Public API Extensions**: Added `resolve_with_cfg()`, `resolve_package_with_cfg()`, and `resolve_package_with_stdlib_and_cfg()` functions to pass cfg values through the resolution pipeline.

- **Pipeline Integration**: Modified `rask-cli` build pipeline to:
  - Create a `CfgConfig` from host environment
  - Call `eliminate_comptime_if()` before desugaring (CC1 pass)
  - Pass cfg values to resolver via `resolve_with_cfg()`

- **Comptime Interpreter**: Added `reset_branch_count()` method to reset the branch counter between independent comptime evaluations, and increased default `branch_quota` from 1,000 to 10,000.

- **MIR Lowering**: Enhanced handling of comptime global constants to properly distinguish between array (Vec) and scalar types, with appropriate dereferencing for scalar globals.

- **Ownership Checking**: Fixed ownership tracking for function arguments with `ArgMode::Own` to properly mark identifiers as moved.

## Implementation Details

- Condition evaluation supports `==`, `!=`, `&&`, `||`, and `!` operators
- The AST rewriter handles nested comptime blocks and recursively processes all statement and expression contexts
- Both statement-level (`StmtKind::Comptime`) and expression-level (`ExprKind::Comptime`) comptime blocks are supported
- Dead branches are eliminated before desugaring, ensuring the resolver sees the final code structure
- The resolver provides a fallback evaluation path for cases where the AST rewriter doesn't apply

https://claude.ai/code/session_01AmGGqYtQUkJPVVMGFWeBje