### PR TITLE
Add MIR interpreter (rask-miri) for compile-time function evaluation

### DIFF
--- a/compiler/Cargo.lock
+++ b/compiler/Cargo.lock
@@ -1356,6 +1356,7 @@ dependencies = [
  "rask-lexer",
  "rask-lint",
  "rask-mir",
+ "rask-miri",
  "rask-mono",
  "rask-ownership",
  "rask-parser",
@@ -1511,6 +1512,14 @@ dependencies = [
  "rask-comptime",
  "rask-mono",
  "rask-types",
+]
+
+[[package]]
+name = "rask-miri"
+version = "0.1.0"
+dependencies = [
+ "rask-mir",
+ "rask-mono",
 ]
 
 [[package]]

--- a/compiler/Cargo.toml
+++ b/compiler/Cargo.toml
@@ -11,6 +11,7 @@ members = [
     "crates/rask-ownership",
     "crates/rask-mono",
     "crates/rask-mir",
+    "crates/rask-miri",
     "crates/rask-codegen",
     "crates/rask-diagnostics",
     "crates/rask-interp",

--- a/compiler/crates/rask-cli/Cargo.toml
+++ b/compiler/crates/rask-cli/Cargo.toml
@@ -25,6 +25,7 @@ rask-describe = { path = "../rask-describe" }
 rask-lint = { path = "../rask-lint" }
 rask-mono = { path = "../rask-mono" }
 rask-mir = { path = "../rask-mir" }
+rask-miri = { path = "../rask-miri" }
 rask-codegen = { path = "../rask-codegen" }
 rask-stdlib = { path = "../rask-stdlib" }
 rask-hidden-params = { path = "../rask-hidden-params" }

--- a/compiler/crates/rask-cli/src/commands/build.rs
+++ b/compiler/crates/rask-cli/src/commands/build.rs
@@ -685,7 +685,10 @@ pub fn cmd_build(path: &str, opts: BuildOptions) {
                                         let cfg = rask_comptime::CfgConfig::from_target_or_host(
                                             opts.target.as_deref(), &opts.profile, resolved_feature_names.clone(),
                                         );
-                                        let comptime_globals = super::codegen::evaluate_comptime_globals(&all_decls, Some(&cfg));
+                                        let comptime_globals = super::codegen::evaluate_comptime_globals(
+                                            &all_decls, Some(&cfg),
+                                            Some(super::codegen::MirEvalContext { mono: &mono, typed: &typed }),
+                                        );
                                         let target = opts.target.as_deref();
 
                                         let build_mode = if opts.profile == "release" {

--- a/compiler/crates/rask-cli/src/commands/codegen.rs
+++ b/compiler/crates/rask-cli/src/commands/codegen.rs
@@ -47,9 +47,13 @@ fn run_pipeline(path: &str, format: Format) -> (MonoProgram, rask_types::TypedPr
 }
 
 /// Evaluate comptime const declarations and return serialized data.
+///
+/// When `mir_ctx` is provided, tries MIR-based evaluation first (via rask-miri),
+/// falling back to the AST interpreter on failure.
 pub fn evaluate_comptime_globals(
     decls: &[rask_ast::decl::Decl],
     cfg: Option<&rask_comptime::CfgConfig>,
+    mir_ctx: Option<MirEvalContext<'_>>,
 ) -> std::collections::HashMap<String, rask_mir::ComptimeGlobalMeta> {
     use rask_ast::decl::DeclKind;
     use rask_ast::stmt::StmtKind;
@@ -88,6 +92,15 @@ pub fn evaluate_comptime_globals(
     }
 
     for (name, init) in comptime_consts {
+        // Try MIR-based evaluation first
+        if let Some(ref ctx) = mir_ctx {
+            if let Some(meta) = try_eval_comptime_mir(&name, init, ctx, decls) {
+                globals.insert(name, meta);
+                continue;
+            }
+        }
+
+        // Fallback: AST interpreter
         comptime_interp.reset_branch_count();
         match comptime_interp.eval_expr(init) {
             Ok(val) => {
@@ -104,6 +117,192 @@ pub fn evaluate_comptime_globals(
     }
 
     globals
+}
+
+/// Context for MIR-based comptime evaluation.
+pub struct MirEvalContext<'a> {
+    pub mono: &'a MonoProgram,
+    pub typed: &'a rask_types::TypedProgram,
+}
+
+/// Try to evaluate a comptime expression via MIR lowering + MiriEngine.
+/// Returns None on any failure (fallback to AST interpreter).
+fn try_eval_comptime_mir(
+    name: &str,
+    init: &rask_ast::expr::Expr,
+    ctx: &MirEvalContext<'_>,
+    decls: &[rask_ast::decl::Decl],
+) -> Option<rask_mir::ComptimeGlobalMeta> {
+    use rask_ast::decl::{DeclKind, FnDecl};
+    use rask_ast::expr::ExprKind;
+    use rask_ast::stmt::{Stmt, StmtKind};
+    use rask_ast::{NodeId, Span};
+
+    // Extract the comptime body
+    let body = match &init.kind {
+        ExprKind::Comptime { body } => body.clone(),
+        ExprKind::Call { func, args } => {
+            // Comptime function call — find the function and use its body
+            if let ExprKind::Ident(func_name) = &func.kind {
+                let fn_decl = decls.iter().find_map(|d| match &d.kind {
+                    DeclKind::Fn(f) if f.name == *func_name && f.is_comptime => Some(f),
+                    _ => None,
+                })?;
+                // For comptime functions with args, bail to AST interpreter for now
+                if !args.is_empty() {
+                    return None;
+                }
+                fn_decl.body.clone()
+            } else {
+                return None;
+            }
+        }
+        _ => return None,
+    };
+
+    // Determine return type from type checker
+    let ret_ty_str = ctx.typed.node_types.get(&init.id)
+        .map(|ty| format!("{ty:?}"))
+        .and_then(|s| {
+            // Map Type debug format to a type string the MIR lowerer understands
+            match s.as_str() {
+                "I64" => Some("i64"),
+                "I32" => Some("i32"),
+                "I16" => Some("i16"),
+                "I8" => Some("i8"),
+                "U64" => Some("u64"),
+                "U32" => Some("u32"),
+                "U16" => Some("u16"),
+                "U8" => Some("u8"),
+                "F64" => Some("f64"),
+                "F32" => Some("f32"),
+                "Bool" => Some("bool"),
+                "Char" => Some("char"),
+                "String" => Some("string"),
+                "Unit" => None,
+                _ => None,
+            }
+        });
+
+    // Build a synthetic function wrapping the comptime block.
+    // Add explicit `return <last_expr>` so MIR lowering captures the value.
+    let mut synth_body = body;
+    if let Some(last) = synth_body.last() {
+        if let StmtKind::Expr(_) = &last.kind {
+            // Last statement is an expression — wrap it in a return
+            let last_owned = synth_body.pop().unwrap();
+            if let StmtKind::Expr(e) = last_owned.kind {
+                synth_body.push(Stmt {
+                    id: NodeId(u32::MAX - 1),
+                    kind: StmtKind::Return(Some(e)),
+                    span: last_owned.span,
+                });
+            }
+        }
+    }
+
+    let synth_name = format!("__comptime_{name}");
+    let synth_decl = rask_ast::decl::Decl {
+        id: NodeId(u32::MAX),
+        kind: DeclKind::Fn(FnDecl {
+            name: synth_name.clone(),
+            type_params: vec![],
+            params: vec![],
+            ret_ty: ret_ty_str.map(|s| s.to_string()),
+            context_clauses: vec![],
+            body: synth_body,
+            is_pub: false,
+            is_private: false,
+            is_comptime: true,
+            is_unsafe: false,
+            abi: None,
+            attrs: vec![],
+            doc: None,
+            span: Span::new(0, 0),
+        }),
+        span: Span::new(0, 0),
+    };
+
+    // Create a minimal MirContext for comptime lowering
+    let empty_comptime = std::collections::HashMap::new();
+    let empty_externs = std::collections::HashSet::new();
+    let empty_packages = std::collections::HashSet::new();
+    let empty_coercions = std::collections::HashMap::new();
+    let empty_rewrites = std::collections::HashMap::new();
+    let type_names: std::collections::HashMap<rask_types::TypeId, String> = ctx.typed.types.iter()
+        .enumerate()
+        .map(|(i, def)| {
+            let tname = match def {
+                rask_types::TypeDef::Struct { name, .. } => name.clone(),
+                rask_types::TypeDef::Enum { name, .. } => name.clone(),
+                rask_types::TypeDef::Trait { name, .. } => name.clone(),
+                rask_types::TypeDef::Union { name, .. } => name.clone(),
+                rask_types::TypeDef::NominalAlias { name, .. } => name.clone(),
+            };
+            (rask_types::TypeId(i as u32), tname)
+        })
+        .collect();
+
+    let mir_ctx = rask_mir::lower::MirContext {
+        struct_layouts: &ctx.mono.struct_layouts,
+        enum_layouts: &ctx.mono.enum_layouts,
+        node_types: &ctx.typed.node_types,
+        type_names: &type_names,
+        comptime_globals: &empty_comptime,
+        extern_funcs: &empty_externs,
+        package_modules: &empty_packages,
+        trait_methods: std::collections::HashMap::new(),
+        line_map: None,
+        source_file: None,
+        shared_elem_types: std::cell::RefCell::new(std::collections::HashMap::new()),
+        comptime_interp: None,
+        trait_coercions: &empty_coercions,
+        call_rewrites: &empty_rewrites,
+    };
+
+    // Lower the synthetic function to MIR
+    let mir_fns = rask_mir::lower::MirLowerer::lower_function(
+        &synth_decl, decls, &mir_ctx,
+    ).ok()?;
+
+    let mir_fn = mir_fns.into_iter().next()?;
+
+    // Also lower any comptime functions that might be called
+    let mut engine = rask_miri::MiriEngine::new(Box::new(rask_miri::PureStdlib));
+    engine.set_struct_layouts(ctx.mono.struct_layouts.clone());
+    engine.set_enum_layouts(ctx.mono.enum_layouts.clone());
+
+    // Register comptime-callable functions
+    for decl in decls {
+        if let DeclKind::Fn(f) = &decl.kind {
+            if f.is_comptime {
+                let fn_decl = rask_ast::decl::Decl {
+                    id: decl.id,
+                    kind: DeclKind::Fn(f.clone()),
+                    span: decl.span,
+                };
+                if let Ok(fns) = rask_mir::lower::MirLowerer::lower_function(
+                    &fn_decl, decls, &mir_ctx,
+                ) {
+                    for f in fns {
+                        engine.register_function(f);
+                    }
+                }
+            }
+        }
+    }
+
+    engine.register_function(mir_fn);
+
+    // Execute
+    let result = engine.execute(&synth_name, vec![]).ok()?;
+
+    // Convert to ComptimeGlobalMeta
+    let type_prefix = result.type_prefix().to_string();
+    let elem_count = result.elem_count();
+    let bytes = result.serialize()?;
+
+    Some(rask_mir::ComptimeGlobalMeta { bytes, elem_count, type_prefix })
 }
 
 /// Check if an expression is a comptime initializer.
@@ -264,7 +463,7 @@ pub fn cmd_mir(path: &str, format: Format) {
     }).collect();
     all_mono_decls.extend(decls.iter().filter(|d| matches!(&d.kind, rask_ast::decl::DeclKind::Extern(_))).cloned());
     let cfg = rask_comptime::CfgConfig::from_host("debug", vec![]);
-    let comptime_globals = evaluate_comptime_globals(&decls, Some(&cfg));
+    let comptime_globals = evaluate_comptime_globals(&decls, Some(&cfg), Some(MirEvalContext { mono: &mono, typed: &typed }));
     let extern_funcs = collect_extern_func_names(&decls);
     let line_map = source.as_deref().map(rask_ast::LineMap::new);
     let type_names: std::collections::HashMap<rask_types::TypeId, String> = typed.types.iter()
@@ -357,7 +556,7 @@ pub fn cmd_compile(path: &str, output_path: Option<&str>, format: Format, quiet:
     let (mono, typed, decls, source) = run_pipeline(path, format);
     let profile = if release { "release" } else { "debug" };
     let cfg = rask_comptime::CfgConfig::from_target_or_host(target, profile, vec![]);
-    let comptime_globals = evaluate_comptime_globals(&decls, Some(&cfg));
+    let comptime_globals = evaluate_comptime_globals(&decls, Some(&cfg), Some(MirEvalContext { mono: &mono, typed: &typed }));
     let build_mode = if release { rask_codegen::BuildMode::Release } else { rask_codegen::BuildMode::Debug };
 
     // Determine output paths

--- a/compiler/crates/rask-cli/src/commands/run.rs
+++ b/compiler/crates/rask-cli/src/commands/run.rs
@@ -577,7 +577,10 @@ fn run_benchmark_file(path: &str, filter: Option<&str>, format: Format) -> Vec<B
         }
     };
     let cfg = rask_comptime::CfgConfig::from_host("debug", vec![]);
-    let comptime_globals = super::codegen::evaluate_comptime_globals(&result.decls, Some(&cfg));
+    let comptime_globals = super::codegen::evaluate_comptime_globals(
+        &result.decls, Some(&cfg),
+        Some(super::codegen::MirEvalContext { mono: &mono, typed: &result.typed }),
+    );
 
     let tmp_dir = std::env::temp_dir();
     let bin_path = tmp_dir.join(format!("rask_bench_{}", process::id()));

--- a/compiler/crates/rask-miri/Cargo.toml
+++ b/compiler/crates/rask-miri/Cargo.toml
@@ -1,0 +1,8 @@
+[package]
+name = "rask-miri"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+rask-mir = { path = "../rask-mir" }
+rask-mono = { path = "../rask-mono" }

--- a/compiler/crates/rask-miri/src/eval.rs
+++ b/compiler/crates/rask-miri/src/eval.rs
@@ -1,0 +1,452 @@
+// SPDX-License-Identifier: (MIT OR Apache-2.0)
+
+//! MIR evaluation loop — execute statements, follow terminators.
+
+use rask_mir::{
+    BlockId, MirBlock, MirConst, MirFunction, MirOperand, MirRValue, MirStmt,
+    MirTerminator,
+};
+
+use crate::intrinsics;
+use crate::memory::StackFrame;
+use crate::{MiriEngine, MiriError, MiriValue};
+
+impl MiriEngine {
+    /// Execute a function by name with the given arguments.
+    pub fn call_function(
+        &mut self,
+        func_name: &str,
+        args: Vec<MiriValue>,
+    ) -> Result<MiriValue, MiriError> {
+        let func = self
+            .functions
+            .get(func_name)
+            .cloned()
+            .ok_or_else(|| {
+                // Not a user-defined function — try stdlib
+                MiriError::UnsupportedOperation(format!("unknown function: {func_name}"))
+            })?;
+
+        self.eval_function(&func, args)
+    }
+
+    /// Execute a MIR function with the given arguments.
+    fn eval_function(
+        &mut self,
+        func: &MirFunction,
+        args: Vec<MiriValue>,
+    ) -> Result<MiriValue, MiriError> {
+        let mut frame = StackFrame::new(func);
+
+        // Initialize parameters
+        for (param, arg) in func.params.iter().zip(args) {
+            frame.set(param.id, arg);
+        }
+
+        self.stack.push(frame)?;
+        let result = self.eval_body(func);
+        self.stack.pop();
+        result
+    }
+
+    /// Execute the body of a function (block-by-block loop).
+    fn eval_body(&mut self, func: &MirFunction) -> Result<MiriValue, MiriError> {
+        let mut current_block_id = func.entry_block;
+
+        loop {
+            let block = self.find_block(func, current_block_id)?;
+
+            // Execute all statements
+            for stmt in &block.statements {
+                self.eval_stmt(stmt)?;
+            }
+
+            // Follow the terminator
+            match &block.terminator {
+                MirTerminator::Return { value } => {
+                    let result = match value {
+                        Some(op) => self.resolve_operand(op)?,
+                        None => MiriValue::Unit,
+                    };
+                    return Ok(result);
+                }
+
+                MirTerminator::Goto { target } => {
+                    self.count_branch_if_backwards(*target, current_block_id)?;
+                    current_block_id = *target;
+                }
+
+                MirTerminator::Branch {
+                    cond,
+                    then_block,
+                    else_block,
+                } => {
+                    let cond_val = self.resolve_operand(cond)?;
+                    let target = if cond_val.as_bool()? {
+                        *then_block
+                    } else {
+                        *else_block
+                    };
+                    self.count_branch_if_backwards(target, current_block_id)?;
+                    current_block_id = target;
+                }
+
+                MirTerminator::Switch {
+                    value,
+                    cases,
+                    default,
+                } => {
+                    let val = self.resolve_operand(value)?;
+                    let tag = val.to_u64().ok_or_else(|| {
+                        MiriError::UnsupportedOperation("switch on non-integer value".to_string())
+                    })?;
+                    let target = cases
+                        .iter()
+                        .find(|(case_val, _)| *case_val == tag)
+                        .map(|(_, block)| *block)
+                        .unwrap_or(*default);
+                    self.count_branch_if_backwards(target, current_block_id)?;
+                    current_block_id = target;
+                }
+
+                MirTerminator::Unreachable => {
+                    return Err(MiriError::Unreachable);
+                }
+
+                MirTerminator::CleanupReturn { value, cleanup_chain } => {
+                    // Execute cleanup blocks in order
+                    for &cleanup_block_id in cleanup_chain {
+                        let cleanup_block = self.find_block(func, cleanup_block_id)?;
+                        for stmt in &cleanup_block.statements {
+                            self.eval_stmt(stmt)?;
+                        }
+                    }
+                    let result = match value {
+                        Some(op) => self.resolve_operand(op)?,
+                        None => MiriValue::Unit,
+                    };
+                    return Ok(result);
+                }
+            }
+        }
+    }
+
+    /// Find a block by ID within a function.
+    fn find_block<'f>(&self, func: &'f MirFunction, id: BlockId) -> Result<&'f MirBlock, MiriError> {
+        func.blocks
+            .iter()
+            .find(|b| b.id == id)
+            .ok_or_else(|| {
+                MiriError::UnsupportedOperation(format!("block {:?} not found", id))
+            })
+    }
+
+    /// Count a backwards branch (for loop detection / quota enforcement).
+    fn count_branch_if_backwards(
+        &mut self,
+        target: BlockId,
+        current: BlockId,
+    ) -> Result<(), MiriError> {
+        if target.0 <= current.0 {
+            self.branch_count += 1;
+            if self.branch_count > self.branch_limit {
+                return Err(MiriError::BranchLimitExceeded(self.branch_limit));
+            }
+        }
+        Ok(())
+    }
+
+    /// Execute a single MIR statement.
+    fn eval_stmt(&mut self, stmt: &MirStmt) -> Result<(), MiriError> {
+        match stmt {
+            MirStmt::Assign { dst, rvalue } => {
+                let value = self.eval_rvalue(rvalue)?;
+                self.stack.current_mut()?.set(*dst, value);
+            }
+
+            MirStmt::Call { dst, func, args } => {
+                let arg_values: Vec<MiriValue> = args
+                    .iter()
+                    .map(|a| self.resolve_operand(a))
+                    .collect::<Result<_, _>>()?;
+
+                let result = if let Some(mir_func) = self.functions.get(&func.name).cloned() {
+                    self.eval_function(&mir_func, arg_values)?
+                } else {
+                    // Try stdlib
+                    match self.stdlib.call(&func.name, &arg_values)? {
+                        Some(v) => v,
+                        None => MiriValue::Unit,
+                    }
+                };
+
+                if let Some(dst) = dst {
+                    self.stack.current_mut()?.set(*dst, result);
+                }
+            }
+
+            MirStmt::Store {
+                addr,
+                offset,
+                value,
+                ..
+            } => {
+                let val = self.resolve_operand(value)?;
+                let base = self.stack.current()?.get(*addr)?.clone();
+
+                // Store into struct field by byte offset
+                if let MiriValue::Struct { layout_id, mut fields } = base {
+                    // Find field index from byte offset using layout
+                    let field_idx = self.field_index_from_offset(layout_id, *offset);
+                    if let Some(idx) = field_idx {
+                        if idx < fields.len() {
+                            fields[idx] = val;
+                            self.stack.current_mut()?.set(
+                                *addr,
+                                MiriValue::Struct { layout_id, fields },
+                            );
+                            return Ok(());
+                        }
+                    }
+                    // Fallback: store back unchanged (offset didn't match)
+                    self.stack.current_mut()?.set(
+                        *addr,
+                        MiriValue::Struct { layout_id, fields },
+                    );
+                } else {
+                    return Err(MiriError::UnsupportedOperation(
+                        format!("Store into non-struct value: {base:?}"),
+                    ));
+                }
+            }
+
+            MirStmt::ArrayStore {
+                base,
+                index,
+                value,
+                ..
+            } => {
+                let idx_val = self.resolve_operand(index)?;
+                let idx = idx_val.to_u64().ok_or_else(|| {
+                    MiriError::UnsupportedOperation("array index must be integer".to_string())
+                })? as usize;
+                let val = self.resolve_operand(value)?;
+
+                let mut arr = self.stack.current()?.get(*base)?.clone();
+                if let MiriValue::Array(ref mut elems) = arr {
+                    if idx >= elems.len() {
+                        return Err(MiriError::UnsupportedOperation(
+                            format!("array index {idx} out of bounds (len {})", elems.len()),
+                        ));
+                    }
+                    elems[idx] = val;
+                    self.stack.current_mut()?.set(*base, arr);
+                } else {
+                    return Err(MiriError::UnsupportedOperation(
+                        "ArrayStore on non-array value".to_string(),
+                    ));
+                }
+            }
+
+            MirStmt::GlobalRef { dst, name } => {
+                // Look up comptime globals
+                if let Some(value) = self.comptime_globals.get(name).cloned() {
+                    self.stack.current_mut()?.set(*dst, value);
+                } else {
+                    return Err(MiriError::UnsupportedOperation(
+                        format!("global '{name}' not found at compile time"),
+                    ));
+                }
+            }
+
+            MirStmt::SourceLocation { line, col } => {
+                self.current_line = *line;
+                self.current_col = *col;
+            }
+
+            MirStmt::EnsurePush { cleanup_block } => {
+                self.stack.current_mut()?.cleanup_stack.push(*cleanup_block);
+            }
+
+            MirStmt::EnsurePop => {
+                self.stack.current_mut()?.cleanup_stack.pop();
+            }
+
+            // Forbidden at comptime
+            MirStmt::ResourceRegister { .. }
+            | MirStmt::ResourceConsume { .. }
+            | MirStmt::ResourceScopeCheck { .. } => {
+                return Err(MiriError::UnsupportedOperation(
+                    "resource types are not available at compile time".to_string(),
+                ));
+            }
+
+            MirStmt::PoolCheckedAccess { .. } => {
+                return Err(MiriError::UnsupportedOperation(
+                    "pool access is not available at compile time".to_string(),
+                ));
+            }
+
+            // Closures — not in initial scope
+            MirStmt::ClosureCreate { .. }
+            | MirStmt::ClosureCall { .. }
+            | MirStmt::LoadCapture { .. }
+            | MirStmt::ClosureDrop { .. } => {
+                return Err(MiriError::UnsupportedOperation(
+                    "closures are not yet supported in compile-time evaluation".to_string(),
+                ));
+            }
+
+            // Trait objects — not in initial scope
+            MirStmt::TraitBox { .. }
+            | MirStmt::TraitCall { .. }
+            | MirStmt::TraitDrop { .. } => {
+                return Err(MiriError::UnsupportedOperation(
+                    "trait objects are not yet supported in compile-time evaluation".to_string(),
+                ));
+            }
+        }
+        Ok(())
+    }
+
+    /// Evaluate an rvalue.
+    fn eval_rvalue(&mut self, rvalue: &MirRValue) -> Result<MiriValue, MiriError> {
+        match rvalue {
+            MirRValue::Use(op) => self.resolve_operand(op),
+
+            MirRValue::BinaryOp { op, left, right } => {
+                let l = self.resolve_operand(left)?;
+                let r = self.resolve_operand(right)?;
+                intrinsics::eval_binop(*op, &l, &r)
+            }
+
+            MirRValue::UnaryOp { op, operand } => {
+                let v = self.resolve_operand(operand)?;
+                intrinsics::eval_unaryop(*op, &v)
+            }
+
+            MirRValue::Cast { value, target_ty } => {
+                let v = self.resolve_operand(value)?;
+                intrinsics::eval_cast(&v, target_ty)
+            }
+
+            MirRValue::Field {
+                base, field_index, ..
+            } => {
+                let base_val = self.resolve_operand(base)?;
+                match base_val {
+                    MiriValue::Struct { fields, .. } => {
+                        let idx = *field_index as usize;
+                        fields.into_iter().nth(idx).ok_or_else(|| {
+                            MiriError::UnsupportedOperation(
+                                format!("field index {idx} out of bounds"),
+                            )
+                        })
+                    }
+                    MiriValue::Tuple(fields) => {
+                        let idx = *field_index as usize;
+                        fields.into_iter().nth(idx).ok_or_else(|| {
+                            MiriError::UnsupportedOperation(
+                                format!("tuple field index {idx} out of bounds"),
+                            )
+                        })
+                    }
+                    // Option/Result — tag is field 0, payload is field 1
+                    MiriValue::Enum { tag, payload, .. } => {
+                        match *field_index {
+                            0 => Ok(MiriValue::U64(tag)),
+                            1 => payload.map(|p| *p).ok_or_else(|| {
+                                MiriError::UnsupportedOperation(
+                                    "enum has no payload".to_string(),
+                                )
+                            }),
+                            _ => Err(MiriError::UnsupportedOperation(
+                                format!("invalid enum field index: {field_index}"),
+                            )),
+                        }
+                    }
+                    _ => Err(MiriError::UnsupportedOperation(
+                        format!("field access on non-struct value: {base_val:?}"),
+                    )),
+                }
+            }
+
+            MirRValue::EnumTag { value } => {
+                let v = self.resolve_operand(value)?;
+                match v {
+                    MiriValue::Enum { tag, .. } => Ok(MiriValue::U64(tag)),
+                    _ => Err(MiriError::UnsupportedOperation(
+                        format!("EnumTag on non-enum value: {v:?}"),
+                    )),
+                }
+            }
+
+            MirRValue::ArrayIndex {
+                base, index, ..
+            } => {
+                let base_val = self.resolve_operand(base)?;
+                let idx_val = self.resolve_operand(index)?;
+                let idx = idx_val.to_u64().ok_or_else(|| {
+                    MiriError::UnsupportedOperation("array index must be integer".to_string())
+                })? as usize;
+
+                match base_val {
+                    MiriValue::Array(elems) => {
+                        elems.into_iter().nth(idx).ok_or_else(|| {
+                            MiriError::UnsupportedOperation(
+                                format!("array index {idx} out of bounds"),
+                            )
+                        })
+                    }
+                    _ => Err(MiriError::UnsupportedOperation(
+                        format!("ArrayIndex on non-array value: {base_val:?}"),
+                    )),
+                }
+            }
+
+            MirRValue::Ref(_) => {
+                Err(MiriError::UnsupportedOperation(
+                    "references are not supported in compile-time evaluation".to_string(),
+                ))
+            }
+
+            MirRValue::Deref(_) => {
+                Err(MiriError::UnsupportedOperation(
+                    "dereferencing is not supported in compile-time evaluation".to_string(),
+                ))
+            }
+        }
+    }
+
+    /// Resolve an operand to a value.
+    pub(crate) fn resolve_operand(&self, op: &MirOperand) -> Result<MiriValue, MiriError> {
+        match op {
+            MirOperand::Local(id) => self.stack.current()?.get(*id).cloned(),
+            MirOperand::Constant(c) => Ok(const_to_value(c)),
+        }
+    }
+
+    /// Find field index from byte offset using struct layout.
+    fn field_index_from_offset(
+        &self,
+        layout_id: rask_mir::StructLayoutId,
+        offset: u32,
+    ) -> Option<usize> {
+        let layout = self.struct_layouts.get(layout_id.0 as usize)?;
+        layout
+            .fields
+            .iter()
+            .position(|f| f.offset == offset)
+    }
+}
+
+/// Convert a MIR constant to a MiriValue.
+fn const_to_value(c: &MirConst) -> MiriValue {
+    match c {
+        MirConst::Int(v) => MiriValue::I64(*v),
+        MirConst::Float(v) => MiriValue::F64(*v),
+        MirConst::Bool(v) => MiriValue::Bool(*v),
+        MirConst::Char(v) => MiriValue::Char(*v),
+        MirConst::String(v) => MiriValue::String(v.clone()),
+    }
+}

--- a/compiler/crates/rask-miri/src/intrinsics.rs
+++ b/compiler/crates/rask-miri/src/intrinsics.rs
@@ -1,0 +1,219 @@
+// SPDX-License-Identifier: (MIT OR Apache-2.0)
+
+//! Arithmetic, comparison, bitwise, unary, and cast operations.
+
+use rask_mir::{BinOp, MirType, UnaryOp};
+
+use crate::{MiriError, MiriValue};
+
+/// Evaluate a binary operation.
+pub fn eval_binop(op: BinOp, left: &MiriValue, right: &MiriValue) -> Result<MiriValue, MiriError> {
+    // String concatenation
+    if let BinOp::Add = op {
+        if let (MiriValue::String(a), MiriValue::String(b)) = (left, right) {
+            return Ok(MiriValue::String(format!("{a}{b}")));
+        }
+    }
+
+    match (left, right) {
+        // i64 (most common path)
+        (MiriValue::I64(a), MiriValue::I64(b)) => eval_binop_i64(op, *a, *b),
+        (MiriValue::I32(a), MiriValue::I32(b)) => eval_binop_i32(op, *a, *b),
+        (MiriValue::I16(a), MiriValue::I16(b)) => eval_binop_i16(op, *a, *b),
+        (MiriValue::I8(a), MiriValue::I8(b)) => eval_binop_i8(op, *a, *b),
+
+        (MiriValue::U64(a), MiriValue::U64(b)) => eval_binop_u64(op, *a, *b),
+        (MiriValue::U32(a), MiriValue::U32(b)) => eval_binop_u32(op, *a, *b),
+        (MiriValue::U16(a), MiriValue::U16(b)) => eval_binop_u16(op, *a, *b),
+        (MiriValue::U8(a), MiriValue::U8(b)) => eval_binop_u8(op, *a, *b),
+
+        (MiriValue::F64(a), MiriValue::F64(b)) => eval_binop_f64(op, *a, *b),
+        (MiriValue::F32(a), MiriValue::F32(b)) => eval_binop_f32(op, *a, *b),
+
+        (MiriValue::Bool(a), MiriValue::Bool(b)) => eval_binop_bool(op, *a, *b),
+
+        (MiriValue::Char(a), MiriValue::Char(b)) => match op {
+            BinOp::Eq => Ok(MiriValue::Bool(a == b)),
+            BinOp::Ne => Ok(MiriValue::Bool(a != b)),
+            BinOp::Lt => Ok(MiriValue::Bool(a < b)),
+            BinOp::Gt => Ok(MiriValue::Bool(a > b)),
+            BinOp::Le => Ok(MiriValue::Bool(a <= b)),
+            BinOp::Ge => Ok(MiriValue::Bool(a >= b)),
+            _ => Err(MiriError::UnsupportedOperation(
+                format!("binary op {op:?} not supported for char"),
+            )),
+        },
+
+        _ => Err(MiriError::UnsupportedOperation(
+            format!("binary op {op:?} on mismatched types: {left:?} vs {right:?}"),
+        )),
+    }
+}
+
+/// Evaluate a unary operation.
+pub fn eval_unaryop(op: UnaryOp, operand: &MiriValue) -> Result<MiriValue, MiriError> {
+    match (op, operand) {
+        (UnaryOp::Neg, MiriValue::I8(v)) => Ok(MiriValue::I8(v.wrapping_neg())),
+        (UnaryOp::Neg, MiriValue::I16(v)) => Ok(MiriValue::I16(v.wrapping_neg())),
+        (UnaryOp::Neg, MiriValue::I32(v)) => Ok(MiriValue::I32(v.wrapping_neg())),
+        (UnaryOp::Neg, MiriValue::I64(v)) => Ok(MiriValue::I64(v.wrapping_neg())),
+        (UnaryOp::Neg, MiriValue::F32(v)) => Ok(MiriValue::F32(-v)),
+        (UnaryOp::Neg, MiriValue::F64(v)) => Ok(MiriValue::F64(-v)),
+
+        (UnaryOp::Not, MiriValue::Bool(v)) => Ok(MiriValue::Bool(!v)),
+
+        (UnaryOp::BitNot, MiriValue::I8(v)) => Ok(MiriValue::I8(!v)),
+        (UnaryOp::BitNot, MiriValue::I16(v)) => Ok(MiriValue::I16(!v)),
+        (UnaryOp::BitNot, MiriValue::I32(v)) => Ok(MiriValue::I32(!v)),
+        (UnaryOp::BitNot, MiriValue::I64(v)) => Ok(MiriValue::I64(!v)),
+        (UnaryOp::BitNot, MiriValue::U8(v)) => Ok(MiriValue::U8(!v)),
+        (UnaryOp::BitNot, MiriValue::U16(v)) => Ok(MiriValue::U16(!v)),
+        (UnaryOp::BitNot, MiriValue::U32(v)) => Ok(MiriValue::U32(!v)),
+        (UnaryOp::BitNot, MiriValue::U64(v)) => Ok(MiriValue::U64(!v)),
+
+        _ => Err(MiriError::UnsupportedOperation(
+            format!("unary op {op:?} not supported for {operand:?}"),
+        )),
+    }
+}
+
+/// Cast a value to a target MIR type.
+pub fn eval_cast(value: &MiriValue, target: &MirType) -> Result<MiriValue, MiriError> {
+    let as_i64 = value.to_i64();
+    let as_u64 = value.to_u64();
+    let as_f64 = value.to_f64();
+
+    match target {
+        MirType::I8 => Ok(MiriValue::I8(as_i64.ok_or_else(|| cant_cast(value, target))? as i8)),
+        MirType::I16 => Ok(MiriValue::I16(as_i64.ok_or_else(|| cant_cast(value, target))? as i16)),
+        MirType::I32 => Ok(MiriValue::I32(as_i64.ok_or_else(|| cant_cast(value, target))? as i32)),
+        MirType::I64 => Ok(MiriValue::I64(as_i64.ok_or_else(|| cant_cast(value, target))?)),
+        MirType::U8 => Ok(MiriValue::U8(as_u64.ok_or_else(|| cant_cast(value, target))? as u8)),
+        MirType::U16 => Ok(MiriValue::U16(as_u64.ok_or_else(|| cant_cast(value, target))? as u16)),
+        MirType::U32 => Ok(MiriValue::U32(as_u64.ok_or_else(|| cant_cast(value, target))? as u32)),
+        MirType::U64 => Ok(MiriValue::U64(as_u64.ok_or_else(|| cant_cast(value, target))?)),
+        MirType::F32 => Ok(MiriValue::F32(as_f64.ok_or_else(|| cant_cast(value, target))? as f32)),
+        MirType::F64 => Ok(MiriValue::F64(as_f64.ok_or_else(|| cant_cast(value, target))?)),
+        MirType::Bool => match value {
+            MiriValue::Bool(b) => Ok(MiriValue::Bool(*b)),
+            MiriValue::I64(v) => Ok(MiriValue::Bool(*v != 0)),
+            _ => Err(cant_cast(value, target)),
+        },
+        MirType::Char => match value {
+            MiriValue::Char(c) => Ok(MiriValue::Char(*c)),
+            MiriValue::U32(v) => {
+                char::from_u32(*v)
+                    .map(MiriValue::Char)
+                    .ok_or_else(|| MiriError::UnsupportedOperation(
+                        format!("invalid char codepoint: {v}"),
+                    ))
+            }
+            _ => Err(cant_cast(value, target)),
+        },
+        _ => Err(cant_cast(value, target)),
+    }
+}
+
+fn cant_cast(value: &MiriValue, target: &MirType) -> MiriError {
+    MiriError::UnsupportedOperation(
+        format!("cannot cast {value:?} to {target:?}"),
+    )
+}
+
+// --- Typed binop implementations ---
+// Macro to reduce repetition across integer types.
+
+macro_rules! impl_int_binop {
+    ($name:ident, $ty:ty, $variant:ident, $signed:expr) => {
+        fn $name(op: BinOp, a: $ty, b: $ty) -> Result<MiriValue, MiriError> {
+            match op {
+                BinOp::Add => Ok(MiriValue::$variant(a.wrapping_add(b))),
+                BinOp::Sub => Ok(MiriValue::$variant(a.wrapping_sub(b))),
+                BinOp::Mul => Ok(MiriValue::$variant(a.wrapping_mul(b))),
+                BinOp::Div => {
+                    if b == 0 { return Err(MiriError::DivisionByZero); }
+                    Ok(MiriValue::$variant(a.wrapping_div(b)))
+                }
+                BinOp::Mod => {
+                    if b == 0 { return Err(MiriError::DivisionByZero); }
+                    Ok(MiriValue::$variant(a.wrapping_rem(b)))
+                }
+                BinOp::Eq => Ok(MiriValue::Bool(a == b)),
+                BinOp::Ne => Ok(MiriValue::Bool(a != b)),
+                BinOp::Lt => Ok(MiriValue::Bool(a < b)),
+                BinOp::Gt => Ok(MiriValue::Bool(a > b)),
+                BinOp::Le => Ok(MiriValue::Bool(a <= b)),
+                BinOp::Ge => Ok(MiriValue::Bool(a >= b)),
+                BinOp::And => Ok(MiriValue::Bool(a != 0 && b != 0)),
+                BinOp::Or => Ok(MiriValue::Bool(a != 0 || b != 0)),
+                BinOp::BitAnd => Ok(MiriValue::$variant(a & b)),
+                BinOp::BitOr => Ok(MiriValue::$variant(a | b)),
+                BinOp::BitXor => Ok(MiriValue::$variant(a ^ b)),
+                BinOp::Shl => Ok(MiriValue::$variant(a.wrapping_shl(b as u32))),
+                BinOp::Shr => Ok(MiriValue::$variant(a.wrapping_shr(b as u32))),
+            }
+        }
+    };
+}
+
+impl_int_binop!(eval_binop_i8, i8, I8, true);
+impl_int_binop!(eval_binop_i16, i16, I16, true);
+impl_int_binop!(eval_binop_i32, i32, I32, true);
+impl_int_binop!(eval_binop_i64, i64, I64, true);
+impl_int_binop!(eval_binop_u8, u8, U8, false);
+impl_int_binop!(eval_binop_u16, u16, U16, false);
+impl_int_binop!(eval_binop_u32, u32, U32, false);
+impl_int_binop!(eval_binop_u64, u64, U64, false);
+
+fn eval_binop_f64(op: BinOp, a: f64, b: f64) -> Result<MiriValue, MiriError> {
+    match op {
+        BinOp::Add => Ok(MiriValue::F64(a + b)),
+        BinOp::Sub => Ok(MiriValue::F64(a - b)),
+        BinOp::Mul => Ok(MiriValue::F64(a * b)),
+        BinOp::Div => Ok(MiriValue::F64(a / b)),
+        BinOp::Mod => Ok(MiriValue::F64(a % b)),
+        BinOp::Eq => Ok(MiriValue::Bool(a == b)),
+        BinOp::Ne => Ok(MiriValue::Bool(a != b)),
+        BinOp::Lt => Ok(MiriValue::Bool(a < b)),
+        BinOp::Gt => Ok(MiriValue::Bool(a > b)),
+        BinOp::Le => Ok(MiriValue::Bool(a <= b)),
+        BinOp::Ge => Ok(MiriValue::Bool(a >= b)),
+        _ => Err(MiriError::UnsupportedOperation(
+            format!("binary op {op:?} not supported for f64"),
+        )),
+    }
+}
+
+fn eval_binop_f32(op: BinOp, a: f32, b: f32) -> Result<MiriValue, MiriError> {
+    match op {
+        BinOp::Add => Ok(MiriValue::F32(a + b)),
+        BinOp::Sub => Ok(MiriValue::F32(a - b)),
+        BinOp::Mul => Ok(MiriValue::F32(a * b)),
+        BinOp::Div => Ok(MiriValue::F32(a / b)),
+        BinOp::Mod => Ok(MiriValue::F32(a % b)),
+        BinOp::Eq => Ok(MiriValue::Bool(a == b)),
+        BinOp::Ne => Ok(MiriValue::Bool(a != b)),
+        BinOp::Lt => Ok(MiriValue::Bool(a < b)),
+        BinOp::Gt => Ok(MiriValue::Bool(a > b)),
+        BinOp::Le => Ok(MiriValue::Bool(a <= b)),
+        BinOp::Ge => Ok(MiriValue::Bool(a >= b)),
+        _ => Err(MiriError::UnsupportedOperation(
+            format!("binary op {op:?} not supported for f32"),
+        )),
+    }
+}
+
+fn eval_binop_bool(op: BinOp, a: bool, b: bool) -> Result<MiriValue, MiriError> {
+    match op {
+        BinOp::Eq => Ok(MiriValue::Bool(a == b)),
+        BinOp::Ne => Ok(MiriValue::Bool(a != b)),
+        BinOp::And => Ok(MiriValue::Bool(a && b)),
+        BinOp::Or => Ok(MiriValue::Bool(a || b)),
+        BinOp::BitAnd => Ok(MiriValue::Bool(a & b)),
+        BinOp::BitOr => Ok(MiriValue::Bool(a | b)),
+        BinOp::BitXor => Ok(MiriValue::Bool(a ^ b)),
+        _ => Err(MiriError::UnsupportedOperation(
+            format!("binary op {op:?} not supported for bool"),
+        )),
+    }
+}

--- a/compiler/crates/rask-miri/src/lib.rs
+++ b/compiler/crates/rask-miri/src/lib.rs
@@ -1,0 +1,767 @@
+// SPDX-License-Identifier: (MIT OR Apache-2.0)
+
+//! MIR interpreter for compile-time function evaluation (CTFE).
+//!
+//! Executes MIR basic blocks directly. Same semantics as compiled code.
+//! Uses `StdlibProvider` for dispatch: `PureStdlib` for comptime (no I/O),
+//! `RealStdlib` (future) for scripting.
+
+mod eval;
+pub mod intrinsics;
+pub mod memory;
+pub mod stdlib;
+
+use std::collections::HashMap;
+use std::fmt;
+
+use rask_mir::{LocalId, MirFunction, StructLayoutId};
+use rask_mono::{StructLayout, EnumLayout};
+
+pub use stdlib::{PureStdlib, StdlibProvider};
+
+// ── Values ──────────────────────────────────────────────────────────
+
+/// Runtime value in the MIR interpreter.
+#[derive(Debug, Clone)]
+pub enum MiriValue {
+    Unit,
+    Bool(bool),
+    I8(i8),
+    I16(i16),
+    I32(i32),
+    I64(i64),
+    U8(u8),
+    U16(u16),
+    U32(u32),
+    U64(u64),
+    F32(f32),
+    F64(f64),
+    Char(char),
+    String(String),
+    Array(Vec<MiriValue>),
+    Tuple(Vec<MiriValue>),
+    Struct {
+        layout_id: StructLayoutId,
+        fields: Vec<MiriValue>,
+    },
+    Enum {
+        tag: u64,
+        payload: Option<Box<MiriValue>>,
+    },
+    /// Function pointer (by name).
+    FuncPtr(String),
+}
+
+impl MiriValue {
+    /// Extract as bool, or error.
+    pub fn as_bool(&self) -> Result<bool, MiriError> {
+        match self {
+            MiriValue::Bool(b) => Ok(*b),
+            MiriValue::I64(v) => Ok(*v != 0),
+            _ => Err(MiriError::UnsupportedOperation(
+                format!("expected bool, got {self:?}"),
+            )),
+        }
+    }
+
+    /// Try to convert to i64 (for numeric casts).
+    pub fn to_i64(&self) -> Option<i64> {
+        match self {
+            MiriValue::I8(v) => Some(*v as i64),
+            MiriValue::I16(v) => Some(*v as i64),
+            MiriValue::I32(v) => Some(*v as i64),
+            MiriValue::I64(v) => Some(*v),
+            MiriValue::U8(v) => Some(*v as i64),
+            MiriValue::U16(v) => Some(*v as i64),
+            MiriValue::U32(v) => Some(*v as i64),
+            MiriValue::U64(v) => Some(*v as i64),
+            MiriValue::F32(v) => Some(*v as i64),
+            MiriValue::F64(v) => Some(*v as i64),
+            MiriValue::Bool(v) => Some(if *v { 1 } else { 0 }),
+            MiriValue::Char(v) => Some(*v as i64),
+            _ => None,
+        }
+    }
+
+    /// Try to convert to u64 (for numeric casts).
+    pub fn to_u64(&self) -> Option<u64> {
+        match self {
+            MiriValue::I8(v) => Some(*v as u64),
+            MiriValue::I16(v) => Some(*v as u64),
+            MiriValue::I32(v) => Some(*v as u64),
+            MiriValue::I64(v) => Some(*v as u64),
+            MiriValue::U8(v) => Some(*v as u64),
+            MiriValue::U16(v) => Some(*v as u64),
+            MiriValue::U32(v) => Some(*v as u64),
+            MiriValue::U64(v) => Some(*v),
+            MiriValue::F32(v) => Some(*v as u64),
+            MiriValue::F64(v) => Some(*v as u64),
+            MiriValue::Bool(v) => Some(if *v { 1 } else { 0 }),
+            MiriValue::Char(v) => Some(*v as u64),
+            _ => None,
+        }
+    }
+
+    /// Try to convert to f64 (for numeric casts).
+    pub fn to_f64(&self) -> Option<f64> {
+        match self {
+            MiriValue::I8(v) => Some(*v as f64),
+            MiriValue::I16(v) => Some(*v as f64),
+            MiriValue::I32(v) => Some(*v as f64),
+            MiriValue::I64(v) => Some(*v as f64),
+            MiriValue::U8(v) => Some(*v as f64),
+            MiriValue::U16(v) => Some(*v as f64),
+            MiriValue::U32(v) => Some(*v as f64),
+            MiriValue::U64(v) => Some(*v as f64),
+            MiriValue::F32(v) => Some(*v as f64),
+            MiriValue::F64(v) => Some(*v),
+            _ => None,
+        }
+    }
+
+    /// Serialize to bytes for embedding in data sections.
+    /// Returns None for types that can't be statically embedded.
+    pub fn serialize(&self) -> Option<Vec<u8>> {
+        match self {
+            MiriValue::Unit => Some(vec![]),
+            MiriValue::Bool(v) => Some(vec![*v as u8]),
+            MiriValue::I8(v) => Some(v.to_le_bytes().to_vec()),
+            MiriValue::I16(v) => Some(v.to_le_bytes().to_vec()),
+            MiriValue::I32(v) => Some(v.to_le_bytes().to_vec()),
+            MiriValue::I64(v) => Some(v.to_le_bytes().to_vec()),
+            MiriValue::U8(v) => Some(v.to_le_bytes().to_vec()),
+            MiriValue::U16(v) => Some(v.to_le_bytes().to_vec()),
+            MiriValue::U32(v) => Some(v.to_le_bytes().to_vec()),
+            MiriValue::U64(v) => Some(v.to_le_bytes().to_vec()),
+            MiriValue::F32(v) => Some(v.to_le_bytes().to_vec()),
+            MiriValue::F64(v) => Some(v.to_le_bytes().to_vec()),
+            MiriValue::Char(v) => Some((*v as u32).to_le_bytes().to_vec()),
+            MiriValue::String(v) => Some(v.as_bytes().to_vec()),
+            MiriValue::Array(elems) => {
+                let mut bytes = Vec::new();
+                for elem in elems {
+                    bytes.extend(elem.serialize()?);
+                }
+                Some(bytes)
+            }
+            MiriValue::Tuple(fields) => {
+                let mut bytes = Vec::new();
+                for field in fields {
+                    bytes.extend(field.serialize()?);
+                }
+                Some(bytes)
+            }
+            MiriValue::Struct { fields, .. } => {
+                let mut bytes = Vec::new();
+                for field in fields {
+                    bytes.extend(field.serialize()?);
+                }
+                Some(bytes)
+            }
+            MiriValue::Enum { .. } | MiriValue::FuncPtr(_) => None,
+        }
+    }
+
+    /// Element count (for arrays/tuples serialized as flat data).
+    pub fn elem_count(&self) -> usize {
+        match self {
+            MiriValue::Array(elems) => elems.len(),
+            MiriValue::Tuple(fields) => fields.len(),
+            _ => 1,
+        }
+    }
+
+    /// Type prefix for codegen dispatch.
+    pub fn type_prefix(&self) -> &'static str {
+        match self {
+            MiriValue::Unit => "Unit",
+            MiriValue::Bool(_) => "Bool",
+            MiriValue::I8(_) => "I8",
+            MiriValue::I16(_) => "I16",
+            MiriValue::I32(_) => "I32",
+            MiriValue::I64(_) => "I64",
+            MiriValue::U8(_) => "U8",
+            MiriValue::U16(_) => "U16",
+            MiriValue::U32(_) => "U32",
+            MiriValue::U64(_) => "U64",
+            MiriValue::F32(_) => "F32",
+            MiriValue::F64(_) => "F64",
+            MiriValue::Char(_) => "Char",
+            MiriValue::String(_) => "String",
+            MiriValue::Array(_) => "Array",
+            MiriValue::Tuple(_) => "Tuple",
+            MiriValue::Struct { .. } => "Struct",
+            MiriValue::Enum { .. } => "Enum",
+            MiriValue::FuncPtr(_) => "FuncPtr",
+        }
+    }
+}
+
+// ── Errors ──────────────────────────────────────────────────────────
+
+/// Errors during MIR interpretation.
+#[derive(Debug, Clone)]
+pub enum MiriError {
+    UninitializedLocal(LocalId),
+    DivisionByZero,
+    BranchLimitExceeded(u64),
+    UnsupportedOperation(String),
+    StackOverflow,
+    Unreachable,
+}
+
+impl MiriError {
+    /// Shorthand for type mismatch errors.
+    pub fn type_mismatch(expected: &str, got: &MiriValue) -> Self {
+        MiriError::UnsupportedOperation(format!("expected {expected}, got {got:?}"))
+    }
+}
+
+impl fmt::Display for MiriError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            MiriError::UninitializedLocal(id) => write!(f, "use of uninitialized local _{}", id.0),
+            MiriError::DivisionByZero => write!(f, "division by zero"),
+            MiriError::BranchLimitExceeded(limit) => {
+                write!(f, "compile-time evaluation exceeded branch limit ({limit})")
+            }
+            MiriError::UnsupportedOperation(msg) => write!(f, "{msg}"),
+            MiriError::StackOverflow => write!(f, "compile-time evaluation exceeded stack depth"),
+            MiriError::Unreachable => write!(f, "reached unreachable code"),
+        }
+    }
+}
+
+impl std::error::Error for MiriError {}
+
+// ── Engine ──────────────────────────────────────────────────────────
+
+/// MIR interpreter engine.
+pub struct MiriEngine {
+    /// All available functions (user-defined MIR).
+    pub(crate) functions: HashMap<String, MirFunction>,
+    /// Struct layouts from monomorphization.
+    pub(crate) struct_layouts: Vec<StructLayout>,
+    /// Enum layouts from monomorphization.
+    #[allow(dead_code)]
+    pub(crate) enum_layouts: Vec<EnumLayout>,
+    /// Stdlib dispatch.
+    pub(crate) stdlib: Box<dyn StdlibProvider>,
+    /// Call stack.
+    pub(crate) stack: memory::CallStack,
+    /// Backwards branch quota (default 1000 per spec CT35).
+    pub(crate) branch_limit: u64,
+    /// Current backwards branch count.
+    pub(crate) branch_count: u64,
+    /// Pre-evaluated comptime globals (available to GlobalRef).
+    pub(crate) comptime_globals: HashMap<String, MiriValue>,
+    /// Current source location (for error messages).
+    pub(crate) current_line: u32,
+    pub(crate) current_col: u32,
+}
+
+impl MiriEngine {
+    /// Create a new engine with the given stdlib provider.
+    pub fn new(stdlib: Box<dyn StdlibProvider>) -> Self {
+        Self {
+            functions: HashMap::new(),
+            struct_layouts: Vec::new(),
+            enum_layouts: Vec::new(),
+            stdlib,
+            stack: memory::CallStack::new(),
+            branch_limit: 1_000,
+            branch_count: 0,
+            comptime_globals: HashMap::new(),
+            current_line: 0,
+            current_col: 0,
+        }
+    }
+
+    /// Register a MIR function.
+    pub fn register_function(&mut self, func: MirFunction) {
+        self.functions.insert(func.name.clone(), func);
+    }
+
+    /// Set struct layouts from monomorphization.
+    pub fn set_struct_layouts(&mut self, layouts: Vec<StructLayout>) {
+        self.struct_layouts = layouts;
+    }
+
+    /// Set enum layouts from monomorphization.
+    pub fn set_enum_layouts(&mut self, layouts: Vec<EnumLayout>) {
+        self.enum_layouts = layouts;
+    }
+
+    /// Set the backwards branch limit.
+    pub fn set_branch_limit(&mut self, limit: u64) {
+        self.branch_limit = limit;
+    }
+
+    /// Register a pre-evaluated comptime global.
+    pub fn register_global(&mut self, name: String, value: MiriValue) {
+        self.comptime_globals.insert(name, value);
+    }
+
+    /// Execute a function by name. Resets branch counter.
+    pub fn execute(
+        &mut self,
+        func_name: &str,
+        args: Vec<MiriValue>,
+    ) -> Result<MiriValue, MiriError> {
+        self.branch_count = 0;
+        self.call_function(func_name, args)
+    }
+}
+
+// ── Tests ───────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use rask_mir::*;
+
+    /// Helper: build a simple MIR function with one block.
+    fn make_func(
+        name: &str,
+        params: Vec<MirLocal>,
+        ret_ty: MirType,
+        locals: Vec<MirLocal>,
+        blocks: Vec<MirBlock>,
+    ) -> MirFunction {
+        MirFunction {
+            name: name.to_string(),
+            params,
+            ret_ty,
+            locals,
+            blocks,
+            entry_block: BlockId(0),
+            is_extern_c: false,
+            source_file: None,
+        }
+    }
+
+    fn local(id: u32, ty: MirType) -> MirLocal {
+        MirLocal {
+            id: LocalId(id),
+            name: None,
+            ty,
+            is_param: false,
+        }
+    }
+
+    fn param(id: u32, ty: MirType) -> MirLocal {
+        MirLocal {
+            id: LocalId(id),
+            name: None,
+            ty,
+            is_param: true,
+        }
+    }
+
+    #[test]
+    fn test_return_constant() {
+        // func f() -> i64 { return 42 }
+        let func = make_func(
+            "f",
+            vec![],
+            MirType::I64,
+            vec![],
+            vec![MirBlock {
+                id: BlockId(0),
+                statements: vec![],
+                terminator: MirTerminator::Return {
+                    value: Some(MirOperand::Constant(MirConst::Int(42))),
+                },
+            }],
+        );
+
+        let mut engine = MiriEngine::new(Box::new(PureStdlib));
+        engine.register_function(func);
+        let result = engine.execute("f", vec![]).unwrap();
+        assert!(matches!(result, MiriValue::I64(42)));
+    }
+
+    #[test]
+    fn test_arithmetic() {
+        // func add(a: i64, b: i64) -> i64 { return a + b }
+        let func = make_func(
+            "add",
+            vec![param(0, MirType::I64), param(1, MirType::I64)],
+            MirType::I64,
+            vec![
+                param(0, MirType::I64),
+                param(1, MirType::I64),
+                local(2, MirType::I64),
+            ],
+            vec![MirBlock {
+                id: BlockId(0),
+                statements: vec![MirStmt::Assign {
+                    dst: LocalId(2),
+                    rvalue: MirRValue::BinaryOp {
+                        op: BinOp::Add,
+                        left: MirOperand::Local(LocalId(0)),
+                        right: MirOperand::Local(LocalId(1)),
+                    },
+                }],
+                terminator: MirTerminator::Return {
+                    value: Some(MirOperand::Local(LocalId(2))),
+                },
+            }],
+        );
+
+        let mut engine = MiriEngine::new(Box::new(PureStdlib));
+        engine.register_function(func);
+        let result = engine.execute("add", vec![MiriValue::I64(10), MiriValue::I64(32)]).unwrap();
+        assert!(matches!(result, MiriValue::I64(42)));
+    }
+
+    #[test]
+    fn test_branch() {
+        // func abs(x: i64) -> i64 {
+        //   if x < 0: return -x
+        //   else: return x
+        // }
+        let func = make_func(
+            "abs",
+            vec![param(0, MirType::I64)],
+            MirType::I64,
+            vec![
+                param(0, MirType::I64),
+                local(1, MirType::Bool),  // cond
+                local(2, MirType::I64),   // result
+            ],
+            vec![
+                MirBlock {
+                    id: BlockId(0),
+                    statements: vec![MirStmt::Assign {
+                        dst: LocalId(1),
+                        rvalue: MirRValue::BinaryOp {
+                            op: BinOp::Lt,
+                            left: MirOperand::Local(LocalId(0)),
+                            right: MirOperand::Constant(MirConst::Int(0)),
+                        },
+                    }],
+                    terminator: MirTerminator::Branch {
+                        cond: MirOperand::Local(LocalId(1)),
+                        then_block: BlockId(1),
+                        else_block: BlockId(2),
+                    },
+                },
+                MirBlock {
+                    id: BlockId(1),
+                    statements: vec![MirStmt::Assign {
+                        dst: LocalId(2),
+                        rvalue: MirRValue::UnaryOp {
+                            op: UnaryOp::Neg,
+                            operand: MirOperand::Local(LocalId(0)),
+                        },
+                    }],
+                    terminator: MirTerminator::Return {
+                        value: Some(MirOperand::Local(LocalId(2))),
+                    },
+                },
+                MirBlock {
+                    id: BlockId(2),
+                    statements: vec![],
+                    terminator: MirTerminator::Return {
+                        value: Some(MirOperand::Local(LocalId(0))),
+                    },
+                },
+            ],
+        );
+
+        let mut engine = MiriEngine::new(Box::new(PureStdlib));
+        engine.register_function(func);
+
+        let r1 = engine.execute("abs", vec![MiriValue::I64(-5)]).unwrap();
+        assert!(matches!(r1, MiriValue::I64(5)));
+
+        let r2 = engine.execute("abs", vec![MiriValue::I64(7)]).unwrap();
+        assert!(matches!(r2, MiriValue::I64(7)));
+    }
+
+    #[test]
+    fn test_loop_with_branch_limit() {
+        // func infinite() -> i64 {
+        //   bb0: goto bb0  (infinite loop)
+        // }
+        let func = make_func(
+            "infinite",
+            vec![],
+            MirType::I64,
+            vec![],
+            vec![MirBlock {
+                id: BlockId(0),
+                statements: vec![],
+                terminator: MirTerminator::Goto {
+                    target: BlockId(0),
+                },
+            }],
+        );
+
+        let mut engine = MiriEngine::new(Box::new(PureStdlib));
+        engine.set_branch_limit(10);
+        engine.register_function(func);
+
+        let result = engine.execute("infinite", vec![]);
+        assert!(matches!(result, Err(MiriError::BranchLimitExceeded(10))));
+    }
+
+    #[test]
+    fn test_function_call() {
+        // func double(x: i64) -> i64 { return x + x }
+        // func main() -> i64 { return double(21) }
+        let double = make_func(
+            "double",
+            vec![param(0, MirType::I64)],
+            MirType::I64,
+            vec![param(0, MirType::I64), local(1, MirType::I64)],
+            vec![MirBlock {
+                id: BlockId(0),
+                statements: vec![MirStmt::Assign {
+                    dst: LocalId(1),
+                    rvalue: MirRValue::BinaryOp {
+                        op: BinOp::Add,
+                        left: MirOperand::Local(LocalId(0)),
+                        right: MirOperand::Local(LocalId(0)),
+                    },
+                }],
+                terminator: MirTerminator::Return {
+                    value: Some(MirOperand::Local(LocalId(1))),
+                },
+            }],
+        );
+
+        let main = make_func(
+            "main",
+            vec![],
+            MirType::I64,
+            vec![local(0, MirType::I64)],
+            vec![MirBlock {
+                id: BlockId(0),
+                statements: vec![MirStmt::Call {
+                    dst: Some(LocalId(0)),
+                    func: FunctionRef::internal("double".to_string()),
+                    args: vec![MirOperand::Constant(MirConst::Int(21))],
+                }],
+                terminator: MirTerminator::Return {
+                    value: Some(MirOperand::Local(LocalId(0))),
+                },
+            }],
+        );
+
+        let mut engine = MiriEngine::new(Box::new(PureStdlib));
+        engine.register_function(double);
+        engine.register_function(main);
+        let result = engine.execute("main", vec![]).unwrap();
+        assert!(matches!(result, MiriValue::I64(42)));
+    }
+
+    #[test]
+    fn test_loop_sum() {
+        // func sum() -> i64 {
+        //   let acc = 0     // local 0
+        //   let i = 0       // local 1
+        //   let cond        // local 2
+        //   bb0: acc = 0, i = 0, goto bb1
+        //   bb1: cond = i < 10, branch cond bb2 bb3
+        //   bb2: acc = acc + i, i = i + 1, goto bb1
+        //   bb3: return acc
+        // }
+        let func = make_func(
+            "sum",
+            vec![],
+            MirType::I64,
+            vec![
+                local(0, MirType::I64),
+                local(1, MirType::I64),
+                local(2, MirType::Bool),
+            ],
+            vec![
+                MirBlock {
+                    id: BlockId(0),
+                    statements: vec![
+                        MirStmt::Assign {
+                            dst: LocalId(0),
+                            rvalue: MirRValue::Use(MirOperand::Constant(MirConst::Int(0))),
+                        },
+                        MirStmt::Assign {
+                            dst: LocalId(1),
+                            rvalue: MirRValue::Use(MirOperand::Constant(MirConst::Int(0))),
+                        },
+                    ],
+                    terminator: MirTerminator::Goto {
+                        target: BlockId(1),
+                    },
+                },
+                MirBlock {
+                    id: BlockId(1),
+                    statements: vec![MirStmt::Assign {
+                        dst: LocalId(2),
+                        rvalue: MirRValue::BinaryOp {
+                            op: BinOp::Lt,
+                            left: MirOperand::Local(LocalId(1)),
+                            right: MirOperand::Constant(MirConst::Int(10)),
+                        },
+                    }],
+                    terminator: MirTerminator::Branch {
+                        cond: MirOperand::Local(LocalId(2)),
+                        then_block: BlockId(2),
+                        else_block: BlockId(3),
+                    },
+                },
+                MirBlock {
+                    id: BlockId(2),
+                    statements: vec![
+                        MirStmt::Assign {
+                            dst: LocalId(0),
+                            rvalue: MirRValue::BinaryOp {
+                                op: BinOp::Add,
+                                left: MirOperand::Local(LocalId(0)),
+                                right: MirOperand::Local(LocalId(1)),
+                            },
+                        },
+                        MirStmt::Assign {
+                            dst: LocalId(1),
+                            rvalue: MirRValue::BinaryOp {
+                                op: BinOp::Add,
+                                left: MirOperand::Local(LocalId(1)),
+                                right: MirOperand::Constant(MirConst::Int(1)),
+                            },
+                        },
+                    ],
+                    terminator: MirTerminator::Goto {
+                        target: BlockId(1),
+                    },
+                },
+                MirBlock {
+                    id: BlockId(3),
+                    statements: vec![],
+                    terminator: MirTerminator::Return {
+                        value: Some(MirOperand::Local(LocalId(0))),
+                    },
+                },
+            ],
+        );
+
+        let mut engine = MiriEngine::new(Box::new(PureStdlib));
+        engine.register_function(func);
+        let result = engine.execute("sum", vec![]).unwrap();
+        // 0+1+2+...+9 = 45
+        assert!(matches!(result, MiriValue::I64(45)));
+    }
+
+    #[test]
+    fn test_division_by_zero() {
+        let func = make_func(
+            "div",
+            vec![],
+            MirType::I64,
+            vec![local(0, MirType::I64)],
+            vec![MirBlock {
+                id: BlockId(0),
+                statements: vec![MirStmt::Assign {
+                    dst: LocalId(0),
+                    rvalue: MirRValue::BinaryOp {
+                        op: BinOp::Div,
+                        left: MirOperand::Constant(MirConst::Int(10)),
+                        right: MirOperand::Constant(MirConst::Int(0)),
+                    },
+                }],
+                terminator: MirTerminator::Return {
+                    value: Some(MirOperand::Local(LocalId(0))),
+                },
+            }],
+        );
+
+        let mut engine = MiriEngine::new(Box::new(PureStdlib));
+        engine.register_function(func);
+        let result = engine.execute("div", vec![]);
+        assert!(matches!(result, Err(MiriError::DivisionByZero)));
+    }
+
+    #[test]
+    fn test_string_constant() {
+        let func = make_func(
+            "greet",
+            vec![],
+            MirType::String,
+            vec![],
+            vec![MirBlock {
+                id: BlockId(0),
+                statements: vec![],
+                terminator: MirTerminator::Return {
+                    value: Some(MirOperand::Constant(MirConst::String("hello".to_string()))),
+                },
+            }],
+        );
+
+        let mut engine = MiriEngine::new(Box::new(PureStdlib));
+        engine.register_function(func);
+        let result = engine.execute("greet", vec![]).unwrap();
+        assert!(matches!(result, MiriValue::String(s) if s == "hello"));
+    }
+
+    #[test]
+    fn test_serialization() {
+        assert_eq!(MiriValue::I64(42).serialize(), Some(42i64.to_le_bytes().to_vec()));
+        assert_eq!(MiriValue::Bool(true).serialize(), Some(vec![1]));
+        assert_eq!(MiriValue::F64(3.14).serialize(), Some(3.14f64.to_le_bytes().to_vec()));
+
+        let arr = MiriValue::Array(vec![MiriValue::I64(1), MiriValue::I64(2), MiriValue::I64(3)]);
+        let bytes = arr.serialize().unwrap();
+        assert_eq!(bytes.len(), 24); // 3 × 8 bytes
+    }
+
+    #[test]
+    fn test_switch() {
+        // func classify(x: i64) -> i64 {
+        //   switch x { 0 => return 10, 1 => return 20, default => return 30 }
+        // }
+        let func = make_func(
+            "classify",
+            vec![param(0, MirType::I64)],
+            MirType::I64,
+            vec![param(0, MirType::I64)],
+            vec![
+                MirBlock {
+                    id: BlockId(0),
+                    statements: vec![],
+                    terminator: MirTerminator::Switch {
+                        value: MirOperand::Local(LocalId(0)),
+                        cases: vec![(0, BlockId(1)), (1, BlockId(2))],
+                        default: BlockId(3),
+                    },
+                },
+                MirBlock {
+                    id: BlockId(1),
+                    statements: vec![],
+                    terminator: MirTerminator::Return {
+                        value: Some(MirOperand::Constant(MirConst::Int(10))),
+                    },
+                },
+                MirBlock {
+                    id: BlockId(2),
+                    statements: vec![],
+                    terminator: MirTerminator::Return {
+                        value: Some(MirOperand::Constant(MirConst::Int(20))),
+                    },
+                },
+                MirBlock {
+                    id: BlockId(3),
+                    statements: vec![],
+                    terminator: MirTerminator::Return {
+                        value: Some(MirOperand::Constant(MirConst::Int(30))),
+                    },
+                },
+            ],
+        );
+
+        let mut engine = MiriEngine::new(Box::new(PureStdlib));
+        engine.register_function(func);
+
+        assert!(matches!(engine.execute("classify", vec![MiriValue::I64(0)]).unwrap(), MiriValue::I64(10)));
+        assert!(matches!(engine.execute("classify", vec![MiriValue::I64(1)]).unwrap(), MiriValue::I64(20)));
+        assert!(matches!(engine.execute("classify", vec![MiriValue::I64(99)]).unwrap(), MiriValue::I64(30)));
+    }
+}

