### PR TITLE
Make strings Copy and update documentation accordingly

### DIFF
--- a/LANGUAGE_GUIDE.md
+++ b/LANGUAGE_GUIDE.md
@@ -155,8 +155,8 @@ up. This is the most fundamental rule.
 
 ### Small Values Copy, Big Values Move
 
-Here's the key insight: some things are cheap to copy (a number, a coordinate, a color),
-and some things are expensive (a big string, a list of 10,000 items).
+Here's the key insight: some things are cheap to copy (a number, a coordinate, a string),
+and some things are expensive (a list of 10,000 items, a large struct).
 
 Rask draws the line at **16 bytes**:
 
@@ -167,15 +167,18 @@ const b = a           // b gets a copy. a is still valid.
 use(a)                // ✓ Fine
 
 // Big (>16 bytes): moves
-const name = "hello world"                 // string > 16 bytes (heap allocated)
-const other = name                         // other takes ownership. name is GONE.
-use(name)                                  // ✗ Compile error: name was moved
+const names = Vec.from(["alice", "bob"])   // Vec owns heap data
+const other = names                        // other takes ownership. names is GONE.
+use(names)                                 // ✗ Compile error: names was moved
 ```
+
+Strings are Copy too — `string` is 16 bytes (immutable, refcounted) and copies like a
+number. See [String Handling](#string-handling) for details.
 
 **Why 16 bytes?** It matches what most CPUs can pass in registers. Copying 16 bytes is
 essentially free—it's what the hardware does anyway for function calls. This covers
-integers, floats, booleans, small structs like `Point { x: f64, y: f64 }`, small enums,
-and handles.
+integers, floats, booleans, strings, small structs like `Point { x: f64, y: f64 }`,
+small enums, and handles.
 
 **Why not let the programmer choose the threshold?** Because changing it changes what
 your code means. If you set it to 8 bytes, a `Point { x: f64, y: f64 }` would suddenly
@@ -187,9 +190,9 @@ predictable.
 If you genuinely need two copies of a big value, say so explicitly:
 
 ```rask
-const name = "hello"
-const backup = name.clone()    // Allocates new memory, copies bytes
-use(name)                      // ✓ Both are valid
+const names = Vec.from(["alice", "bob"])
+const backup = names.clone()   // Allocates new memory, copies elements
+use(names)                     // ✓ Both are valid
 use(backup)                    // ✓ Independent copies
 ```
 
@@ -368,7 +371,7 @@ func apply_buff(pool: Pool<Entity>, h: Handle<Entity>) -> () or Error {
 `with` also works as an expression—the last expression in the block is the value:
 
 ```rask
-const name = with pool[h] as const entity { entity.name.clone() }
+const name = with pool[h] as entity { entity.name }
 ```
 
 One-liner shorthand (parallels `if cond: expr`):

--- a/README.md
+++ b/README.md
@@ -129,7 +129,7 @@ I'm not pretending there aren't tradeoffs. Here's what you give up:
 - String slices in structs → store indices or use StringPool
 - Arbitrary graphs → use Pool<T> with handles
 
-**More `.clone()` calls:** In string-heavy code (CLI parsing, HTTP routing) you'll see ~5% of lines with an explicit clone. I think that's better than lifetime annotations everywhere.
+**More `.clone()` calls:** Collections and large structs require explicit `.clone()` to share. Strings are Copy (no cloning needed), so clones concentrate at API boundaries for collection types. I think that's better than lifetime annotations everywhere.
 
 The upside, if the approach works out:
 - No use-after-free, no dangling pointers, no data races

--- a/docs/blog/_posts/2026-02-20-the-soul-of-rask.md
+++ b/docs/blog/_posts/2026-02-20-the-soul-of-rask.md
@@ -32,9 +32,11 @@ In C++, `auto result = greeting + " " + name` creates two temporary strings and 
 Rask doesn't do this. Large values move, not copy. If you want a copy, you write `.clone()`. Operators don't allocate behind your back. When something is expensive, you can see it in the code:
 
 ```rask
-const name = user.name.clone()                  // explicit: this copies
+const items = user.inventory.clone()            // explicit: this copies
 process(own user)                               // explicit: ownership transferred
 ```
+
+Strings are the deliberate exception — `string` is immutable, refcounted, and Copy (16 bytes). It copies like an integer, no `.clone()` needed. I think that's fine because immutability eliminates aliased mutation risk, and the compiler elides most refcount operations anyway.
 
 This is transparency winning over convenience. Some languages let you write `a + b` on strings and hide the allocation inside the operator. I'd rather make you call a function that says what it does.
 

--- a/specs/compiler/clone-elision.md
+++ b/specs/compiler/clone-elision.md
@@ -11,15 +11,15 @@ When a `.clone()` call is the last use of a value, the compiler replaces the clo
 
 ## The Problem
 
-Rask's "no storable references" design means more `.clone()` calls than Rust. The spec acknowledges this (~5% of lines in string-heavy code). But many clones are unnecessary:
+Rask's "no storable references" design means more `.clone()` calls than Rust. With strings now Copy (immutable, refcounted), the remaining clones concentrate on collections (`Vec`, `Map`). But many clones are unnecessary:
 
 ```rask
