### PR TITLE
Mark compiler architecture as decided with implementation status

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -260,13 +260,17 @@ Start with [CORE_DESIGN.md](specs/CORE_DESIGN.md). For specs: [specs/README.md](
 | HTTP | Client + server, linear Responder, HttpClient | [http.md](specs/stdlib/http.md) |
 | Time | Duration, Instant, SystemTime, Duration scaling | [time.md](specs/stdlib/time.md) |
 | OS | Env, args, subprocess spawning, signal handling | [os.md](specs/stdlib/os.md) |
+| Compiler architecture | IR layers, SSA pipeline, analysis framework, pass manager, CTFE, debug info | [architecture.md](specs/compiler/architecture.md) |
+| Code generation | MIR-based pipeline, Cranelift backend, runtime library | [codegen.md](specs/compiler/codegen.md) |
 
 ### Open
 
 | Area | Status |
 |------|--------|
-| Build system | Skeleton only |
+| Build system | Mostly working, cross-package symbol export still open |
 | Macros/attributes | Not specified |
+| Frontend caching | LSP works, incremental check caching not yet implemented |
+| Parallel compilation | Semantic hashing done, rayon parallelism not yet implemented |
 
 See [TODO.md](TODO.md) for full list.
 

--- a/TODO.md
+++ b/TODO.md
@@ -157,6 +157,17 @@ Hardening for the package ecosystem. Not blocking any examples.
 - [x] Tuple spec, destructuring spec
 - [x] `format!` rejected (string interpolation covers it)
 
+### Compiler Architecture
+- [x] Analysis foundation — dominator tree, dataflow framework, liveness, escape, intervals, typestate, loops, call graph
+- [x] SSA construction + de-SSA — hybrid SSA pipeline (`comp.architecture/IR3`)
+- [x] String RC insertion + elision — `rc_insert.rs`, `rc_elide.rs`
+- [x] MIR CTFE — `rask-miri` crate (MIR interpreter for comptime evaluation)
+- [x] Debug info — DWARF emission via `debug_info.rs`
+- [x] Inlining — cross-function MIR inliner with call graph analysis
+- [x] Advanced analyses — handle typestate, bounds check elimination, generation coalescing, interval analysis
+- [x] MIR optimization passes — DCE, clone elision, string append, state machine (async), constant propagation
+- [x] Architecture spec promoted from proposed to decided
+
 ### Design Decisions
 - [x] Serialization / encoding spec
 - [x] Granular unsafe operations — keep blanket unsafe blocks

--- a/specs/README.md
+++ b/specs/README.md
@@ -184,4 +184,4 @@ See [concurrency/README.md](concurrency/README.md) for the layered design.
 
 ## Status
 
-Most specs are in **Draft** status. See [TODO.md](../TODO.md) for open questions.
+Most language specs are **Decided**. Compiler architecture specs (phases A-G) are implemented. See [TODO.md](../TODO.md) for remaining open items.

--- a/specs/compiler/architecture.md
+++ b/specs/compiler/architecture.md
@@ -1,13 +1,13 @@
 <!-- id: comp.architecture -->
-<!-- status: proposed -->
-<!-- summary: Target compiler architecture — IR layers, analysis framework, pass pipeline, CTFE, debug info -->
+<!-- status: decided -->
+<!-- summary: Compiler architecture — IR layers, analysis framework, pass pipeline, CTFE, debug info -->
 <!-- depends: compiler/codegen.md, compiler/advanced-analyses.md, compiler/clone-elision.md, compiler/string-refcount-elision.md, compiler/incremental.md, compiler/effects.md -->
 
 # Compiler Architecture
 
-The compiler grew feature-by-feature. This spec defines the target architecture so that string RC optimization, SSO strings, MIR-based CTFE, reflection, debugging, borrow analysis, effects, incremental compilation, and parallel compilation all have clean extension points — not bolted on after the fact.
+The compiler architecture — IR layers, analysis framework, pass pipeline, CTFE, debug info. String RC optimization, SSO strings, MIR-based CTFE, reflection, debugging, borrow analysis, effects, incremental compilation, and parallel compilation all have clean extension points.
 
-I'm writing this now because every one of those features touches the MIR layer. If MIR's structure is wrong, every feature fights it. Getting the bones right means each feature is a pass, not a rewrite.
+Every one of those features touches the MIR layer. If MIR's structure is wrong, every feature fights it. Getting the bones right means each feature is a pass, not a rewrite.
 
 ---
 
@@ -554,17 +554,17 @@ The LSP path runs the frontend (lex → typecheck → ownership) and stops — i
 
 ## Implementation Phases
 
-| Phase | What | Enables |
-|-------|------|---------|
-| **A: Analysis foundation** | Dominator tree, dataflow framework, liveness | Everything else |
-| **B: SSA** | SSA construction + de-SSA | String RC, constant prop, precise analyses |
-| **C: String RC** | RC insertion/fusion/elision/reuse for strings | `comp.string-refcount-elision`, SSO preparation |
-| **D: MIR CTFE** | MIR interpreter crate | Comptime correctness, reflection |
-| **E: Debug info** | Spans on MIR, DWARF emission | Debugger support |
-| **F: Inlining** ✓ | Cross-function inliner with span preservation | Wider optimization window for per-function passes |
-| **G: Advanced analyses** ✓ | Handle typestate (TS1-TS8, MA1-MA5), frozen enforcement (EF1-EF6, FL1), interval analysis (IV1-IV7), bounds check elimination (BE1-BE4) | `comp.advanced` spec |
-| **H: Interactive compilation** | Frontend caching, LSP mode, suggested fixes, error restructuring | Modern dev experience |
-| **I: Parallel + Incremental** | Rayon, MIR serialization, MIR cache layer | Build performance |
+| Phase | What | Enables | Status |
+|-------|------|---------|--------|
+| **A: Analysis foundation** | Dominator tree, dataflow framework, liveness | Everything else | ✅ Done — `analysis/dominators.rs`, `analysis/dataflow.rs`, `analysis/liveness.rs`, `analysis/escape.rs`, `analysis/intervals.rs`, `analysis/typestate.rs`, `analysis/loops.rs`, `analysis/call_graph.rs` |
+| **B: SSA** | SSA construction + de-SSA | String RC, constant prop, precise analyses | ✅ Done — `transform/ssa.rs` |
+| **C: String RC** | RC insertion/fusion/elision/reuse for strings | `comp.string-refcount-elision`, SSO preparation | ✅ Done — `transform/rc_insert.rs`, `transform/rc_elide.rs` |
+| **D: MIR CTFE** | MIR interpreter crate | Comptime correctness, reflection | ✅ Done — `rask-miri` crate (`lib.rs`, `memory.rs`, `eval.rs`, `intrinsics.rs`, `stdlib.rs`) |
+| **E: Debug info** | Spans on MIR, DWARF emission | Debugger support | ✅ Done — `rask-codegen/src/debug_info.rs` |
+| **F: Inlining** | Cross-function inliner with span preservation | Wider optimization window for per-function passes | ✅ Done — `transform/inline.rs`, `analysis/call_graph.rs` |
+| **G: Advanced analyses** | Handle typestate (TS1-TS8, MA1-MA5), frozen enforcement (EF1-EF6, FL1), interval analysis (IV1-IV7), bounds check elimination (BE1-BE4) | `comp.advanced` spec | ✅ Done — `transform/typestate.rs`, `transform/bounds_elim.rs`, `transform/gen_coalesce.rs`, `analysis/typestate.rs`, `analysis/intervals.rs` |
+| **H: Interactive compilation** | Frontend caching, LSP mode, suggested fixes, error restructuring | Modern dev experience | Partial — LSP server works (`rask-lsp`), frontend caching and suggested fixes not yet implemented |
+| **I: Parallel + Incremental** | Rayon, MIR serialization, MIR cache layer | Build performance | Partial — semantic hashing done (`rask-semantic-hash`), MIR serialization and parallel codegen not yet implemented |
 
 Phase A is prerequisite for B, C, G. Phases D, E, F are independent of each other. Phase H can start early — frontend caching and error restructuring don't depend on MIR work. Phase I is independent but benefits from all others.
 

--- a/specs/compiler/codegen.md
+++ b/specs/compiler/codegen.md
@@ -12,7 +12,7 @@ Rask compiles through non-SSA MIR (mid-level IR) as control-flow graph. Monomorp
 | Rule | Description |
 |------|-------------|
 | **P1: MIR intermediary** | All source compiles through MIR before backend lowering |
-| **P2: Non-SSA** | MIR uses non-SSA form; backends construct SSA internally |
+| **P2: Hybrid SSA** | MIR is non-SSA during initial lowering, converted to SSA for optimization, de-SSA before codegen. Superseded by `comp.architecture/IR3` |
 | **P3: Cranelift dev** | Dev builds use Cranelift backend |
 | **P4: LLVM release** | Release builds may use LLVM backend (additive, future) |
 | **P5: Runtime link** | Executables link against `rask-rt` static library |
@@ -226,7 +226,7 @@ FIX: Ensure all call sites provide concrete type arguments.
 
 **P1, P2 (MIR as intermediary):** AST is tree-shaped with high-level constructs (ensure, try, pattern matching). Backend IRs are flat CFGs. MIR separates Rask-specific lowering from backend-specific lowering. Adding a second backend is straightforward.
 
-**P2 (non-SSA):** Cranelift's `FunctionBuilder` accepts non-SSA input. LLVM has `mem2reg`. Non-SSA MIR is the simplest form both backends accept.
+**P2 (hybrid SSA):** MIR lowering produces non-SSA (simpler generation), then converts to SSA for optimization passes that need precise def-use chains (string RC, constant propagation, escape analysis). De-SSA before codegen. See `comp.architecture/IR3` for rationale.
 
 **P3 (Cranelift first):** Pure Rust, no external dependencies. ~40% faster compilation than LLVM. ~10-15% slower runtime output — acceptable during language development. Industry precedent: Rust adding Cranelift for dev builds, Zig uses LLVM for release + custom backend for dev.
 


### PR DESCRIPTION
## Summary

This PR promotes the compiler architecture specification from "proposed" to "decided" status and documents the implementation status of all planned phases (A-I). The changes reflect that core compiler infrastructure (phases A-G) has been completed, with partial implementation of interactive compilation (H) and parallel/incremental compilation (I).

## Key Changes

- **Architecture spec status**: Updated `specs/compiler/architecture.md` from "proposed" to "decided"
- **Implementation tracking**: Added a "Status" column to the implementation phases table documenting:
  - ✅ Phases A-G fully implemented with specific file references
  - Partial completion for phases H (LSP server works, frontend caching pending) and I (semantic hashing done, MIR serialization pending)
- **Codegen spec clarification**: Updated `specs/compiler/codegen.md` rule P2 to reflect the actual hybrid SSA approach (non-SSA lowering → SSA optimization → de-SSA codegen) rather than pure non-SSA
- **Documentation updates**:
  - Refined architecture introduction to be more concise and less first-person
  - Updated `TODO.md` with completed compiler architecture work items
  - Updated `CLAUDE.md` to list compiler architecture and codegen as decided specs
  - Updated `specs/README.md` status to reflect that language specs are decided and compiler phases A-G are implemented

## Implementation Details

The changes document that the compiler now has:
- Complete analysis foundation (dominators, dataflow, liveness, escape, intervals, typestate, loops, call graph)
- Hybrid SSA pipeline for optimization
- String RC insertion and elision passes
- MIR-based CTFE via `rask-miri` crate
- DWARF debug info emission
- Cross-function inlining with call graph analysis
- Advanced analyses (typestate, bounds checking, generation coalescing)
- Comprehensive MIR optimization passes

This represents the completion of the core compiler architecture design and implementation.

https://claude.ai/code/session_01KKgdMjDDiRMA3kJRLdr6RA