### PR TITLE
Add cross-package function and type resolution support

### DIFF
--- a/compiler/crates/rask-cli/src/commands/build.rs
+++ b/compiler/crates/rask-cli/src/commands/build.rs
@@ -617,6 +617,28 @@ pub fn cmd_build(path: &str, opts: BuildOptions) {
             let mut all_decls: Vec<_> = root_pkg.all_decls().cloned().collect();
             rask_desugar::desugar(&mut all_decls);
 
+            // Collect imported package module names and all their declarations.
+            // All dependency declarations (public and private) are included so
+            // internal calls within dependency functions resolve correctly.
+            let mut package_modules = std::collections::HashSet::new();
+            let mut dep_decls = Vec::new();
+            for pkg in registry.packages() {
+                if pkg.id == root_id { continue; }
+                package_modules.insert(pkg.name.clone());
+                for decl in pkg.all_decls() {
+                    match &decl.kind {
+                        rask_ast::decl::DeclKind::Fn(_)
+                        | rask_ast::decl::DeclKind::Struct(_)
+                        | rask_ast::decl::DeclKind::Enum(_)
+                        | rask_ast::decl::DeclKind::Impl(_)
+                        | rask_ast::decl::DeclKind::Const(_) => {
+                            dep_decls.push(decl.clone());
+                        }
+                        _ => {}
+                    }
+                }
+            }
+
             // Resolve with stdlib decls in stdlib_mode (bypasses shadow checks)
             let stdlib_decls = rask_stdlib::StubRegistry::compilable_decls();
 
@@ -651,9 +673,14 @@ pub fn cmd_build(path: &str, opts: BuildOptions) {
                             } else {
                                 // Merge stdlib decls for mono/codegen
                                 all_decls.extend(stdlib_decls);
+                                // Merge dependency decls so mono/MIR can find them.
+                                // Desugar first so string interpolation etc. works.
+                                let mut dep_decls_desugared = dep_decls.clone();
+                                rask_desugar::desugar(&mut dep_decls_desugared);
+                                all_decls.extend(dep_decls_desugared);
                                 rask_hidden_params::desugar_hidden_params(&mut all_decls);
 
-                                match rask_mono::monomorphize(&typed, &all_decls) {
+                                match rask_mono::monomorphize_with_packages(&typed, &all_decls, package_modules.clone()) {
                                     Ok(mono) => {
                                         let cfg = rask_comptime::CfgConfig::from_target_or_host(
                                             opts.target.as_deref(), &opts.profile, resolved_feature_names.clone(),
@@ -669,6 +696,7 @@ pub fn cmd_build(path: &str, opts: BuildOptions) {
                                         match super::compile::compile_to_object(
                                             &mono, &typed, &all_decls, &comptime_globals,
                                             None, None, target, &obj_str, build_mode, Some(&cfg),
+                                            &package_modules,
                                         ) {
                                             Ok(()) => {
                                                 // Cache the compiled object (XC1)

--- a/compiler/crates/rask-cli/src/commands/codegen.rs
+++ b/compiler/crates/rask-cli/src/commands/codegen.rs
@@ -292,6 +292,7 @@ pub fn cmd_mir(path: &str, format: Format) {
     let mut mir_interp = rask_comptime::ComptimeInterpreter::new();
     mir_interp.inject_cfg(&cfg);
     mir_interp.register_functions(&decls);
+    let empty_packages = std::collections::HashSet::new();
     let mir_ctx = rask_mir::lower::MirContext {
         struct_layouts: &mono.struct_layouts,
         enum_layouts: &mono.enum_layouts,
@@ -299,6 +300,7 @@ pub fn cmd_mir(path: &str, format: Format) {
         type_names: &type_names,
         comptime_globals: &comptime_globals,
         extern_funcs: &extern_funcs,
+        package_modules: &empty_packages,
         trait_methods,
         line_map: line_map.as_ref(),
         source_file: Some(path),
@@ -383,9 +385,11 @@ pub fn cmd_compile(path: &str, output_path: Option<&str>, format: Format, quiet:
     };
     let obj_path = format!("{}.o", bin_path);
 
+    let empty_packages = std::collections::HashSet::new();
     if let Err(errors) = super::compile::compile_to_object(
         &mono, &typed, &decls, &comptime_globals,
         Some(path), source.as_deref(), target, &obj_path, build_mode, Some(&cfg),
+        &empty_packages,
     ) {
         for e in &errors {
             eprintln!("{}: {}", output::error_label(), e);

--- a/compiler/crates/rask-cli/src/commands/compile.rs
+++ b/compiler/crates/rask-cli/src/commands/compile.rs
@@ -24,6 +24,7 @@ pub fn compile_to_object(
     obj_path: &str,
     build_mode: rask_codegen::BuildMode,
     cfg: Option<&rask_comptime::CfgConfig>,
+    package_modules: &std::collections::HashSet<String>,
 ) -> Result<(), Vec<String>> {
     let mut errors = Vec::new();
 
@@ -82,6 +83,7 @@ pub fn compile_to_object(
         type_names: &type_names,
         comptime_globals,
         extern_funcs: &extern_funcs,
+        package_modules,
         line_map: line_map.as_ref(),
         source_file,
         shared_elem_types: std::cell::RefCell::new(std::collections::HashMap::new()),
@@ -391,6 +393,7 @@ pub fn compile_benchmarks_to_object(
         interp.register_functions(decls);
         std::cell::RefCell::new(interp)
     });
+    let empty_packages = std::collections::HashSet::new();
     let mir_ctx = rask_mir::lower::MirContext {
         struct_layouts: &mono.struct_layouts,
         enum_layouts: &mono.enum_layouts,
@@ -398,6 +401,7 @@ pub fn compile_benchmarks_to_object(
         type_names: &type_names,
         comptime_globals,
         extern_funcs: &extern_funcs,
+        package_modules: &empty_packages,
         trait_methods: bench_trait_methods,
         line_map: line_map.as_ref(),
         source_file,

--- a/compiler/crates/rask-codegen/src/builder.rs
+++ b/compiler/crates/rask-codegen/src/builder.rs
@@ -1942,7 +1942,7 @@ impl<'a> FunctionBuilder<'a> {
             }
 
             // Vec remove_at: add out-param for the removed element
-            "Vec_remove" => {
+            "Vec_remove" | "Vec_remove_at" => {
                 // args: [vec, index] → [vec, index, &out]
                 let ss = builder.create_sized_stack_slot(StackSlotData::new(
                     StackSlotKind::ExplicitSlot, 8, 0,

--- a/compiler/crates/rask-codegen/src/dispatch.rs
+++ b/compiler/crates/rask-codegen/src/dispatch.rs
@@ -168,6 +168,13 @@ pub fn stdlib_entries() -> Vec<StdlibEntry> {
             ret_ty: Some(types::I64),
             can_panic: true,
         },
+        StdlibEntry {
+            mir_name: "Vec_remove_at",
+            c_name: "rask_vec_remove_at",
+            params: &[types::I64, types::I64, types::I64],
+            ret_ty: Some(types::I64),
+            can_panic: true,
+        },
 
         // ── Subscript (desugared from args[0] → args.index(0)) ─
         // Bare "index" kept: desugaring doesn't have receiver type info

--- a/compiler/crates/rask-mir/src/lower/expr.rs
+++ b/compiler/crates/rask-mir/src/lower/expr.rs
@@ -502,6 +502,28 @@ impl<'a> MirLowerer<'a> {
                 // before lowering it as a value expression.
                 if let ExprKind::Ident(name) = &object.kind {
                     if !self.locals.contains_key(name) {
+                        // Cross-package call: pkg.func() → direct call to func
+                        if self.ctx.package_modules.contains(name) {
+                            let func_name = method.clone();
+                            let mut arg_operands = Vec::new();
+                            for arg in args {
+                                let (op, _) = self.lower_expr(&arg.expr)?;
+                                arg_operands.push(op);
+                            }
+                            let ret_ty = self
+                                .func_sigs
+                                .get(&func_name)
+                                .map(|s| s.ret_ty.clone())
+                                .unwrap_or_else(|| super::stdlib_return_mir_type(&func_name));
+                            let result_local = self.builder.alloc_temp(ret_ty.clone());
+                            self.builder.push_stmt(MirStmt::Call {
+                                dst: Some(result_local),
+                                func: FunctionRef::internal(func_name),
+                                args: arg_operands,
+                            });
+                            return Ok((MirOperand::Local(result_local), ret_ty));
+                        }
+
                         // Comptime global: TABLE.get(0) → GlobalRef + Vec_get
                         if let Some(meta) = self.ctx.comptime_globals.get(name) {
                             let type_prefix = meta.type_prefix.clone();
@@ -845,9 +867,11 @@ impl<'a> MirLowerer<'a> {
                         self.local_type_prefix.get(var_name)
                             .map(|p| matches!(p.as_str(), "string" | "f32x4" | "f32x8" | "f64x2" | "f64x4" | "i32x4" | "i32x8" | "Ptr"))
                             .unwrap_or(false)
-                        || matches!(obj_ty, MirType::Ptr)
                     } else {
-                        matches!(obj_ty, MirType::Ptr)
+                        // Unknown type from complex expression — default to native
+                        // binop. The common case is numeric field access chains
+                        // (e.g. self.entries.len() / 2) where Ptr means lost type info.
+                        false
                     }
                 };
 
@@ -1127,9 +1151,10 @@ impl<'a> MirLowerer<'a> {
                         | "substr" | "substring" | "repeat" | "reverse"
                         | "lines" | "split" | "split_whitespace"
                         | "char_at" | "index_of"
-                        | "chars" | "push_str" | "push_char" => Some("string".to_string()),
+                        | "chars" | "push_str" | "push_char"
+                        | "compare" => Some("string".to_string()),
                         // Vec / iterator (no other Rask type has these)
-                        "to_vec" | "chunks" | "skip"
+                        "push" | "remove_at" | "to_vec" | "chunks" | "skip"
                         | "map" | "filter" | "collect"
                         | "enumerate" | "any" | "all" | "find" | "fold"
                         | "for_each" | "flat_map" | "take" | "zip"
@@ -1223,6 +1248,55 @@ impl<'a> MirLowerer<'a> {
                     .map(|s| s.ret_ty.clone())
                     .unwrap_or_else(|| super::stdlib_return_mir_type(&qualified_name)));
 
+                // Struct clone: inline field-by-field copy with deep clone for
+                // heap fields (string, Vec, Map). Avoids needing a generated
+                // runtime clone function for every user struct.
+                if method == "clone" {
+                    if let MirType::Struct(StructLayoutId(id)) = &obj_ty {
+                        if let Some(layout) = self.ctx.struct_layouts.get(*id as usize).cloned() {
+                            let result_local = self.builder.alloc_temp(obj_ty.clone());
+                            let src = all_args[0].clone();
+                            for field in &layout.fields {
+                                let field_val = self.builder.alloc_temp(MirType::I64);
+                                self.builder.push_stmt(MirStmt::Assign {
+                                    dst: field_val,
+                                    rvalue: MirRValue::Field {
+                                        base: src.clone(),
+                                        field_index: field.offset,
+                                        byte_offset: None,
+                                        field_size: None,
+                                    },
+                                });
+                                // Deep clone heap types
+                                let clone_fn = match &field.ty {
+                                    rask_types::Type::String => Some("string_clone"),
+                                    rask_types::Type::UnresolvedNamed(n) if n == "string" => Some("string_clone"),
+                                    rask_types::Type::UnresolvedGeneric { name, .. } if name == "Vec" => Some("Vec_clone"),
+                                    rask_types::Type::UnresolvedGeneric { name, .. } if name == "Map" => Some("Map_clone"),
+                                    _ => None,
+                                };
+                                let store_val = if let Some(cfn) = clone_fn {
+                                    let cloned = self.builder.alloc_temp(MirType::I64);
+                                    self.builder.push_stmt(MirStmt::Call {
+                                        dst: Some(cloned),
+                                        func: FunctionRef::internal(cfn.to_string()),
+                                        args: vec![MirOperand::Local(field_val)],
+                                    });
+                                    MirOperand::Local(cloned)
+                                } else {
+                                    MirOperand::Local(field_val)
+                                };
+                                self.builder.push_stmt(MirStmt::Store {
+                                    addr: result_local,
+                                    offset: field.offset,
+                                    value: store_val,
+                                });
+                            }
+                            return Ok((MirOperand::Local(result_local), obj_ty));
+                        }
+                    }
+                }
+
                 let result_local = self.builder.alloc_temp(ret_ty.clone());
                 self.builder.push_stmt(MirStmt::Call {
                     dst: Some(result_local),
@@ -1256,6 +1330,35 @@ impl<'a> MirLowerer<'a> {
                 if let ExprKind::Ident(name) = &object.kind {
                     if let Some(val) = primitive_type_constant(name, field) {
                         return Ok(val);
+                    }
+                }
+
+                // Cross-package type access: pkg.Type → treat field as the type name.
+                // Subsequent field access (pkg.DbError.NotFound) chains through
+                // enum variant resolution on the resolved type.
+                if let ExprKind::Ident(name) = &object.kind {
+                    if self.ctx.package_modules.contains(name) {
+                        // Look up the field as an enum type
+                        if let Some((idx, layout)) = self.ctx.find_enum(field) {
+                            let enum_ty = MirType::Enum(EnumLayoutId(idx));
+                            let result_local = self.builder.alloc_temp(enum_ty.clone());
+                            // Default-initialize (tag 0) — caller will likely access a variant
+                            self.builder.push_stmt(MirStmt::Store {
+                                addr: result_local,
+                                offset: layout.tag_offset,
+                                value: MirOperand::Constant(MirConst::Int(0)),
+                            });
+                            return Ok((MirOperand::Local(result_local), enum_ty));
+                        }
+                        // Look up as a struct type
+                        if let Some((idx, _)) = self.ctx.find_struct(field) {
+                            let struct_ty = MirType::Struct(StructLayoutId(idx));
+                            let result_local = self.builder.alloc_temp(struct_ty.clone());
+                            return Ok((MirOperand::Local(result_local), struct_ty));
+                        }
+                        // Fallback: treat as an opaque type reference
+                        let result_local = self.builder.alloc_temp(MirType::I64);
+                        return Ok((MirOperand::Local(result_local), MirType::I64));
                     }
                 }
 

--- a/compiler/crates/rask-mir/src/lower/mod.rs
+++ b/compiler/crates/rask-mir/src/lower/mod.rs
@@ -97,6 +97,9 @@ pub struct MirContext<'a> {
     pub comptime_globals: &'a HashMap<String, ComptimeGlobalMeta>,
     /// Names of extern "C" functions — calls emit FunctionRef::extern_c().
     pub extern_funcs: &'a std::collections::HashSet<String>,
+    /// Names of imported external packages — used to recognize cross-package
+    /// qualified calls like `pkg.func()` and `pkg.Type` field access.
+    pub package_modules: &'a std::collections::HashSet<String>,
     /// Line map for converting byte offsets to line:col (None in tests)
     pub line_map: Option<&'a LineMap>,
     /// Source file path for runtime error messages (None in tests)
@@ -124,6 +127,8 @@ impl<'a> MirContext<'a> {
             std::sync::LazyLock::new(HashMap::new);
         static EMPTY_EXTERNS: std::sync::LazyLock<std::collections::HashSet<String>> =
             std::sync::LazyLock::new(std::collections::HashSet::new);
+        static EMPTY_PACKAGES: std::sync::LazyLock<std::collections::HashSet<String>> =
+            std::sync::LazyLock::new(std::collections::HashSet::new);
         static EMPTY_TYPE_NAMES: std::sync::LazyLock<HashMap<rask_types::TypeId, String>> =
             std::sync::LazyLock::new(HashMap::new);
         static EMPTY_COERCIONS: std::sync::LazyLock<HashMap<NodeId, String>> =
@@ -137,6 +142,7 @@ impl<'a> MirContext<'a> {
             type_names: &EMPTY_TYPE_NAMES,
             comptime_globals: &EMPTY_COMPTIME,
             extern_funcs: &EMPTY_EXTERNS,
+            package_modules: &EMPTY_PACKAGES,
             line_map: None,
             source_file: None,
             shared_elem_types: std::cell::RefCell::new(HashMap::new()),
@@ -2480,6 +2486,7 @@ mod tests {
             type_names: &type_names,
             comptime_globals: &comptime_globals,
             extern_funcs: &extern_funcs,
+            package_modules: &std::collections::HashSet::new(),
             shared_elem_types: std::cell::RefCell::new(HashMap::new()),
             line_map: None,
             source_file: None,
@@ -2533,6 +2540,7 @@ mod tests {
             type_names: &type_names,
             comptime_globals: &comptime_globals,
             extern_funcs: &extern_funcs,
+            package_modules: &std::collections::HashSet::new(),
             shared_elem_types: std::cell::RefCell::new(HashMap::new()),
             line_map: None,
             source_file: None,
@@ -2592,6 +2600,7 @@ mod tests {
             type_names: &type_names,
             comptime_globals: &comptime_globals,
             extern_funcs: &extern_funcs,
+            package_modules: &std::collections::HashSet::new(),
             shared_elem_types: std::cell::RefCell::new(HashMap::new()),
             line_map: None,
             source_file: None,

--- a/compiler/crates/rask-mono/src/lib.rs
+++ b/compiler/crates/rask-mono/src/lib.rs
@@ -169,7 +169,20 @@ pub fn monomorphize(
     program: &TypedProgram,
     decls: &[Decl],
 ) -> Result<MonoProgram, MonomorphizeError> {
+    monomorphize_with_packages(program, decls, std::collections::HashSet::new())
+}
+
+/// Monomorphize with cross-package module awareness.
+///
+/// `package_modules` contains names of imported external packages so the
+/// reachability pass correctly discovers `pkg.func()` calls.
+pub fn monomorphize_with_packages(
+    program: &TypedProgram,
+    decls: &[Decl],
+    package_modules: std::collections::HashSet<String>,
+) -> Result<MonoProgram, MonomorphizeError> {
     let mut mono = Monomorphizer::new(decls, &program.call_type_args);
+    mono.set_package_modules(package_modules);
 
     if !mono.add_entry("main") {
         return Err(MonomorphizeError::NoEntryPoint);

--- a/compiler/crates/rask-mono/src/reachability.rs
+++ b/compiler/crates/rask-mono/src/reachability.rs
@@ -48,6 +48,8 @@ pub struct Monomorphizer<'a> {
     method_by_bare_name: HashMap<String, Vec<String>>,
     /// Resolved type args per call site (from typechecker)
     call_type_args: &'a HashMap<NodeId, Vec<Type>>,
+    /// External package module names — `pkg.func()` enqueues `func`, not `pkg_func`
+    package_modules: std::collections::HashSet<String>,
     /// Already processed (name, type_args) pairs
     seen: HashMap<(String, Vec<Type>), bool>,
     /// BFS work queue
@@ -142,11 +144,17 @@ impl<'a> Monomorphizer<'a> {
             method_table,
             method_by_bare_name,
             call_type_args,
+            package_modules: std::collections::HashSet::new(),
             seen: HashMap::new(),
             queue: VecDeque::new(),
             results: Vec::new(),
             call_rewrites: HashMap::new(),
         }
+    }
+
+    /// Set the external package module names for cross-package call discovery.
+    pub fn set_package_modules(&mut self, modules: std::collections::HashSet<String>) {
+        self.package_modules = modules;
     }
 
     /// Seed the work queue with main()
@@ -298,8 +306,14 @@ impl<'a> Monomorphizer<'a> {
                     .unwrap_or_default();
 
                 // Static method call: Type.method() → enqueue "Type_method"
+                // Cross-package call: pkg.func() → enqueue "func" (the function
+                // is registered under its original name from the dependency).
                 if let ExprKind::Ident(name) = &object.kind {
-                    self.enqueue(format!("{}_{}", name, method), type_args.clone());
+                    if self.package_modules.contains(name) {
+                        self.enqueue(method.clone(), type_args.clone());
+                    } else {
+                        self.enqueue(format!("{}_{}", name, method), type_args.clone());
+                    }
                 }
 
                 // Instance method call: value.method() → enqueue all methods


### PR DESCRIPTION
## Summary
This PR adds support for cross-package function calls and type access in the Rask compiler. It enables code to call functions from imported packages using qualified syntax (e.g., `pkg.func()`) and access types from those packages (e.g., `pkg.Type`), with proper monomorphization and MIR lowering.

## Key Changes

- **Cross-package call discovery**: Modified the monomorphizer to recognize `pkg.func()` calls where `pkg` is an imported package module, enqueueing the function by its original name rather than a mangled name.

- **Cross-package type access**: Added MIR lowering support for `pkg.Type` field access patterns, allowing resolution of enum variants and struct types from external packages.

- **Struct clone implementation**: Implemented inline field-by-field struct cloning with deep cloning for heap types (string, Vec, Map), avoiding the need for generated runtime clone functions.

- **Package module tracking**: 
  - Added `package_modules` HashSet to track imported package names throughout the compilation pipeline
  - Threaded this information through monomorphization, MIR lowering, and code generation
  - Collected all dependency declarations (public and private) during build to ensure internal calls within dependency functions resolve correctly

- **Method type inference improvements**: Refined type prefix detection for method calls to better handle complex expressions and avoid incorrect type assumptions.

- **Standard library method additions**: Extended method type inference to recognize `compare` (string), `push` and `remove_at` (Vec) methods.

- **Vec_remove_at codegen**: Added stdlib dispatch entry and builder support for the `Vec_remove_at` function.

## Implementation Details

- Dependency declarations are desugared before merging into the compilation unit to ensure string interpolation and other transformations work correctly
- Cross-package calls bypass the normal static method name mangling (Type_method) and use the original function name
- Type access from packages defaults to creating temporary locals of the appropriate type (enum, struct, or opaque I64)
- The struct clone implementation generates field-by-field copy code with conditional deep cloning based on field types

https://claude.ai/code/session_01YPv15yiw68B4PfvPU8zagZ