-const path = config.path.clone()
-do_something(path)
-// config.path is never used again — the clone was pointless
+const items = config.items.clone()
+do_something(items)
+// config.items is never used again — the clone was pointless
 ```
 
-The compiler can see that `config.path` has no subsequent uses. The clone allocates and copies data that was about to be dropped anyway.
+The compiler can see that `config.items` has no subsequent uses. The clone allocates and copies data that was about to be dropped anyway.
 
 ## Rules
 
@@ -38,9 +38,9 @@ The compiler can see that `config.path` has no subsequent uses. The clone alloca
 <!-- test: skip -->
 ```rask
 func process(config: Config) {
-    const name = config.name.clone()   // [clone elided → move]
-    send(name)
-    // config.name never used again → clone becomes move
+    const items = config.items.clone()   // [clone elided → move]
+    send(items)
+    // config.items never used again → clone becomes move
 }
 ```
 

--- a/specs/concurrency/sync.md
+++ b/specs/concurrency/sync.md
@@ -44,7 +44,7 @@ let config = Shared.new(AppConfig {
 // Inline access (single expression)
 const timeout = config.read().timeout
 config.write().timeout = 60.seconds
-const name = config.read().user.name.clone()
+const name = config.read().user.name
 
 // Multi-statement access (with block)
 const timeout = with config.read() as c { c.timeout }

--- a/specs/memory/allocators.md
+++ b/specs/memory/allocators.md
@@ -69,7 +69,7 @@ Unnamed (`using Allocator`) is enough when you only need collections to auto-res
 func build_index(items: Vec<Item>) -> Map<string, Item> using Allocator {
     const map = Map.new()    // uses the caller's allocator
     for item in items {
-        map.insert(item.name.clone(), item)
+        map.insert(item.name, item)
     }
     return map
 }

--- a/specs/memory/borrowing.md
+++ b/specs/memory/borrowing.md
@@ -132,7 +132,7 @@ pool[h].pos.normalize()      // Method chain (E2)
 <!-- test: skip -->
 ```rask
 const timeout = config.read().timeout           // Copy out (E4)
-const name = config.read().user.name.clone()    // Clone non-Copy
+const name = config.read().user.name             // Copy out (string is Copy)
 config.write().timeout = 60.seconds             // In-place mutation (E3)
 queue.lock().push(item)                         // Mutex inline access
 
@@ -192,7 +192,7 @@ with pool[h1] as e1, pool[h2] as e2 {
 }
 
 // Expression context — produces a value
-const name = with pool[h] as entity { entity.name.clone() }
+const name = with pool[h] as entity { entity.name }
 
 // One-liner shorthand
 with pool[h] as e: e.health -= 10

--- a/specs/memory/closures.md
+++ b/specs/memory/closures.md
@@ -151,19 +151,21 @@ A closure that captures a block-scoped borrow (struct field, array view) inherit
 <!-- test: skip -->
 ```rask
 const entity = get_entity()
-const name = entity.name            // block-scoped borrow (struct field)
-const f = || process(name)         // f inherits scope constraint
+const tags = entity.tags            // block-scoped borrow (struct field, non-Copy)
+const f = || process(tags)         // f inherits scope constraint
 f()                                 // OK: called in same scope
 return f                            // ERROR: cannot escape scope
 ```
+
+Note: Copy fields like `string` don't create scope-limited closures — `const name = entity.name` produces an owned copy, not a borrow. Only non-Copy fields (like `Vec<string>`) create block-scoped borrows that limit closures.
 
 <!-- test: compile-fail -->
 ```rask
 let outer_closure
 {
     const entity = get_entity()
-    const name = entity.name
-    outer_closure = || process(name)  // ERROR: outer_closure outlives entity
+    const tags = entity.tags
+    outer_closure = || process(tags)  // ERROR: outer_closure outlives entity
 }
 ```
 
@@ -171,8 +173,8 @@ let outer_closure
 
 <!-- test: skip -->
 ```rask
-const name = entity.name.clone()   // owned copy
-const f = || process(name)         // captures owned value
+const tags = entity.tags.clone()   // owned copy
+const f = || process(tags)         // captures owned value
 return f                            // OK: no scope constraint
 ```
 
@@ -195,8 +197,8 @@ func store_callback<F: Fn()>(f: F) {
     const holder = Holder { callback: f }  // ERROR if F is scope-limited
 }
 
-const name = entity.name
-const greet = || print(name)   // scope-limited (captures a borrow)
+const tags = entity.tags
+const greet = || print(tags)   // scope-limited (captures a borrow)
 
 run_twice(greet)              // OK: run_twice doesn't store F
 store_callback(greet)         // ERROR: store_callback tries to store F
