### PR TITLE
Fix cross-package symbol export and stdlib NodeId collisions

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -267,7 +267,7 @@ Start with [CORE_DESIGN.md](specs/CORE_DESIGN.md). For specs: [specs/README.md](
 
 | Area | Status |
 |------|--------|
-| Build system | Mostly working, cross-package symbol export still open |
+| Build system | Working, including cross-package symbol export |
 | Macros/attributes | Not specified |
 | Frontend caching | LSP works, incremental check caching not yet implemented |
 | Parallel compilation | Semantic hashing done, rayon parallelism not yet implemented |

--- a/TODO.md
+++ b/TODO.md
@@ -47,7 +47,7 @@ Ownership checking works for common patterns but has gaps in error reporting and
 
 Single-file compilation works. Multi-file packages have symbol visibility issues.
 
-- [ ] **Cross-package public symbol export** — `public` types/funcs not visible via `import pkg` in workspace path deps. `lsm.DbError` resolves to `no such field on __module_lsm`. Blocks multi-package examples.
+- [x] **Cross-package public symbol export** — `public` types/funcs not visible via `import pkg` in workspace path deps. Fixed: resolver now inserts resolutions for imported symbols in field access; stdlib NodeIds no longer collide with user code; type checker resolves qualified type names (`pkg.Type`).
 - [x] **Parser: empty guard else block** — `expr is Ok else {}` with empty braces causes brace mismatch.
 
 ## 8. Build Infrastructure & Security

--- a/compiler/crates/rask-resolve/src/resolver.rs
+++ b/compiler/crates/rask-resolve/src/resolver.rs
@@ -1485,6 +1485,11 @@ impl Resolver {
                     }
 
                     if self.imported_symbols.contains(name) {
+                        // Resolve the imported identifier so the type checker
+                        // has a proper NodeId → SymbolId mapping.
+                        if let Some(sym_id) = self.scopes.lookup(name) {
+                            self.resolutions.insert(object.id, sym_id);
+                        }
                         return;
                     }
                     // Skip resolution for primitive type constants (u64.MAX, etc.)
@@ -2385,5 +2390,97 @@ mod tests {
         let resolved = result.unwrap();
         assert!(!resolved.external_decls.contains_key("lib"),
             "Package with only private types should not appear in external_decls");
+    }
+
+    #[test]
+    fn test_imported_symbol_field_access_resolved() {
+        // Regression: field access on an imported type (e.g., DbError.NotFound)
+        // must insert a resolution for the object ident, even though it's in
+        // imported_symbols. Without this, stale resolutions from other passes
+        // (stdlib) can leak through.
+        use crate::PackageRegistry;
+        use std::path::PathBuf;
+        use rask_ast::expr::{Expr, ExprKind};
+        use rask_ast::stmt::{Stmt, StmtKind};
+
+        let mut registry = PackageRegistry::new();
+
+        let _lib_pkg = registry.add_package_with_decls(
+            "lib".to_string(),
+            vec!["lib".to_string()],
+            PathBuf::from("/lib"),
+            vec![make_pub_enum_decl("DbError", &["NotFound", "Corruption"])],
+        );
+
+        let app_pkg = registry.add_package(
+            "app".to_string(),
+            vec!["app".to_string()],
+            PathBuf::from("/app"),
+        );
+
+        // Build: import lib; import lib.DbError; func main() { DbError.NotFound }
+        let field_expr = Expr {
+            id: NodeId(10),
+            kind: ExprKind::Field {
+                object: Box::new(Expr {
+                    id: NodeId(11),
+                    kind: ExprKind::Ident("DbError".to_string()),
+                    span: Span::new(0, 7),
+                }),
+                field: "NotFound".to_string(),
+            },
+            span: Span::new(0, 16),
+        };
+
+        let main_decl = Decl {
+            id: NodeId(12),
+            kind: DeclKind::Fn(FnDecl {
+                name: "main".to_string(),
+                type_params: vec![],
+                params: vec![],
+                ret_ty: None,
+                context_clauses: vec![],
+                body: vec![Stmt {
+                    id: NodeId(13),
+                    kind: StmtKind::Expr(field_expr),
+                    span: Span::new(0, 16),
+                }],
+                is_pub: false,
+                is_private: false,
+                is_comptime: false,
+                is_unsafe: false,
+                abi: None,
+                attrs: vec![],
+                doc: None,
+                span: Span::new(0, 20),
+            }),
+            span: Span::new(0, 20),
+        };
+
+        let decls = vec![
+            make_import_decl(vec!["lib"], None, false, false),
+            make_import_decl(vec!["lib", "DbError"], None, false, false),
+            main_decl,
+        ];
+
+        let result = Resolver::resolve_package(&decls, &registry, app_pkg);
+        assert!(result.is_ok(), "Should resolve: {:?}", result.err());
+
+        let resolved = result.unwrap();
+
+        // The DbError ident (NodeId 11) must have a resolution pointing to the
+        // exported Enum symbol, not be left unresolved.
+        assert!(
+            resolved.resolutions.contains_key(&NodeId(11)),
+            "DbError ident in field access must be resolved"
+        );
+
+        let sym_id = resolved.resolutions[&NodeId(11)];
+        let sym = resolved.symbols.get(sym_id).expect("symbol should exist");
+        assert!(
+            matches!(sym.kind, SymbolKind::Enum { .. }),
+            "DbError should resolve to Enum, got {:?}",
+            sym.kind
+        );
     }
 }

