### PR TITLE
Add C interop methods for string type

### DIFF
--- a/compiler/crates/rask-codegen/src/dispatch.rs
+++ b/compiler/crates/rask-codegen/src/dispatch.rs
@@ -384,6 +384,22 @@ pub fn stdlib_entries() -> Vec<StdlibEntry> {
             ret_ty: Some(types::I64),
             can_panic: false,
         },
+        // as_c_str(): null-terminated pointer for C interop (same as ptr — strings are always null-terminated)
+        StdlibEntry {
+            mir_name: "string_as_c_str",
+            c_name: "rask_string_ptr",
+            params: &[types::I64],
+            ret_ty: Some(types::I64),
+            can_panic: false,
+        },
+        // string.from_c(ptr): copy from null-terminated C string
+        StdlibEntry {
+            mir_name: "string_from_c",
+            c_name: "rask_string_from",
+            params: &[types::I64],
+            ret_ty: Some(types::I64),
+            can_panic: false,
+        },
         // rask_string_concat(a, b: const RaskString*) → RaskString*
         StdlibEntry {
             mir_name: "concat",

--- a/compiler/crates/rask-interp/src/builtins/collections.rs
+++ b/compiler/crates/rask-interp/src/builtins/collections.rs
@@ -1115,6 +1115,15 @@ impl Interpreter {
             (TypeConstructorKind::String, "new") => {
                 Ok(Value::String(Arc::new(Mutex::new(String::new()))))
             }
+            (TypeConstructorKind::String, "from_c") => {
+                // In the interpreter, from_c just copies the string (no real raw pointers).
+                // Accept either a string or int (simulated pointer) argument.
+                match args.first() {
+                    Some(Value::String(s)) => Ok(Value::String(Arc::new(Mutex::new(s.lock().unwrap().clone())))),
+                    Some(Value::Int(_)) => Ok(Value::String(Arc::new(Mutex::new(String::new())))),
+                    _ => Ok(Value::String(Arc::new(Mutex::new(String::new())))),
+                }
+            }
             (TypeConstructorKind::Pool, "new") => {
                 Ok(Value::Pool(Arc::new(Mutex::new(PoolData::with_type_param(type_param.clone())))))
             }

--- a/compiler/crates/rask-interp/src/builtins/strings.rs
+++ b/compiler/crates/rask-interp/src/builtins/strings.rs
@@ -292,6 +292,10 @@ impl Interpreter {
                     variant_index: 0,
                 })
             }
+            // C interop: returns raw pointer (simulated as Int in interpreter)
+            "as_c_str" | "as_ptr" => {
+                Ok(Value::Int(0)) // Opaque pointer — meaningful only in compiled code
+            }
             _ => Err(RuntimeError::NoSuchMethod {
                 ty: "string".to_string(),
                 method: method.to_string(),

--- a/compiler/crates/rask-mir/src/lower/expr.rs
+++ b/compiler/crates/rask-mir/src/lower/expr.rs
@@ -1182,7 +1182,8 @@ impl<'a> MirLowerer<'a> {
                         | "lines" | "split" | "split_whitespace"
                         | "char_at" | "index_of"
                         | "chars" | "push_str" | "push_char"
-                        | "compare" => Some("string".to_string()),
+                        | "compare"
+                        | "as_c_str" | "as_ptr" => Some("string".to_string()),
                         // Vec / iterator (no other Rask type has these)
                         "push" | "remove_at" | "to_vec" | "chunks" | "skip"
                         | "map" | "filter" | "collect"

--- a/compiler/crates/rask-mir/src/lower/mod.rs
+++ b/compiler/crates/rask-mir/src/lower/mod.rs
@@ -1545,6 +1545,7 @@ fn stdlib_return_mir_type(func_name: &str) -> MirType {
     }
     // String-returning functions
     if func_name == "string_new" || func_name == "string_from"
+        || func_name == "string_from_c"
         || func_name == "string_clone"
         || func_name == "Vec_join" || func_name == "Vec_join_i64"
         || func_name.ends_with("_to_string") || func_name.ends_with("_to_uppercase")

--- a/stdlib/string.rk
+++ b/stdlib/string.rk
@@ -84,4 +84,16 @@ extend string {
 
     /// Iterate over characters (same as chars).
     public func iter(self) -> Iterator<char> { }
+
+    // ── C interop ────────────────────────────────────────────
+
+    /// Null-terminated pointer for C APIs. Zero-cost (strings are always null-terminated).
+    /// Pointer is valid as long as the string is alive.
+    public unsafe func as_c_str(self) -> *u8 { }
+
+    /// Raw data pointer + .len() for pointer+length C APIs.
+    public unsafe func as_ptr(self) -> *u8 { }
+
+    /// Copy from a null-terminated C string. Caller must ensure ptr is valid.
+    public unsafe func from_c(ptr: *u8) -> string { }
 }


### PR DESCRIPTION
## Summary
Add C interoperability methods to the string type, enabling safe and ergonomic interaction with C APIs that use null-terminated strings and raw pointers.

## Key Changes

- **New string methods in stdlib**:
  - `as_c_str()`: Returns a null-terminated pointer for C APIs (zero-cost, as strings are already null-terminated internally)
  - `as_ptr()`: Returns raw data pointer for pointer+length C APIs
  - `from_c(ptr: *u8)`: Creates a string by copying from a null-terminated C string

- **Compiler codegen support**:
  - Added `string_as_c_str` → `rask_string_ptr` and `string_from_c` → `rask_string_from` stdlib entries in dispatch
  - Updated MIR lowering to recognize `as_c_str` and `as_ptr` as string methods
  - Updated return type resolution to handle `string_from_c` as a string-returning function

- **Interpreter support**:
  - Implemented `from_c` builtin to copy strings (simulated pointer handling)
  - Implemented `as_c_str` and `as_ptr` builtins to return opaque pointer values (simulated as Int)

## Implementation Details

All three methods are marked `unsafe` in the public API, reflecting the inherent safety considerations when working with raw pointers and C interop. The interpreter provides simulation support for testing, while the compiled code will use actual C runtime functions for pointer manipulation.

https://claude.ai/code/session_012XoL7ZHXS21FebVcc6m6GS