@@ -208,17 +210,17 @@ store_callback(greet)         // ERROR: store_callback tries to store F
 ```
 ERROR [mem.closures/SL2]: closure cannot escape scope
    |
-3  |  const name = entity.name
+3  |  const tags = entity.tags
    |               ^^^^^^^^^^^ borrowed from 'entity' (line 2)
-4  |  const f = || process(name)
+4  |  const f = || process(tags)
    |            ^^^^^^^^^^^^^^^^^ closure captures scoped borrow
 5  |  return f
    |  ^^^^^^^^ cannot escape scope where 'entity' lives
 
 FIX: Clone to owned data:
 
-  const name = entity.name.clone()
-  const f = || process(name)
+  const tags = entity.tags.clone()
+  const f = || process(tags)
   return f                          // OK: no scoped borrows
 ```
 

--- a/stdlib/http.rk
+++ b/stdlib/http.rk
@@ -427,7 +427,7 @@ func write_raw(conn_fd: i64, data: string) {
 
 // Parse "http://host:port/path" into (host, port, path).
 func parse_url(url: string) -> (string, string, string) or HttpError {
-    let rest = url.clone()
+    let rest = url
 
     // Strip scheme
     if rest.starts_with("http://") {
@@ -437,7 +437,7 @@ func parse_url(url: string) -> (string, string, string) or HttpError {
     }
 
     // Split host+port from path at first /
-    let host_port = rest.clone()
+    let host_port = rest
     let path = "/"
     const slash = rest.find("/")
     if slash is Some(pos) {
@@ -446,7 +446,7 @@ func parse_url(url: string) -> (string, string, string) or HttpError {
     }
 
     // Split host from port at last :
-    let host = host_port.clone()
+    let host = host_port
     let port = "80"
     const colon = host_port.find(":")
     if colon is Some(cpos) {

--- a/tutorials/learn-rask/09_ownership.rk
+++ b/tutorials/learn-rask/09_ownership.rk
@@ -61,10 +61,15 @@ func example_copy_vs_move() {
     // copy — both valid
     println("x = {x}, y = {y}")
 
-    // Collections move — use .clone() for an independent copy
+    // Strings are Copy — they copy like numbers (16 bytes, refcounted)
     const name = "Besse"
-    const other = name.clone()
+    const other = name          // copy — both valid, no .clone() needed
     println("name = {name}, other = {other}")
+
+    // Collections move — use .clone() for an independent copy
+    const names = Vec.from(["Besse", "Dagny"])
+    const backup = names.clone()
+    println("names len = {names.len()}, backup len = {backup.len()}")
     // Borrows data — can read but not modify
     // Borrows data mutably — can modify the caller's value
 }

--- a/tutorials/learn-rask/solutions/14_strings.rk
+++ b/tutorials/learn-rask/solutions/14_strings.rk
@@ -12,7 +12,7 @@ func parse_wind(metar: string) -> Wind {
 }
 
 func format_flight_plan(departure: string, arrival: string, waypoints: Vec<string>) -> string {
-    let result = departure.clone()
+    let result = departure
     for wp in waypoints {
         result = "{result} → {wp}"
     }


### PR DESCRIPTION
## Summary
This change establishes `string` as a Copy type in Rask, eliminating the need for explicit `.clone()` calls on strings throughout the codebase. Strings are immutable, refcounted (16 bytes), and now copy like integers. This reduces boilerplate while maintaining safety, with the compiler eliding most refcount operations.

## Key Changes

- **Type system**: `string` is now Copy (immutable, refcounted, 16 bytes)
- **Documentation updates**: 
  - Updated language guide to clarify Copy semantics and string behavior
  - Revised memory/borrowing specs to reflect string as Copy
  - Updated closure examples to use non-Copy types (`Vec`) for demonstrating scope constraints
  - Clarified the 16-byte Copy threshold with strings as an example
- **Code examples**: Removed unnecessary `.clone()` calls on strings throughout:
  - `stdlib/http.rk`: Removed string clones in `parse_url()`
  - `tutorials/learn-rask/09_ownership.rk`: Added example showing strings copy without `.clone()`, contrasted with Vec which requires it
  - `tutorials/learn-rask/solutions/14_strings.rk`: Removed string clone in `format_flight_plan()`
  - `specs/memory/allocators.md`: Removed string clone in `build_index()`
  - `specs/concurrency/sync.md`: Removed string clone in shared config access
- **Closure documentation**: Updated examples to use `Vec<string>` (non-Copy) instead of `string` for demonstrating scope-limited closures, since strings no longer create scope constraints
- **Clone elision spec**: Updated to reflect that remaining clones concentrate on collections (`Vec`, `Map`) rather than strings

## Notable Details

- Strings remain the deliberate exception to the "large values move" rule because immutability eliminates aliased mutation risk
- The refcount overhead is acceptable because the compiler elides most refcount operations
- This reduces the ~5% clone overhead mentioned in string-heavy code to focus only on collection types

https://claude.ai/code/session_01YYZiEoMhpAaXioX6hTrHke