--- a/compiler/crates/rask-miri/src/memory.rs
+++ b/compiler/crates/rask-miri/src/memory.rs
@@ -1,0 +1,99 @@
+// SPDX-License-Identifier: (MIT OR Apache-2.0)
+
+//! Virtual memory model for the MIR interpreter.
+//!
+//! Stack frames hold locals indexed by LocalId. No heap — comptime
+//! doesn't allow pools, raw pointers, or runtime allocations.
+
+use rask_mir::{LocalId, MirFunction, MirType};
+
+use crate::{MiriError, MiriValue};
+
+/// A single stack frame: one per function call.
+pub struct StackFrame {
+    /// Local variable slots, indexed by `LocalId.0`.
+    /// `None` means uninitialized.
+    pub locals: Vec<Option<MiriValue>>,
+    /// Function name (for error messages).
+    pub func_name: String,
+    /// Types of each local (for type-aware operations).
+    pub local_types: Vec<MirType>,
+    /// Ensure cleanup stack: block IDs to execute on scope exit.
+    pub cleanup_stack: Vec<rask_mir::BlockId>,
+}
+
+impl StackFrame {
+    /// Create a frame for the given function, with all locals uninitialized.
+    pub fn new(func: &MirFunction) -> Self {
+        let local_count = func.locals.len();
+        Self {
+            locals: vec![None; local_count],
+            func_name: func.name.clone(),
+            local_types: func.locals.iter().map(|l| l.ty.clone()).collect(),
+            cleanup_stack: Vec::new(),
+        }
+    }
+
+    /// Read a local. Errors if uninitialized.
+    pub fn get(&self, id: LocalId) -> Result<&MiriValue, MiriError> {
+        let idx = id.0 as usize;
+        self.locals
+            .get(idx)
+            .and_then(|slot| slot.as_ref())
+            .ok_or(MiriError::UninitializedLocal(id))
+    }
+
+    /// Write a local.
+    pub fn set(&mut self, id: LocalId, value: MiriValue) {
+        let idx = id.0 as usize;
+        if idx >= self.locals.len() {
+            self.locals.resize(idx + 1, None);
+        }
+        self.locals[idx] = Some(value);
+    }
+
+    /// Get the type of a local.
+    pub fn local_type(&self, id: LocalId) -> Option<&MirType> {
+        self.local_types.get(id.0 as usize)
+    }
+}
+
+/// Call stack: manages nested function calls.
+pub struct CallStack {
+    pub frames: Vec<StackFrame>,
+    /// Maximum call depth (default 256, reasonable for comptime).
+    pub max_depth: usize,
+}
+
+impl CallStack {
+    pub fn new() -> Self {
+        Self {
+            frames: Vec::new(),
+            max_depth: 256,
+        }
+    }
+
+    pub fn push(&mut self, frame: StackFrame) -> Result<(), MiriError> {
+        if self.frames.len() >= self.max_depth {
+            return Err(MiriError::StackOverflow);
+        }
+        self.frames.push(frame);
+        Ok(())
+    }
+
+    pub fn pop(&mut self) -> Option<StackFrame> {
+        self.frames.pop()
+    }
+
+    pub fn current(&self) -> Result<&StackFrame, MiriError> {
+        self.frames.last().ok_or(MiriError::StackOverflow)
+    }
+
+    pub fn current_mut(&mut self) -> Result<&mut StackFrame, MiriError> {
+        self.frames.last_mut().ok_or(MiriError::StackOverflow)
+    }
+
+    pub fn depth(&self) -> usize {
+        self.frames.len()
+    }
+}

