### PR TITLE
Add small string optimization (SSO) to string type specification

### DIFF
--- a/specs/compiler/memory-layout.md
+++ b/specs/compiler/memory-layout.md
@@ -95,7 +95,7 @@ Result<i32, string>:
   padding: 7 bytes (to align to 8-byte string)
   payload union at offset 8:
     - Ok variant: i32 (4 bytes)
-    - Err variant: string (16 bytes: ptr + len)
+    - Err variant: string (16 bytes: tagged union, see String section)
 
 Total size: 8 (discriminant+padding) + 16 (union) = 24 bytes
 Alignment: 8 bytes (string's alignment)
@@ -377,17 +377,23 @@ struct Handle<T> {
 
 ## String
 
-Built-in `string` type:
+Built-in `string` type. 16 bytes, tagged union (`std.strings/S8`). The MSB of the last byte discriminates between heap and SSO modes:
 
-```rask
-struct string {
-    ptr: *u8,          // offset 0, 8 bytes
-    len: usize,        // offset 8, 8 bytes
-}
-// Total: 16 bytes
+```
+Heap mode (last byte MSB = 0):
+  [header_ptr: *u8 (8B)][len: usize (8B)]
+  Header at ptr: { refcount: atomic_u32, capacity: u32, data: [u8] }
+
+SSO mode (last byte MSB = 1):
+  [inline_data: [u8; 15]][len_tag: u8]
+  Length = len_tag & 0x7F (range 0..15)
 ```
 
-Heap data is UTF-8 bytes, no null terminator unless needed for FFI.
+Total: 16 bytes. Alignment: 8 bytes. Both modes are Copy (16-byte memcpy).
+
+SSO strings store UTF-8 data directly in the 16-byte value — no heap pointer, no refcount. Heap strings point to a refcounted header followed by UTF-8 data, no null terminator unless needed for FFI.
+
+Strings ≤ 15 bytes (including all single-byte-per-char ASCII strings up to 15 chars) use SSO. Strings > 15 bytes use heap mode. `string_builder.build()` produces SSO when the result fits.
 
 ## References and Slices
 

--- a/specs/compiler/string-refcount-elision.md
+++ b/specs/compiler/string-refcount-elision.md
@@ -7,7 +7,7 @@
 
 # String Refcount Elision
 
-`string` is Copy — assignment copies 16 bytes and bumps an atomic refcount. The atomic increment/decrement pair is the main runtime cost. This pass eliminates those atomic ops when the compiler can prove they're unnecessary.
+`string` is Copy — assignment copies 16 bytes. For heap strings (> 15 bytes), the copy also bumps an atomic refcount. SSO strings (≤ 15 bytes, `std.strings/S8`) have no refcount — they're pure value copies and bypass this pass entirely. For the remaining heap strings, the atomic increment/decrement pair is the main runtime cost. This pass eliminates those atomic ops when the compiler can prove they're unnecessary.
 
 This is a compiler optimization. No user annotation, no semantic change. Strings behave identically whether ops are elided or not.
 
@@ -20,6 +20,7 @@ This is a compiler optimization. No user annotation, no semantic change. Strings
 | **RE3: Literal propagation** | String literals have sentinel refcount (`std.strings/S6`). Compiler tracks "provably literal" through local analysis — no inc/dec needed |
 | **RE4: Borrow chain elision** | `f(g(s))` where `s` is borrowed at each call → no refcount ops at call boundaries. Follows from `mem.ownership/O2` borrow inference |
 | **RE5: IDE annotation** | IDE shows `[rc elided]` ghost text on string copies where refcount ops are skipped |
+| **RE6: SSO bypass** | SSO strings (≤ 15 bytes, `std.strings/S8`) have no refcount. All refcount operations on SSO strings are no-ops by construction. The elision pass skips SSO-typed bindings entirely |
 
 ## Examples
 
@@ -105,16 +106,19 @@ If none of these conditions hold at function exit, the binding's refcount ops ar
 | String returned from function | NOT elided — escapes to caller |
 | String copy in loop | Conservative — NOT elided unless loop body is sole-use per iteration |
 | Multiple copies of same string, some escape | Only non-escaping copies elided |
+| SSO string (≤ 15 bytes) | RE6 — no refcount exists, skip entirely |
+| String transitions SSO → heap (e.g., concat result) | New heap string gets normal refcount treatment |
 
 ## Implementation
 
 MIR-level optimization pass, runs after clone elision (`comp.clone-elision`):
 
 1. Identify all string-typed bindings in the function
-2. For each binding, set `rc_required = false`
-3. Walk the MIR: set `rc_required = true` if any escape condition (above) applies
-4. For bindings where `rc_required` is still false, replace all `atomic_inc`/`atomic_dec` with no-ops
-5. For RE1 specifically: detect copy-then-drop pairs and cancel them regardless of escape status
+2. For bindings provably SSO (constant ≤ 15 bytes, literal ≤ 15 bytes): skip — no refcount ops emitted (RE6)
+3. For remaining bindings, set `rc_required = false`
+4. Walk the MIR: set `rc_required = true` if any escape condition (above) applies
+5. For bindings where `rc_required` is still false, replace all `atomic_inc`/`atomic_dec` with no-ops
+6. For RE1 specifically: detect copy-then-drop pairs and cancel them regardless of escape status
 
 Compile-time cost: O(n) per function — single forward pass over MIR. Negligible.
 
@@ -134,7 +138,9 @@ Compile-time cost: O(n) per function — single forward pass over MIR. Negligibl
 
 **RE5 (IDE annotation):** Same rationale as `comp.clone-elision/CE5`. Visibility helps developers understand the cost model. Over time, developers learn which patterns are free and write naturally efficient code.
 
-**Expected impact:** Based on the string audit (~60 copies across ~5,000 lines of validation programs), RE1 alone covers the most common pattern. Estimate 70-80% of string copy/drop pairs have their atomics elided in typical code.
+**RE6 (SSO bypass):** SSO strings (`std.strings/S8`) have no heap header and no refcount field. The elision pass doesn't need to analyze them — there's nothing to elide. This is the first line of defense: strings ≤ 15 bytes never generate atomic ops in the first place. RE1–RE5 handle the remaining heap strings.
+
+**Expected impact:** SSO eliminates refcount ops for the most common short strings (field names, status codes, short identifiers, error tags). Based on the string audit (~60 copies across ~5,000 lines of validation programs), a significant fraction are short strings that would be SSO. For the remaining heap strings, RE1 alone covers the most common pattern. Combined estimate: 85-90% of string copy/drop pairs have zero atomic overhead.
 
 ### Why This Is String-Only
 

--- a/specs/stdlib/strings.md
+++ b/specs/stdlib/strings.md
@@ -11,13 +11,38 @@ Immutable refcounted `string` type with UTF-8 validation, inline slicing for zer
 
 | Rule | Description |
 |------|-------------|
-| **S1: Immutable, refcounted, Copy** | `string` is UTF-8, immutable, 16 bytes `(header_ptr, len)`. Header: `(refcount: atomic_u32, capacity: u32, data: [u8])`. Under VS1 threshold → implicit Copy |
+| **S1: Immutable, refcounted, Copy** | `string` is UTF-8, immutable, 16 bytes (tagged union — see S8). Under VS1 threshold → implicit Copy |
 | **S2: Inline slicing** | `s[i..j]` creates a temporary view valid only within the expression |
 | **S3: Public APIs use string** | Never use `string_view` or `StringSlice` in public APIs |
 | **S4: UTF-8 required** | Strings must contain valid UTF-8. Validated at construction |
 | **S5: Byte indices** | Slicing uses byte indices. Mid-codepoint slice panics at runtime |
-| **S6: Refcount semantics** | Atomic refcount in heap header. Literals use sentinel refcount (never freed/decremented). Compiler elides atomic ops for provably sole-owner strings (see `comp.string-refcount-elision`). This is a language primitive — not available to user-defined types |
+| **S6: Refcount semantics** | Atomic refcount in heap header. SSO strings (S8) bypass refcounting entirely. Literals ≤ 15 bytes use SSO; longer literals use sentinel refcount (never freed/decremented). Compiler elides atomic ops for provably sole-owner heap strings (see `comp.string-refcount-elision`). This is a language primitive — not available to user-defined types |
 | **S7: Builder for mutation** | `push_str`, `push_char`, `truncate`, `clear` live on `string_builder` only. `string` has no mutation methods |
+| **S8: Small string optimization** | Strings ≤ 15 bytes are stored inline in the 16-byte value (no heap allocation, no refcount). Longer strings use heap mode with refcounted header. Layout is a tagged union — discriminant is the MSB of the last byte. User-facing semantics are identical in both modes |
+
+### Internal Layout (S1 + S8)
+
+16 bytes, tagged union. The MSB of the last byte discriminates between modes:
+
+```
+Heap mode (last byte MSB = 0):
+  [header_ptr: *u8 (8B)][len: usize (8B)]
+  Header at ptr: { refcount: atomic_u32, capacity: u32, data: [u8] }
+
+SSO mode (last byte MSB = 1):
+  [inline_data: [u8; 15]][len_tag: u8]
+  Length = len_tag & 0x7F (range 0..15)
+```
+
+SSO strings are pure value copies — no heap, no refcount. Heap strings share backing storage via atomic refcount. Both modes are 16 bytes, both are Copy. The mode is invisible to user code.
+
+| String variant | Refcount | Allocation | Copy cost |
+|----------------|----------|------------|-----------|
+| SSO (≤ 15 bytes) | None | None | 16-byte memcpy |
+| Literal (> 15 bytes) | Sentinel (never freed) | Static | 16-byte memcpy |
+| Literal (≤ 15 bytes) | None (SSO) | None | 16-byte memcpy |
+| Heap (shared) | Atomic inc/dec | Heap | 16-byte memcpy + atomic inc |
+| Heap (unique, elided) | Skipped (RE1/RE2) | Heap | 16-byte memcpy |
 
 | Type | Description | Ownership | Storable? |
 |------|-------------|-----------|-----------|
@@ -32,11 +57,11 @@ Immutable refcounted `string` type with UTF-8 validation, inline slicing for zer
 
 | Rule | Description |
 |------|-------------|
-| **O1: Copy on assign** | `const s2 = s1` copies 16-byte header + atomic increment. Both remain valid |
+| **O1: Copy on assign** | `const s2 = s1` copies 16 bytes. For heap strings, atomic refcount increment. For SSO strings, plain memcpy (no refcount). Both remain valid |
 | **O2: Borrow inferred** | `func foo(s: string)` borrows for call duration. No refcount change |
 | **O3: Explicit take** | `func foo(take s: string)` transfers ownership, decrements caller's count |
 
-> `string` is Copy. No `.clone()` needed — assignment copies the 16-byte header and bumps the refcount. This is one of the few types that owns heap memory but is still Copy, because the immutable + refcounted design makes sharing safe.
+> `string` is Copy. No `.clone()` needed — assignment copies 16 bytes. For SSO strings (≤ 15 bytes), that's it — no heap, no refcount. For heap strings, the refcount is bumped atomically. This is one of the few types that owns heap memory but is still Copy, because the immutable + refcounted design makes sharing safe.
 
 ## Inline Slicing
 
@@ -118,7 +143,7 @@ Iterators borrow for expression scope only. Cannot be stored.
 
 | Operation | Return Type | Notes |
 |-----------|-------------|-------|
-| `"literal"` | `string` | Static storage, compile-time validated, sentinel refcount (never freed) |
+| `"literal"` | `string` | Compile-time validated. ≤ 15 bytes → SSO (inline, no allocation). > 15 bytes → static storage, sentinel refcount (never freed) |
 | `string.from_utf8(bytes)` | `Result<string, utf8_error>` | Validates bytes |
 | `string.from_char(c)` | `string` | Single-char string |
 | `string.repeat(s, n)` or `s.repeat(n)` | `string` | `s` repeated `n` times, allocates |
@@ -222,7 +247,7 @@ const csv = headers.join(",")      // CSV header row
 
 | Operation | Cost | Notes |
 |-----------|------|-------|
-| `s1 == s2` | O(1) or O(n) | Pointer+length fast path: same backing buffer and same length → equal without byte comparison. Otherwise byte-wise (length check first) |
+| `s1 == s2` | O(1) or O(n) | SSO: byte comparison (length check first, then memcmp). Heap: pointer+length fast path — same backing buffer and same length → equal without byte comparison. Otherwise byte-wise |
 | `s1 < s2` | O(n) | Lexicographic |
 | `s.hash()` | O(n) | Not cached |
 
@@ -315,7 +340,9 @@ FIX:
 | Slice not on char boundary | S5 | Panic at runtime |
 | Embedded `\0` in string | — | Valid; `to_cstring()` returns error |
 | Allocation failure | — | Returns `Result` error |
-| String literal | S6 | Sentinel refcount, never freed/decremented |
+| String literal ≤ 15 bytes | S8 | SSO — inline value, no heap, no refcount |
+| String literal > 15 bytes | S6 | Sentinel refcount, never freed/decremented |
+| Short string (≤ 15 bytes) | S8 | SSO — pure value copy, no atomic ops |
 | `string_view` of freed source | — | Undefined behavior (user's responsibility) |
 | `string_view` out of bounds | — | Panic on `s[view]`, `None` on `s.substr(view)` |
 | `StringSlice` with stale handle | — | `pool.get(slice)` returns `None` |
@@ -337,7 +364,7 @@ FIX:
 
 Immutable wins over COW: no hidden mutation cost, builder is sole owner so mutation is always O(1). Refcount over GC: deterministic, fits the ownership model. Builder pattern is established (Go, C#, Java) and concentrated in few callsites (~8 `.build()` calls across a 1,114-line renderer).
 
-This is one of the few cases where a type owns heap memory but is still Copy. The immutable + refcounted design makes sharing safe — there's no aliased mutation to worry about. The 16-byte `(header_ptr, len)` representation fits under the VS1 threshold.
+This is one of the few cases where a type owns heap memory but is still Copy. The immutable + refcounted design makes sharing safe — there's no aliased mutation to worry about. The 16-byte representation (tagged union — see S8) fits under the VS1 threshold. SSO means most short strings never touch the heap at all.
 
 **S2 (inline slicing):** Strings own heap buffers — they're growable sources, same as Vec. Slices are temporary views for the expression. `.to_string()` copies bytes into a new independent string — no shared backing. A 50-byte slice must not silently retain a 10MB source buffer. The `.to_string()` calls are honest cost markers bounded by the slice size, not the source size.
 
@@ -348,6 +375,8 @@ This is one of the few cases where a type owns heap memory but is still Copy. Th
 **S6 (refcount semantics):** Atomic refcount enables safe sharing across tasks. Sentinel refcount for literals avoids overhead on the most common case. Compiler optimization for provably sole-owner strings eliminates atomic ops when sharing can't happen.
 
 **S7 (builder for mutation):** All mutation lives on `string_builder`. This means `string` is truly immutable — no COW surprise, no hidden cost. The builder is always the sole owner of its buffer, so mutation is always O(1) amortized.
+
+**S8 (small string optimization):** Short strings are the most common case in many programs — field names, status codes, short identifiers, small log messages. The 15-byte threshold covers the vast majority of these. Without SSO, every string — even `"OK"` — heap-allocates and atomic-refcounts. With SSO, short strings are pure 16-byte values: no heap, no refcount, same cost as copying an `i128`. The tagged union uses a well-proven technique (same approach as libc++ and fbstring): the MSB of the last byte discriminates between SSO and heap mode. The 16-byte size and Copy semantics are unchanged — SSO is invisible to user code. `string_builder.build()` produces an SSO string when the result is ≤ 15 bytes, avoiding the heap allocation entirely.
 
 ### Why Immutable Strings?
 
@@ -482,7 +511,7 @@ for (i, c) in text.char_indices() {
 - `string` implements `Displayable`, `Hashable`, `Comparable` traits. Copy is structural (S1)
 - All types (`string`, `string_view`, `string_builder`, `StringPool`, `StringSlice`) are in core prelude
 - String builders can contain linear resources; `build()` consumes builder to preserve linearity
-- String literals and interpolation at comptime produce static strings (sentinel refcount)
+- String literals ≤ 15 bytes produce SSO values (inline, no allocation). Longer literals use static storage with sentinel refcount. Comptime interpolation follows the same rule based on result length
 
 ### Implementation Notes (Interpreter)
 


### PR DESCRIPTION
## Summary

This PR introduces small string optimization (SSO) to the `string` type specification, allowing strings ≤ 15 bytes to be stored inline without heap allocation or refcounting. The 16-byte `string` value becomes a tagged union that discriminates between SSO mode (inline storage) and heap mode (refcounted) using the MSB of the last byte.

## Key Changes

- **S1 (Immutable, refcounted, Copy):** Updated to describe `string` as a 16-byte tagged union instead of a simple `(ptr, len)` pair
- **S6 (Refcount semantics):** Clarified that SSO strings bypass refcounting entirely; only heap strings > 15 bytes use sentinel refcount for literals
- **S8 (New rule):** Added comprehensive small string optimization rule with:
  - Tagged union layout (SSO vs. heap mode discrimination via MSB of last byte)
  - Detailed internal layout diagrams for both modes
  - Comparison table showing refcount, allocation, and copy costs for each string variant
- **Ownership section (O1):** Updated to explain that SSO strings use plain memcpy while heap strings perform atomic refcount increment
- **Literal construction:** Updated to note that literals ≤ 15 bytes produce SSO values (inline, no allocation)
- **Equality comparison (S1):** Clarified that SSO strings use byte comparison while heap strings use pointer+length fast path
- **Error handling:** Added separate entries for SSO vs. heap string literals in the error handling table
- **Rationale section:** Added detailed justification for S8, explaining why 15-byte threshold covers most common use cases
- **Memory layout spec:** Updated `string` layout documentation to describe the tagged union structure and SSO/heap mode discrimination
- **Refcount elision spec:** Added RE6 rule explaining that SSO strings bypass the elision pass entirely since they have no refcount; updated expected impact estimate to 85-90% (up from 70-80%) due to SSO eliminating refcount ops for short strings

## Implementation Details

- SSO uses a well-proven technique (same as libc++ and fbstring): MSB of the last byte discriminates between modes
- Inline data capacity is 15 bytes; length is stored in the low 7 bits of the tag byte
- Both SSO and heap modes remain 16 bytes and Copy, making the optimization invisible to user code
- `string_builder.build()` automatically produces SSO strings when results fit within 15 bytes
- The change is purely a specification update with no breaking changes to user-facing semantics

https://claude.ai/code/session_019mnEUGdTzknHtQpru9xsjC