### PR TITLE
Improve aggregate type handling and Pool/generic type support

### DIFF
--- a/compiler/crates/rask-codegen/src/builder.rs
+++ b/compiler/crates/rask-codegen/src/builder.rs
@@ -20,6 +20,8 @@ enum CallAdapt {
     None,
     /// Result is void* — load the i64 value from the returned pointer
     DerefResult,
+    /// Result is void* — wrap as Option: NULL→None(tag=1), non-NULL→Some(tag=0, deref)
+    DerefOption,
     /// Pop-style: value written to this stack slot by callee
     PopOutParam(StackSlot),
 }
@@ -329,7 +331,7 @@ impl<'a> FunctionBuilder<'a> {
                 builder.def_var(*var, val);
             }
 
-            MirStmt::Store { addr, offset, value } => {
+            MirStmt::Store { addr, offset, value, store_size } => {
                 let addr_val = builder.use_var(*var_map.get(addr)
                     .ok_or_else(|| CodegenError::UnsupportedFeature("Address variable not found".to_string()))?);
 
@@ -370,6 +372,19 @@ impl<'a> FunctionBuilder<'a> {
 
                 if !is_aggregate {
                     let val = Self::lower_operand(builder, value, var_map, string_globals, func_refs)?;
+                    let val_ty = builder.func.dfg.value_type(val);
+
+                    // Layout uses 8-byte slots for all scalars. Widen sub-8-byte
+                    // values to fill the full slot — otherwise a 4-byte f32 store
+                    // leaves stale upper bytes that corrupt the f64 read-back.
+                    let val = if val_ty == types::F32 {
+                        builder.ins().fpromote(types::F64, val)
+                    } else if val_ty.is_int() && val_ty.bits() < 64 {
+                        Self::convert_value(builder, val, val_ty, types::I64)
+                    } else {
+                        val
+                    };
+
                     let flags = MemFlags::new();
                     builder.ins().store(flags, val, addr_val, *offset as i32);
                 }
@@ -637,6 +652,7 @@ impl<'a> FunctionBuilder<'a> {
                             ))?;
 
                         // Post-call result handling
+                        let mut slot_already_written = false;
                         let val = match adapt {
                             CallAdapt::DerefResult => {
                                 // Result is void* — load the value from it.
@@ -651,6 +667,68 @@ impl<'a> FunctionBuilder<'a> {
                                     builder.ins().load(load_ty, MemFlags::new(), ptr, 0)
                                 } else {
                                     builder.ins().iconst(types::I64, 0)
+                                }
+                            }
+                            CallAdapt::DerefOption => {
+                                // Result is void*: NULL → None, non-NULL → Some(deref).
+                                // Write tag+payload into the destination stack slot.
+                                let results = builder.inst_results(call_inst);
+                                let ptr = if !results.is_empty() { results[0] } else {
+                                    builder.ins().iconst(types::I64, 0)
+                                };
+                                if let Some((ss, slot_size)) = stack_slot_map.get(dst_id) {
+                                    slot_already_written = true;
+                                    let zero = builder.ins().iconst(types::I64, 0);
+                                    let is_null = builder.ins().icmp(IntCC::Equal, ptr, zero);
+                                    let then_block = builder.create_block();
+                                    let else_block = builder.create_block();
+                                    let merge_block = builder.create_block();
+                                    builder.ins().brif(is_null, then_block, &[], else_block, &[]);
+
+                                    // NULL path: tag = 1 (None)
+                                    builder.switch_to_block(then_block);
+                                    builder.seal_block(then_block);
+                                    let one = builder.ins().iconst(types::I64, 1);
+                                    builder.ins().stack_store(one, *ss, 0);
+                                    builder.ins().jump(merge_block, &[]);
+
+                                    // non-NULL path: tag = 0 (Some), payload copied from ptr
+                                    builder.switch_to_block(else_block);
+                                    builder.seal_block(else_block);
+                                    let tag_some = builder.ins().iconst(types::I64, 0);
+                                    builder.ins().stack_store(tag_some, *ss, 0);
+                                    // Copy payload: for scalars (slot_size=16) just load one word;
+                                    // for aggregates copy word-by-word from ptr into slot at offset 8+.
+                                    let payload_size = *slot_size as i32 - 8;
+                                    let mut off = 0i32;
+                                    while off + 8 <= payload_size {
+                                        let word = builder.ins().load(types::I64, MemFlags::new(), ptr, off);
+                                        builder.ins().stack_store(word, *ss, 8 + off);
+                                        off += 8;
+                                    }
+                                    if payload_size - off >= 4 {
+                                        let word = builder.ins().load(types::I32, MemFlags::new(), ptr, off);
+                                        builder.ins().stack_store(word, *ss, 8 + off);
+                                        off += 4;
+                                    }
+                                    if payload_size - off >= 2 {
+                                        let word = builder.ins().load(types::I16, MemFlags::new(), ptr, off);
+                                        builder.ins().stack_store(word, *ss, 8 + off);
+                                        off += 2;
+                                    }
+                                    if payload_size - off >= 1 {
+                                        let word = builder.ins().load(types::I8, MemFlags::new(), ptr, off);
+                                        builder.ins().stack_store(word, *ss, 8 + off);
+                                    }
+                                    builder.ins().jump(merge_block, &[]);
+
+                                    builder.switch_to_block(merge_block);
+                                    builder.seal_block(merge_block);
+                                    // Return dummy value — real data is in the stack slot
+                                    builder.ins().iconst(types::I64, 0)
+                                } else {
+                                    // No stack slot — just deref like DerefResult
+                                    builder.ins().load(types::I64, MemFlags::new(), ptr, 0)
                                 }
                             }
                             CallAdapt::PopOutParam(ss) => {
@@ -681,11 +759,19 @@ impl<'a> FunctionBuilder<'a> {
                         };
                         // If destination has a stack slot (aggregate type), handle differently
                         // for internal Rask functions vs C stdlib functions.
-                        if let Some((ss, size)) = stack_slot_map.get(dst_id) {
+                        // DerefOption already wrote directly to the stack slot.
+                        if slot_already_written {
+                            // Nothing to do — DerefOption already populated the slot
+                        } else if let Some((ss, size)) = stack_slot_map.get(dst_id) {
                             if internal_fns.contains(&func.name) {
-                                // Internal function returns a pointer to its stack-allocated aggregate.
-                                // Copy the data into our own stack slot before it goes stale.
-                                Self::copy_aggregate(builder, final_val, *ss, *size);
+                                // Internal function returns aggregate data loaded from its stack.
+                                // Store directly into our stack slot (value, not pointer).
+                                if *size <= 8 {
+                                    builder.ins().stack_store(final_val, *ss, 0);
+                                } else {
+                                    // Larger aggregates: copy from returned pointer
+                                    Self::copy_aggregate(builder, final_val, *ss, *size);
+                                }
                             } else if Self::is_negative_err_fn(&func.name) {
                                 // C function uses negative return = error convention.
                                 Self::wrap_result_into_slot(builder, final_val, *ss);
@@ -778,16 +864,17 @@ impl<'a> FunctionBuilder<'a> {
                     // as Cranelift IR, avoiding the C function call overhead.
                     //
                     // Pool layout (verified by _Static_assert in pool.c):
+                    //   offset 16: slot_stride (i64)
                     //   offset 24: cap (i64)
                     //   offset 40: slots (ptr)
-                    // Slot layout (stride=16 for elem_size=8):
+                    // Slot layout (stride varies by elem_size):
                     //   offset 0: generation (u32)
                     //   offset 8: data (elem_size bytes)
+                    const POOL_STRIDE_OFFSET: i32 = 16;
                     const POOL_CAP_OFFSET: i32 = 24;
                     const POOL_SLOTS_OFFSET: i32 = 40;
                     const SLOT_GEN_OFFSET: i32 = 0;
                     const SLOT_DATA_OFFSET: i32 = 8;
-                    const SLOT_STRIDE_SHIFT: i64 = 4; // log2(16)
 
                     // 1. Extract index and generation from packed i64 handle
                     //    handle = index:32 | generation:32
@@ -824,11 +911,12 @@ impl<'a> FunctionBuilder<'a> {
                     }
                     builder.ins().trap(cranelift_codegen::ir::TrapCode::unwrap_user(1));
 
-                    // bounds_ok: load slots pointer, compute slot address
+                    // bounds_ok: load slots pointer and stride, compute slot address
                     builder.switch_to_block(bounds_ok);
                     builder.seal_block(bounds_ok);
                     let slots = builder.ins().load(types::I64, MemFlags::new(), pool_val, POOL_SLOTS_OFFSET);
-                    let slot_offset = builder.ins().ishl_imm(index, SLOT_STRIDE_SHIFT);
+                    let stride = builder.ins().load(types::I64, MemFlags::new(), pool_val, POOL_STRIDE_OFFSET);
+                    let slot_offset = builder.ins().imul(index, stride);
                     let slot_addr = builder.ins().iadd(slots, slot_offset);
 
                     // 3. Generation check
@@ -867,13 +955,10 @@ impl<'a> FunctionBuilder<'a> {
                         .ok_or_else(|| CodegenError::UnsupportedFeature(
                             "Pool access destination not found".to_string()
                         ))?;
-                    if is_struct {
-                        let data_ptr = builder.ins().iadd_imm(slot_addr, SLOT_DATA_OFFSET as i64);
-                        builder.def_var(*var, data_ptr);
-                    } else {
-                        let val = builder.ins().load(load_ty, MemFlags::new(), slot_addr, SLOT_DATA_OFFSET);
-                        builder.def_var(*var, val);
-                    }
+                    // Always return pointer to slot data — pool[h] is used
+                    // for mutation, so callers need the address.
+                    let data_ptr = builder.ins().iadd_imm(slot_addr, SLOT_DATA_OFFSET as i64);
+                    builder.def_var(*var, data_ptr);
                 } else {
                     // ── Debug mode: call C function ──────────────────────
                     let call_inst = if let Some(file_str) = source_file {
@@ -903,12 +988,10 @@ impl<'a> FunctionBuilder<'a> {
                             .ok_or_else(|| CodegenError::UnsupportedFeature(
                                 "Pool access destination not found".to_string()
                             ))?;
-                        if is_struct {
-                            builder.def_var(*var, ptr);
-                        } else {
-                            let val = builder.ins().load(load_ty, MemFlags::new(), ptr, 0);
-                            builder.def_var(*var, val);
-                        }
+                        // Always return raw pointer — pool[h] is used for
+                        // mutation (pool[h].field = val), so callers need
+                        // the address, not the loaded value.
+                        builder.def_var(*var, ptr);
                     }
                 }
             }
@@ -1275,6 +1358,31 @@ impl<'a> FunctionBuilder<'a> {
         }
     }
 
+    /// True when a struct field's declared type uses stack-slot (aggregate)
+    /// representation in codegen. These fields return a pointer into the parent
+    /// struct rather than a loaded scalar.
+    fn is_aggregate_field_type(ty: &RaskType) -> bool {
+        match ty {
+            // Primitives, opaque pointers — scalar
+            RaskType::Unit | RaskType::Bool
+            | RaskType::I8 | RaskType::I16 | RaskType::I32 | RaskType::I64 | RaskType::I128
+            | RaskType::U8 | RaskType::U16 | RaskType::U32 | RaskType::U64 | RaskType::U128
+            | RaskType::F32 | RaskType::F64
+            | RaskType::Char | RaskType::String
+            | RaskType::Fn { .. } | RaskType::Slice(_) => false,
+            // Runtime-opaque pointer types (Vec, Map, Pool, Handle, Channel, ...)
+            RaskType::UnresolvedGeneric { .. } | RaskType::Generic { .. } => false,
+            // Niche-optimized Option<Handle<T>> — scalar (sentinel value, no tag)
+            RaskType::Option(inner)
+                if matches!(inner.as_ref(), RaskType::UnresolvedGeneric { name, .. } if name == "Handle") =>
+            {
+                false
+            }
+            // User-defined enums/structs, tuples, arrays, Option, Result — aggregate
+            _ => true,
+        }
+    }
+
     #[allow(clippy::too_many_arguments)]
     fn lower_rvalue(
         builder: &mut ClifFunctionBuilder,
@@ -1454,20 +1562,18 @@ impl<'a> FunctionBuilder<'a> {
                     Some(MirType::Struct(id)) => {
                         if let Some(layout) = struct_layouts.get(id.0 as usize) {
                             if let Some(field) = layout.fields.get(*field_index as usize) {
-                                // Aggregate field (embedded struct): return pointer, don't load
-                                if field.size > 8 {
+                                // Aggregate field: return pointer into parent struct.
+                                // Covers both >8-byte structs and ≤8-byte enums/structs
+                                // that use stack-slot representation in codegen.
+                                if field.size > 8 || Self::is_aggregate_field_type(&field.ty) {
                                     let addr = builder.ins().iadd_imm(base_val, field.offset as i64);
                                     return Ok(addr);
                                 }
-                                // Derive Cranelift load type from field's declared type
+                                // Scalar field. Layout uses 8-byte slots; load at storage
+                                // width to avoid reading wrong bytes (e.g. lower f64 half).
                                 load_ty = match &field.ty {
-                                    RaskType::F64 => types::F64,
-                                    RaskType::F32 => types::F32,
-                                    RaskType::Bool => types::I8,
-                                    RaskType::I8 | RaskType::U8 => types::I8,
-                                    RaskType::I16 | RaskType::U16 => types::I16,
-                                    RaskType::I32 | RaskType::U32 | RaskType::Char => types::I32,
-                                    _ => load_ty,
+                                    RaskType::F64 | RaskType::F32 => types::F64,
+                                    _ => types::I64,
                                 };
                                 field.offset as i32
                             } else {
@@ -1535,7 +1641,21 @@ impl<'a> FunctionBuilder<'a> {
                 }
 
                 let flags = MemFlags::new();
-                Ok(builder.ins().load(load_ty, flags, base_val, offset))
+                let loaded = builder.ins().load(load_ty, flags, base_val, offset);
+
+                // Narrow from storage type to declared type when needed.
+                // E.g., f32 field stored as f64 in 8-byte slot → fdemote.
+                let result = if let Some(exp) = expected_ty {
+                    let loaded_ty = builder.func.dfg.value_type(loaded);
+                    if loaded_ty != exp {
+                        Self::convert_value(builder, loaded, loaded_ty, exp)
+                    } else {
+                        loaded
+                    }
+                } else {
+                    loaded
+                };
+                Ok(result)
             }
 
             // Enum discriminant extraction: load tag byte from base pointer
@@ -1630,18 +1750,54 @@ impl<'a> FunctionBuilder<'a> {
         _mir_blocks: &[rask_mir::MirBlock],
         _locals: &[rask_mir::MirLocal],
         func_refs: &HashMap<String, FuncRef>,
-        _struct_layouts: &[StructLayout],
-        _enum_layouts: &[EnumLayout],
+        struct_layouts: &[StructLayout],
+        enum_layouts: &[EnumLayout],
         string_globals: &HashMap<String, GlobalValue>,
         _comptime_globals: &HashMap<String, GlobalValue>,
         _panicking_fns: &HashSet<String>,
-        _stack_slot_map: &HashMap<LocalId, (StackSlot, u32)>,
+        stack_slot_map: &HashMap<LocalId, (StackSlot, u32)>,
         _internal_fns: &HashSet<String>,
         cleanup_chain_blocks: &HashMap<Vec<BlockId>, cranelift_codegen::ir::Block>,
     ) -> CodegenResult<()> {
         match term {
             MirTerminator::Return { value } => {
-                Self::emit_return(builder, value.as_ref(), ret_ty, var_map, string_globals, func_refs)?;
+                // For small aggregate return values (≤8 bytes) in stack slots,
+                // load the data and return it directly.
+                // For larger aggregates, return the stack slot address. The caller
+                // copies from it immediately via copy_aggregate (the callee stack
+                // is still accessible at that point on x86-64).
+                if let Some(stack_info) = Self::return_stack_info(value.as_ref(), stack_slot_map) {
+                    let (_local_id, ss, size) = stack_info;
+                    if size <= 8 {
+                        let loaded = builder.ins().stack_load(types::I64, ss, 0);
+                        builder.ins().return_(&[loaded]);
+                    } else {
+                        // Return pointer to stack slot data for copy_aggregate
+                        Self::emit_return(builder, value.as_ref(), ret_ty, var_map, string_globals, func_refs)?;
+                    }
+                } else if matches!(ret_ty, MirType::Result { .. } | MirType::Option(_)) {
+                    // Function returns Result/Option but value is a plain scalar
+                    // (e.g. `return 42` in a function returning `i32 or string`).
+                    // Wrap the value as Ok/Some in a temporary stack slot and return
+                    // the slot address so the caller can copy_aggregate.
+                    let slot_size = Self::resolve_type_alloc_size(ret_ty, struct_layouts, enum_layouts)
+                        .unwrap_or(16);
+                    let ss = builder.create_sized_stack_slot(StackSlotData::new(
+                        StackSlotKind::ExplicitSlot,
+                        slot_size,
+                        0,
+                    ));
+                    let val = if let Some(val_op) = value.as_ref() {
+                        Self::lower_operand_typed(builder, val_op, var_map, Some(types::I64), string_globals, func_refs)?
+                    } else {
+                        builder.ins().iconst(types::I64, 0)
+                    };
+                    Self::wrap_ok_into_slot(builder, val, ss);
+                    let addr = builder.ins().stack_addr(types::I64, ss, 0);
+                    builder.ins().return_(&[addr]);
+                } else {
+                    Self::emit_return(builder, value.as_ref(), ret_ty, var_map, string_globals, func_refs)?;
+                }
             }
 
             MirTerminator::Goto { target } => {
@@ -1764,6 +1920,20 @@ impl<'a> FunctionBuilder<'a> {
         Ok(())
     }
 
+    /// Check if a return value comes from a stack-allocated aggregate local.
+    /// Returns the (stack_slot, size) if so.
+    fn return_stack_info(
+        value: Option<&MirOperand>,
+        stack_slot_map: &HashMap<LocalId, (StackSlot, u32)>,
+    ) -> Option<(LocalId, StackSlot, u32)> {
+        if let Some(MirOperand::Local(id)) = value {
+            if let Some((ss, size)) = stack_slot_map.get(id) {
+                return Some((*id, *ss, *size));
+            }
+        }
+        None
+    }
+
     /// Compute the actual allocation size for a MirType, resolving struct/enum
     /// sizes from layouts. Unlike MirType::size() which returns 8 for Struct/Enum
     /// (pointer size), this returns the true layout size. Needed for stack slots
@@ -1857,7 +2027,8 @@ impl<'a> FunctionBuilder<'a> {
         matches!(name,
             "net_tcp_listen" | "TcpListener_accept" |
             "TcpConnection_read_http_request" | "TcpConnection_write_http_response" |
-            "Sender_send" | "Sender_try_send"
+            "Sender_send" | "Sender_try_send" |
+            "ThreadHandle_join" | "Thread_join"
         )
     }
 
@@ -1906,11 +2077,9 @@ impl<'a> FunctionBuilder<'a> {
                 args.insert(1, val_size);
                 CallAdapt::None
             }
-            "Pool_new" => {
-                let elem_size = builder.ins().iconst(types::I64, 8);
-                args.insert(0, elem_size);
-                CallAdapt::None
-            }
+            // Pool_new: MIR injects elem_size as first arg.
+            // No special codegen handling needed.
+            "Pool_new" => CallAdapt::None,
 
             // Vec push/set: wrap value arg as pointer
             "Vec_push" => {
@@ -1976,8 +2145,15 @@ impl<'a> FunctionBuilder<'a> {
                 CallAdapt::None
             }
 
-            // Map get: wrap key as pointer, deref result
-            "Map_get" | "Map_get_unwrap" => {
+            // Map get: wrap key as pointer, wrap result as Option
+            "Map_get" => {
+                if args.len() >= 2 {
+                    let key = args[1];
+                    args[1] = Self::value_to_ptr(builder, key);
+                }
+                CallAdapt::DerefOption
+            }
+            "Map_get_unwrap" => {
                 if args.len() >= 2 {
                     let key = args[1];
                     args[1] = Self::value_to_ptr(builder, key);
@@ -2030,8 +2206,12 @@ impl<'a> FunctionBuilder<'a> {
                 CallAdapt::None
             }
 
-            // Pool get/index: result is void*, deref to get value
-            "Pool_get" | "Pool_index" | "Pool_checked_access" => CallAdapt::DerefResult,
+            // Pool get: result is void*, wrap as Option storing the
+            // pointer itself (not dereferenced) so field access works
+            // through it regardless of element struct size.
+            "Pool_get" => CallAdapt::DerefOption,
+            // Pool index: return raw pointer for mutation (pool[h].field = val)
+            "Pool_index" | "Pool_checked_access" => CallAdapt::None,
 
             // Channel_unbuffered: MIR injects elem_size; builder appends capacity=0
             "Channel_unbuffered" => {

--- a/compiler/crates/rask-codegen/src/dispatch.rs
+++ b/compiler/crates/rask-codegen/src/dispatch.rs
@@ -225,6 +225,14 @@ pub fn stdlib_entries() -> Vec<StdlibEntry> {
             ret_ty: Some(types::I64),
             can_panic: false,
         },
+        // rask_vec_join_i64(v: Vec<i64>*, separator: string*) → string*
+        StdlibEntry {
+            mir_name: "Vec_join_i64",
+            c_name: "rask_vec_join_i64",
+            params: &[types::I64, types::I64],
+            ret_ty: Some(types::I64),
+            can_panic: false,
+        },
 
         // rask_vec_sort(v: RaskVec*) → void
         StdlibEntry {

--- a/compiler/crates/rask-codegen/src/tests.rs
+++ b/compiler/crates/rask-codegen/src/tests.rs
@@ -648,8 +648,8 @@ mod tests {
             ],
             blocks: vec![
                 block(0, vec![
-                    MirStmt::Store { addr: LocalId(0), offset: 0, value: i32_const(10) },
-                    MirStmt::Store { addr: LocalId(0), offset: 4, value: i32_const(20) },
+                    MirStmt::Store { addr: LocalId(0), offset: 0, value: i32_const(10), store_size: None },
+                    MirStmt::Store { addr: LocalId(0), offset: 4, value: i32_const(20), store_size: None },
                     assign(1, MirRValue::Field { base: local_op(0), field_index: 1, byte_offset: None, field_size: None }),
                 ], ret(Some(local_op(1)))),
             ],
@@ -971,8 +971,8 @@ mod tests {
             ],
             blocks: vec![
                 block(0, vec![
-                    MirStmt::Store { addr: LocalId(0), offset: 0, value: i32_const(1) },
-                    MirStmt::Store { addr: LocalId(0), offset: 4, value: i32_const(2) },
+                    MirStmt::Store { addr: LocalId(0), offset: 0, value: i32_const(1), store_size: None },
+                    MirStmt::Store { addr: LocalId(0), offset: 4, value: i32_const(2), store_size: None },
                 ], ret(Some(i32_const(0)))),
             ],
             entry_block: BlockId(0),
@@ -1007,8 +1007,8 @@ mod tests {
             ],
             blocks: vec![
                 block(0, vec![
-                    MirStmt::Store { addr: LocalId(0), offset: 0, value: MirOperand::Constant(MirConst::Int(0)) },
-                    MirStmt::Store { addr: LocalId(0), offset: 4, value: i32_const(42) },
+                    MirStmt::Store { addr: LocalId(0), offset: 0, value: MirOperand::Constant(MirConst::Int(0)), store_size: None },
+                    MirStmt::Store { addr: LocalId(0), offset: 4, value: i32_const(42), store_size: None },
                     assign(1, MirRValue::EnumTag { value: local_op(0) }),
                 ], ret(Some(local_op(1)))),
             ],

--- a/compiler/crates/rask-mir/src/closures.rs
+++ b/compiler/crates/rask-mir/src/closures.rs
@@ -529,6 +529,7 @@ mod tests {
                         addr: LocalId(1),
                         offset: 0,
                         value: MirOperand::Local(LocalId(0)),
+                        store_size: None,
                     },
                 ], ret(None)),
             ],

--- a/compiler/crates/rask-mir/src/display.rs
+++ b/compiler/crates/rask-mir/src/display.rs
@@ -145,7 +145,7 @@ impl fmt::Display for MirStmt {
             MirStmt::Assign { dst, rvalue } => {
                 write!(f, "_{} = {}", dst.0, rvalue)
             }
-            MirStmt::Store { addr, offset, value } => {
+            MirStmt::Store { addr, offset, value, .. } => {
                 write!(f, "*(_{}+{}) = {}", addr.0, offset, value)
             }
             MirStmt::Call { dst, func, args } => {

--- a/compiler/crates/rask-mir/src/lower/expr.rs
+++ b/compiler/crates/rask-mir/src/lower/expr.rs
@@ -181,6 +181,7 @@ impl<'a> MirLowerer<'a> {
                             addr: result_local,
                             offset: 0,
                             value: MirOperand::Constant(MirConst::Int(1)), // tag = None
+                            store_size: None,
                         });
                         Ok((MirOperand::Local(result_local), option_ty))
                     }
@@ -280,6 +281,7 @@ impl<'a> MirLowerer<'a> {
             // Function call — direct or through closure
             ExprKind::Call { func, args } => {
                 let mut arg_operands = Vec::new();
+                let mut arg_mir_types = Vec::new();
                 for a in args {
                     let (op, mir_ty) = self.lower_expr(&a.expr)?;
                     // TR5: implicit trait coercion — emit TraitBox if type checker flagged this arg
@@ -289,6 +291,7 @@ impl<'a> MirLowerer<'a> {
                     } else {
                         arg_operands.push(op);
                     }
+                    arg_mir_types.push(mir_ty);
                 }
 
                 // Non-ident callees: field access, returned functions, etc.
@@ -386,13 +389,21 @@ impl<'a> MirLowerer<'a> {
                     "Ok" | "Some" | "Err" => {
                         let tag = self.variant_tag(&func_name);
                         // Derive the result MirType from type checker info if available.
-                        // Fallback to Result/Option so codegen allocates a stack slot.
+                        // Fallback uses the payload's actual type so aggregate payloads
+                        // get a correctly-sized stack slot.
+                        let payload_ty = arg_mir_types.first().cloned().unwrap_or(MirType::I64);
                         let fallback_ty = if func_name == "Some" {
-                            MirType::Option(Box::new(MirType::I64))
+                            MirType::Option(Box::new(payload_ty.clone()))
+                        } else if func_name == "Ok" {
+                            MirType::Result {
+                                ok: Box::new(payload_ty.clone()),
+                                err: Box::new(MirType::I64),
+                            }
                         } else {
+                            // Err
                             MirType::Result {
                                 ok: Box::new(MirType::I64),
-                                err: Box::new(MirType::I64),
+                                err: Box::new(payload_ty.clone()),
                             }
                         };
                         let result_ty = self.lookup_expr_type(expr)
@@ -407,12 +418,14 @@ impl<'a> MirLowerer<'a> {
                             addr: result_local,
                             offset: 0,
                             value: MirOperand::Constant(MirConst::Int(tag)),
+                            store_size: None,
                         });
                         if let Some(payload) = arg_operands.first() {
                             self.builder.push_stmt(MirStmt::Store {
                                 addr: result_local,
                                 offset: 8,
                                 value: payload.clone(),
+                                store_size: None,
                             });
                         }
                         return Ok((MirOperand::Local(result_local), result_ty));
@@ -592,6 +605,7 @@ impl<'a> MirLowerer<'a> {
                                 addr: result_local,
                                 offset: tag_offset,
                                 value: MirOperand::Constant(MirConst::Int(tag_val as i64)),
+                                store_size: None,
                             });
 
                             // Store payload fields
@@ -606,6 +620,7 @@ impl<'a> MirLowerer<'a> {
                                     addr: result_local,
                                     offset,
                                     value: val,
+                                    store_size: None,
                                 });
                             }
 
@@ -760,6 +775,13 @@ impl<'a> MirLowerer<'a> {
                                     // Shared: data_size goes last → (data_ptr, data_size)
                                     arg_operands.push(size_op);
                                 }
+                            }
+                            // Pool.new(): inject elem_size so pool allocates
+                            // correctly-sized slots for struct elements.
+                            if base_name == "Pool" && method == "new" {
+                                let elem_size = self.generic_inner_struct_size(name);
+                                let size_op = MirOperand::Constant(MirConst::Int(elem_size));
+                                arg_operands.insert(0, size_op);
                             }
 
                             // Map.new() with string keys → use string hash/eq
@@ -1001,10 +1023,17 @@ impl<'a> MirLowerer<'a> {
                 // Vec_get panics on OOB → unwrap is a no-op.
                 // Map_get returns NULL on missing key → rewrite to Map_get_unwrap.
                 if method == "unwrap" && args.is_empty() {
-                    if let ExprKind::MethodCall { method: inner_method, .. } = &object.kind {
+                    if let ExprKind::MethodCall { method: inner_method, object: inner_obj, .. } = &object.kind {
                         if inner_method == "get" {
-                            self.builder.rewrite_last_call("Map_get", "Map_get_unwrap");
-                            return Ok((obj_op, obj_ty));
+                            // Only rewrite Map_get → Map_get_unwrap, not Pool_get
+                            let is_map = if let ExprKind::Ident(name) = &inner_obj.kind {
+                                self.local_type_prefix.get(name.as_str())
+                                    .map_or(false, |p| p == "Map")
+                            } else { false };
+                            if is_map {
+                                self.builder.rewrite_last_call("Map_get", "Map_get_unwrap");
+                                return Ok((obj_op, obj_ty));
+                            }
                         }
                     }
                 }
@@ -1239,6 +1268,30 @@ impl<'a> MirLowerer<'a> {
                             self.collection_elem_types.get(&key).cloned()
                                 .or_else(|| self.ctx.shared_elem_types.borrow().get(&key).cloned())
                         })
+                } else if qualified_name == "Pool_get" {
+                    // Pool.get returns Option<T> — extract T from tracked element type
+                    let elem_ty = Self::vec_tracking_key(object)
+                        .and_then(|key| {
+                            self.collection_elem_types.get(&key).cloned()
+                                .or_else(|| self.ctx.shared_elem_types.borrow().get(&key).cloned())
+                        })
+                        // Fallback: extract from Pool<T> generic parameter
+                        .or_else(|| {
+                            self.ctx.lookup_raw_type(object.id)
+                                .and_then(|ty| match ty {
+                                    rask_types::Type::UnresolvedGeneric { args, .. } => {
+                                        args.first().and_then(|a| match a {
+                                            rask_types::GenericArg::Type(t) => Some(t.as_ref()),
+                                            _ => None,
+                                        })
+                                    }
+                                    _ => None,
+                                })
+                                .map(|elem_ty| self.ctx.type_to_mir(elem_ty))
+                                .filter(|t| !matches!(t, MirType::Ptr))
+                        })
+                        .unwrap_or(MirType::I64);
+                    Some(MirType::Option(Box::new(elem_ty)))
                 } else {
                     None
                 }.unwrap_or_else(|| self
@@ -1268,13 +1321,7 @@ impl<'a> MirLowerer<'a> {
                                     },
                                 });
                                 // Deep clone heap types
-                                let clone_fn = match &field.ty {
-                                    rask_types::Type::String => Some("string_clone"),
-                                    rask_types::Type::UnresolvedNamed(n) if n == "string" => Some("string_clone"),
-                                    rask_types::Type::UnresolvedGeneric { name, .. } if name == "Vec" => Some("Vec_clone"),
-                                    rask_types::Type::UnresolvedGeneric { name, .. } if name == "Map" => Some("Map_clone"),
-                                    _ => None,
-                                };
+                                let clone_fn = Self::clone_fn_for_type(&field.ty);
                                 let store_val = if let Some(cfn) = clone_fn {
                                     let cloned = self.builder.alloc_temp(MirType::I64);
                                     self.builder.push_stmt(MirStmt::Call {
@@ -1290,22 +1337,49 @@ impl<'a> MirLowerer<'a> {
                                     addr: result_local,
                                     offset: field.offset,
                                     value: store_val,
+                                    store_size: None,
                                 });
                             }
                             return Ok((MirOperand::Local(result_local), obj_ty));
                         }
                     }
+                    // Enum clone: copy tag, then switch on tag to deep-clone
+                    // heap fields per variant.
+                    if let MirType::Enum(EnumLayoutId(id)) = &obj_ty {
+                        if let Some(layout) = self.ctx.enum_layouts.get(*id as usize).cloned() {
+                            return self.lower_enum_clone(&layout, &all_args[0], obj_ty);
+                        }
+                    }
                 }
+
+                // Pool.alloc(value) → Pool_insert(pool, elem_ptr)
+                // Pool_alloc takes no element arg; codegen Pool_insert appends elem_size
+                let (final_name, final_args) = if qualified_name == "Pool_alloc" && all_args.len() == 2 {
+                    ("Pool_insert".to_string(), all_args)
+                } else if qualified_name == "Vec_join" {
+                    // Vec_join assumes Vec<string>; use Vec_join_i64 for non-string elements
+                    let is_string = Self::vec_tracking_key(object)
+                        .and_then(|key| self.collection_elem_types.get(&key).cloned()
+                            .or_else(|| self.ctx.shared_elem_types.borrow().get(&key).cloned()))
+                        .map_or(false, |ty| matches!(ty, MirType::String));
+                    if is_string {
+                        (qualified_name.clone(), all_args)
+                    } else {
+                        ("Vec_join_i64".to_string(), all_args)
+                    }
+                } else {
+                    (qualified_name.clone(), all_args)
+                };
 
                 let result_local = self.builder.alloc_temp(ret_ty.clone());
                 self.builder.push_stmt(MirStmt::Call {
                     dst: Some(result_local),
-                    func: FunctionRef::internal(qualified_name.clone()),
-                    args: all_args,
+                    func: FunctionRef::internal(final_name.clone()),
+                    args: final_args,
                 });
 
                 // W2a/W2b: Re-resolve pool bindings after pool mutators inside `with` blocks
-                if matches!(qualified_name.as_str(),
+                if matches!(final_name.as_str(),
                     "Pool_insert" | "Pool_remove" | "Pool_clear" | "Pool_drain" | "Pool_alloc"
                 ) {
                     if let ExprKind::Ident(pool_var) = &object.kind {
@@ -1347,6 +1421,7 @@ impl<'a> MirLowerer<'a> {
                                 addr: result_local,
                                 offset: layout.tag_offset,
                                 value: MirOperand::Constant(MirConst::Int(0)),
+                                store_size: None,
                             });
                             return Ok((MirOperand::Local(result_local), enum_ty));
                         }
@@ -1374,6 +1449,7 @@ impl<'a> MirLowerer<'a> {
                                     addr: result_local,
                                     offset: layout.tag_offset,
                                     value: MirOperand::Constant(MirConst::Int(variant.tag as i64)),
+                                    store_size: None,
                                 });
                                 return Ok((MirOperand::Local(result_local), enum_ty));
                             }
@@ -1397,7 +1473,18 @@ impl<'a> MirLowerer<'a> {
                         if let Some((idx, fl)) = layout.fields.iter().enumerate()
                             .find(|(_, f)| f.name == *field)
                         {
-                            (idx as u32, self.ctx.resolve_type_str(&format!("{}", fl.ty)), Some(fl.offset), Some(fl.size))
+                            // Resolve field type from layout; if generic/unresolved,
+                            // prefer the type checker's type for this expression.
+                            let mut ft = self.ctx.resolve_type_str(&format!("{}", fl.ty));
+                            if matches!(ft, MirType::Ptr | MirType::I64) {
+                                if let Some(raw) = self.ctx.lookup_raw_type(expr.id) {
+                                    let tc_ty = self.ctx.type_to_mir(raw);
+                                    if !matches!(tc_ty, MirType::Ptr) {
+                                        ft = tc_ty;
+                                    }
+                                }
+                            }
+                            (idx as u32, ft, Some(fl.offset), Some(fl.size))
                         } else {
                             (0, MirType::I64, None, None)
                         }
@@ -1718,6 +1805,7 @@ impl<'a> MirLowerer<'a> {
                         addr: result_local,
                         offset: i as u32 * elem_size,
                         value: elem_op,
+                        store_size: None,
                     });
                 }
                 Ok((MirOperand::Local(result_local), array_ty))
@@ -1743,6 +1831,7 @@ impl<'a> MirLowerer<'a> {
                         addr: result_local,
                         offset,
                         value: elem_op,
+                        store_size: None,
                     });
                     offset += elem_size;
                 }
@@ -1751,24 +1840,64 @@ impl<'a> MirLowerer<'a> {
 
             // Struct literal
             ExprKind::StructLit { name, fields, .. } => {
-                let (result_ty, layout) = if let Some((idx, sl)) = self.ctx.find_struct(name) {
-                    (MirType::Struct(StructLayoutId(idx)), Some(sl))
+                // Check for enum variant constructor: "EnumName.VariantName { ... }"
+                let (result_ty, layout, enum_variant_info) = if let Some(dot_pos) = name.find('.') {
+                    let enum_name = &name[..dot_pos];
+                    let variant_name = &name[dot_pos + 1..];
+                    if let Some((idx, el)) = self.ctx.find_enum(enum_name) {
+                        let variant_info = el.variants.iter().find(|v| v.name == variant_name)
+                            .map(|v| (v.tag, v.payload_offset, v.fields.clone()));
+                        (MirType::Enum(EnumLayoutId(idx)), None, variant_info)
+                    } else if let Some((idx, sl)) = self.ctx.find_struct(name) {
+                        (MirType::Struct(StructLayoutId(idx)), Some(sl), None)
+                    } else {
+                        (MirType::Ptr, None, None)
+                    }
+                } else if let Some((idx, sl)) = self.ctx.find_struct(name) {
+                    (MirType::Struct(StructLayoutId(idx)), Some(sl), None)
                 } else {
-                    (MirType::Ptr, None)
+                    (MirType::Ptr, None, None)
                 };
 
                 let result_local = self.builder.alloc_temp(result_ty.clone());
+
+                // For enum variants, store the tag first
+                if let Some((tag, payload_offset, ref variant_fields)) = enum_variant_info {
+                    // Store discriminant tag at offset 0
+                    self.builder.push_stmt(MirStmt::Store {
+                        addr: result_local,
+                        offset: 0,
+                        value: MirOperand::Constant(MirConst::Int(tag as i64)),
+                        store_size: None,
+                    });
+                    // Store fields at their offsets within the payload
+                    for field in fields.iter() {
+                        let (val_op, _) = self.lower_expr(&field.value)?;
+                        let vf = variant_fields.iter()
+                            .find(|f| f.name == field.name);
+                        let offset = vf.map(|f| payload_offset + f.offset)
+                            .unwrap_or(payload_offset);
+                        let store_size = vf.map(|f| f.size);
+                        self.builder.push_stmt(MirStmt::Store {
+                            addr: result_local,
+                            offset,
+                            value: val_op,
+                            store_size,
+                        });
+                    }
+                } else {
                 for field in fields.iter() {
                     let (val_op, _) = self.lower_expr(&field.value)?;
-                    // Look up field offset from layout
-                    let offset = layout
-                        .and_then(|sl| sl.fields.iter().find(|f| f.name == field.name))
-                        .map(|f| f.offset)
-                        .unwrap_or(0);
+                    // Look up field offset and size from layout
+                    let field_layout = layout
+                        .and_then(|sl| sl.fields.iter().find(|f| f.name == field.name));
+                    let offset = field_layout.map(|f| f.offset).unwrap_or(0);
+                    let store_size = field_layout.map(|f| f.size);
                     self.builder.push_stmt(MirStmt::Store {
                         addr: result_local,
                         offset,
                         value: val_op,
+                        store_size,
                     });
 
                     // Propagate Vec element types from source var to struct field.
@@ -1784,6 +1913,7 @@ impl<'a> MirLowerer<'a> {
                         }
                     }
                 }
+                } // end else (non-enum-variant struct literal)
                 Ok((MirOperand::Local(result_local), result_ty))
             }
 
@@ -2036,6 +2166,7 @@ impl<'a> MirLowerer<'a> {
                             addr: result_local,
                             offset: i * elem_size,
                             value: val.clone(),
+                            store_size: None,
                         });
                     }
                     return Ok((MirOperand::Local(result_local), array_ty));
@@ -2538,6 +2669,9 @@ impl<'a> MirLowerer<'a> {
         let patterns_imply_enum = if !is_enum && !is_result_or_option {
             arms.iter().any(|arm| match &arm.pattern {
                 Pattern::Constructor { name, .. } => is_variant_name(name),
+                Pattern::Struct { name, .. } => {
+                    self.resolve_pattern_tag(name).is_some()
+                }
                 Pattern::Ident(name) => {
                     self.resolve_pattern_tag(name).is_some()
                         || matches!(name.as_str(), "Ok" | "Err" | "Some" | "None")
@@ -2612,6 +2746,13 @@ impl<'a> MirLowerer<'a> {
                         cases.push((*v as u64, arm_blocks[i]));
                     } else if let ExprKind::Bool(b) = &lit_expr.kind {
                         cases.push((if *b { 1 } else { 0 }, arm_blocks[i]));
+                    } else {
+                        cases.push((i as u64, arm_blocks[i]));
+                    }
+                }
+                Pattern::Struct { name, .. } => {
+                    if let Some(tag) = self.resolve_pattern_tag(name) {
+                        cases.push((tag, arm_blocks[i]));
                     } else {
                         cases.push((i as u64, arm_blocks[i]));
                     }
@@ -2718,9 +2859,11 @@ impl<'a> MirLowerer<'a> {
                     }
                 } else if let Pattern::Struct { name, fields, .. } = &arm.pattern {
                     // Named-field destructuring: Shape.Circle { radius }
+                    // Strip enum prefix: "Shape.Circle" → "Circle"
+                    let variant_name = name.rsplit('.').next().unwrap_or(name);
                     if let MirType::Enum(crate::types::EnumLayoutId(idx)) = &scrutinee_ty {
                         if let Some(layout) = self.ctx.enum_layouts.get(*idx as usize) {
-                            if let Some(variant) = layout.variants.iter().find(|v| v.name == *name) {
+                            if let Some(variant) = layout.variants.iter().find(|v| v.name == variant_name) {
                                 for (field_name, field_pat) in fields {
                                     if let Pattern::Ident(binding) = field_pat {
                                         if let Some((field_idx, field_layout)) = variant.fields.iter()
@@ -3618,6 +3761,7 @@ impl<'a> MirLowerer<'a> {
                 addr: state_ptr,
                 offset: 0,
                 value: MirOperand::Constant(crate::operand::MirConst::Int(0)),
+                store_size: None,
             });
 
             // Store captured variables into the state struct.
@@ -3630,6 +3774,7 @@ impl<'a> MirLowerer<'a> {
                         addr: state_ptr,
                         offset: state_offset,
                         value: MirOperand::Local(cap.local_id),
+                        store_size: None,
                     });
                 }
             }
@@ -3961,11 +4106,13 @@ impl<'a> MirLowerer<'a> {
             addr: out,
             offset: 0,
             value: MirOperand::Constant(MirConst::Int(1)),
+            store_size: None,
         });
         self.builder.push_stmt(MirStmt::Store {
             addr: out,
             offset: 8,
             value: MirOperand::Local(new_err),
+            store_size: None,
         });
         self.builder.terminate(MirTerminator::Goto { target: merge_block });
 
@@ -4027,22 +4174,26 @@ impl<'a> MirLowerer<'a> {
             addr: wrapped,
             offset: 0,
             value: MirOperand::Constant(MirConst::Int(constructor_tag)),
+            store_size: None,
         });
         self.builder.push_stmt(MirStmt::Store {
             addr: wrapped,
             offset: 8,
             value: MirOperand::Local(err_payload),
+            store_size: None,
         });
         // Re-wrap as Err(wrapped)
         self.builder.push_stmt(MirStmt::Store {
             addr: out,
             offset: 0,
             value: MirOperand::Constant(MirConst::Int(1)), // Err tag
+            store_size: None,
         });
         self.builder.push_stmt(MirStmt::Store {
             addr: out,
             offset: 8,
             value: MirOperand::Local(wrapped),
+            store_size: None,
         });
         self.builder.terminate(MirTerminator::Goto { target: merge_block });
 
@@ -4077,6 +4228,7 @@ impl<'a> MirLowerer<'a> {
                 addr: arr_local,
                 offset: i as u32 * elem_size,
                 value: op,
+                store_size: None,
             });
         }
 
@@ -4401,6 +4553,7 @@ impl<'a> MirLowerer<'a> {
                 addr: result,
                 offset: field.offset,
                 value: MirOperand::Local(field_val),
+                store_size: None,
             });
         }
 
@@ -4493,6 +4646,123 @@ impl<'a> MirLowerer<'a> {
                 _ => return None, // Chain must be method calls all the way down
             }
         }
+    }
+
+    /// Clone function name for a type, or None if the type is Copy.
+    fn clone_fn_for_type(ty: &rask_types::Type) -> Option<&'static str> {
+        match ty {
+            rask_types::Type::String => Some("string_clone"),
+            rask_types::Type::UnresolvedNamed(n) if n == "string" => Some("string_clone"),
+            rask_types::Type::UnresolvedGeneric { name, .. } if name == "Vec" => Some("Vec_clone"),
+            rask_types::Type::UnresolvedGeneric { name, .. } if name == "Map" => Some("Map_clone"),
+            _ => None,
+        }
+    }
+
+    /// Emit inline clone for an enum value: shallow copy the full block,
+    /// then switch on the tag to deep-clone heap fields per variant.
+    fn lower_enum_clone(
+        &mut self,
+        layout: &rask_mono::EnumLayout,
+        src: &MirOperand,
+        obj_ty: MirType,
+    ) -> Result<TypedOperand, LoweringError> {
+        let result = self.builder.alloc_temp(obj_ty.clone());
+
+        // Shallow copy: copy each 8-byte word from src to result
+        let num_words = (layout.size as u32 + 7) / 8;
+        for i in 0..num_words {
+            let offset = i * 8;
+            let word = self.builder.alloc_temp(MirType::I64);
+            self.builder.push_stmt(MirStmt::Assign {
+                dst: word,
+                rvalue: MirRValue::Field {
+                    base: src.clone(),
+                    field_index: offset,
+                    byte_offset: None,
+                    field_size: None,
+                },
+            });
+            self.builder.push_stmt(MirStmt::Store {
+                addr: result,
+                offset,
+                value: MirOperand::Local(word),
+                store_size: None,
+            });
+        }
+
+        // Check if any variant has heap fields needing deep clone
+        let needs_switch = layout.variants.iter().any(|v| {
+            v.fields.iter().any(|f| Self::clone_fn_for_type(&f.ty).is_some())
+        });
+
+        if needs_switch {
+            // Read the tag
+            let tag = self.builder.alloc_temp(MirType::I64);
+            self.builder.push_stmt(MirStmt::Assign {
+                dst: tag,
+                rvalue: MirRValue::Field {
+                    base: MirOperand::Local(result),
+                    field_index: layout.tag_offset,
+                    byte_offset: None,
+                    field_size: None,
+                },
+            });
+
+            let exit_block = self.builder.create_block();
+            let mut cases = Vec::new();
+
+            for variant in &layout.variants {
+                let has_heap = variant.fields.iter().any(|f| Self::clone_fn_for_type(&f.ty).is_some());
+                if !has_heap {
+                    // No heap fields — shallow copy is sufficient, skip
+                    continue;
+                }
+                let vblock = self.builder.create_block();
+                cases.push((variant.tag as u64, vblock));
+
+                self.builder.switch_to_block(vblock);
+                for field in &variant.fields {
+                    if let Some(cfn) = Self::clone_fn_for_type(&field.ty) {
+                        let abs_offset = variant.payload_offset + field.offset;
+                        let field_val = self.builder.alloc_temp(MirType::I64);
+                        self.builder.push_stmt(MirStmt::Assign {
+                            dst: field_val,
+                            rvalue: MirRValue::Field {
+                                base: MirOperand::Local(result),
+                                field_index: abs_offset,
+                                byte_offset: None,
+                                field_size: None,
+                            },
+                        });
+                        let cloned = self.builder.alloc_temp(MirType::I64);
+                        self.builder.push_stmt(MirStmt::Call {
+                            dst: Some(cloned),
+                            func: FunctionRef::internal(cfn.to_string()),
+                            args: vec![MirOperand::Local(field_val)],
+                        });
+                        self.builder.push_stmt(MirStmt::Store {
+                            addr: result,
+                            offset: abs_offset,
+                            value: MirOperand::Local(cloned),
+                            store_size: None,
+                        });
+                    }
+                }
+                self.builder.terminate(MirTerminator::Goto { target: exit_block });
+            }
+
+            // Default case (variants with no heap fields) goes straight to exit
+            self.builder.terminate(MirTerminator::Switch {
+                value: MirOperand::Local(tag),
+                cases,
+                default: exit_block,
+            });
+
+            self.builder.switch_to_block(exit_block);
+        }
+
+        Ok((MirOperand::Local(result), obj_ty))
     }
 
     /// Try to handle an iterator terminal method (.collect, .fold, .any, etc.)
@@ -4765,12 +5035,14 @@ impl<'a> MirLowerer<'a> {
                         addr: tuple_local,
                         offset: 0,
                         value: MirOperand::Local(idx),
+                        store_size: None,
                     });
                     // field 1: element (offset 8, aligned)
                     self.builder.push_stmt(MirStmt::Store {
                         addr: tuple_local,
                         offset: 8,
                         value: current_op,
+                        store_size: None,
                     });
                     current_op = MirOperand::Local(tuple_local);
                     current_ty = tuple_ty;
@@ -4883,11 +5155,25 @@ impl<'a> MirLowerer<'a> {
                 });
                 self.locals.insert(elem_name.clone(), (elem_param, final_ty));
 
+                // A continue block for after the inlined body finishes normally
+                let after_body = self.builder.create_block();
+
+                // Redirect `return` inside the closure to assign to acc and continue the loop
+                let saved_return_target = self.inline_return_target.take();
+                self.inline_return_target = Some((acc, setup.inc_block));
+
                 let (result_op, _) = self.lower_expr(body)?;
+
+                self.inline_return_target = saved_return_target;
+
+                // Normal (non-return) path: assign result to acc
                 self.builder.push_stmt(MirStmt::Assign {
                     dst: acc,
                     rvalue: MirRValue::Use(result_op),
                 });
+                self.builder.terminate(MirTerminator::Goto { target: after_body });
+
+                self.builder.switch_to_block(after_body);
 
                 self.locals.remove(acc_name);
                 self.locals.remove(elem_name);
@@ -5061,13 +5347,14 @@ impl<'a> MirLowerer<'a> {
         chain: &super::IterChain<'_>,
         predicate: &Expr,
     ) -> Result<TypedOperand, LoweringError> {
-        // Result: Option represented as Ptr (tag 0 = Some, tag 1 = None)
-        let result = self.builder.alloc_temp(MirType::Ptr);
+        // Result: Option<I64> (tag at offset 0, payload at offset 8)
+        let result = self.builder.alloc_temp(MirType::Option(Box::new(MirType::I64)));
         // Start as None (tag = 1)
         self.builder.push_stmt(MirStmt::Store {
             addr: result,
             offset: 0,
             value: MirOperand::Constant(MirConst::Int(1)),
+            store_size: None,
         });
 
         let setup = self.setup_iter_chain_loop(chain)?;
@@ -5090,17 +5377,19 @@ impl<'a> MirLowerer<'a> {
             addr: result,
             offset: 0,
             value: MirOperand::Constant(MirConst::Int(0)), // Some tag
+            store_size: None,
         });
         self.builder.push_stmt(MirStmt::Store {
             addr: result,
             offset: 8,
             value: final_op,
+            store_size: None,
         });
         self.builder.terminate(MirTerminator::Goto { target: setup.exit_block });
 
         self.emit_iter_increment(setup.idx, setup.inc_block, setup.check_block);
         self.builder.switch_to_block(setup.exit_block);
-        Ok((MirOperand::Local(result), MirType::Ptr))
+        Ok((MirOperand::Local(result), MirType::Option(Box::new(MirType::I64))))
     }
 }
 

--- a/compiler/crates/rask-mir/src/lower/mod.rs
+++ b/compiler/crates/rask-mir/src/lower/mod.rs
@@ -161,6 +161,19 @@ impl<'a> MirContext<'a> {
             .map(|(i, s)| (i as u32, s))
     }
 
+    /// Size in bytes for a MirType. Struct/Enum sizes come from layouts; scalars are 8.
+    pub fn mir_type_size(&self, ty: &MirType) -> u32 {
+        match ty {
+            MirType::Struct(StructLayoutId(id)) => {
+                self.struct_layouts.get(*id as usize).map_or(8, |s| s.size)
+            }
+            MirType::Enum(EnumLayoutId(id)) => {
+                self.enum_layouts.get(*id as usize).map_or(8, |e| e.size)
+            }
+            _ => 8,
+        }
+    }
+
     pub fn find_enum(&self, name: &str) -> Option<(u32, &EnumLayout)> {
         self.enum_layouts
             .iter()
@@ -238,6 +251,15 @@ impl<'a> MirContext<'a> {
                     MirType::Struct(StructLayoutId(idx))
                 } else if let Some((idx, _)) = self.find_enum(name) {
                     MirType::Enum(EnumLayoutId(idx))
+                } else if let Some(base) = name.split('<').next() {
+                    // Generic type like "Box<i64>" — try base name "Box"
+                    if let Some((idx, _)) = self.find_struct(base) {
+                        MirType::Struct(StructLayoutId(idx))
+                    } else if let Some((idx, _)) = self.find_enum(base) {
+                        MirType::Enum(EnumLayoutId(idx))
+                    } else {
+                        MirType::Ptr
+                    }
                 } else {
                     MirType::Ptr
                 }
@@ -476,6 +498,10 @@ pub struct MirLowerer<'a> {
     /// W2a/W2b: Active `with` pool bindings for re-resolution after pool mutators.
     /// Maps pool variable name → Vec of (handle_local, binding_local, pool_local).
     with_pool_bindings: HashMap<String, Vec<(LocalId, LocalId, LocalId)>>,
+    /// When set, `return expr` inside an inlined closure body assigns to the
+    /// target local and jumps to the continuation block instead of emitting
+    /// MirTerminator::Return.  Used by fold/reduce/etc.
+    inline_return_target: Option<(LocalId, BlockId)>,
 }
 
 impl<'a> MirLowerer<'a> {
@@ -662,6 +688,7 @@ impl<'a> MirLowerer<'a> {
             channel_elem_sizes: HashMap::new(),
             local_full_type: HashMap::new(),
             with_pool_bindings: HashMap::new(),
+            inline_return_target: None,
         };
 
         // Resolve Self type from function name: "Document_delete_line" → "Document"
@@ -700,11 +727,16 @@ impl<'a> MirLowerer<'a> {
                     let elem_mir = ctx.resolve_type_str(elem_str);
                     lowerer.collection_elem_types.insert(param.name.clone(), elem_mir);
                 }
+                if let Some(elem_str) = param_ty_str.strip_prefix("Pool<").and_then(|s| s.strip_suffix('>')) {
+                    let elem_mir = ctx.resolve_type_str(elem_str);
+                    lowerer.collection_elem_types.insert(param.name.clone(), elem_mir);
+                }
             }
 
             // Function-type params (|args| -> ret) are closures passed as arguments.
             // Register them so call sites emit ClosureCall instead of Call.
-            if param_ty_str.starts_with('|') {
+            // Parser normalizes |T| -> R to "func(T) -> R", so check both forms.
+            if param_ty_str.starts_with('|') || param_ty_str.starts_with("func(") {
                 lowerer.closure_locals.insert(param.name.clone());
                 let ret_ty = if let Some(arrow_pos) = param_ty_str.rfind("-> ") {
                     let ret_str = param_ty_str[arrow_pos + 3..].trim();
@@ -1442,6 +1474,7 @@ fn func_return_type_prefix(func_name: &str) -> Option<&'static str> {
         | "string_lines" | "string_split" | "string_split_whitespace"
         | "Map_keys" | "Map_values" => Some("Vec"),
         "Vec_pop" | "Vec_get" | "Map_get" => Some("Option"),
+        "Thread_spawn" => Some("ThreadHandle"),
         "Shared_clone" => Some("Shared"),
         "Mutex_new" => Some("Mutex"),
         "Sender_clone" => Some("Sender"),
@@ -1481,9 +1514,22 @@ fn stdlib_return_mir_type(func_name: &str) -> MirType {
         // handle into a Result stack slot (tag at offset 0, payload at 8).
         // Without this, field extraction uses offset 0 (the tag) instead
         // of 8, returning wrong handle values for non-first inserts.
-        "Pool_insert" => return MirType::Result {
+        "Pool_alloc" | "Pool_insert" => return MirType::Result {
             ok: Box::new(MirType::I64),
             err: Box::new(MirType::I64),
+        },
+        "Map_get" => return MirType::Option(Box::new(MirType::I64)),
+        "ThreadHandle_join" | "Thread_join" => return MirType::Result {
+            ok: Box::new(MirType::I64),
+            err: Box::new(MirType::String),
+        },
+        "string_parse_i32" | "string_parse_i64" | "string_parse_int" => return MirType::Result {
+            ok: Box::new(MirType::I64),
+            err: Box::new(MirType::String),
+        },
+        "string_parse_f64" | "string_parse_float" | "string_parse" => return MirType::Result {
+            ok: Box::new(MirType::F64),
+            err: Box::new(MirType::String),
         },
         _ => {}
     }
@@ -1502,6 +1548,7 @@ fn stdlib_return_mir_type(func_name: &str) -> MirType {
     // String-returning functions
     if func_name == "string_new" || func_name == "string_from"
         || func_name == "string_clone"
+        || func_name == "Vec_join" || func_name == "Vec_join_i64"
         || func_name.ends_with("_to_string") || func_name.ends_with("_to_uppercase")
         || func_name.ends_with("_to_lowercase") || func_name.ends_with("_trim")
         || func_name.ends_with("_trim_start") || func_name.ends_with("_trim_end")

--- a/compiler/crates/rask-mir/src/lower/stmt.rs
+++ b/compiler/crates/rask-mir/src/lower/stmt.rs
@@ -81,7 +81,19 @@ impl<'a> MirLowerer<'a> {
                 } else {
                     None
                 };
-                self.builder.terminate(MirTerminator::Return { value });
+                // Inside an inlined closure (e.g. fold callback), redirect
+                // return to an assignment + goto instead of a real return.
+                if let Some((dst_local, cont_block)) = self.inline_return_target {
+                    if let Some(val) = value {
+                        self.builder.push_stmt(MirStmt::Assign {
+                            dst: dst_local,
+                            rvalue: MirRValue::Use(val),
+                        });
+                    }
+                    self.builder.terminate(MirTerminator::Goto { target: cont_block });
+                } else {
+                    self.builder.terminate(MirTerminator::Return { value });
+                }
                 Ok(())
             }
 
@@ -111,7 +123,13 @@ impl<'a> MirLowerer<'a> {
                             } else { 0 }
                         } else if let Some((_, _, Some(bo), _)) = Self::resolve_tuple_field(&obj_ty, field) {
                             bo
-                        } else { 0 };
+                        } else {
+                            // Base is a raw pointer (I64/Ptr) — field offset unknown.
+                            // With correct element type tracking, pool[h] and pool.get(h)
+                            // return Struct-typed results so this path shouldn't fire
+                            // for pool operations.
+                            0
+                        };
                         let base_local = match obj_op {
                             MirOperand::Local(id) => id,
                             _ => {
@@ -127,6 +145,7 @@ impl<'a> MirLowerer<'a> {
                             addr: base_local,
                             offset,
                             value: val_op,
+                            store_size: None,
                         });
                     }
                     // Index assignment: a[i] = val
@@ -171,6 +190,7 @@ impl<'a> MirLowerer<'a> {
                             addr: addr_local,
                             offset: 0,
                             value: val_op,
+                            store_size: None,
                         });
                     }
                     _ => {
@@ -462,6 +482,21 @@ impl<'a> MirLowerer<'a> {
                 }
             }
         }
+        // Track element type for Pool<T>.new() constructors:
+        // const pool = Pool<Node>.new() → collection_elem_types["pool"] = Struct(Node)
+        if let ExprKind::MethodCall { object, method, .. } = &init.kind {
+            if let ExprKind::Ident(obj_name) = &object.kind {
+                let base_name = obj_name.split('<').next().unwrap_or(obj_name);
+                if base_name == "Pool" && method == "new" {
+                    if let Some(inner) = obj_name.split('<').nth(1).and_then(|s| s.strip_suffix('>')) {
+                        let elem_mir = self.ctx.resolve_type_str(inner);
+                        if !matches!(elem_mir, MirType::Ptr | MirType::I64) {
+                            self.collection_elem_types.insert(name.to_string(), elem_mir);
+                        }
+                    }
+                }
+            }
+        }
         // Iterator terminal .collect() returns a Vec
         if let ExprKind::MethodCall { method, .. } = &init.kind {
             if method == "collect" {
@@ -506,6 +541,17 @@ impl<'a> MirLowerer<'a> {
             let closure_fn = format!("{}__closure_{}", self.parent_name, self.closure_counter - 1);
             if let Some(sig) = self.func_sigs.get(&closure_fn).cloned() {
                 self.func_sigs.insert(name.to_string(), sig);
+            }
+        }
+
+        // Track locals assigned from calls that return closure types.
+        // e.g., `const add_5 = make_adder(5)` where make_adder returns |i32| -> i32.
+        // Check via type checker's node_types: if init expr has Type::Fn, it's a closure.
+        if !is_closure {
+            if let Some(rask_types::Type::Fn { ret, .. }) = self.ctx.node_types.get(&init.id) {
+                self.closure_locals.insert(name.to_string());
+                let ret_mir = self.ctx.type_to_mir(ret);
+                self.func_sigs.insert(name.to_string(), super::FuncSig { ret_ty: ret_mir });
             }
         }
 
@@ -1286,4 +1332,5 @@ impl<'a> MirLowerer<'a> {
         self.builder.switch_to_block(setup.exit_block);
         Ok(())
     }
+
 }

--- a/compiler/crates/rask-mir/src/stmt.rs
+++ b/compiler/crates/rask-mir/src/stmt.rs
@@ -15,6 +15,9 @@ pub enum MirStmt {
         addr: LocalId,
         offset: u32,
         value: MirOperand,
+        /// Byte size of the store (e.g. 4 for f32, 1 for bool).
+        /// When None, codegen uses the natural size of the value.
+        store_size: Option<u32>,
     },
     Call {
         dst: Option<LocalId>,

--- a/compiler/crates/rask-mir/src/transform/state_machine.rs
+++ b/compiler/crates/rask-mir/src/transform/state_machine.rs
@@ -549,6 +549,7 @@ fn generate_poll_fn(
                         addr: state_ptr,
                         offset: field.offset,
                         value: MirOperand::Local(new_id),
+                        store_size: None,
                     });
                 }
             }
@@ -558,6 +559,7 @@ fn generate_poll_fn(
                 addr: state_ptr,
                 offset: 0,
                 value: MirOperand::Constant(MirConst::Int((seg_idx + 1) as i64)),
+                store_size: None,
             });
 
             builder.terminate(MirTerminator::Return {
@@ -601,10 +603,11 @@ fn remap_stmt(
             dst: remap_id(*dst, map),
             rvalue: remap_rvalue(rvalue, map),
         },
-        MirStmt::Store { addr, offset, value } => MirStmt::Store {
+        MirStmt::Store { addr, offset, value, store_size } => MirStmt::Store {
             addr: remap_id(*addr, map),
             offset: *offset,
             value: remap_operand(value, map),
+            store_size: *store_size,
         },
         MirStmt::Call { dst, func, args } => MirStmt::Call {
             dst: dst.map(|d| remap_id(d, map)),

--- a/compiler/crates/rask-mono/src/layout.rs
+++ b/compiler/crates/rask-mono/src/layout.rs
@@ -190,6 +190,12 @@ fn align_up(val: u32, align: u32) -> u32 {
 pub(crate) fn parse_field_type(s: &str) -> Type {
     let s = s.trim();
 
+    // Option shorthand: T? → Option<T>
+    if s.ends_with('?') {
+        let inner = parse_field_type(&s[..s.len() - 1]);
+        return Type::Option(Box::new(inner));
+    }
+
     // Result type: "T or E"
     if let Some(idx) = s.find(" or ") {
         let ok = parse_field_type(&s[..idx]);

--- a/compiler/crates/rask-mono/src/lib.rs
+++ b/compiler/crates/rask-mono/src/lib.rs
@@ -191,12 +191,6 @@ pub fn monomorphize_with_packages(
     mono.run();
 
     // Compute layouts for concrete (non-generic) struct/enum types.
-    // Generic types need concrete type_args for correct field sizes;
-    // their layouts are computed per-instantiation, not here.
-    // Layout cache lets structs reference other user-defined types.
-    //
-    // Topological sort ensures types are processed after their dependencies,
-    // so a struct referencing an enum declared later gets the correct layout.
     let mut layout_cache = LayoutCache::new();
     let mut struct_layouts = Vec::new();
     let mut enum_layouts = Vec::new();
@@ -219,6 +213,37 @@ pub fn monomorphize_with_packages(
                 let layout = compute_union_layout(decl, &layout_cache);
                 layout_cache.insert(u.name.clone(), (layout.size, layout.align));
                 struct_layouts.push(layout);
+            }
+            _ => {}
+        }
+    }
+
+    // Compute layouts for generic struct/enum types. The 8-byte-everything
+    // layout model means all scalar type parameters produce the same field
+    // sizes, so a single layout per generic struct suffices. Use i64 as the
+    // placeholder type for each type parameter.
+    for decl in decls {
+        match &decl.kind {
+            DeclKind::Struct(s) if !s.type_params.is_empty() => {
+                let placeholder_args: Vec<Type> = s.type_params.iter()
+                    .map(|_| Type::I64)
+                    .collect();
+                let mut layout = compute_struct_layout(decl, &placeholder_args, &layout_cache);
+                // Strip type params from name so struct literals ("Box") match
+                let base_name = s.name.split('<').next().unwrap_or(&s.name).to_string();
+                layout.name = base_name.clone();
+                layout_cache.insert(base_name, (layout.size, layout.align));
+                struct_layouts.push(layout);
+            }
+            DeclKind::Enum(e) if !e.type_params.is_empty() => {
+                let placeholder_args: Vec<Type> = e.type_params.iter()
+                    .map(|_| Type::I64)
+                    .collect();
+                let mut layout = compute_enum_layout(decl, &placeholder_args, &layout_cache);
+                let base_name = e.name.split('<').next().unwrap_or(&e.name).to_string();
+                layout.name = base_name.clone();
+                layout_cache.insert(base_name, (layout.size, layout.align));
+                enum_layouts.push(layout);
             }
             _ => {}
         }

--- a/compiler/crates/rask-mono/src/reachability.rs
+++ b/compiler/crates/rask-mono/src/reachability.rs
@@ -76,11 +76,23 @@ fn register_method(
         kind: DeclKind::Fn(method.clone()),
         span: parent_decl.span,
     };
-    method_table.insert(qualified.clone(), wrapped);
+    method_table.insert(qualified.clone(), wrapped.clone());
     method_by_bare_name
         .entry(method.name.clone())
         .or_default()
-        .push(qualified);
+        .push(qualified.clone());
+
+    // For generic types like Box<T>, also register under the stripped name (Box_new)
+    // so MIR calls that strip generic params can resolve the method.
+    let base = type_name.split('<').next().unwrap_or(type_name);
+    if base != type_name {
+        let stripped = format!("{}_{}", base, method.name);
+        method_table.entry(stripped.clone()).or_insert(wrapped);
+        method_by_bare_name
+            .entry(method.name.clone())
+            .or_default()
+            .push(stripped);
+    }
 }
 
 impl<'a> Monomorphizer<'a> {

--- a/compiler/runtime/vec.c
+++ b/compiler/runtime/vec.c
@@ -203,6 +203,21 @@ RaskString *rask_vec_join(const RaskVec *src, const RaskString *sep) {
     return result;
 }
 
+// join(vec_of_ints, separator) — convert integers to strings and concatenate.
+RaskString *rask_vec_join_i64(const RaskVec *src, const RaskString *sep) {
+    RaskString *result = rask_string_new();
+    if (!src || src->len == 0) return result;
+    for (int64_t i = 0; i < src->len; i++) {
+        if (i > 0 && sep) {
+            rask_string_append(result, sep);
+        }
+        int64_t val = *(int64_t *)(src->data + i * src->elem_size);
+        RaskString *s = rask_i64_to_string(val);
+        rask_string_append(result, s);
+    }
+    return result;
+}
+
 // slice(vec, start, end) — returns a new Vec with elements [start..end).
 RaskVec *rask_vec_slice(const RaskVec *src, int64_t start, int64_t end) {
     if (!src) return rask_vec_new(8);


### PR DESCRIPTION
## Summary
This PR enhances the MIR lowerer and codegen to properly handle aggregate types (structs, enums, arrays), improve Pool collection support with correct element sizing, and fix generic type resolution. The changes ensure that stack-allocated aggregates are correctly sized and that Pool operations work with struct elements.

## Key Changes

### Aggregate Type Handling
- Added `store_size` field to `MirStmt::Store` to track the byte size of stored values, enabling proper handling of sub-8-byte types (f32, i8, etc.) that need widening to fill 8-byte stack slots
- Implemented `is_aggregate_field_type()` to identify which struct fields use stack-slot (aggregate) representation in codegen, ensuring correct load/store behavior
- Fixed field access to return pointers for aggregate fields rather than loading values, preventing data corruption

### Pool Collection Support
- Added element size injection for `Pool.new()` constructors so pools allocate correctly-sized slots for struct elements
- Implemented `Pool_get` return type inference to properly construct `Option<T>` where T is the tracked element type
- Fixed Pool access to always return pointers (for mutation) rather than loaded values
- Updated Pool slot stride calculation to use dynamic stride from pool metadata instead of hardcoded shift

### Generic Type Resolution
- Added layout computation for generic struct/enum types using i64 as placeholder for type parameters
- Implemented generic type name stripping (e.g., "Box<T>" → "Box") for struct literal matching and method resolution
- Fixed `resolve_type_str()` to handle generic types by extracting base name and looking up layouts

### Enum and Result/Option Improvements
- Enhanced enum variant constructor support in struct literals ("EnumName.VariantName { ... }")
- Improved `Some`/`Ok`/`Err` constructor type inference to use actual payload types instead of defaulting to i64
- Added enum clone support with tag copying and per-variant heap field deep-cloning
- Fixed pattern matching to recognize enum variant constructors in struct pattern form

### Method Call Optimizations
- Implemented `Vec_join_i64` for joining vectors of integers (non-string elements)
- Added `Pool_alloc` → `Pool_insert` rewriting to properly handle pool insertion
- Fixed `Map_get().unwrap()` optimization to only apply to Map, not Pool

### Codegen Improvements
- Added `CallAdapt::DerefOption` to handle functions returning `Option<T>` as void* (NULL → None, non-NULL → Some)
- Improved internal function result handling to store directly into stack slots for ≤8-byte aggregates
- Fixed field type resolution to prefer type checker information for generic/unresolved types

### Type Tracking
- Extended element type tracking to Pool collections alongside Vec and Map
- Improved type inference for collection operations to use tracked element types

## Notable Implementation Details
- Stack slots now use 8-byte alignment for all scalars; sub-8-byte values are widened to prevent reading stale upper bytes
- Pool layout now includes dynamic stride at offset 16, allowing variable-sized elements
- Generic type layouts use i64 as placeholder since the 8-byte-everything model makes all scalar parameters equivalent
- Enum variant constructors in struct literal syntax are now properly recognized and lowered with correct tag and field offsets

https://claude.ai/code/session_01619AyYko5WQsr9SP7sD2wm