--- a/compiler/crates/rask-stdlib/src/stubs.rs
+++ b/compiler/crates/rask-stdlib/src/stubs.rs
@@ -107,13 +107,17 @@ impl StubRegistry {
     /// referenced by impl blocks and function bodies.
     pub fn compilable_decls() -> Vec<Decl> {
         let mut decls = Vec::new();
+        // Start NodeIds high to avoid collision with user code NodeIds.
+        let mut next_id: u32 = 1_000_000;
 
         for (_filename, source) in STUB_SOURCES {
             let lex_result = rask_lexer::Lexer::new(source).tokenize();
             if !lex_result.is_ok() {
                 continue;
             }
-            let parse_result = rask_parser::Parser::new(lex_result.tokens).parse();
+            let mut parser = rask_parser::Parser::new_with_start_id(lex_result.tokens, next_id);
+            let parse_result = parser.parse();
+            next_id = parser.next_node_id();
             let has_fn_body = parse_result.decls.iter().any(|d| match &d.kind {
                 DeclKind::Fn(f) => !f.body.is_empty(),
                 DeclKind::Impl(i) => i.methods.iter().any(|m| !m.body.is_empty()),
@@ -145,13 +149,16 @@ impl StubRegistry {
     /// function bodies. Injected into the monomorphizer for layout computation.
     pub fn compilable_struct_defs() -> Vec<Decl> {
         let mut decls = Vec::new();
+        let mut next_id: u32 = 2_000_000;
 
         for (_filename, source) in STUB_SOURCES {
             let lex_result = rask_lexer::Lexer::new(source).tokenize();
             if !lex_result.is_ok() {
                 continue;
             }
-            let parse_result = rask_parser::Parser::new(lex_result.tokens).parse();
+            let mut parser = rask_parser::Parser::new_with_start_id(lex_result.tokens, next_id);
+            let parse_result = parser.parse();
+            next_id = parser.next_node_id();
             let has_fn_body = parse_result.decls.iter().any(|d| match &d.kind {
                 DeclKind::Fn(f) => !f.body.is_empty(),
                 DeclKind::Impl(i) => i.methods.iter().any(|m| !m.body.is_empty()),

--- a/compiler/crates/rask-types/src/checker/generics.rs
+++ b/compiler/crates/rask-types/src/checker/generics.rs
@@ -54,6 +54,17 @@ impl TypeChecker {
                 if let Some(type_id) = self.types.get_type_id(name) {
                     return Type::Named(type_id);
                 }
+                // Qualified type name: "pkg.Type" → look up "Type" then "pkg$Type"
+                if let Some(dot) = name.find('.') {
+                    let type_name = &name[dot + 1..];
+                    if let Some(type_id) = self.types.get_type_id(type_name) {
+                        return Type::Named(type_id);
+                    }
+                    let prefixed = format!("{}${}", &name[..dot], type_name);
+                    if let Some(type_id) = self.types.get_type_id(&prefixed) {
+                        return Type::Named(type_id);
+                    }
+                }
                 ty.clone()
             }
             Type::UnresolvedGeneric { name, args } => {


### PR DESCRIPTION
## Summary
This PR fixes symbol resolution for imported types accessed via field notation (e.g., `DbError.NotFound`) and prevents NodeId collisions between stdlib stubs and user code that could cause stale resolutions to leak through.

## Key Changes

- **Resolver: Insert resolutions for imported symbols in field access**
  - When resolving field access on an imported identifier (e.g., `DbError.NotFound`), the resolver now inserts a proper NodeId → SymbolId mapping for the object identifier
  - This prevents stale resolutions from previous passes (stdlib) from leaking through
  - Added regression test `test_imported_symbol_field_access_resolved` to verify the fix

- **Stdlib: Prevent NodeId collisions with user code**
  - Modified `StubRegistry::compilable_decls()` to start NodeIds at 1,000,000
  - Modified `StubRegistry::compilable_struct_defs()` to start NodeIds at 2,000,000
  - Uses new `Parser::new_with_start_id()` API to ensure stdlib-generated AST nodes don't collide with user code NodeIds
  - Tracks `next_node_id()` across multiple stub source files to maintain unique IDs

- **Type checker: Resolve qualified type names**
  - Added support for resolving qualified type names in the form `pkg.Type`
  - Looks up both the bare type name and the prefixed variant (`pkg$Type`)
  - Enables proper type resolution for cross-package type references

- **Documentation updates**
  - Updated CLAUDE.md to reflect that cross-package symbol export is now working
  - Updated TODO.md to mark the cross-package public symbol export task as complete with details of the fix

## Implementation Details

The core issue was that imported symbols accessed via field notation weren't getting proper resolutions inserted, allowing stale mappings from stdlib parsing to persist. Combined with NodeId collisions between stdlib stubs and user code, this caused type checker failures when accessing exported enum variants or other fields on imported types.

The fix ensures:
1. All imported symbol references get explicit resolutions
2. Stdlib AST nodes use disjoint NodeId ranges from user code
3. Type checker can resolve both simple and qualified type names

https://claude.ai/code/session_01NuKp8s2tER1NQ6krQqoi4R