--- a/compiler/crates/rask-miri/src/stdlib.rs
+++ b/compiler/crates/rask-miri/src/stdlib.rs
@@ -1,0 +1,91 @@
+// SPDX-License-Identifier: (MIT OR Apache-2.0)
+
+//! Stdlib dispatch for the MIR interpreter.
+//!
+//! `PureStdlib` handles comptime (no I/O). `RealStdlib` (future) handles scripting.
+
+use crate::{MiriError, MiriValue};
+
+/// Dispatch trait for stdlib function calls.
+///
+/// The MIR interpreter calls this when it encounters a `Call` to a function
+/// that isn't in its function table (i.e., not user-defined MIR).
+pub trait StdlibProvider {
+    /// Try to handle a stdlib call. Returns:
+    /// - `Ok(Some(value))` — call handled, return value
+    /// - `Ok(None)` — call handled, no return value (void)
+    /// - `Err(...)` — call failed or not recognized
+    fn call(&mut self, name: &str, args: &[MiriValue]) -> Result<Option<MiriValue>, MiriError>;
+}
+
+/// Comptime stdlib: pure computation only, no I/O.
+pub struct PureStdlib;
+
+impl StdlibProvider for PureStdlib {
+    fn call(&mut self, name: &str, args: &[MiriValue]) -> Result<Option<MiriValue>, MiriError> {
+        match name {
+            // String methods
+            "string_len" | "str_len" => {
+                let s = args.first().ok_or_else(|| MiriError::UnsupportedOperation(
+                    format!("{name}: missing argument"),
+                ))?;
+                match s {
+                    MiriValue::String(s) => Ok(Some(MiriValue::I64(s.len() as i64))),
+                    _ => Err(MiriError::type_mismatch("string", s)),
+                }
+            }
+            "string_is_empty" | "str_is_empty" => {
+                let s = args.first().ok_or_else(|| MiriError::UnsupportedOperation(
+                    format!("{name}: missing argument"),
+                ))?;
+                match s {
+                    MiriValue::String(s) => Ok(Some(MiriValue::Bool(s.is_empty()))),
+                    _ => Err(MiriError::type_mismatch("string", s)),
+                }
+            }
+            "string_contains" => {
+                if args.len() < 2 {
+                    return Err(MiriError::UnsupportedOperation(
+                        format!("{name}: expected 2 arguments"),
+                    ));
+                }
+                match (&args[0], &args[1]) {
+                    (MiriValue::String(haystack), MiriValue::String(needle)) => {
+                        Ok(Some(MiriValue::Bool(haystack.contains(needle.as_str()))))
+                    }
+                    _ => Err(MiriError::UnsupportedOperation(
+                        format!("{name}: expected string arguments"),
+                    )),
+                }
+            }
+            "string_concat" | "string_add" => {
+                if args.len() < 2 {
+                    return Err(MiriError::UnsupportedOperation(
+                        format!("{name}: expected 2 arguments"),
+                    ));
+                }
+                match (&args[0], &args[1]) {
+                    (MiriValue::String(a), MiriValue::String(b)) => {
+                        Ok(Some(MiriValue::String(format!("{a}{b}"))))
+                    }
+                    _ => Err(MiriError::UnsupportedOperation(
+                        format!("{name}: expected string arguments"),
+                    )),
+                }
+            }
+
+            // Printing (comptime diagnostic — future @comptime_print)
+            "print" | "println" => {
+                Err(MiriError::UnsupportedOperation(
+                    "I/O is not available at compile time".to_string(),
+                ))
+            }
+
+            _ => {
+                Err(MiriError::UnsupportedOperation(
+                    format!("function '{name}' is not available at compile time"),
+                ))
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary

This PR introduces **rask-miri**, a new MIR interpreter crate that enables compile-time function evaluation (CTFE) by directly executing MIR basic blocks. The interpreter uses a pluggable stdlib dispatch system (`StdlibProvider`) to support different execution contexts: `PureStdlib` for comptime (no I/O) and extensibility for future scripting modes.

## Key Changes

- **New crate: `rask-miri`** with four main modules:
  - `lib.rs`: Core value types (`MiriValue`), error handling (`MiriError`), and the `MiriEngine` orchestrator
  - `eval.rs`: MIR evaluation loop — executes statements, follows terminators, manages control flow
  - `intrinsics.rs`: Arithmetic, comparison, bitwise, unary, and cast operations for all numeric types
  - `memory.rs`: Virtual memory model with stack frames and call stack management
  - `stdlib.rs`: Pluggable stdlib dispatch with `PureStdlib` implementation for comptime

- **MIR value representation** (`MiriValue` enum):
  - Primitive types: `Unit`, `Bool`, `I8`–`I64`, `U8`–`U64`, `F32`, `F64`, `Char`, `String`
  - Composite types: `Array`, `Tuple`, `Struct`, `Enum`
  - Function pointers: `FuncPtr`
  - Serialization support for embedding in data sections

- **Engine features**:
  - Function registration and execution with argument passing
  - Struct and enum layout support from monomorphization
  - Backwards branch counting with configurable limits (default 1000 per spec CT35) to prevent infinite loops
  - Pre-evaluated comptime globals registry
  - Call stack with configurable depth limit (256 frames)
  - Source location tracking for error messages

- **Statement execution** supports:
  - Local variable assignment and initialization
  - Binary and unary operations
  - Function calls (both user-defined MIR and stdlib dispatch)
  - Struct field stores and array element stores
  - Global references
  - Cleanup/ensure block management
  - Proper error handling for unsupported operations (resources, pools, closures, trait objects)

- **Control flow**:
  - `Return`, `Goto`, `Branch`, `Switch`, `Unreachable` terminators
  - `CleanupReturn` with cleanup block execution
  - Backwards branch detection for loop quota enforcement

- **Integration with codegen pipeline**:
  - New `MirEvalContext` for passing monomorphized program and type information
  - `try_eval_comptime_mir()` function that synthesizes a wrapper function from comptime expressions
  - Fallback to AST interpreter on MIR evaluation failure
  - Updated `evaluate_comptime_globals()` to attempt MIR-based evaluation first

- **Comprehensive test suite** covering:
  - Constant returns
  - Arithmetic operations
  - Branching and conditionals
  - Loop detection with branch limits
  - Function calls and recursion
  - Loop accumulation patterns

## Implementation Details

- **Type-safe value conversions**: `to_i64()`, `to_u64()`, `to_f64()` methods handle numeric casts with proper semantics
- **Lazy evaluation**: Operands resolved on-demand during statement execution
- **Struct field access**: Uses byte offset mapping to layout information for field stores
- **Error propagation**: All operations return `Result<MiriValue, MiriError>` for graceful failure handling
- **Stdlib dispatch**: Trait-based design allows swapping implementations without changing the interpreter core
- **No heap allocation**: Comptime evaluation uses only stack frames; no pools, raw pointers, or runtime allocations permitted

https://claude.ai/code/session_019iFUSsBm6nAkcscDfRNtPM