### PR TITLE
Implement small string optimization (SSO) for RaskStr

### DIFF
--- a/compiler/crates/rask-codegen/src/builder.rs
+++ b/compiler/crates/rask-codegen/src/builder.rs
@@ -45,6 +45,12 @@ enum CallAdapt {
     DerefOption,
     /// Pop-style: value written to this stack slot by callee
     PopOutParam(StackSlot),
+    /// String out-param: callee wrote 16-byte RaskStr to this slot.
+    /// Result is the slot address (pointer), not a loaded value.
+    StringOutParam(StackSlot),
+    /// Result is void* pointing to 16-byte string element in Vec.
+    /// Copy to dst's stack slot.
+    DerefStringElement,
 }
 
 pub struct FunctionBuilder<'a> {
@@ -336,9 +342,22 @@ impl<'a> FunctionBuilder<'a> {
                     val = Self::convert_value(builder, val, val_ty, dst_ty);
                 }
 
-                let var = ctx.var_map.get(dst)
-                    .ok_or_else(|| CodegenError::UnsupportedFeature("Variable not found".to_string()))?;
-                builder.def_var(*var, val);
+                // String assignment: copy 16 bytes from source to dst stack slot.
+                // Cannot alias pointers — both variables may be live simultaneously.
+                if dst_local.ty == MirType::String {
+                    if let Some((dst_ss, _)) = ctx.stack_slot_map.get(dst) {
+                        Self::copy_aggregate(builder, val, *dst_ss, 16);
+                        // Don't update the variable — it already points to the stack slot
+                    } else {
+                        let var = ctx.var_map.get(dst)
+                            .ok_or_else(|| CodegenError::UnsupportedFeature("Variable not found".to_string()))?;
+                        builder.def_var(*var, val);
+                    }
+                } else {
+                    let var = ctx.var_map.get(dst)
+                        .ok_or_else(|| CodegenError::UnsupportedFeature("Variable not found".to_string()))?;
+                    builder.def_var(*var, val);
+                }
             }
 
             MirStmtKind::Store { addr, offset, value, store_size } => {
@@ -1135,7 +1154,7 @@ impl<'a> FunctionBuilder<'a> {
                 }
 
                 // Adapt args for typed runtime API
-                let adapt = Self::adapt_stdlib_call(builder, &func.name, &mut arg_vals, args, ctx);
+                let adapt = Self::adapt_stdlib_call(builder, &func.name, &mut arg_vals, args, dst, ctx);
 
                 // Re-read signature after adaptation (arg count may have changed)
                 let ext_func = &builder.func.dfg.ext_funcs[*func_ref];
@@ -1263,6 +1282,29 @@ impl<'a> FunctionBuilder<'a> {
                         CallAdapt::PopOutParam(ss) => {
                             // Value was written to stack slot by callee
                             builder.ins().stack_load(types::I64, ss, 0)
+                        }
+                        CallAdapt::StringOutParam(ss) => {
+                            // 16-byte RaskStr written to stack slot — return slot address.
+                            // If this slot is the dst's own slot, mark as already written.
+                            if let Some((dst_ss, _)) = ctx.stack_slot_map.get(dst_id) {
+                                if *dst_ss == ss {
+                                    slot_already_written = true;
+                                }
+                            }
+                            builder.ins().stack_addr(types::I64, ss, 0)
+                        }
+                        CallAdapt::DerefStringElement => {
+                            // void* pointing to 16-byte string in collection.
+                            // Copy to dst's stack slot.
+                            let results = builder.inst_results(call_inst);
+                            let ptr = if !results.is_empty() { results[0] } else {
+                                builder.ins().iconst(types::I64, 0)
+                            };
+                            if let Some((ss, _)) = ctx.stack_slot_map.get(dst_id) {
+                                Self::copy_aggregate(builder, ptr, *ss, 16);
+                                slot_already_written = true;
+                            }
+                            ptr
                         }
                         _ => {
                             let results = builder.inst_results(call_inst);
@@ -1993,6 +2035,7 @@ impl<'a> FunctionBuilder<'a> {
                 let max_align = fields.iter().map(|f| f.align()).max().unwrap_or(1);
                 Some((offset + max_align - 1) & !(max_align - 1))
             }
+            MirType::String => Some(16),
             MirType::Slice(_) | MirType::TraitObject { .. } => Some(ty.size()),
             MirType::Union(variants) => {
                 let max = variants.iter()
@@ -2077,82 +2120,207 @@ impl<'a> FunctionBuilder<'a> {
     /// Adapt stdlib call args for the typed runtime API.
     /// Injects elem_size args, wraps values as pointers, adds out-params.
     /// Returns the post-call adaptation needed.
+    /// Check if a function produces a string (has out-param as first parameter).
+    fn is_string_out_param_fn(name: &str) -> bool {
+        matches!(name,
+            "string_new" | "string_from" | "string_concat" | "string_substr"
+            | "string_to_lowercase" | "string_to_uppercase"
+            | "string_trim" | "string_trim_start" | "string_trim_end"
+            | "string_repeat" | "string_reverse" | "string_replace"
+            | "string_push_byte" | "string_push_char"
+            | "string_append" | "string_append_cstr" | "string_push_str"
+            | "i64_to_string" | "bool_to_string" | "f64_to_string" | "char_to_string"
+            | "string_builder_build"
+            | "Vec_join" | "Vec_join_i64"
+            | "fs_read_file" | "fs_canonicalize"
+            | "io_read_line" | "io_read_string"
+            | "json_encode" | "json_encode_string" | "json_encode_i64"
+            | "json_buf_finish" | "json_buf_finish_array" | "json_get_string"
+        )
+    }
+
     fn adapt_stdlib_call(
         builder: &mut ClifFunctionBuilder,
         func_name: &str,
         args: &mut Vec<Value>,
         mir_args: &[MirOperand],
+        dst: Option<&LocalId>,
         ctx: &CodegenCtx,
     ) -> CallAdapt {
+        // string_clone / string_to_owned: copy 16 bytes to dst, then RC inc on dst.
+        if func_name == "string_clone" || func_name == "string_to_owned" {
+            if let Some(dst_id) = dst {
+                if let Some((dst_ss, _)) = ctx.stack_slot_map.get(dst_id) {
+                    // args[0] = source string pointer. Copy 16 bytes to dst slot.
+                    if !args.is_empty() {
+                        let src_ptr = args[0];
+                        Self::copy_aggregate(builder, src_ptr, *dst_ss, 16);
+                    }
+                    // Now call rask_string_clone on the dst (for RC inc)
+                    let dst_addr = builder.ins().stack_addr(types::I64, *dst_ss, 0);
+                    args[0] = dst_addr;
+                    return CallAdapt::StringOutParam(*dst_ss);
+                }
+            }
+            // Fallthrough: no dst stack slot — just call clone for RC inc
+            return CallAdapt::None;
+        }
+
+        // String-producing functions: inject out-param as first arg
+        if Self::is_string_out_param_fn(func_name) {
+            // Use dst's stack slot directly if available, otherwise create a temp
+            let ss = dst
+                .and_then(|id| ctx.stack_slot_map.get(id))
+                .map(|(ss, _)| *ss)
+                .unwrap_or_else(|| builder.create_sized_stack_slot(StackSlotData::new(
+                    StackSlotKind::ExplicitSlot, 16, 0,
+                )));
+            let addr = builder.ins().stack_addr(types::I64, ss, 0);
+            args.insert(0, addr);
+            return CallAdapt::StringOutParam(ss);
+        }
+
         match func_name {
-            // Constructors: inject elem_size / key_size+val_size
+            // Constructors: inject elem_size / key_size+val_size if not already provided
+            // by MIR lowering. MIR lowering injects sizes for Vec.new() / Map.new()
+            // through the generic type path; other call sites (iterators, variants)
+            // don't inject sizes and need the default.
             "Vec_new" => {
-                let elem_size = builder.ins().iconst(types::I64, 8);
-                args.insert(0, elem_size);
+                if args.is_empty() {
+                    let elem_size = builder.ins().iconst(types::I64, 8);
+                    args.insert(0, elem_size);
+                }
                 CallAdapt::None
             }
             "Map_new" | "Map_new_string_keys" => {
-                let key_size = builder.ins().iconst(types::I64, 8);
-                let val_size = builder.ins().iconst(types::I64, 8);
-                args.insert(0, key_size);
-                args.insert(1, val_size);
+                if args.is_empty() {
+                    let key_size = builder.ins().iconst(types::I64, 8);
+                    let val_size = builder.ins().iconst(types::I64, 8);
+                    args.insert(0, key_size);
+                    args.insert(1, val_size);
+                }
                 CallAdapt::None
             }
             // Pool_new: MIR injects elem_size as first arg.
             // No special codegen handling needed.
             "Pool_new" => CallAdapt::None,
 
-            // Vec push/set: wrap value arg as pointer
+            // Vec push/set: wrap value arg as pointer.
+            // For string elements, the arg is already a pointer to 16-byte data.
             "Vec_push" => {
-                // args: [vec, value] → [vec, &value]
                 if args.len() >= 2 {
-                    let val = args[1];
-                    args[1] = Self::value_to_ptr(builder, val);
+                    let is_string = mir_args.get(1)
+                        .and_then(|a| Self::operand_mir_type(a, ctx.locals))
+                        .map(|t| t == MirType::String)
+                        .unwrap_or(false);
+                    if !is_string {
+                        let val = args[1];
+                        args[1] = Self::value_to_ptr(builder, val);
+                    }
                 }
                 CallAdapt::None
             }
             "Vec_set" => {
-                // args: [vec, index, value] → [vec, index, &value]
                 if args.len() >= 3 {
-                    let val = args[2];
-                    args[2] = Self::value_to_ptr(builder, val);
+                    let is_string = mir_args.get(2)
+                        .and_then(|a| Self::operand_mir_type(a, ctx.locals))
+                        .map(|t| t == MirType::String)
+                        .unwrap_or(false);
+                    if !is_string {
+                        let val = args[2];
+                        args[2] = Self::value_to_ptr(builder, val);
+                    }
                 }
                 CallAdapt::None
             }
 
             // Vec pop: add out-param, load result from it
             "Vec_pop" => {
-                // args: [vec] → [vec, &out]
-                let ss = builder.create_sized_stack_slot(StackSlotData::new(
-                    StackSlotKind::ExplicitSlot, 8, 0,
-                ));
-                let addr = builder.ins().stack_addr(types::I64, ss, 0);
-                args.push(addr);
-                CallAdapt::PopOutParam(ss)
+                // Use dst stack slot for string types, otherwise 8-byte temp
+                let is_string_dst = dst
+                    .and_then(|id| ctx.locals.iter().find(|l| l.id == *id))
+                    .map(|l| l.ty == MirType::String)
+                    .unwrap_or(false);
+                if is_string_dst {
+                    let ss = dst
+                        .and_then(|id| ctx.stack_slot_map.get(id))
+                        .map(|(ss, _)| *ss)
+                        .unwrap_or_else(|| builder.create_sized_stack_slot(StackSlotData::new(
+                            StackSlotKind::ExplicitSlot, 16, 0,
+                        )));
+                    let addr = builder.ins().stack_addr(types::I64, ss, 0);
+                    args.push(addr);
+                    CallAdapt::StringOutParam(ss)
+                } else {
+                    let ss = builder.create_sized_stack_slot(StackSlotData::new(
+                        StackSlotKind::ExplicitSlot, 8, 0,
+                    ));
+                    let addr = builder.ins().stack_addr(types::I64, ss, 0);
+                    args.push(addr);
+                    CallAdapt::PopOutParam(ss)
+                }
             }
 
             // Vec remove_at: add out-param for the removed element
             "Vec_remove" | "Vec_remove_at" => {
-                // args: [vec, index] → [vec, index, &out]
-                let ss = builder.create_sized_stack_slot(StackSlotData::new(
-                    StackSlotKind::ExplicitSlot, 8, 0,
-                ));
-                let addr = builder.ins().stack_addr(types::I64, ss, 0);
-                args.push(addr);
-                CallAdapt::PopOutParam(ss)
+                let is_string_dst = dst
+                    .and_then(|id| ctx.locals.iter().find(|l| l.id == *id))
+                    .map(|l| l.ty == MirType::String)
+                    .unwrap_or(false);
+                if is_string_dst {
+                    let ss = dst
+                        .and_then(|id| ctx.stack_slot_map.get(id))
+                        .map(|(ss, _)| *ss)
+                        .unwrap_or_else(|| builder.create_sized_stack_slot(StackSlotData::new(
+                            StackSlotKind::ExplicitSlot, 16, 0,
+                        )));
+                    let addr = builder.ins().stack_addr(types::I64, ss, 0);
+                    args.push(addr);
+                    CallAdapt::StringOutParam(ss)
+                } else {
+                    let ss = builder.create_sized_stack_slot(StackSlotData::new(
+                        StackSlotKind::ExplicitSlot, 8, 0,
+                    ));
+                    let addr = builder.ins().stack_addr(types::I64, ss, 0);
+                    args.push(addr);
+                    CallAdapt::PopOutParam(ss)
+                }
             }
 
-            // Vec get/index: result is void*, deref to get value
-            "Vec_get" | "Vec_get_unchecked" | "Vec_index" | "index" => CallAdapt::DerefResult,
+            // Vec get/index: result is void*, deref to get value.
+            // For string elements, copy 16 bytes from returned ptr to dst slot.
+            "Vec_get" | "Vec_get_unchecked" | "Vec_index" | "index" => {
+                let is_string_dst = dst
+                    .and_then(|id| ctx.locals.iter().find(|l| l.id == *id))
+                    .map(|l| l.ty == MirType::String)
+                    .unwrap_or(false);
+                if is_string_dst {
+                    CallAdapt::DerefStringElement
+                } else {
+                    CallAdapt::DerefResult
+                }
+            }
 
-            // Map insert: wrap key and value as pointers
+            // Map insert: wrap key and value as pointers.
+            // String keys/values are already pointers to 16-byte data.
             "Map_insert" => {
-                // args: [map, key, value] → [map, &key, &value]
                 if args.len() >= 3 {
-                    let key = args[1];
-                    let val = args[2];
-                    args[1] = Self::value_to_ptr(builder, key);
-                    args[2] = Self::value_to_ptr(builder, val);
+                    let key_is_str = mir_args.get(1)
+                        .and_then(|a| Self::operand_mir_type(a, ctx.locals))
+                        .map(|t| t == MirType::String)
+                        .unwrap_or(false);
+                    let val_is_str = mir_args.get(2)
+                        .and_then(|a| Self::operand_mir_type(a, ctx.locals))
+                        .map(|t| t == MirType::String)
+                        .unwrap_or(false);
+                    if !key_is_str {
+                        let key = args[1];
+                        args[1] = Self::value_to_ptr(builder, key);
+                    }
+                    if !val_is_str {
+                        let val = args[2];
+                        args[2] = Self::value_to_ptr(builder, val);
+                    }
                 }
                 CallAdapt::None
             }
@@ -2160,8 +2328,14 @@ impl<'a> FunctionBuilder<'a> {
             // Map contains_key/remove: wrap key as pointer
             "Map_contains_key" | "Map_remove" => {
                 if args.len() >= 2 {
-                    let key = args[1];
-                    args[1] = Self::value_to_ptr(builder, key);
+                    let key_is_str = mir_args.get(1)
+                        .and_then(|a| Self::operand_mir_type(a, ctx.locals))
+                        .map(|t| t == MirType::String)
+                        .unwrap_or(false);
+                    if !key_is_str {
+                        let key = args[1];
+                        args[1] = Self::value_to_ptr(builder, key);
+                    }
                 }
                 CallAdapt::None
             }
@@ -2169,17 +2343,33 @@ impl<'a> FunctionBuilder<'a> {
             // Map get: wrap key as pointer, wrap result as Option
             "Map_get" => {
                 if args.len() >= 2 {
-                    let key = args[1];
-                    args[1] = Self::value_to_ptr(builder, key);
+                    let key_is_str = mir_args.get(1)
+                        .and_then(|a| Self::operand_mir_type(a, ctx.locals))
+                        .map(|t| t == MirType::String)
+                        .unwrap_or(false);
+                    if !key_is_str {
+                        let key = args[1];
+                        args[1] = Self::value_to_ptr(builder, key);
+                    }
                 }
                 CallAdapt::DerefOption
             }
             "Map_get_unwrap" => {
                 if args.len() >= 2 {
-                    let key = args[1];
-                    args[1] = Self::value_to_ptr(builder, key);
+                    let key_is_str = mir_args.get(1)
+                        .and_then(|a| Self::operand_mir_type(a, ctx.locals))
+                        .map(|t| t == MirType::String)
+                        .unwrap_or(false);
+                    if !key_is_str {
+                        let key = args[1];
+                        args[1] = Self::value_to_ptr(builder, key);
+                    }
                 }
-                CallAdapt::DerefResult
+                let is_string_dst = dst
+                    .and_then(|id| ctx.locals.iter().find(|l| l.id == *id))
+                    .map(|l| l.ty == MirType::String)
+                    .unwrap_or(false);
+                if is_string_dst { CallAdapt::DerefStringElement } else { CallAdapt::DerefResult }
             }
 
             // Pool insert: wrap value as pointer, wrap return as Ok Result
@@ -2394,19 +2584,34 @@ impl<'a> FunctionBuilder<'a> {
                         Ok(builder.ins().iconst(types::I32, *c as i64))
                     }
                     MirConst::String(s) => {
-                        // String constants: get raw char* from data section,
-                        // then wrap in RaskString via rask_string_from().
+                        // String constants: allocate a 16-byte stack slot,
+                        // get raw char* from data section, call rask_string_from(out, cstr).
                         if let Some(gv) = ctx.string_globals.get(s.as_str()) {
                             let raw_ptr = builder.ins().global_value(types::I64, *gv);
+                            let tmp_slot = builder.create_sized_stack_slot(StackSlotData::new(
+                                StackSlotKind::ExplicitSlot, 16, 0,
+                            ));
+                            let out_ptr = builder.ins().stack_addr(types::I64, tmp_slot, 0);
                             if let Some(string_from_ref) = ctx.func_refs.get("string_from") {
-                                let call = builder.ins().call(*string_from_ref, &[raw_ptr]);
-                                let results = builder.inst_results(call);
-                                Ok(results[0])
+                                builder.ins().call(*string_from_ref, &[out_ptr, raw_ptr]);
+                                Ok(out_ptr)
                             } else {
                                 return Err(CodegenError::FunctionNotFound("string_from".to_string()))
                             }
                         } else {
-                            Ok(builder.ins().iconst(types::I64, 0))
+                            // Empty string: SSO with remaining=15
+                            let tmp_slot = builder.create_sized_stack_slot(StackSlotData::new(
+                                StackSlotKind::ExplicitSlot, 16, 0,
+                            ));
+                            // Zero first 8 bytes
+                            let zero = builder.ins().iconst(types::I64, 0);
+                            builder.ins().stack_store(zero, tmp_slot, 0);
+                            // Second 8 bytes: remaining=15 in byte 15 (offset 7 of second word)
+                            // Byte 15 = 0x0F → second i64 = 0x0F00_0000_0000_0000
+                            let hi = builder.ins().iconst(types::I64, 0x0F00_0000_0000_0000u64 as i64);
+                            builder.ins().stack_store(hi, tmp_slot, 8);
+                            let out_ptr = builder.ins().stack_addr(types::I64, tmp_slot, 0);
+                            Ok(out_ptr)
                         }
                     }
                 }

--- a/compiler/crates/rask-codegen/src/dispatch.rs
+++ b/compiler/crates/rask-codegen/src/dispatch.rs
@@ -226,20 +226,20 @@ pub fn stdlib_entries() -> Vec<StdlibEntry> {
             ret_ty: Some(types::I64),
             can_panic: false,
         },
-        // rask_vec_join(v: Vec<string>*, separator: string*) → string*
+        // rask_vec_join(out: RaskStr*, v: Vec<string>*, separator: RaskStr*) → void
         StdlibEntry {
             mir_name: "Vec_join",
             c_name: "rask_vec_join",
-            params: &[types::I64, types::I64],
-            ret_ty: Some(types::I64),
+            params: &[types::I64, types::I64, types::I64],
+            ret_ty: None,
             can_panic: false,
         },
-        // rask_vec_join_i64(v: Vec<i64>*, separator: string*) → string*
+        // rask_vec_join_i64(out: RaskStr*, v: Vec<i64>*, separator: RaskStr*) → void
         StdlibEntry {
             mir_name: "Vec_join_i64",
             c_name: "rask_vec_join_i64",
-            params: &[types::I64, types::I64],
-            ret_ty: Some(types::I64),
+            params: &[types::I64, types::I64, types::I64],
+            ret_ty: None,
             can_panic: false,
         },
 
@@ -336,7 +336,12 @@ pub fn stdlib_entries() -> Vec<StdlibEntry> {
         },
 
         // ── String operations ──────────────────────────────────
-        // rask_string_free(s: RaskString*) → void
+        // SSO: strings are 16-byte RaskStr values on stack. Functions receive
+        // pointers to caller's stack slots. String-producing functions take
+        // RaskStr *out as first param and return void.
+
+        // RC operations (codegen calls after inline tag check)
+        // rask_string_free(s: const RaskStr*) → void
         StdlibEntry {
             mir_name: "string_free",
             c_name: "rask_string_free",
@@ -344,23 +349,51 @@ pub fn stdlib_entries() -> Vec<StdlibEntry> {
             ret_ty: None,
             can_panic: false,
         },
-        // rask_string_new() → RaskString*
+        // rask_string_clone(s: const RaskStr*) → void (RC inc only)
+        StdlibEntry {
+            mir_name: "string_clone",
+            c_name: "rask_string_clone",
+            params: &[types::I64],
+            ret_ty: None,
+            can_panic: false,
+        },
+        // string.to_owned() → alias for clone (RC inc, value copy in codegen)
+        StdlibEntry {
+            mir_name: "string_to_owned",
+            c_name: "rask_string_clone",
+            params: &[types::I64],
+            ret_ty: None,
+            can_panic: false,
+        },
+
+        // Constructors (out-param)
+        // rask_string_new(out: RaskStr*) → void
         StdlibEntry {
             mir_name: "string_new",
             c_name: "rask_string_new",
-            params: &[],
-            ret_ty: Some(types::I64),
+            params: &[types::I64],
+            ret_ty: None,
             can_panic: false,
         },
-        // rask_string_from(cstr: const char*) → RaskString*
+        // rask_string_from(out: RaskStr*, cstr: const char*) → void
         StdlibEntry {
             mir_name: "string_from",
             c_name: "rask_string_from",
-            params: &[types::I64],
-            ret_ty: Some(types::I64),
+            params: &[types::I64, types::I64],
+            ret_ty: None,
             can_panic: false,
         },
-        // rask_string_len(s: const RaskString*) → i64
+        // string.from_c(ptr): copy from null-terminated C string
+        StdlibEntry {
+            mir_name: "string_from_c",
+            c_name: "rask_string_from",
+            params: &[types::I64, types::I64],
+            ret_ty: None,
+            can_panic: false,
+        },
+
+        // Read-only accessors (no signature change — param is pointer to 16B value)
+        // rask_string_len(s: const RaskStr*) → i64
         StdlibEntry {
             mir_name: "string_len",
             c_name: "rask_string_len",
@@ -368,7 +401,7 @@ pub fn stdlib_entries() -> Vec<StdlibEntry> {
             ret_ty: Some(types::I64),
             can_panic: false,
         },
-        // rask_string_eq(a, b: const RaskString*) → i64 (0 or 1)
+        // rask_string_eq(a, b: const RaskStr*) → i64
         StdlibEntry {
             mir_name: "string_eq",
             c_name: "rask_string_eq",
@@ -376,7 +409,7 @@ pub fn stdlib_entries() -> Vec<StdlibEntry> {
             ret_ty: Some(types::I64),
             can_panic: false,
         },
-        // rask_string_ptr(s: const RaskString*) → const char*
+        // rask_string_ptr(s: const RaskStr*) → const char*
         StdlibEntry {
             mir_name: "string_as_ptr",
             c_name: "rask_string_ptr",
@@ -384,7 +417,6 @@ pub fn stdlib_entries() -> Vec<StdlibEntry> {
             ret_ty: Some(types::I64),
             can_panic: false,
         },
-        // as_c_str(): null-terminated pointer for C interop (same as ptr — strings are always null-terminated)
         StdlibEntry {
             mir_name: "string_as_c_str",
             c_name: "rask_string_ptr",
@@ -392,52 +424,9 @@ pub fn stdlib_entries() -> Vec<StdlibEntry> {
             ret_ty: Some(types::I64),
             can_panic: false,
         },
-        // string.from_c(ptr): copy from null-terminated C string
-        StdlibEntry {
-            mir_name: "string_from_c",
-            c_name: "rask_string_from",
-            params: &[types::I64],
-            ret_ty: Some(types::I64),
-            can_panic: false,
-        },
-        // rask_string_concat(a, b: const RaskString*) → RaskString*
-        StdlibEntry {
-            mir_name: "concat",
-            c_name: "rask_string_concat",
-            params: &[types::I64, types::I64],
-            ret_ty: Some(types::I64),
-            can_panic: false,
-        },
-        // rask_string_append(s: RaskString*, other: const RaskString*) → RaskString*
-        // Returns s (or a COW copy if refcount > 1).
-        StdlibEntry {
-            mir_name: "string_append",
-            c_name: "rask_string_append",
-            params: &[types::I64, types::I64],
-            ret_ty: Some(types::I64),
-            can_panic: false,
-        },
-        // rask_string_append_cstr(s: RaskString*, cstr: const char*) → RaskString*
-        // COW-safe variant for string constant args.
-        StdlibEntry {
-            mir_name: "string_append_cstr",
-            c_name: "rask_string_append_cstr",
-            params: &[types::I64, types::I64],
-            ret_ty: Some(types::I64),
-            can_panic: false,
-        },
-
-        // ── String methods ────────────────────────────────────
         StdlibEntry {
             mir_name: "string_is_empty",
             c_name: "rask_string_is_empty",
-            params: &[types::I64],
-            ret_ty: Some(types::I64),
-            can_panic: false,
-        },
-        StdlibEntry {
-            mir_name: "string_to_uppercase",
-            c_name: "rask_string_to_uppercase",
             params: &[types::I64],
             ret_ty: Some(types::I64),
             can_panic: false,
@@ -471,41 +460,6 @@ pub fn stdlib_entries() -> Vec<StdlibEntry> {
             can_panic: false,
         },
         StdlibEntry {
-            mir_name: "string_repeat",
-            c_name: "rask_string_repeat",
-            params: &[types::I64, types::I64],
-            ret_ty: Some(types::I64),
-            can_panic: false,
-        },
-        StdlibEntry {
-            mir_name: "string_reverse",
-            c_name: "rask_string_reverse",
-            params: &[types::I64],
-            ret_ty: Some(types::I64),
-            can_panic: false,
-        },
-        StdlibEntry {
-            mir_name: "string_trim_start",
-            c_name: "rask_string_trim_start",
-            params: &[types::I64],
-            ret_ty: Some(types::I64),
-            can_panic: false,
-        },
-        StdlibEntry {
-            mir_name: "string_trim_end",
-            c_name: "rask_string_trim_end",
-            params: &[types::I64],
-            ret_ty: Some(types::I64),
-            can_panic: false,
-        },
-        StdlibEntry {
-            mir_name: "string_to_lowercase",
-            c_name: "rask_string_to_lowercase",
-            params: &[types::I64],
-            ret_ty: Some(types::I64),
-            can_panic: false,
-        },
-        StdlibEntry {
             mir_name: "string_starts_with",
             c_name: "rask_string_starts_with",
             params: &[types::I64, types::I64],
@@ -513,36 +467,26 @@ pub fn stdlib_entries() -> Vec<StdlibEntry> {
             can_panic: false,
         },
         StdlibEntry {
-            mir_name: "string_lines",
-            c_name: "rask_string_lines",
-            params: &[types::I64],
-            ret_ty: Some(types::I64),
-            can_panic: false,
-        },
-        StdlibEntry {
-            mir_name: "string_trim",
-            c_name: "rask_string_trim",
-            params: &[types::I64],
-            ret_ty: Some(types::I64),
-            can_panic: false,
-        },
-        // Result_map_err: both closure and variant constructor forms
-        // are expanded inline at MIR level (lower_map_err / lower_map_err_constructor).
-        StdlibEntry {
-            mir_name: "string_split",
-            c_name: "rask_string_split",
+            mir_name: "string_ends_with",
+            c_name: "rask_string_ends_with",
             params: &[types::I64, types::I64],
             ret_ty: Some(types::I64),
             can_panic: false,
         },
         StdlibEntry {
-            mir_name: "string_split_whitespace",
-            c_name: "rask_string_split_whitespace",
-            params: &[types::I64],
+            mir_name: "string_contains",
+            c_name: "rask_string_contains",
+            params: &[types::I64, types::I64],
             ret_ty: Some(types::I64),
             can_panic: false,
         },
-        // Fallback: unresolved .parse() defaults to parse_float (f64-returning)
+        StdlibEntry {
+            mir_name: "string_byte_at",
+            c_name: "rask_string_byte_at",
+            params: &[types::I64, types::I64],
+            ret_ty: Some(types::I64),
+            can_panic: false,
+        },
         StdlibEntry {
             mir_name: "string_parse",
             c_name: "rask_string_parse_float",
@@ -565,68 +509,207 @@ pub fn stdlib_entries() -> Vec<StdlibEntry> {
             can_panic: false,
         },
         StdlibEntry {
-            mir_name: "string_byte_at",
-            c_name: "rask_string_byte_at",
-            params: &[types::I64, types::I64],
+            mir_name: "string_parse_i32",
+            c_name: "rask_string_parse_int",
+            params: &[types::I64],
             ret_ty: Some(types::I64),
             can_panic: false,
         },
+        StdlibEntry {
+            mir_name: "string_parse_i64",
+            c_name: "rask_string_parse_int",
+            params: &[types::I64],
+            ret_ty: Some(types::I64),
+            can_panic: false,
+        },
+        StdlibEntry {
+            mir_name: "string_parse_f64",
+            c_name: "rask_string_parse_float",
+            params: &[types::I64],
+            ret_ty: Some(types::F64),
+            can_panic: false,
+        },
+
+        // String-producing operations (out-param: RaskStr *out as first param, void return)
+        // rask_string_concat(out, a, b: const RaskStr*) → void
+        StdlibEntry {
+            mir_name: "concat",
+            c_name: "rask_string_concat",
+            params: &[types::I64, types::I64, types::I64],
+            ret_ty: None,
+            can_panic: false,
+        },
+        // rask_string_substr(out, s: const RaskStr*, start, end: i64) → void
         StdlibEntry {
             mir_name: "string_substr",
             c_name: "rask_string_substr",
-            params: &[types::I64, types::I64, types::I64],
-            ret_ty: Some(types::I64),
+            params: &[types::I64, types::I64, types::I64, types::I64],
+            ret_ty: None,
+            can_panic: false,
+        },
+        // rask_string_to_lowercase(out, s: const RaskStr*) → void
+        StdlibEntry {
+            mir_name: "string_to_lowercase",
+            c_name: "rask_string_to_lowercase",
+            params: &[types::I64, types::I64],
+            ret_ty: None,
             can_panic: false,
         },
         StdlibEntry {
-            mir_name: "string_ends_with",
-            c_name: "rask_string_ends_with",
+            mir_name: "string_to_uppercase",
+            c_name: "rask_string_to_uppercase",
             params: &[types::I64, types::I64],
-            ret_ty: Some(types::I64),
+            ret_ty: None,
             can_panic: false,
         },
+        StdlibEntry {
+            mir_name: "string_trim",
+            c_name: "rask_string_trim",
+            params: &[types::I64, types::I64],
+            ret_ty: None,
+            can_panic: false,
+        },
+        StdlibEntry {
+            mir_name: "string_trim_start",
+            c_name: "rask_string_trim_start",
+            params: &[types::I64, types::I64],
+            ret_ty: None,
+            can_panic: false,
+        },
+        StdlibEntry {
+            mir_name: "string_trim_end",
+            c_name: "rask_string_trim_end",
+            params: &[types::I64, types::I64],
+            ret_ty: None,
+            can_panic: false,
+        },
+        // rask_string_repeat(out, s: const RaskStr*, count: i64) → void
+        StdlibEntry {
+            mir_name: "string_repeat",
+            c_name: "rask_string_repeat",
+            params: &[types::I64, types::I64, types::I64],
+            ret_ty: None,
+            can_panic: false,
+        },
+        StdlibEntry {
+            mir_name: "string_reverse",
+            c_name: "rask_string_reverse",
+            params: &[types::I64, types::I64],
+            ret_ty: None,
+            can_panic: false,
+        },
+        // rask_string_replace(out, s, from, to: const RaskStr*) → void
         StdlibEntry {
             mir_name: "string_replace",
             c_name: "rask_string_replace",
+            params: &[types::I64, types::I64, types::I64, types::I64],
+            ret_ty: None,
+            can_panic: false,
+        },
+
+        // Builder operations (out-param: RaskStr *out, const RaskStr *s, ...)
+        // rask_string_append(out, s, other: const RaskStr*) → void
+        StdlibEntry {
+            mir_name: "string_append",
+            c_name: "rask_string_append",
             params: &[types::I64, types::I64, types::I64],
+            ret_ty: None,
+            can_panic: false,
+        },
+        // rask_string_append_cstr(out, s: const RaskStr*, cstr: const char*) → void
+        StdlibEntry {
+            mir_name: "string_append_cstr",
+            c_name: "rask_string_append_cstr",
+            params: &[types::I64, types::I64, types::I64],
+            ret_ty: None,
+            can_panic: false,
+        },
+        // rask_string_push_str(out, s, other: const RaskStr*) → void
+        StdlibEntry {
+            mir_name: "string_push_str",
+            c_name: "rask_string_push_str",
+            params: &[types::I64, types::I64, types::I64],
+            ret_ty: None,
+            can_panic: false,
+        },
+        // rask_string_push_char(out, s: const RaskStr*, cp: i32) → void
+        StdlibEntry {
+            mir_name: "string_push_char",
+            c_name: "rask_string_push_char",
+            params: &[types::I64, types::I64, types::I32],
+            ret_ty: None,
+            can_panic: false,
+        },
+        StdlibEntry {
+            mir_name: "string_push",
+            c_name: "rask_string_push_char",
+            params: &[types::I64, types::I64, types::I32],
+            ret_ty: None,
+            can_panic: false,
+        },
+
+        // Vec-returning operations (elements are 16-byte RaskStr values)
+        StdlibEntry {
+            mir_name: "string_lines",
+            c_name: "rask_string_lines",
+            params: &[types::I64],
+            ret_ty: Some(types::I64),
+            can_panic: false,
+        },
+        // Result_map_err: both closure and variant constructor forms
+        // are expanded inline at MIR level (lower_map_err / lower_map_err_constructor).
+        StdlibEntry {
+            mir_name: "string_split",
+            c_name: "rask_string_split",
+            params: &[types::I64, types::I64],
             ret_ty: Some(types::I64),
             can_panic: false,
         },
         StdlibEntry {
-            mir_name: "string_contains",
-            c_name: "rask_string_contains",
-            params: &[types::I64, types::I64],
+            mir_name: "string_split_whitespace",
+            c_name: "rask_string_split_whitespace",
+            params: &[types::I64],
+            ret_ty: Some(types::I64),
+            can_panic: false,
+        },
+        StdlibEntry {
+            mir_name: "string_chars",
+            c_name: "rask_string_chars",
+            params: &[types::I64],
             ret_ty: Some(types::I64),
             can_panic: false,
         },
 
-        // ── Conversion to string ──────────────────────────────
+        // ── Conversion to string (out-param) ──────────────────
+        // rask_i64_to_string(out: RaskStr*, val: i64) → void
         StdlibEntry {
             mir_name: "i64_to_string",
             c_name: "rask_i64_to_string",
-            params: &[types::I64],
-            ret_ty: Some(types::I64),
+            params: &[types::I64, types::I64],
+            ret_ty: None,
             can_panic: false,
         },
         StdlibEntry {
             mir_name: "bool_to_string",
             c_name: "rask_bool_to_string",
-            params: &[types::I64],
-            ret_ty: Some(types::I64),
+            params: &[types::I64, types::I64],
+            ret_ty: None,
             can_panic: false,
         },
+        // rask_f64_to_string(out: RaskStr*, val: f64) → void
         StdlibEntry {
             mir_name: "f64_to_string",
             c_name: "rask_f64_to_string",
-            params: &[types::F64],
-            ret_ty: Some(types::I64),
+            params: &[types::I64, types::F64],
+            ret_ty: None,
             can_panic: false,
         },
+        // rask_char_to_string(out: RaskStr*, cp: i32) → void
         StdlibEntry {
             mir_name: "char_to_string",
             c_name: "rask_char_to_string",
-            params: &[types::I32],
-            ret_ty: Some(types::I64),
+            params: &[types::I64, types::I32],
+            ret_ty: None,
             can_panic: false,
         },
 
@@ -1171,8 +1254,8 @@ pub fn stdlib_entries() -> Vec<StdlibEntry> {
         StdlibEntry {
             mir_name: "io_read_line",
             c_name: "rask_io_read_line",
-            params: &[],
-            ret_ty: Some(types::I64),
+            params: &[types::I64],
+            ret_ty: None,
             can_panic: false,
         },
 
@@ -1180,8 +1263,8 @@ pub fn stdlib_entries() -> Vec<StdlibEntry> {
         StdlibEntry {
             mir_name: "fs_read_file",
             c_name: "rask_fs_read_file",
-            params: &[types::I64],
-            ret_ty: Some(types::I64),
+            params: &[types::I64, types::I64],
+            ret_ty: None,
             can_panic: false,
         },
         StdlibEntry {
@@ -1215,8 +1298,8 @@ pub fn stdlib_entries() -> Vec<StdlibEntry> {
         StdlibEntry {
             mir_name: "fs_canonicalize",
             c_name: "rask_fs_canonicalize",
-            params: &[types::I64],
-            ret_ty: Some(types::I64),
+            params: &[types::I64, types::I64],
+            ret_ty: None,
             can_panic: false,
         },
         StdlibEntry {
@@ -1324,9 +1407,9 @@ pub fn stdlib_entries() -> Vec<StdlibEntry> {
         // ── I/O primitives (used by Rask stdlib HTTP parser) ─────────
         StdlibEntry {
             mir_name: "io_read_string",
-            c_name: "rask_io_read_string",
-            params: &[types::I64, types::I64],
-            ret_ty: Some(types::I64),
+            c_name: "rask_io_read_until_close",
+            params: &[types::I64, types::I64, types::I64],
+            ret_ty: None,
             can_panic: false,
         },
         StdlibEntry {
@@ -1380,8 +1463,8 @@ pub fn stdlib_entries() -> Vec<StdlibEntry> {
         StdlibEntry {
             mir_name: "json_encode",
             c_name: "rask_json_encode",
-            params: &[types::I64],
-            ret_ty: Some(types::I64),
+            params: &[types::I64, types::I64],
+            ret_ty: None,
             can_panic: false,
         },
 
@@ -1389,15 +1472,15 @@ pub fn stdlib_entries() -> Vec<StdlibEntry> {
         StdlibEntry {
             mir_name: "json_encode_string",
             c_name: "rask_json_encode_string",
-            params: &[types::I64],
-            ret_ty: Some(types::I64),
+            params: &[types::I64, types::I64],
+            ret_ty: None,
             can_panic: false,
         },
         StdlibEntry {
             mir_name: "json_encode_i64",
             c_name: "rask_json_encode_i64",
-            params: &[types::I64],
-            ret_ty: Some(types::I64),
+            params: &[types::I64, types::I64],
+            ret_ty: None,
             can_panic: false,
         },
         StdlibEntry {
@@ -1445,8 +1528,8 @@ pub fn stdlib_entries() -> Vec<StdlibEntry> {
         StdlibEntry {
             mir_name: "json_buf_finish",
             c_name: "rask_json_buf_finish",
-            params: &[types::I64],
-            ret_ty: Some(types::I64),
+            params: &[types::I64, types::I64],
+            ret_ty: None,
             can_panic: false,
         },
         // JSON array buffer — Vec serialization
@@ -1495,8 +1578,8 @@ pub fn stdlib_entries() -> Vec<StdlibEntry> {
         StdlibEntry {
             mir_name: "json_buf_finish_array",
             c_name: "rask_json_buf_finish_array",
-            params: &[types::I64],
-            ret_ty: Some(types::I64),
+            params: &[types::I64, types::I64],
+            ret_ty: None,
             can_panic: false,
         },
         StdlibEntry {
@@ -1509,8 +1592,8 @@ pub fn stdlib_entries() -> Vec<StdlibEntry> {
         StdlibEntry {
             mir_name: "json_get_string",
             c_name: "rask_json_get_string",
-            params: &[types::I64, types::I64],
-            ret_ty: Some(types::I64),
+            params: &[types::I64, types::I64, types::I64],
+            ret_ty: None,
             can_panic: false,
         },
         StdlibEntry {
@@ -1562,21 +1645,6 @@ pub fn stdlib_entries() -> Vec<StdlibEntry> {
         StdlibEntry {
             mir_name: "Map_clone",
             c_name: "rask_map_clone",
-            params: &[types::I64],
-            ret_ty: Some(types::I64),
-            can_panic: false,
-        },
-        StdlibEntry {
-            mir_name: "string_clone",
-            c_name: "rask_string_clone",
-            params: &[types::I64],
-            ret_ty: Some(types::I64),
-            can_panic: false,
-        },
-        // string.to_owned() → alias for clone
-        StdlibEntry {
-            mir_name: "string_to_owned",
-            c_name: "rask_string_clone",
             params: &[types::I64],
             ret_ty: Some(types::I64),
             can_panic: false,

--- a/compiler/crates/rask-mir/src/lower/collections.rs
+++ b/compiler/crates/rask-mir/src/lower/collections.rs
@@ -355,7 +355,8 @@ impl<'a> MirLowerer<'a> {
             MirType::I16 | MirType::U16 => 2,
             MirType::I32 | MirType::U32 | MirType::F32 | MirType::Char => 4,
             MirType::I64 | MirType::U64 | MirType::F64 | MirType::Ptr
-            | MirType::String | MirType::FuncPtr(_) | MirType::Handle => 8,
+            | MirType::FuncPtr(_) | MirType::Handle => 8,
+            MirType::String => 16,
             MirType::Struct(StructLayoutId(id)) => {
                 self.ctx.struct_layouts.get(*id as usize)
                     .map(|l| l.size as i64)
@@ -372,6 +373,25 @@ impl<'a> MirLowerer<'a> {
             | MirType::SimdVector { .. } | MirType::TraitObject { .. } => ty.size() as i64,
             MirType::Void => 0,
         }
+    }
+
+    /// Size of the Nth generic type parameter in a name like "Vec<string>" or "Map<string, i64>".
+    /// Returns 16 for string, struct layout size for structs, 8 otherwise.
+    pub(super) fn generic_type_param_size(&self, generic_name: &str, index: usize) -> i64 {
+        let inner = generic_name.split('<').nth(1)
+            .and_then(|s| s.strip_suffix('>'));
+        if let Some(params_str) = inner {
+            let params: Vec<&str> = params_str.split(',').map(|s| s.trim()).collect();
+            if let Some(type_name) = params.get(index) {
+                if *type_name == "string" {
+                    return 16;
+                }
+                if let Some((_, layout)) = self.ctx.find_struct(type_name) {
+                    return layout.size as i64;
+                }
+            }
+        }
+        8 // scalar default
     }
 
     /// Clone function name for a type, or None if the type is Copy.

--- a/compiler/crates/rask-mir/src/lower/expr.rs
+++ b/compiler/crates/rask-mir/src/lower/expr.rs
@@ -785,6 +785,21 @@ impl<'a> MirLowerer<'a> {
                                 arg_operands.insert(0, size_op);
                             }
 
+                            // Vec.new(): inject elem_size so runtime allocates correct slots.
+                            // string elements need 16 bytes; structs use layout size; default 8.
+                            if base_name == "Vec" && method == "new" {
+                                let elem_size = self.generic_type_param_size(name, 0);
+                                let size_op = MirOperand::Constant(MirConst::Int(elem_size));
+                                arg_operands.insert(0, size_op);
+                            }
+                            // Map.new(): inject key_size, val_size
+                            if (base_name == "Map") && method == "new" {
+                                let key_size = self.generic_type_param_size(name, 0);
+                                let val_size = self.generic_type_param_size(name, 1);
+                                arg_operands.insert(0, MirOperand::Constant(MirConst::Int(key_size)));
+                                arg_operands.insert(1, MirOperand::Constant(MirConst::Int(val_size)));
+                            }
+
                             // Map.new() with string keys → use string hash/eq
                             let func_name = if func_name == "Map_new" {
                                 let has_string_keys = self.ctx.lookup_raw_type(expr.id)

--- a/compiler/runtime/map.c
+++ b/compiler/runtime/map.c
@@ -45,11 +45,10 @@ int rask_eq_bytes(const void *a, const void *b, int64_t key_size) {
     return memcmp(a, b, (size_t)key_size) == 0;
 }
 
-// String-keyed maps: key slot holds a RaskString*, hash/eq use string content
+// String-keyed maps: key slot holds a 16-byte RaskStr value, hash/eq use string content
 uint64_t rask_hash_string_key(const void *key, int64_t key_size) {
     (void)key_size;
-    const RaskString *s = *(RaskString *const *)key;
-    if (!s) return 0;
+    const RaskStr *s = (const RaskStr *)key;
     int64_t len = rask_string_len(s);
     const char *data = rask_string_ptr(s);
     uint64_t h = 0xcbf29ce484222325ULL;
@@ -62,10 +61,10 @@ uint64_t rask_hash_string_key(const void *key, int64_t key_size) {
 
 int rask_eq_string_key(const void *a, const void *b, int64_t key_size) {
     (void)key_size;
-    const RaskString *sa = *(RaskString *const *)a;
-    const RaskString *sb = *(RaskString *const *)b;
-    if (sa == sb) return 1;
-    if (!sa || !sb) return 0;
+    const RaskStr *sa = (const RaskStr *)a;
+    const RaskStr *sb = (const RaskStr *)b;
+    // Fast path: bitwise identical (same SSO or same heap pointer+len)
+    if (memcmp(sa, sb, 16) == 0) return 1;
     int64_t la = rask_string_len(sa);
     int64_t lb = rask_string_len(sb);
     if (la != lb) return 0;

--- a/compiler/runtime/rask_runtime.h
+++ b/compiler/runtime/rask_runtime.h
@@ -176,6 +176,10 @@ int64_t rask_char_to_lowercase(int32_t c);
 int64_t rask_char_len_utf8(int32_t c);
 int64_t rask_char_eq(int32_t a, int32_t b);
 
+// ─── Vec (string-dependent) ─────────────────────────────────
+void     rask_vec_join(RaskStr *out, const RaskVec *src, const RaskStr *sep);
+void     rask_vec_join_i64(RaskStr *out, const RaskVec *src, const RaskStr *sep);
+
 // ─── Map ────────────────────────────────────────────────────
 // Open-addressing hash map with linear probing.
 // Keys and values stored as raw bytes. Uses FNV-1a hashing + memcmp by default.
@@ -273,6 +277,11 @@ int64_t  rask_random_range(int64_t lo, int64_t hi);
 // ─── FS module ──────────────────────────────────────────────
 // Higher-level file operations. Return FILE* as i64.
 
+int8_t      rask_fs_exists(const RaskStr *path);
+void        rask_fs_read_file(RaskStr *out, const RaskStr *path);
+void        rask_fs_write_file(const RaskStr *path, const RaskStr *content);
+RaskVec    *rask_fs_read_lines(const RaskStr *path);
+RaskVec    *rask_fs_list_dir(const RaskStr *path);
 int64_t     rask_fs_open(const RaskStr *path);
 int64_t     rask_fs_create(const RaskStr *path);
 void        rask_fs_canonicalize(RaskStr *out, const RaskStr *path);
@@ -292,6 +301,10 @@ void        rask_file_write(int64_t file, const RaskStr *content);
 void        rask_file_write_all(int64_t file, const RaskStr *content);
 void        rask_file_write_line(int64_t file, const RaskStr *content);
 RaskVec    *rask_file_lines(int64_t file);
+
+// ─── IO module ──────────────────────────────────────────────
+void        rask_io_read_line(RaskStr *out);
+int64_t     rask_io_write_string(int64_t fd, int64_t str_ptr);
 
 // ─── Time module ────────────────────────────────────────────
 // Instant = i64 nanoseconds (CLOCK_MONOTONIC), Duration = i64 nanoseconds.
@@ -327,6 +340,7 @@ void         rask_json_buf_add_bool(RaskJsonBuf *buf, const RaskStr *key, int64_
 void         rask_json_buf_add_raw(RaskJsonBuf *buf, const RaskStr *key, const RaskStr *raw_json);
 void         rask_json_buf_finish(RaskStr *out, RaskJsonBuf *buf);
 
+void         rask_json_encode(RaskStr *out, int64_t value_ptr);
 void         rask_json_encode_string(RaskStr *out, const RaskStr *s);
 void         rask_json_encode_i64(RaskStr *out, int64_t val);
 

--- a/compiler/runtime/rask_runtime.h
+++ b/compiler/runtime/rask_runtime.h
@@ -83,50 +83,83 @@ void    *rask_vec_first(const RaskVec *v);
 void    *rask_vec_last(const RaskVec *v);
 
 // ─── String ─────────────────────────────────────────────────
-// UTF-8 immutable refcounted string, always null-terminated.
-// Clone is O(1) (atomic refcount increment). Free decrements and frees at 0.
+// 16-byte tagged union with small string optimization (SSO).
+//
+// SSO mode (MSB of byte 15 = 0):
+//   [data: u8[15]][remaining: u8]   remaining = 15 - len
+//   Unused data bytes zeroed → always null-terminated.
+//
+// Heap mode (MSB of byte 15 = 1):
+//   [header_ptr: *u8 (8B)][tagged_len: u64 (8B)]
+//   tagged_len = len | (1<<63). Header: { refcount_u32, cap_u32, data[] }
+//
+// RC only applies to heap mode. Sentinel refcount (UINT32_MAX) = static literal.
 
-typedef struct RaskString RaskString;
+typedef union {
+    struct { uint8_t data[15]; uint8_t remaining; } sso;  // remaining = 15 - len
+    struct { uint8_t *header; uint64_t tagged_len; } heap; // tagged_len = len | (1<<63)
+    uint8_t raw[16];
+} RaskStr;
 
-RaskString *rask_string_new(void);
-RaskString *rask_string_from(const char *s);
-RaskString *rask_string_from_bytes(const char *data, int64_t len);
-void        rask_string_free(RaskString *s);
-int64_t     rask_string_len(const RaskString *s);
-const char *rask_string_ptr(const RaskString *s);
-RaskString *rask_string_push_byte(RaskString *s, uint8_t byte);
-RaskString *rask_string_push_char(RaskString *s, int32_t codepoint);
-RaskString *rask_string_append(RaskString *s, const RaskString *other);
-RaskString *rask_string_append_cstr(RaskString *s, const char *cstr);
-RaskString *rask_string_clone(const RaskString *s);
-int64_t     rask_string_eq(const RaskString *a, const RaskString *b);
-int64_t     rask_string_byte_at(const RaskString *s, int64_t pos);
-RaskString *rask_string_substr(const RaskString *s, int64_t start, int64_t end);
-RaskString *rask_string_concat(const RaskString *a, const RaskString *b);
-int64_t     rask_string_contains(const RaskString *haystack, const RaskString *needle);
-RaskString *rask_string_to_lowercase(const RaskString *s);
-int64_t     rask_string_starts_with(const RaskString *s, const RaskString *prefix);
-int64_t     rask_string_ends_with(const RaskString *s, const RaskString *suffix);
-RaskVec    *rask_string_lines(const RaskString *s);
-RaskString *rask_string_trim(const RaskString *s);
-RaskVec    *rask_string_split(const RaskString *s, const RaskString *sep);
-RaskVec    *rask_string_split_whitespace(const RaskString *s);
-RaskString *rask_string_replace(const RaskString *s, const RaskString *from, const RaskString *to);
-int64_t     rask_string_parse_int(const RaskString *s);
-double      rask_string_parse_float(const RaskString *s);
-int64_t     rask_string_is_empty(const RaskString *s);
-RaskString *rask_string_to_uppercase(const RaskString *s);
-int64_t     rask_string_find(const RaskString *haystack, const RaskString *needle);
-int64_t     rask_string_rfind(const RaskString *haystack, const RaskString *needle);
-int64_t     rask_string_char_at(const RaskString *s, int64_t index);
-RaskString *rask_string_repeat(const RaskString *s, int64_t count);
-RaskString *rask_string_reverse(const RaskString *s);
-RaskString *rask_string_trim_start(const RaskString *s);
-RaskString *rask_string_trim_end(const RaskString *s);
-RaskString *rask_i64_to_string(int64_t val);
-RaskString *rask_bool_to_string(int64_t val);
-RaskString *rask_f64_to_string(double val);
-RaskString *rask_char_to_string(int32_t codepoint);
+// Constructors (out-param)
+void        rask_string_new(RaskStr *out);
+void        rask_string_from(RaskStr *out, const char *s);
+void        rask_string_from_bytes(RaskStr *out, const char *data, int64_t len);
+
+// RC operations — codegen calls after inline tag check (RC5)
+void        rask_string_free(const RaskStr *s);
+void        rask_string_clone(const RaskStr *s);
+
+// Read-only accessors
+int64_t     rask_string_len(const RaskStr *s);
+const char *rask_string_ptr(const RaskStr *s);
+int64_t     rask_string_is_empty(const RaskStr *s);
+int64_t     rask_string_eq(const RaskStr *a, const RaskStr *b);
+int64_t     rask_string_compare(const RaskStr *a, const RaskStr *b);
+int64_t     rask_string_lt(const RaskStr *a, const RaskStr *b);
+int64_t     rask_string_gt(const RaskStr *a, const RaskStr *b);
+int64_t     rask_string_le(const RaskStr *a, const RaskStr *b);
+int64_t     rask_string_ge(const RaskStr *a, const RaskStr *b);
+int64_t     rask_string_byte_at(const RaskStr *s, int64_t pos);
+int64_t     rask_string_char_at(const RaskStr *s, int64_t index);
+int64_t     rask_string_contains(const RaskStr *haystack, const RaskStr *needle);
+int64_t     rask_string_starts_with(const RaskStr *s, const RaskStr *prefix);
+int64_t     rask_string_ends_with(const RaskStr *s, const RaskStr *suffix);
+int64_t     rask_string_find(const RaskStr *haystack, const RaskStr *needle);
+int64_t     rask_string_rfind(const RaskStr *haystack, const RaskStr *needle);
+int64_t     rask_string_parse_int(const RaskStr *s);
+double      rask_string_parse_float(const RaskStr *s);
+
+// String-producing operations (out-param: RaskStr *out as first param)
+void        rask_string_concat(RaskStr *out, const RaskStr *a, const RaskStr *b);
+void        rask_string_substr(RaskStr *out, const RaskStr *s, int64_t start, int64_t end);
+void        rask_string_to_lowercase(RaskStr *out, const RaskStr *s);
+void        rask_string_to_uppercase(RaskStr *out, const RaskStr *s);
+void        rask_string_trim(RaskStr *out, const RaskStr *s);
+void        rask_string_trim_start(RaskStr *out, const RaskStr *s);
+void        rask_string_trim_end(RaskStr *out, const RaskStr *s);
+void        rask_string_repeat(RaskStr *out, const RaskStr *s, int64_t count);
+void        rask_string_reverse(RaskStr *out, const RaskStr *s);
+void        rask_string_replace(RaskStr *out, const RaskStr *s, const RaskStr *from, const RaskStr *to);
+
+// Builder operations (out-param: mutates string via promote-to-heap)
+void        rask_string_push_byte(RaskStr *out, const RaskStr *s, uint8_t byte);
+void        rask_string_push_char(RaskStr *out, const RaskStr *s, int32_t codepoint);
+void        rask_string_append(RaskStr *out, const RaskStr *s, const RaskStr *other);
+void        rask_string_append_cstr(RaskStr *out, const RaskStr *s, const char *cstr);
+void        rask_string_push_str(RaskStr *out, const RaskStr *s, const RaskStr *other);
+
+// Vec-returning operations (elements are RaskStr, elem_size=16)
+RaskVec    *rask_string_lines(const RaskStr *s);
+RaskVec    *rask_string_split(const RaskStr *s, const RaskStr *sep);
+RaskVec    *rask_string_split_whitespace(const RaskStr *s);
+RaskVec    *rask_string_chars(const RaskStr *s);
+
+// Conversion to string (out-param)
+void        rask_i64_to_string(RaskStr *out, int64_t val);
+void        rask_bool_to_string(RaskStr *out, int64_t val);
+void        rask_f64_to_string(RaskStr *out, double val);
+void        rask_char_to_string(RaskStr *out, int32_t codepoint);
 
 // Char predicates — operate on Unicode codepoints (i32).
 int64_t rask_char_is_digit(int32_t c);
@@ -238,26 +271,26 @@ int64_t  rask_random_bool(void);
 int64_t  rask_random_range(int64_t lo, int64_t hi);
 
 // ─── FS module ──────────────────────────────────────────────
-// Higher-level file operations. Return FILE* or RaskString* as i64.
+// Higher-level file operations. Return FILE* as i64.
 
-int64_t     rask_fs_open(const RaskString *path);
-int64_t     rask_fs_create(const RaskString *path);
-RaskString *rask_fs_canonicalize(const RaskString *path);
-int64_t     rask_fs_copy(const RaskString *from, const RaskString *to);
-void        rask_fs_rename(const RaskString *from, const RaskString *to);
-void        rask_fs_remove(const RaskString *path);
-void        rask_fs_create_dir(const RaskString *path);
-void        rask_fs_create_dir_all(const RaskString *path);
-void        rask_fs_append_file(const RaskString *path, const RaskString *content);
+int64_t     rask_fs_open(const RaskStr *path);
+int64_t     rask_fs_create(const RaskStr *path);
+void        rask_fs_canonicalize(RaskStr *out, const RaskStr *path);
+int64_t     rask_fs_copy(const RaskStr *from, const RaskStr *to);
+void        rask_fs_rename(const RaskStr *from, const RaskStr *to);
+void        rask_fs_remove(const RaskStr *path);
+void        rask_fs_create_dir(const RaskStr *path);
+void        rask_fs_create_dir_all(const RaskStr *path);
+void        rask_fs_append_file(const RaskStr *path, const RaskStr *content);
 
 // ─── File instance methods ──────────────────────────────────
 // Operate on FILE* handles returned by rask_fs_open/rask_fs_create.
 
 void        rask_file_close(int64_t file);
-RaskString *rask_file_read_all(int64_t file);
-void        rask_file_write(int64_t file, const RaskString *content);
-void        rask_file_write_all(int64_t file, const RaskString *content);
-void        rask_file_write_line(int64_t file, const RaskString *content);
+void        rask_file_read_all(RaskStr *out, int64_t file);
+void        rask_file_write(int64_t file, const RaskStr *content);
+void        rask_file_write_all(int64_t file, const RaskStr *content);
+void        rask_file_write_line(int64_t file, const RaskStr *content);
 RaskVec    *rask_file_lines(int64_t file);
 
 // ─── Time module ────────────────────────────────────────────
@@ -275,11 +308,11 @@ int64_t rask_time_Instant_duration_since(int64_t self_ns, int64_t other_ns);
 // ─── Net module ─────────────────────────────────────────────
 // Basic TCP socket operations.
 
-int64_t rask_net_tcp_listen(const RaskString *addr);
-int64_t rask_net_tcp_connect(const RaskString *addr);
+int64_t rask_net_tcp_listen(const RaskStr *addr);
+int64_t rask_net_tcp_connect(const RaskStr *addr);
 
 // Response reading (reads until EOF for Connection: close pattern).
-RaskString *rask_io_read_until_close(int64_t fd, int64_t max_len);
+void    rask_io_read_until_close(RaskStr *out, int64_t fd, int64_t max_len);
 
 // ─── JSON module ────────────────────────────────────────────
 // Encode helpers — used by codegen-generated struct serialization.
@@ -287,34 +320,34 @@ RaskString *rask_io_read_until_close(int64_t fd, int64_t max_len);
 typedef struct RaskJsonBuf RaskJsonBuf;
 
 RaskJsonBuf *rask_json_buf_new(void);
-void         rask_json_buf_add_string(RaskJsonBuf *buf, const RaskString *key, const RaskString *val);
-void         rask_json_buf_add_i64(RaskJsonBuf *buf, const RaskString *key, int64_t val);
-void         rask_json_buf_add_f64(RaskJsonBuf *buf, const RaskString *key, double val);
-void         rask_json_buf_add_bool(RaskJsonBuf *buf, const RaskString *key, int64_t val);
-void         rask_json_buf_add_raw(RaskJsonBuf *buf, const RaskString *key, const RaskString *raw_json);
-RaskString  *rask_json_buf_finish(RaskJsonBuf *buf);
+void         rask_json_buf_add_string(RaskJsonBuf *buf, const RaskStr *key, const RaskStr *val);
+void         rask_json_buf_add_i64(RaskJsonBuf *buf, const RaskStr *key, int64_t val);
+void         rask_json_buf_add_f64(RaskJsonBuf *buf, const RaskStr *key, double val);
+void         rask_json_buf_add_bool(RaskJsonBuf *buf, const RaskStr *key, int64_t val);
+void         rask_json_buf_add_raw(RaskJsonBuf *buf, const RaskStr *key, const RaskStr *raw_json);
+void         rask_json_buf_finish(RaskStr *out, RaskJsonBuf *buf);
 
-RaskString  *rask_json_encode_string(const RaskString *s);
-RaskString  *rask_json_encode_i64(int64_t val);
+void         rask_json_encode_string(RaskStr *out, const RaskStr *s);
+void         rask_json_encode_i64(RaskStr *out, int64_t val);
 
 // JSON array buffer — keyless element encoding for Vec serialization.
 RaskJsonBuf *rask_json_buf_new_array(void);
-void         rask_json_buf_array_add_raw(RaskJsonBuf *buf, const RaskString *raw_json);
-void         rask_json_buf_array_add_string(RaskJsonBuf *buf, const RaskString *val);
+void         rask_json_buf_array_add_raw(RaskJsonBuf *buf, const RaskStr *raw_json);
+void         rask_json_buf_array_add_string(RaskJsonBuf *buf, const RaskStr *val);
 void         rask_json_buf_array_add_i64(RaskJsonBuf *buf, int64_t val);
 void         rask_json_buf_array_add_f64(RaskJsonBuf *buf, double val);
 void         rask_json_buf_array_add_bool(RaskJsonBuf *buf, int64_t val);
-RaskString  *rask_json_buf_finish_array(RaskJsonBuf *buf);
+void         rask_json_buf_finish_array(RaskStr *out, RaskJsonBuf *buf);
 
 // Decode helpers — minimal JSON object parser.
 typedef struct RaskJsonObj RaskJsonObj;
 
-RaskJsonObj *rask_json_parse(const RaskString *s);
-RaskString  *rask_json_get_string(RaskJsonObj *obj, const char *key);
+RaskJsonObj *rask_json_parse(const RaskStr *s);
+void         rask_json_get_string(RaskStr *out, RaskJsonObj *obj, const char *key);
 int64_t      rask_json_get_i64(RaskJsonObj *obj, const char *key);
 double       rask_json_get_f64(RaskJsonObj *obj, const char *key);
 int8_t       rask_json_get_bool(RaskJsonObj *obj, const char *key);
-int64_t      rask_json_decode(const RaskString *s);
+int64_t      rask_json_decode(const RaskStr *s);
 
 // ─── CLI args ───────────────────────────────────────────────
 

--- a/compiler/runtime/runtime.c
+++ b/compiler/runtime/runtime.c
@@ -55,10 +55,8 @@ void rask_print_u64(uint64_t val) {
     printf("%llu", (unsigned long long)val);
 }
 
-void rask_print_string(const RaskString *s) {
-    if (s) {
-        fputs(rask_string_ptr(s), stdout);
-    }
+void rask_print_string(const RaskStr *s) {
+    fputs(rask_string_ptr(s), stdout);
 }
 
 void rask_print_newline(void) {
@@ -112,14 +110,15 @@ int64_t rask_io_write(int64_t fd, const void *buf, int64_t len) {
 int64_t rask_clone(int64_t value) { return value; }
 
 // ─── CLI module ───────────────────────────────────────────────────
-// cli.args() → Vec of RaskString* pointers.
+// cli.args() → Vec of RaskStr values (16 bytes each).
 
 RaskVec *rask_cli_args(void) {
-    RaskVec *v = rask_vec_new(sizeof(RaskString *));
+    RaskVec *v = rask_vec_new(16);
     int64_t count = rask_args_count();
     for (int64_t i = 0; i < count; i++) {
         const char *arg = rask_args_get(i);
-        RaskString *s = rask_string_from(arg);
+        RaskStr s;
+        rask_string_from(&s, arg);
         rask_vec_push(v, &s);
     }
     return v;
@@ -127,9 +126,9 @@ RaskVec *rask_cli_args(void) {
 
 // ─── FS module ────────────────────────────────────────────────────
 
-RaskVec *rask_fs_read_lines(const RaskString *path) {
-    RaskVec *v = rask_vec_new(sizeof(RaskString *));
-    const char *p = path ? rask_string_ptr(path) : "";
+RaskVec *rask_fs_read_lines(const RaskStr *path) {
+    RaskVec *v = rask_vec_new(16);
+    const char *p = rask_string_ptr(path);
 
     FILE *f = fopen(p, "r");
     if (!f) return v;
@@ -140,7 +139,8 @@ RaskVec *rask_fs_read_lines(const RaskString *path) {
         if (len > 0 && buf[len - 1] == '\n') buf[--len] = '\0';
         if (len > 0 && buf[len - 1] == '\r') buf[--len] = '\0';
 
-        RaskString *line = rask_string_from_bytes(buf, (int64_t)len);
+        RaskStr line;
+        rask_string_from_bytes(&line, buf, (int64_t)len);
         rask_vec_push(v, &line);
     }
 
@@ -150,23 +150,24 @@ RaskVec *rask_fs_read_lines(const RaskString *path) {
 
 // ─── IO module ────────────────────────────────────────────────────
 
-RaskString *rask_io_read_line(void) {
+void rask_io_read_line(RaskStr *out) {
     char buf[4096];
     if (!fgets(buf, sizeof(buf), stdin)) {
-        return rask_string_new();
+        rask_string_new(out);
+        return;
     }
     size_t len = strlen(buf);
     if (len > 0 && buf[len - 1] == '\n') buf[--len] = '\0';
     if (len > 0 && buf[len - 1] == '\r') buf[--len] = '\0';
-    return rask_string_from_bytes(buf, (int64_t)len);
+    rask_string_from_bytes(out, buf, (int64_t)len);
 }
 
 // ─── More FS module ───────────────────────────────────────────────
 
-RaskString *rask_fs_read_file(const RaskString *path) {
-    const char *p = path ? rask_string_ptr(path) : "";
+void rask_fs_read_file(RaskStr *out, const RaskStr *path) {
+    const char *p = rask_string_ptr(path);
     FILE *f = fopen(p, "rb");
-    if (!f) return rask_string_new();
+    if (!f) { rask_string_new(out); return; }
     fseek(f, 0, SEEK_END);
     long size = ftell(f);
     fseek(f, 0, SEEK_SET);
@@ -174,23 +175,22 @@ RaskString *rask_fs_read_file(const RaskString *path) {
     size_t n = fread(buf, 1, (size_t)size, f);
     buf[n] = '\0';
     fclose(f);
-    RaskString *s = rask_string_from_bytes(buf, (int64_t)n);
+    rask_string_from_bytes(out, buf, (int64_t)n);
     rask_free(buf);
-    return s;
 }
 
-void rask_fs_write_file(const RaskString *path, const RaskString *content) {
-    const char *p = path ? rask_string_ptr(path) : "";
-    const char *c = content ? rask_string_ptr(content) : "";
-    int64_t clen = content ? rask_string_len(content) : 0;
+void rask_fs_write_file(const RaskStr *path, const RaskStr *content) {
+    const char *p = rask_string_ptr(path);
+    const char *c = rask_string_ptr(content);
+    int64_t clen = rask_string_len(content);
     FILE *f = fopen(p, "wb");
     if (!f) return;
     fwrite(c, 1, (size_t)clen, f);
     fclose(f);
 }
 
-int8_t rask_fs_exists(const RaskString *path) {
-    const char *p = path ? rask_string_ptr(path) : "";
+int8_t rask_fs_exists(const RaskStr *path) {
+    const char *p = rask_string_ptr(path);
     FILE *f = fopen(p, "r");
     if (f) { fclose(f); return 1; }
     return 0;
@@ -198,29 +198,29 @@ int8_t rask_fs_exists(const RaskString *path) {
 
 // ─── More FS module ───────────────────────────────────────────────
 
-int64_t rask_fs_open(const RaskString *path) {
-    const char *p = path ? rask_string_ptr(path) : "";
+int64_t rask_fs_open(const RaskStr *path) {
+    const char *p = rask_string_ptr(path);
     FILE *f = fopen(p, "r");
     return (int64_t)(uintptr_t)f;
 }
 
-int64_t rask_fs_create(const RaskString *path) {
-    const char *p = path ? rask_string_ptr(path) : "";
+int64_t rask_fs_create(const RaskStr *path) {
+    const char *p = rask_string_ptr(path);
     FILE *f = fopen(p, "w");
     return (int64_t)(uintptr_t)f;
 }
 
-RaskString *rask_fs_canonicalize(const RaskString *path) {
-    const char *p = path ? rask_string_ptr(path) : "";
+void rask_fs_canonicalize(RaskStr *out, const RaskStr *path) {
+    const char *p = rask_string_ptr(path);
     char resolved[4096];
     char *r = realpath(p, resolved);
-    if (!r) return rask_string_new();
-    return rask_string_from(resolved);
+    if (!r) { rask_string_new(out); return; }
+    rask_string_from(out, resolved);
 }
 
-int64_t rask_fs_copy(const RaskString *from, const RaskString *to) {
-    const char *src = from ? rask_string_ptr(from) : "";
-    const char *dst = to ? rask_string_ptr(to) : "";
+int64_t rask_fs_copy(const RaskStr *from, const RaskStr *to) {
+    const char *src = rask_string_ptr(from);
+    const char *dst = rask_string_ptr(to);
     FILE *in = fopen(src, "rb");
     if (!in) return -1;
     FILE *out = fopen(dst, "wb");
@@ -237,26 +237,26 @@ int64_t rask_fs_copy(const RaskString *from, const RaskString *to) {
     return total;
 }
 
-void rask_fs_rename(const RaskString *from, const RaskString *to) {
-    const char *s = from ? rask_string_ptr(from) : "";
-    const char *d = to ? rask_string_ptr(to) : "";
+void rask_fs_rename(const RaskStr *from, const RaskStr *to) {
+    const char *s = rask_string_ptr(from);
+    const char *d = rask_string_ptr(to);
     rename(s, d);
 }
 
-void rask_fs_remove(const RaskString *path) {
-    const char *p = path ? rask_string_ptr(path) : "";
+void rask_fs_remove(const RaskStr *path) {
+    const char *p = rask_string_ptr(path);
     remove(p);
 }
 
 #include <sys/stat.h>
 
-void rask_fs_create_dir(const RaskString *path) {
-    const char *p = path ? rask_string_ptr(path) : "";
+void rask_fs_create_dir(const RaskStr *path) {
+    const char *p = rask_string_ptr(path);
     mkdir(p, 0755);
 }
 
-void rask_fs_create_dir_all(const RaskString *path) {
-    const char *p = path ? rask_string_ptr(path) : "";
+void rask_fs_create_dir_all(const RaskStr *path) {
+    const char *p = rask_string_ptr(path);
     char tmp[4096];
     snprintf(tmp, sizeof(tmp), "%s", p);
     for (char *c = tmp + 1; *c; c++) {
@@ -269,10 +269,10 @@ void rask_fs_create_dir_all(const RaskString *path) {
     mkdir(tmp, 0755);
 }
 
-void rask_fs_append_file(const RaskString *path, const RaskString *content) {
-    const char *p = path ? rask_string_ptr(path) : "";
-    const char *c = content ? rask_string_ptr(content) : "";
-    int64_t clen = content ? rask_string_len(content) : 0;
+void rask_fs_append_file(const RaskStr *path, const RaskStr *content) {
+    const char *p = rask_string_ptr(path);
+    const char *c = rask_string_ptr(content);
+    int64_t clen = rask_string_len(content);
     FILE *f = fopen(p, "ab");
     if (!f) return;
     fwrite(c, 1, (size_t)clen, f);
@@ -287,9 +287,9 @@ void rask_file_close(int64_t file) {
     if (f) fclose(f);
 }
 
-RaskString *rask_file_read_all(int64_t file) {
+void rask_file_read_all(RaskStr *out, int64_t file) {
     FILE *f = (FILE *)(uintptr_t)file;
-    if (!f) return rask_string_new();
+    if (!f) { rask_string_new(out); return; }
     // Read from current position to end
     long start = ftell(f);
     fseek(f, 0, SEEK_END);
@@ -299,20 +299,19 @@ RaskString *rask_file_read_all(int64_t file) {
     char *buf = (char *)rask_alloc((int64_t)size + 1);
     size_t n = fread(buf, 1, (size_t)size, f);
     buf[n] = '\0';
-    RaskString *s = rask_string_from_bytes(buf, (int64_t)n);
+    rask_string_from_bytes(out, buf, (int64_t)n);
     rask_free(buf);
-    return s;
 }
 
-void rask_file_write(int64_t file, const RaskString *content) {
+void rask_file_write(int64_t file, const RaskStr *content) {
     FILE *f = (FILE *)(uintptr_t)file;
-    if (!f || !content) return;
+    if (!f) return;
     fwrite(rask_string_ptr(content), 1, (size_t)rask_string_len(content), f);
 }
 
-void rask_file_write_all(int64_t file, const RaskString *content) {
+void rask_file_write_all(int64_t file, const RaskStr *content) {
     FILE *f = (FILE *)(uintptr_t)file;
-    if (!f || !content) return;
+    if (!f) return;
     const char *ptr = rask_string_ptr(content);
     size_t remaining = (size_t)rask_string_len(content);
     while (remaining > 0) {
@@ -324,17 +323,15 @@ void rask_file_write_all(int64_t file, const RaskString *content) {
     fflush(f);
 }
 
-void rask_file_write_line(int64_t file, const RaskString *content) {
+void rask_file_write_line(int64_t file, const RaskStr *content) {
     FILE *f = (FILE *)(uintptr_t)file;
     if (!f) return;
-    if (content) {
-        fwrite(rask_string_ptr(content), 1, (size_t)rask_string_len(content), f);
-    }
+    fwrite(rask_string_ptr(content), 1, (size_t)rask_string_len(content), f);
     fputc('\n', f);
 }
 
 RaskVec *rask_file_lines(int64_t file) {
-    RaskVec *v = rask_vec_new(sizeof(RaskString *));
+    RaskVec *v = rask_vec_new(16);
     FILE *f = (FILE *)(uintptr_t)file;
     if (!f) return v;
     // Rewind to start
@@ -344,7 +341,8 @@ RaskVec *rask_file_lines(int64_t file) {
         size_t len = strlen(buf);
         if (len > 0 && buf[len - 1] == '\n') buf[--len] = '\0';
         if (len > 0 && buf[len - 1] == '\r') buf[--len] = '\0';
-        RaskString *line = rask_string_from_bytes(buf, (int64_t)len);
+        RaskStr line;
+        rask_string_from_bytes(&line, buf, (int64_t)len);
         rask_vec_push(v, &line);
     }
     return v;
@@ -357,8 +355,8 @@ RaskVec *rask_file_lines(int64_t file) {
 #include <arpa/inet.h>
 #include <netdb.h>
 
-int64_t rask_net_tcp_listen(const RaskString *addr) {
-    const char *a = addr ? rask_string_ptr(addr) : "0.0.0.0:0";
+int64_t rask_net_tcp_listen(const RaskStr *addr) {
+    const char *a = rask_string_ptr(addr);
 
     // Parse "host:port"
     char host[256] = "0.0.0.0";
@@ -401,8 +399,8 @@ int64_t rask_net_tcp_accept(int64_t listen_fd) {
     return (int64_t)client;
 }
 
-int64_t rask_net_tcp_connect(const RaskString *addr) {
-    const char *a = addr ? rask_string_ptr(addr) : "127.0.0.1:80";
+int64_t rask_net_tcp_connect(const RaskStr *addr) {
+    const char *a = rask_string_ptr(addr);
 
     // Parse "host:port"
     char host[256] = "127.0.0.1";
@@ -447,8 +445,8 @@ int64_t rask_net_tcp_connect(const RaskString *addr) {
 
 // ─── String-based socket I/O (used by Rask stdlib HTTP parser) ────
 
-// Read up to max_len bytes from fd, return as RaskString.
-RaskString *rask_io_read_string(int64_t fd, int64_t max_len) {
+// Read up to max_len bytes from fd, return as RaskStr.
+static void io_read_string(RaskStr *out, int64_t fd, int64_t max_len) {
     if (max_len <= 0 || max_len > 1024 * 1024) max_len = 65536;
     char *buf = (char *)rask_alloc(max_len);
     int64_t total = 0;
@@ -463,23 +461,19 @@ RaskString *rask_io_read_string(int64_t fd, int64_t max_len) {
             for (int64_t i = total - 4; i >= 0 && i >= total - n - 3; i--) {
                 if (buf[i] == '\r' && buf[i+1] == '\n' &&
                     buf[i+2] == '\r' && buf[i+3] == '\n') {
-                    // Found header boundary — check Content-Length for body
-                    // For simplicity, just return what we have (sufficient for
-                    // simple JSON APIs where body fits in first read)
                     goto done;
                 }
             }
         }
     }
 done:;
-    RaskString *s = rask_string_from_bytes(buf, total);
+    rask_string_from_bytes(out, buf, total);
     rask_free(buf);
-    return s;
 }
 
 // Read until connection closes or max_len reached. For HTTP client responses
 // where Connection: close is used.
-RaskString *rask_io_read_until_close(int64_t fd, int64_t max_len) {
+void rask_io_read_until_close(RaskStr *out, int64_t fd, int64_t max_len) {
     if (max_len <= 0 || max_len > 4 * 1024 * 1024) max_len = 1048576;
     char *buf = (char *)rask_alloc(max_len);
     int64_t total = 0;
@@ -488,14 +482,13 @@ RaskString *rask_io_read_until_close(int64_t fd, int64_t max_len) {
         if (n <= 0) break;
         total += n;
     }
-    RaskString *s = rask_string_from_bytes(buf, total);
+    rask_string_from_bytes(out, buf, total);
     rask_free(buf);
-    return s;
 }
 
-// Write a RaskString to fd. Returns bytes written or -1.
+// Write a RaskStr to fd. Returns bytes written or -1.
 int64_t rask_io_write_string(int64_t fd, int64_t str_ptr) {
-    const RaskString *s = (const RaskString *)(uintptr_t)str_ptr;
+    const RaskStr *s = (const RaskStr *)(uintptr_t)str_ptr;
     if (!s) return 0;
     const char *data = rask_string_ptr(s);
     int64_t len = rask_string_len(s);
@@ -516,21 +509,28 @@ void rask_io_close_fd(int64_t fd) {
 // ─── HTTP helpers (called from Rask stdlib via extern "C") ──────
 
 // Parse HTTP/1.1 request from socket fd. Returns pointer to
-// [method, path, body, headers] struct (4 x i64).
+// [method, path, body, headers] — each string field is a 16-byte RaskStr.
+// Layout: [RaskStr method (16B)][RaskStr path (16B)][RaskStr body (16B)][Map* headers (8B)]
 int64_t rask_http_parse_request(int64_t conn_fd) {
-    RaskString *raw = rask_io_read_string(conn_fd, 65536);
-    if (!raw || rask_string_len(raw) == 0) {
+    RaskStr raw;
+    io_read_string(&raw, conn_fd, 65536);
+    if (rask_string_len(&raw) == 0) {
         // Empty request — return minimal struct
-        int64_t *req = (int64_t *)rask_alloc(sizeof(int64_t) * 4);
-        req[0] = (int64_t)(uintptr_t)rask_string_from_bytes("GET", 3);
-        req[1] = (int64_t)(uintptr_t)rask_string_from_bytes("/", 1);
-        req[2] = (int64_t)(uintptr_t)rask_string_from_bytes("", 0);
-        req[3] = (int64_t)(uintptr_t)rask_map_new(8, 8);
+        // Allocate: 3 * 16 bytes (strings) + 8 bytes (map ptr) = 56 bytes
+        uint8_t *req = (uint8_t *)rask_alloc(56);
+        memset(req, 0, 56);
+        RaskStr *method = (RaskStr *)req;
+        RaskStr *path = (RaskStr *)(req + 16);
+        RaskStr *body = (RaskStr *)(req + 32);
+        rask_string_from_bytes(method, "GET", 3);
+        rask_string_from_bytes(path, "/", 1);
+        rask_string_new(body);
+        *(int64_t *)(req + 48) = (int64_t)(uintptr_t)rask_map_new(16, 16);
         return (int64_t)(uintptr_t)req;
     }
 
-    const char *data = rask_string_ptr(raw);
-    int64_t len = rask_string_len(raw);
+    const char *data = rask_string_ptr(&raw);
+    int64_t len = rask_string_len(&raw);
 
     // Find end of headers (\r\n\r\n)
     int64_t header_end = -1;
@@ -543,14 +543,6 @@ int64_t rask_http_parse_request(int64_t conn_fd) {
     }
     if (header_end < 0) header_end = len;
 
-    // Extract body (after \r\n\r\n)
-    RaskString *body;
-    if (header_end + 4 < len) {
-        body = rask_string_from_bytes(data + header_end + 4, len - header_end - 4);
-    } else {
-        body = rask_string_from_bytes("", 0);
-    }
-
     // Parse request line: "METHOD PATH HTTP/1.1\r\n"
     int64_t first_space = -1, second_space = -1;
     for (int64_t i = 0; i < header_end; i++) {
@@ -561,18 +553,31 @@ int64_t rask_http_parse_request(int64_t conn_fd) {
         if (data[i] == '\r') break;
     }
 
-    RaskString *method, *path;
+    // Allocate result: 3 RaskStr (48B) + 1 Map* (8B) = 56B
+    uint8_t *req = (uint8_t *)rask_alloc(56);
+    memset(req, 0, 56);
+    RaskStr *method = (RaskStr *)req;
+    RaskStr *path_str = (RaskStr *)(req + 16);
+    RaskStr *body = (RaskStr *)(req + 32);
+
     if (first_space > 0 && second_space > first_space) {
-        method = rask_string_from_bytes(data, first_space);
-        path = rask_string_from_bytes(data + first_space + 1,
-                                       second_space - first_space - 1);
+        rask_string_from_bytes(method, data, first_space);
+        rask_string_from_bytes(path_str, data + first_space + 1,
+                               second_space - first_space - 1);
     } else {
-        method = rask_string_from_bytes("GET", 3);
-        path = rask_string_from_bytes("/", 1);
+        rask_string_from_bytes(method, "GET", 3);
+        rask_string_from_bytes(path_str, "/", 1);
     }
 
-    // Parse headers
-    RaskMap *headers = rask_map_new(8, 8);
+    // Extract body (after \r\n\r\n)
+    if (header_end + 4 < len) {
+        rask_string_from_bytes(body, data + header_end + 4, len - header_end - 4);
+    } else {
+        rask_string_new(body);
+    }
+
+    // Parse headers — map stores RaskStr keys and values (16B each)
+    RaskMap *headers = rask_map_new_string_keys(16, 16);
     int64_t line_start = -1;
     // Find start of second line (after first \r\n)
     for (int64_t i = 0; i < header_end; i++) {
@@ -595,34 +600,31 @@ int64_t rask_http_parse_request(int64_t conn_fd) {
                 if (data[i] == ':' && data[i+1] == ' ') { colon = i; break; }
             }
             if (colon > pos) {
-                RaskString *key = rask_string_from_bytes(data + pos, colon - pos);
-                RaskString *val = rask_string_from_bytes(data + colon + 2,
-                                                          line_end - colon - 2);
-                int64_t key_ptr = (int64_t)(uintptr_t)key;
-                int64_t val_ptr = (int64_t)(uintptr_t)val;
-                rask_map_insert(headers, &key_ptr, &val_ptr);
+                RaskStr key, val;
+                rask_string_from_bytes(&key, data + pos, colon - pos);
+                rask_string_from_bytes(&val, data + colon + 2,
+                                       line_end - colon - 2);
+                rask_map_insert(headers, &key, &val);
             }
             // Skip \r\n to next line
             pos = line_end + 2;
         }
     }
 
-    // Build HttpRequest struct: [method, path, body, headers]
-    int64_t *req = (int64_t *)rask_alloc(sizeof(int64_t) * 4);
-    req[0] = (int64_t)(uintptr_t)method;
-    req[1] = (int64_t)(uintptr_t)path;
-    req[2] = (int64_t)(uintptr_t)body;
-    req[3] = (int64_t)(uintptr_t)headers;
+    *(int64_t *)(req + 48) = (int64_t)(uintptr_t)headers;
+
+    rask_string_free(&raw);
     return (int64_t)(uintptr_t)req;
 }
 
 // Format and write HTTP response to socket fd.
-// resp_ptr points to [status(i64), headers(Map*), body(String*)].
+// resp_ptr points to [RaskStr status_str (16B) ... ] — but currently uses
+// [status(i64), headers(Map*), body_ptr]. Keep old ABI for now.
 int64_t rask_http_write_response(int64_t conn_fd, int64_t response_ptr) {
     int64_t *resp = (int64_t *)(uintptr_t)response_ptr;
     int64_t status = resp[0];
     RaskMap *headers = (RaskMap *)(uintptr_t)resp[1];
-    RaskString *body = (RaskString *)(uintptr_t)resp[2];
+    const RaskStr *body = (const RaskStr *)(uintptr_t)resp[2];
 
     const char *reason = "OK";
     switch ((int)status) {
@@ -637,42 +639,49 @@ int64_t rask_http_write_response(int64_t conn_fd, int64_t response_ptr) {
     int64_t body_len = body ? rask_string_len(body) : 0;
 
     // Build response into a growable string
-    RaskString *out = rask_string_new();
+    RaskStr out;
+    rask_string_new(&out);
     char line_buf[256];
-    int n = snprintf(line_buf, sizeof(line_buf),
-                     "HTTP/1.1 %d %s\r\n", (int)status, reason);
-    rask_string_append_cstr(out, line_buf);
+    snprintf(line_buf, sizeof(line_buf),
+             "HTTP/1.1 %d %s\r\n", (int)status, reason);
+    rask_string_append_cstr(&out, &out, line_buf);
 
     // Write user headers from Map
     if (headers && rask_map_len(headers) > 0) {
         RaskVec *keys = rask_map_keys(headers);
         for (int64_t i = 0; i < rask_vec_len(keys); i++) {
-            int64_t *key_slot = (int64_t *)rask_vec_get(keys, i);
-            if (!key_slot) continue;
-            RaskString *key = (RaskString *)(uintptr_t)*key_slot;
-            int64_t *val_slot = (int64_t *)rask_map_get(headers, key_slot);
-            if (!val_slot) continue;
-            RaskString *val = (RaskString *)(uintptr_t)*val_slot;
-            rask_string_append_cstr(out, rask_string_ptr(key));
-            rask_string_append_cstr(out, ": ");
-            rask_string_append_cstr(out, rask_string_ptr(val));
-            rask_string_append_cstr(out, "\r\n");
+            RaskStr *key = (RaskStr *)rask_vec_get(keys, i);
+            if (!key) continue;
+            RaskStr *val = (RaskStr *)rask_map_get(headers, key);
+            if (!val) continue;
+            RaskStr tmp;
+            rask_string_append_cstr(&tmp, &out, rask_string_ptr(key));
+            rask_string_free(&out);
+            rask_string_append_cstr(&out, &tmp, ": ");
+            rask_string_free(&tmp);
+            rask_string_append_cstr(&tmp, &out, rask_string_ptr(val));
+            rask_string_free(&out);
+            rask_string_append_cstr(&out, &tmp, "\r\n");
+            rask_string_free(&tmp);
         }
         rask_vec_free(keys);
     }
 
     // Content-Length header
-    n = snprintf(line_buf, sizeof(line_buf),
-                 "Content-Length: %lld\r\n\r\n", (long long)body_len);
-    rask_string_append_cstr(out, line_buf);
+    snprintf(line_buf, sizeof(line_buf),
+             "Content-Length: %lld\r\n\r\n", (long long)body_len);
+    RaskStr tmp;
+    rask_string_append_cstr(&tmp, &out, line_buf);
+    rask_string_free(&out);
+    out = tmp;
 
     // Write header + body
-    rask_io_write_string(conn_fd, (int64_t)(uintptr_t)out);
+    rask_io_write_string(conn_fd, (int64_t)(uintptr_t)&out);
     if (body_len > 0) {
         rask_io_write_string(conn_fd, (int64_t)(uintptr_t)body);
     }
 
-    rask_string_free(out);
+    rask_string_free(&out);
     return 0;
 }
 
@@ -692,8 +701,9 @@ int64_t rask_map_from(int64_t pairs_ptr) {
 }
 
 // Stub: generic json.encode — returns JSON string representation.
-RaskString *rask_json_encode(int64_t value_ptr) {
-    return rask_string_from_bytes("{}", 2);
+void rask_json_encode(RaskStr *out, int64_t value_ptr) {
+    (void)value_ptr;
+    rask_string_from_bytes(out, "{}", 2);
 }
 
 // ─── JSON module ──────────────────────────────────────────────────
@@ -753,19 +763,15 @@ RaskJsonBuf *rask_json_buf_new(void) {
     return b;
 }
 
-void rask_json_buf_add_string(RaskJsonBuf *buf, const RaskString *key, const RaskString *val) {
+void rask_json_buf_add_string(RaskJsonBuf *buf, const RaskStr *key, const RaskStr *val) {
     if (buf->field_count > 0) json_buf_append_cstr(buf, ",");
     json_buf_append_escaped(buf, rask_string_ptr(key), rask_string_len(key));
     json_buf_append_cstr(buf, ":");
-    if (val) {
-        json_buf_append_escaped(buf, rask_string_ptr(val), rask_string_len(val));
-    } else {
-        json_buf_append_cstr(buf, "null");
-    }
+    json_buf_append_escaped(buf, rask_string_ptr(val), rask_string_len(val));
     buf->field_count++;
 }
 
-void rask_json_buf_add_i64(RaskJsonBuf *buf, const RaskString *key, int64_t val) {
+void rask_json_buf_add_i64(RaskJsonBuf *buf, const RaskStr *key, int64_t val) {
     if (buf->field_count > 0) json_buf_append_cstr(buf, ",");
     json_buf_append_escaped(buf, rask_string_ptr(key), rask_string_len(key));
     char num[32];
@@ -774,7 +780,7 @@ void rask_json_buf_add_i64(RaskJsonBuf *buf, const RaskString *key, int64_t val)
     buf->field_count++;
 }
 
-void rask_json_buf_add_f64(RaskJsonBuf *buf, const RaskString *key, double val) {
+void rask_json_buf_add_f64(RaskJsonBuf *buf, const RaskStr *key, double val) {
     if (buf->field_count > 0) json_buf_append_cstr(buf, ",");
     json_buf_append_escaped(buf, rask_string_ptr(key), rask_string_len(key));
     char num[64];
@@ -783,31 +789,26 @@ void rask_json_buf_add_f64(RaskJsonBuf *buf, const RaskString *key, double val) 
     buf->field_count++;
 }
 
-void rask_json_buf_add_bool(RaskJsonBuf *buf, const RaskString *key, int64_t val) {
+void rask_json_buf_add_bool(RaskJsonBuf *buf, const RaskStr *key, int64_t val) {
     if (buf->field_count > 0) json_buf_append_cstr(buf, ",");
     json_buf_append_escaped(buf, rask_string_ptr(key), rask_string_len(key));
     json_buf_append_cstr(buf, val ? ":true" : ":false");
     buf->field_count++;
 }
 
-void rask_json_buf_add_raw(RaskJsonBuf *buf, const RaskString *key, const RaskString *raw_json) {
+void rask_json_buf_add_raw(RaskJsonBuf *buf, const RaskStr *key, const RaskStr *raw_json) {
     if (buf->field_count > 0) json_buf_append_cstr(buf, ",");
     json_buf_append_escaped(buf, rask_string_ptr(key), rask_string_len(key));
     json_buf_append_cstr(buf, ":");
-    if (raw_json) {
-        json_buf_append(buf, rask_string_ptr(raw_json), rask_string_len(raw_json));
-    } else {
-        json_buf_append_cstr(buf, "null");
-    }
+    json_buf_append(buf, rask_string_ptr(raw_json), rask_string_len(raw_json));
     buf->field_count++;
 }
 
-RaskString *rask_json_buf_finish(RaskJsonBuf *buf) {
+void rask_json_buf_finish(RaskStr *out, RaskJsonBuf *buf) {
     json_buf_append_cstr(buf, "}");
-    RaskString *s = rask_string_from_bytes(buf->data, buf->len);
+    rask_string_from_bytes(out, buf->data, buf->len);
     rask_free(buf->data);
     rask_free(buf);
-    return s;
 }
 
 // ─── JSON array buffer ──────────────────────────────────────────
@@ -822,23 +823,15 @@ RaskJsonBuf *rask_json_buf_new_array(void) {
     return b;
 }
 
-void rask_json_buf_array_add_raw(RaskJsonBuf *buf, const RaskString *raw_json) {
+void rask_json_buf_array_add_raw(RaskJsonBuf *buf, const RaskStr *raw_json) {
     if (buf->field_count > 0) json_buf_append_cstr(buf, ",");
-    if (raw_json) {
-        json_buf_append(buf, rask_string_ptr(raw_json), rask_string_len(raw_json));
-    } else {
-        json_buf_append_cstr(buf, "null");
-    }
+    json_buf_append(buf, rask_string_ptr(raw_json), rask_string_len(raw_json));
     buf->field_count++;
 }
 
-void rask_json_buf_array_add_string(RaskJsonBuf *buf, const RaskString *val) {
+void rask_json_buf_array_add_string(RaskJsonBuf *buf, const RaskStr *val) {
     if (buf->field_count > 0) json_buf_append_cstr(buf, ",");
-    if (val) {
-        json_buf_append_escaped(buf, rask_string_ptr(val), rask_string_len(val));
-    } else {
-        json_buf_append_cstr(buf, "null");
-    }
+    json_buf_append_escaped(buf, rask_string_ptr(val), rask_string_len(val));
     buf->field_count++;
 }
 
@@ -864,34 +857,28 @@ void rask_json_buf_array_add_bool(RaskJsonBuf *buf, int64_t val) {
     buf->field_count++;
 }
 
-RaskString *rask_json_buf_finish_array(RaskJsonBuf *buf) {
+void rask_json_buf_finish_array(RaskStr *out, RaskJsonBuf *buf) {
     json_buf_append_cstr(buf, "]");
-    RaskString *s = rask_string_from_bytes(buf->data, buf->len);
+    rask_string_from_bytes(out, buf->data, buf->len);
     rask_free(buf->data);
     rask_free(buf);
-    return s;
 }
 
-RaskString *rask_json_encode_string(const RaskString *s) {
+void rask_json_encode_string(RaskStr *out, const RaskStr *s) {
     struct RaskJsonBuf b;
     b.cap = 256;
     b.data = (char *)rask_alloc(b.cap);
     b.len = 0;
     b.field_count = 0;
-    if (s) {
-        json_buf_append_escaped(&b, rask_string_ptr(s), rask_string_len(s));
-    } else {
-        json_buf_append_cstr(&b, "null");
-    }
-    RaskString *result = rask_string_from_bytes(b.data, b.len);
+    json_buf_append_escaped(&b, rask_string_ptr(s), rask_string_len(s));
+    rask_string_from_bytes(out, b.data, b.len);
     rask_free(b.data);
-    return result;
 }
 
-RaskString *rask_json_encode_i64(int64_t val) {
+void rask_json_encode_i64(RaskStr *out, int64_t val) {
     char buf[32];
     int len = snprintf(buf, sizeof(buf), "%lld", (long long)val);
-    return rask_string_from_bytes(buf, (int64_t)len);
+    rask_string_from_bytes(out, buf, (int64_t)len);
 }
 
 // ─── JSON decode ──────────────────────────────────────────────────
@@ -902,7 +889,7 @@ struct RaskJsonField {
     char key[128];
     enum { JSON_STRING, JSON_NUMBER, JSON_BOOL } type;
     union {
-        RaskString *str_val;
+        RaskStr str_val;
         double num_val;
         int8_t bool_val;
     };
@@ -917,35 +904,57 @@ static void json_skip_ws(const char **p) {
     while (**p == ' ' || **p == '\t' || **p == '\n' || **p == '\r') (*p)++;
 }
 
-static RaskString *json_parse_string(const char **p) {
-    if (**p != '"') return rask_string_new();
+static void json_parse_string(RaskStr *out, const char **p) {
+    if (**p != '"') { rask_string_new(out); return; }
     (*p)++;
-    RaskString *s = rask_string_new();
+    // Scan for closing quote to know total length
+    const char *start = *p;
+    int has_escapes = 0;
+    while (**p && **p != '"') {
+        if (**p == '\\') { has_escapes = 1; (*p)++; if (**p) (*p)++; }
+        else (*p)++;
+    }
+    if (!has_escapes) {
+        // Fast path: no escapes, just copy the raw bytes
+        rask_string_from_bytes(out, start, (int64_t)(*p - start));
+        if (**p == '"') (*p)++;
+        return;
+    }
+    // Slow path: unescape. Reset and rebuild.
+    *p = start;
+    RaskStr s;
+    rask_string_new(&s);
     while (**p && **p != '"') {
         if (**p == '\\' && *(*p + 1)) {
             char c = *(*p + 1);
+            uint8_t byte;
             switch (c) {
-                case '"': case '\\': case '/':
-                    rask_string_push_byte(s, (uint8_t)c); break;
-                case 'n': rask_string_push_byte(s, '\n'); break;
-                case 't': rask_string_push_byte(s, '\t'); break;
-                case 'r': rask_string_push_byte(s, '\r'); break;
-                default: rask_string_push_byte(s, (uint8_t)c); break;
+                case '"': case '\\': case '/': byte = (uint8_t)c; break;
+                case 'n': byte = '\n'; break;
+                case 't': byte = '\t'; break;
+                case 'r': byte = '\r'; break;
+                default: byte = (uint8_t)c; break;
             }
+            RaskStr tmp;
+            rask_string_push_byte(&tmp, &s, byte);
+            rask_string_free(&s);
+            s = tmp;
             *p += 2;
         } else {
-            rask_string_push_byte(s, (uint8_t)**p);
+            RaskStr tmp;
+            rask_string_push_byte(&tmp, &s, (uint8_t)**p);
+            rask_string_free(&s);
+            s = tmp;
             (*p)++;
         }
     }
     if (**p == '"') (*p)++;
-    return s;
+    *out = s;
 }
 
-RaskJsonObj *rask_json_parse(const RaskString *s) {
+RaskJsonObj *rask_json_parse(const RaskStr *s) {
     RaskJsonObj *obj = (RaskJsonObj *)rask_alloc(sizeof(RaskJsonObj));
     memset(obj, 0, sizeof(RaskJsonObj));
-    if (!s) return obj;
 
     const char *p = rask_string_ptr(s);
     json_skip_ws(&p);
@@ -958,10 +967,11 @@ RaskJsonObj *rask_json_parse(const RaskString *s) {
         if (*p == ',') { p++; json_skip_ws(&p); }
 
         if (*p != '"') break;
-        RaskString *key = json_parse_string(&p);
+        RaskStr key;
+        json_parse_string(&key, &p);
         struct RaskJsonField *f = &obj->fields[obj->count];
-        snprintf(f->key, sizeof(f->key), "%s", rask_string_ptr(key));
-        rask_string_free(key);
+        snprintf(f->key, sizeof(f->key), "%s", rask_string_ptr(&key));
+        rask_string_free(&key);
 
         json_skip_ws(&p);
         if (*p != ':') break;
@@ -970,14 +980,14 @@ RaskJsonObj *rask_json_parse(const RaskString *s) {
 
         if (*p == '"') {
             f->type = JSON_STRING;
-            f->str_val = json_parse_string(&p);
+            json_parse_string(&f->str_val, &p);
         } else if (*p == 't' || *p == 'f') {
             f->type = JSON_BOOL;
             if (strncmp(p, "true", 4) == 0) { f->bool_val = 1; p += 4; }
             else if (strncmp(p, "false", 5) == 0) { f->bool_val = 0; p += 5; }
         } else if (*p == 'n' && strncmp(p, "null", 4) == 0) {
             f->type = JSON_STRING;
-            f->str_val = NULL;
+            rask_string_new(&f->str_val);
             p += 4;
         } else {
             f->type = JSON_NUMBER;
@@ -998,10 +1008,12 @@ static struct RaskJsonField *json_find_field(RaskJsonObj *obj, const char *key) 
     return NULL;
 }
 
-RaskString *rask_json_get_string(RaskJsonObj *obj, const char *key) {
+void rask_json_get_string(RaskStr *out, RaskJsonObj *obj, const char *key) {
     struct RaskJsonField *f = json_find_field(obj, key);
-    if (!f || f->type != JSON_STRING) return rask_string_new();
-    return f->str_val ? rask_string_clone(f->str_val) : rask_string_new();
+    if (!f || f->type != JSON_STRING) { rask_string_new(out); return; }
+    // Copy the field's string value
+    *out = f->str_val;
+    rask_string_clone(out); // RC inc if heap
 }
 
 int64_t rask_json_get_i64(RaskJsonObj *obj, const char *key) {
@@ -1022,7 +1034,7 @@ int8_t rask_json_get_bool(RaskJsonObj *obj, const char *key) {
     return f->bool_val;
 }
 
-int64_t rask_json_decode(const RaskString *s) {
+int64_t rask_json_decode(const RaskStr *s) {
     return (int64_t)(uintptr_t)rask_json_parse(s);
 }
 

--- a/compiler/runtime/string.c
+++ b/compiler/runtime/string.c
@@ -1,9 +1,19 @@
 // SPDX-License-Identifier: (MIT OR Apache-2.0)
 
-// String — UTF-8 immutable refcounted string, always null-terminated.
-// Internal buffer has room for the null byte beyond the reported length.
-// Refcounted: clone is O(1) (atomic increment), free decrements and frees at 0.
-// Sentinel refcount (INT32_MAX) marks literals that are never freed.
+// String — 16-byte tagged union with small string optimization (SSO).
+//
+// SSO mode (MSB of byte 15 = 0):
+//   [data: u8[15]][remaining: u8]   remaining = 15 - len
+//   Unused data bytes zeroed → always null-terminated.
+//
+// Heap mode (MSB of byte 15 = 1):
+//   [header_ptr: *u8 (8B)][tagged_len: u64 (8B)]
+//   tagged_len = len | RASK_HEAP_FLAG
+//   Header: { atomic_u32 refcount, u32 capacity, u8 data[] }
+//   Single contiguous allocation. Data null-terminated.
+//
+// Refcounting only applies to heap mode. SSO strings have no refcount.
+// Sentinel refcount (UINT32_MAX) marks static literals — never freed.
 
 #include "rask_runtime.h"
 #include <stdio.h>
@@ -11,131 +21,584 @@
 #include <string.h>
 #include <dirent.h>
 
-#define RASK_RC_SENTINEL INT32_MAX
+#define RASK_HEAP_FLAG   ((uint64_t)1 << 63)
+#define RASK_RC_SENTINEL UINT32_MAX
+#define RASK_SSO_MAX     15
 
-struct RaskString {
-    int32_t refcount; // atomic; RASK_RC_SENTINEL = never freed
-    char   *data;
-    int64_t len;
-    int64_t cap; // capacity excluding null terminator
-};
+// ─── Inline helpers ─────────────────────────────────────────
 
-// Copy-on-write: if buffer is shared (refcount > 1), detach into a private copy.
-// Returns s if sole owner, or a new RaskString with its own buffer.
-static RaskString *string_cow(RaskString *s) {
-    if (!s || s->refcount <= 1) return s;
-    if (s->refcount == RASK_RC_SENTINEL) {
-        // Literal — create a mutable copy
-        RaskString *new_s = (RaskString *)rask_alloc(sizeof(RaskString));
-        new_s->refcount = 1;
-        new_s->len = s->len;
-        new_s->cap = s->len;
-        new_s->data = (char *)rask_alloc(s->len + 1);
-        memcpy(new_s->data, s->data, (size_t)s->len + 1);
-        return new_s;
-    }
-    // Shared — detach
-    RaskString *new_s = (RaskString *)rask_alloc(sizeof(RaskString));
-    new_s->refcount = 1;
-    new_s->len = s->len;
-    new_s->cap = s->len;
-    new_s->data = (char *)rask_alloc(s->len + 1);
-    memcpy(new_s->data, s->data, (size_t)s->len + 1);
-    __atomic_sub_fetch(&s->refcount, 1, __ATOMIC_ACQ_REL);
-    return new_s;
+static inline int str_is_heap(const RaskStr *s) {
+    return (s->raw[15] & 0x80) != 0;
 }
 
-static void string_grow(RaskString *s, int64_t needed) {
-    if (needed <= s->cap) return;
-    int64_t new_cap = s->cap ? s->cap : 8;
+static inline int64_t str_len(const RaskStr *s) {
+    if (str_is_heap(s))
+        return (int64_t)(s->heap.tagged_len & ~RASK_HEAP_FLAG);
+    return 15 - (int64_t)s->sso.remaining;
+}
+
+static inline const char *str_data(const RaskStr *s) {
+    if (str_is_heap(s))
+        return (const char *)(s->heap.header + 8);
+    return (const char *)s->sso.data;
+}
+
+// Heap header accessors
+static inline uint32_t *heap_rc(const RaskStr *s) {
+    return (uint32_t *)s->heap.header;
+}
+
+static inline uint32_t heap_cap(const RaskStr *s) {
+    return *(uint32_t *)(s->heap.header + 4);
+}
+
+// ─── Constructors ───────────────────────────────────────────
+
+static void str_make_sso(RaskStr *out, const char *data, int64_t len) {
+    memset(out->raw, 0, 16);
+    if (len > 0) memcpy(out->sso.data, data, (size_t)len);
+    out->sso.remaining = (uint8_t)(15 - len);
+}
+
+static void str_make_heap(RaskStr *out, const char *data, int64_t len) {
+    int64_t cap = len;
+    // Header: [refcount: u32][capacity: u32][data: u8[cap+1]]
+    uint8_t *header = (uint8_t *)rask_alloc(8 + cap + 1);
+    *(uint32_t *)header = 1;              // refcount = 1
+    *(uint32_t *)(header + 4) = (uint32_t)cap; // capacity
+    if (len > 0) memcpy(header + 8, data, (size_t)len);
+    header[8 + len] = '\0';
+    out->heap.header = header;
+    out->heap.tagged_len = (uint64_t)len | RASK_HEAP_FLAG;
+}
+
+static void str_make(RaskStr *out, const char *data, int64_t len) {
+    if (len <= RASK_SSO_MAX)
+        str_make_sso(out, data, len);
+    else
+        str_make_heap(out, data, len);
+}
+
+void rask_string_new(RaskStr *out) {
+    str_make_sso(out, NULL, 0);
+}
+
+void rask_string_from(RaskStr *out, const char *cstr) {
+    if (!cstr) { rask_string_new(out); return; }
+    int64_t len = (int64_t)strlen(cstr);
+    str_make(out, cstr, len);
+}
+
+void rask_string_from_bytes(RaskStr *out, const char *data, int64_t len) {
+    if (!data || len <= 0) { rask_string_new(out); return; }
+    str_make(out, data, len);
+}
+
+// ─── RC operations ──────────────────────────────────────────
+
+void rask_string_free(const RaskStr *s) {
+    if (!str_is_heap(s)) return;
+    uint32_t *rc = heap_rc(s);
+    if (*rc == RASK_RC_SENTINEL) return;
+    if (__atomic_sub_fetch(rc, 1, __ATOMIC_ACQ_REL) == 0) {
+        uint32_t cap = heap_cap(s);
+        rask_realloc(s->heap.header, 8 + cap + 1, 0);
+    }
+}
+
+void rask_string_clone(const RaskStr *s) {
+    if (!str_is_heap(s)) return;
+    uint32_t *rc = heap_rc(s);
+    if (*rc == RASK_RC_SENTINEL) return;
+    __atomic_add_fetch(rc, 1, __ATOMIC_RELAXED);
+}
+
+// ─── Accessors ──────────────────────────────────────────────
+
+int64_t rask_string_len(const RaskStr *s) {
+    return str_len(s);
+}
+
+const char *rask_string_ptr(const RaskStr *s) {
+    return str_data(s);
+}
+
+int64_t rask_string_is_empty(const RaskStr *s) {
+    return str_len(s) == 0 ? 1 : 0;
+}
+
+// ─── Equality and comparison ────────────────────────────────
+
+int64_t rask_string_eq(const RaskStr *a, const RaskStr *b) {
+    int64_t alen = str_len(a);
+    int64_t blen = str_len(b);
+    if (alen != blen) return 0;
+    if (alen == 0) return 1;
+    return memcmp(str_data(a), str_data(b), (size_t)alen) == 0;
+}
+
+int64_t rask_string_compare(const RaskStr *a, const RaskStr *b) {
+    const char *ad = str_data(a);
+    int64_t alen = str_len(a);
+    const char *bd = str_data(b);
+    int64_t blen = str_len(b);
+    int64_t min_len = alen < blen ? alen : blen;
+    int cmp = memcmp(ad, bd, (size_t)min_len);
+    if (cmp != 0) return cmp < 0 ? -1 : 1;
+    if (alen < blen) return -1;
+    if (alen > blen) return 1;
+    return 0;
+}
+
+int64_t rask_string_lt(const RaskStr *a, const RaskStr *b) {
+    return rask_string_compare(a, b) < 0;
+}
+int64_t rask_string_gt(const RaskStr *a, const RaskStr *b) {
+    return rask_string_compare(a, b) > 0;
+}
+int64_t rask_string_le(const RaskStr *a, const RaskStr *b) {
+    return rask_string_compare(a, b) <= 0;
+}
+int64_t rask_string_ge(const RaskStr *a, const RaskStr *b) {
+    return rask_string_compare(a, b) >= 0;
+}
+
+// ─── Read-only operations ───────────────────────────────────
+
+int64_t rask_string_byte_at(const RaskStr *s, int64_t pos) {
+    int64_t len = str_len(s);
+    if (pos < 0 || pos >= len) return 0;
+    return (int64_t)(uint8_t)str_data(s)[pos];
+}
+
+int64_t rask_string_char_at(const RaskStr *s, int64_t index) {
+    int64_t len = str_len(s);
+    if (index < 0 || index >= len) return -1;
+    const char *d = str_data(s);
+    unsigned char c = (unsigned char)d[index];
+    if (c < 0x80) return c;
+    if ((c & 0xE0) == 0xC0 && index + 1 < len) {
+        return ((c & 0x1F) << 6) | (d[index + 1] & 0x3F);
+    }
+    if ((c & 0xF0) == 0xE0 && index + 2 < len) {
+        return ((c & 0x0F) << 12) | ((d[index + 1] & 0x3F) << 6)
+             | (d[index + 2] & 0x3F);
+    }
+    if ((c & 0xF8) == 0xF0 && index + 3 < len) {
+        return ((c & 0x07) << 18) | ((d[index + 1] & 0x3F) << 12)
+             | ((d[index + 2] & 0x3F) << 6) | (d[index + 3] & 0x3F);
+    }
+    return c;
+}
+
+int64_t rask_string_contains(const RaskStr *haystack, const RaskStr *needle) {
+    int64_t hlen = str_len(haystack);
+    int64_t nlen = str_len(needle);
+    if (nlen == 0) return 1;
+    if (nlen > hlen) return 0;
+    const char *h = str_data(haystack);
+    const char *n = str_data(needle);
+    for (int64_t i = 0; i <= hlen - nlen; i++) {
+        if (memcmp(h + i, n, (size_t)nlen) == 0) return 1;
+    }
+    return 0;
+}
+
+int64_t rask_string_starts_with(const RaskStr *s, const RaskStr *prefix) {
+    int64_t slen = str_len(s);
+    int64_t plen = str_len(prefix);
+    if (plen == 0) return 1;
+    if (slen < plen) return 0;
+    return memcmp(str_data(s), str_data(prefix), (size_t)plen) == 0 ? 1 : 0;
+}
+
+int64_t rask_string_ends_with(const RaskStr *s, const RaskStr *suffix) {
+    int64_t slen = str_len(s);
+    int64_t xlen = str_len(suffix);
+    if (xlen == 0) return 1;
+    if (slen < xlen) return 0;
+    return memcmp(str_data(s) + slen - xlen, str_data(suffix), (size_t)xlen) == 0 ? 1 : 0;
+}
+
+int64_t rask_string_find(const RaskStr *haystack, const RaskStr *needle) {
+    int64_t hlen = str_len(haystack);
+    int64_t nlen = str_len(needle);
+    if (nlen == 0) return 0;
+    if (nlen > hlen) return -1;
+    const char *h = str_data(haystack);
+    const char *n = str_data(needle);
+    for (int64_t i = 0; i <= hlen - nlen; i++) {
+        if (memcmp(h + i, n, (size_t)nlen) == 0) return i;
+    }
+    return -1;
+}
+
+int64_t rask_string_rfind(const RaskStr *haystack, const RaskStr *needle) {
+    int64_t hlen = str_len(haystack);
+    int64_t nlen = str_len(needle);
+    if (nlen == 0) return hlen;
+    if (nlen > hlen) return -1;
+    const char *h = str_data(haystack);
+    const char *n = str_data(needle);
+    for (int64_t i = hlen - nlen; i >= 0; i--) {
+        if (memcmp(h + i, n, (size_t)nlen) == 0) return i;
+    }
+    return -1;
+}
+
+int64_t rask_string_parse_int(const RaskStr *s) {
+    if (str_len(s) == 0) return 0;
+    return (int64_t)atoll(str_data(s));
+}
+
+double rask_string_parse_float(const RaskStr *s) {
+    if (str_len(s) == 0) return 0.0;
+    return atof(str_data(s));
+}
+
+// ─── String-producing operations (out-param) ────────────────
+
+void rask_string_concat(RaskStr *out, const RaskStr *a, const RaskStr *b) {
+    int64_t alen = str_len(a);
+    int64_t blen = str_len(b);
+    int64_t total = rask_safe_add(alen, blen);
+    const char *ad = str_data(a);
+    const char *bd = str_data(b);
+    if (total <= RASK_SSO_MAX) {
+        memset(out->raw, 0, 16);
+        if (alen > 0) memcpy(out->sso.data, ad, (size_t)alen);
+        if (blen > 0) memcpy(out->sso.data + alen, bd, (size_t)blen);
+        out->sso.remaining = (uint8_t)(15 - total);
+    } else {
+        uint8_t *header = (uint8_t *)rask_alloc(8 + total + 1);
+        *(uint32_t *)header = 1;
+        *(uint32_t *)(header + 4) = (uint32_t)total;
+        if (alen > 0) memcpy(header + 8, ad, (size_t)alen);
+        if (blen > 0) memcpy(header + 8 + alen, bd, (size_t)blen);
+        header[8 + total] = '\0';
+        out->heap.header = header;
+        out->heap.tagged_len = (uint64_t)total | RASK_HEAP_FLAG;
+    }
+}
+
+void rask_string_substr(RaskStr *out, const RaskStr *s, int64_t start, int64_t end) {
+    int64_t slen = str_len(s);
+    if (start < 0) start = 0;
+    if (end > slen) end = slen;
+    if (start >= end) { rask_string_new(out); return; }
+    str_make(out, str_data(s) + start, end - start);
+}
+
+void rask_string_to_lowercase(RaskStr *out, const RaskStr *s) {
+    int64_t len = str_len(s);
+    if (len == 0) { rask_string_new(out); return; }
+    const char *d = str_data(s);
+    // Build into a temp buffer, then make SSO or heap
+    char *buf = (char *)rask_alloc(len);
+    for (int64_t i = 0; i < len; i++) {
+        char c = d[i];
+        buf[i] = (c >= 'A' && c <= 'Z') ? c + 32 : c;
+    }
+    str_make(out, buf, len);
+    rask_realloc(buf, len, 0);
+}
+
+void rask_string_to_uppercase(RaskStr *out, const RaskStr *s) {
+    int64_t len = str_len(s);
+    if (len == 0) { rask_string_new(out); return; }
+    const char *d = str_data(s);
+    char *buf = (char *)rask_alloc(len);
+    for (int64_t i = 0; i < len; i++) {
+        unsigned char c = (unsigned char)d[i];
+        buf[i] = (c >= 'a' && c <= 'z') ? (char)(c - 32) : (char)c;
+    }
+    str_make(out, buf, len);
+    rask_realloc(buf, len, 0);
+}
+
+void rask_string_trim(RaskStr *out, const RaskStr *s) {
+    int64_t len = str_len(s);
+    if (len == 0) { rask_string_new(out); return; }
+    const char *d = str_data(s);
+    const char *start = d;
+    const char *end = d + len;
+    while (start < end && (*start == ' ' || *start == '\t' || *start == '\n' || *start == '\r'))
+        start++;
+    while (end > start && (end[-1] == ' ' || end[-1] == '\t' || end[-1] == '\n' || end[-1] == '\r'))
+        end--;
+    str_make(out, start, (int64_t)(end - start));
+}
+
+void rask_string_trim_start(RaskStr *out, const RaskStr *s) {
+    int64_t len = str_len(s);
+    if (len == 0) { rask_string_new(out); return; }
+    const char *d = str_data(s);
+    int64_t start = 0;
+    while (start < len && (d[start] == ' ' || d[start] == '\t'
+           || d[start] == '\n' || d[start] == '\r'))
+        start++;
+    str_make(out, d + start, len - start);
+}
+
+void rask_string_trim_end(RaskStr *out, const RaskStr *s) {
+    int64_t len = str_len(s);
+    if (len == 0) { rask_string_new(out); return; }
+    const char *d = str_data(s);
+    int64_t end = len;
+    while (end > 0 && (d[end - 1] == ' ' || d[end - 1] == '\t'
+           || d[end - 1] == '\n' || d[end - 1] == '\r'))
+        end--;
+    str_make(out, d, end);
+}
+
+void rask_string_repeat(RaskStr *out, const RaskStr *s, int64_t count) {
+    int64_t slen = str_len(s);
+    if (slen == 0 || count <= 0) { rask_string_new(out); return; }
+    int64_t total = rask_safe_mul(slen, count);
+    const char *d = str_data(s);
+    if (total <= RASK_SSO_MAX) {
+        memset(out->raw, 0, 16);
+        for (int64_t i = 0; i < count; i++)
+            memcpy(out->sso.data + i * slen, d, (size_t)slen);
+        out->sso.remaining = (uint8_t)(15 - total);
+    } else {
+        uint8_t *header = (uint8_t *)rask_alloc(8 + total + 1);
+        *(uint32_t *)header = 1;
+        *(uint32_t *)(header + 4) = (uint32_t)total;
+        for (int64_t i = 0; i < count; i++)
+            memcpy(header + 8 + i * slen, d, (size_t)slen);
+        header[8 + total] = '\0';
+        out->heap.header = header;
+        out->heap.tagged_len = (uint64_t)total | RASK_HEAP_FLAG;
+    }
+}
+
+void rask_string_reverse(RaskStr *out, const RaskStr *s) {
+    int64_t len = str_len(s);
+    if (len == 0) { rask_string_new(out); return; }
+    const char *d = str_data(s);
+    char *buf = (char *)rask_alloc(len);
+    for (int64_t i = 0; i < len; i++)
+        buf[i] = d[len - 1 - i];
+    str_make(out, buf, len);
+    rask_realloc(buf, len, 0);
+}
+
+void rask_string_replace(RaskStr *out, const RaskStr *s, const RaskStr *from, const RaskStr *to) {
+    int64_t slen = str_len(s);
+    int64_t flen = str_len(from);
+    if (slen == 0) { rask_string_new(out); return; }
+    if (flen == 0) {
+        // No match possible — copy input
+        str_make(out, str_data(s), slen);
+        return;
+    }
+
+    int64_t tlen = str_len(to);
+    const char *sd = str_data(s);
+    const char *fd = str_data(from);
+    const char *td = str_data(to);
+
+    // Count occurrences
+    int64_t count = 0;
+    const char *p = sd;
+    const char *end = sd + slen;
+    while (p + flen <= end) {
+        if (memcmp(p, fd, (size_t)flen) == 0) { count++; p += flen; }
+        else p++;
+    }
+
+    int64_t new_len = rask_safe_add(slen, rask_safe_mul(count, tlen - flen));
+    char *buf = (char *)rask_alloc(new_len);
+    char *dst = buf;
+    p = sd;
+    while (p < end) {
+        if (p + flen <= end && memcmp(p, fd, (size_t)flen) == 0) {
+            if (tlen > 0) memcpy(dst, td, (size_t)tlen);
+            dst += tlen;
+            p += flen;
+        } else {
+            *dst++ = *p++;
+        }
+    }
+    str_make(out, buf, new_len);
+    rask_realloc(buf, new_len, 0);
+}
+
+// ─── Split / lines / chars → Vec ────────────────────────────
+
+RaskVec *rask_string_lines(const RaskStr *s) {
+    RaskVec *v = rask_vec_new(16); // elem_size = sizeof(RaskStr) = 16
+    int64_t slen = str_len(s);
+    if (slen == 0) return v;
+    const char *p = str_data(s);
+    const char *end = p + slen;
+    while (p < end) {
+        const char *nl = (const char *)memchr(p, '\n', (size_t)(end - p));
+        int64_t len = nl ? (int64_t)(nl - p) : (int64_t)(end - p);
+        RaskStr line;
+        str_make(&line, p, len);
+        rask_vec_push(v, &line);
+        p = nl ? nl + 1 : end;
+    }
+    return v;
+}
+
+RaskVec *rask_string_split(const RaskStr *s, const RaskStr *sep) {
+    RaskVec *v = rask_vec_new(16);
+    int64_t slen = str_len(s);
+    int64_t sep_len = str_len(sep);
+    const char *p = str_data(s);
+    const char *end = p + slen;
+    const char *sepd = str_data(sep);
+
+    if (sep_len == 0) {
+        for (int64_t i = 0; i < slen; i++) {
+            RaskStr c;
+            str_make_sso(&c, p + i, 1);
+            rask_vec_push(v, &c);
+        }
+        return v;
+    }
+
+    while (p <= end) {
+        const char *found = NULL;
+        if (p < end) {
+            for (const char *q = p; q + sep_len <= end; q++) {
+                if (memcmp(q, sepd, (size_t)sep_len) == 0) {
+                    found = q;
+                    break;
+                }
+            }
+        }
+        int64_t chunk = found ? (int64_t)(found - p) : (int64_t)(end - p);
+        RaskStr part;
+        str_make(&part, p, chunk);
+        rask_vec_push(v, &part);
+        if (!found) break;
+        p = found + sep_len;
+    }
+    return v;
+}
+
+RaskVec *rask_string_split_whitespace(const RaskStr *s) {
+    RaskVec *v = rask_vec_new(16);
+    int64_t slen = str_len(s);
+    if (slen == 0) return v;
+    const char *p = str_data(s);
+    const char *end = p + slen;
+    while (p < end) {
+        while (p < end && (*p == ' ' || *p == '\t' || *p == '\n' || *p == '\r'))
+            p++;
+        if (p >= end) break;
+        const char *start = p;
+        while (p < end && *p != ' ' && *p != '\t' && *p != '\n' && *p != '\r')
+            p++;
+        RaskStr tok;
+        str_make(&tok, start, p - start);
+        rask_vec_push(v, &tok);
+    }
+    return v;
+}
+
+RaskVec *rask_string_chars(const RaskStr *s) {
+    RaskVec *v = rask_vec_new(8);
+    int64_t len = str_len(s);
+    const char *d = str_data(s);
+    for (int64_t i = 0; i < len; i++) {
+        int64_t ch = (int64_t)(uint8_t)d[i];
+        rask_vec_push(v, &ch);
+    }
+    return v;
+}
+
+// ─── Builder operations (out-param) ─────────────────────────
+// Builder always works in heap mode. Promotes SSO to heap on first use.
+
+// Ensure s is a sole-owner heap string. Returns header pointer.
+// Writes the promoted/detached value to *out.
+static uint8_t *builder_ensure_heap(RaskStr *out, const RaskStr *s) {
+    int64_t len = str_len(s);
+    if (!str_is_heap(s)) {
+        // Promote SSO to heap
+        const char *d = str_data(s);
+        int64_t cap = len < 8 ? 8 : len;
+        uint8_t *header = (uint8_t *)rask_alloc(8 + cap + 1);
+        *(uint32_t *)header = 1;
+        *(uint32_t *)(header + 4) = (uint32_t)cap;
+        if (len > 0) memcpy(header + 8, d, (size_t)len);
+        header[8 + len] = '\0';
+        out->heap.header = header;
+        out->heap.tagged_len = (uint64_t)len | RASK_HEAP_FLAG;
+        return header;
+    }
+    uint32_t *rc = heap_rc(s);
+    if (*rc != 1 && *rc != RASK_RC_SENTINEL) {
+        // Shared — detach (COW)
+        const char *d = str_data(s);
+        int64_t cap = len;
+        uint8_t *header = (uint8_t *)rask_alloc(8 + cap + 1);
+        *(uint32_t *)header = 1;
+        *(uint32_t *)(header + 4) = (uint32_t)cap;
+        if (len > 0) memcpy(header + 8, d, (size_t)len);
+        header[8 + len] = '\0';
+        __atomic_sub_fetch(rc, 1, __ATOMIC_ACQ_REL);
+        out->heap.header = header;
+        out->heap.tagged_len = (uint64_t)len | RASK_HEAP_FLAG;
+        return header;
+    }
+    if (*rc == RASK_RC_SENTINEL) {
+        // Literal — create mutable copy
+        const char *d = str_data(s);
+        int64_t cap = len;
+        uint8_t *header = (uint8_t *)rask_alloc(8 + cap + 1);
+        *(uint32_t *)header = 1;
+        *(uint32_t *)(header + 4) = (uint32_t)cap;
+        if (len > 0) memcpy(header + 8, d, (size_t)len);
+        header[8 + len] = '\0';
+        out->heap.header = header;
+        out->heap.tagged_len = (uint64_t)len | RASK_HEAP_FLAG;
+        return header;
+    }
+    // Sole owner — use as-is
+    *out = *s;
+    return out->heap.header;
+}
+
+static void builder_grow(RaskStr *out, int64_t needed) {
+    uint32_t cap = heap_cap(out);
+    if (needed <= (int64_t)cap) return;
+    int64_t new_cap = cap ? cap : 8;
     while (new_cap < needed) {
         if (new_cap > INT64_MAX / 2) rask_panic("string capacity overflow");
         new_cap *= 2;
     }
-    // +1 for null terminator
-    s->data = (char *)rask_realloc(s->data, s->cap + 1, new_cap + 1);
-    s->cap = new_cap;
+    out->heap.header = (uint8_t *)rask_realloc(out->heap.header,
+        8 + cap + 1, 8 + new_cap + 1);
+    *(uint32_t *)(out->heap.header + 4) = (uint32_t)new_cap;
 }
 
-RaskString *rask_string_new(void) {
-    RaskString *s = (RaskString *)rask_alloc(sizeof(RaskString));
-    s->refcount = 1;
-    s->data = (char *)rask_alloc(1);
-    s->data[0] = '\0';
-    s->len = 0;
-    s->cap = 0;
-    return s;
+void rask_string_push_byte(RaskStr *out, const RaskStr *s, uint8_t byte) {
+    builder_ensure_heap(out, s);
+    int64_t len = str_len(out);
+    builder_grow(out, len + 1);
+    out->heap.header[8 + len] = byte;
+    len++;
+    out->heap.header[8 + len] = '\0';
+    out->heap.tagged_len = (uint64_t)len | RASK_HEAP_FLAG;
 }
 
-RaskString *rask_string_from(const char *cstr) {
-    if (!cstr) return rask_string_new();
-    int64_t len = (int64_t)strlen(cstr);
-    RaskString *s = (RaskString *)rask_alloc(sizeof(RaskString));
-    s->refcount = 1;
-    s->data = (char *)rask_alloc(len + 1);
-    memcpy(s->data, cstr, (size_t)len + 1);
-    s->len = len;
-    s->cap = len;
-    return s;
-}
-
-RaskString *rask_string_from_bytes(const char *data, int64_t len) {
-    if (!data || len <= 0) return rask_string_new();
-    RaskString *s = (RaskString *)rask_alloc(sizeof(RaskString));
-    s->refcount = 1;
-    s->data = (char *)rask_alloc(len + 1);
-    memcpy(s->data, data, (size_t)len);
-    s->data[len] = '\0';
-    s->len = len;
-    s->cap = len;
-    return s;
-}
-
-void rask_string_free(RaskString *s) {
-    if (!s) return;
-    if (s->refcount == RASK_RC_SENTINEL) return;
-    if (__atomic_sub_fetch(&s->refcount, 1, __ATOMIC_ACQ_REL) == 0) {
-        if (s->data) rask_realloc(s->data, s->cap + 1, 0);
-        rask_realloc(s, (int64_t)sizeof(RaskString), 0);
-    }
-}
-
-int64_t rask_string_len(const RaskString *s) {
-    return s ? s->len : 0;
-}
-
-const char *rask_string_ptr(const RaskString *s) {
-    if (!s) return "";
-    return s->data;
-}
-
-RaskString *rask_string_push_byte(RaskString *s, uint8_t byte) {
-    if (!s) return s;
-    s = string_cow(s);
-    string_grow(s, s->len + 1);
-    s->data[s->len] = (char)byte;
-    s->len++;
-    s->data[s->len] = '\0';
-    return s;
-}
-
-// Encode a Unicode codepoint as UTF-8 and append it.
-RaskString *rask_string_push_char(RaskString *s, int32_t cp) {
-    if (!s) return s;
+void rask_string_push_char(RaskStr *out, const RaskStr *s, int32_t cp) {
     uint8_t buf[4];
     int n;
-    if (cp < 0) {
-        return s;
-    } else if (cp <= 0x7F) {
-        buf[0] = (uint8_t)cp;
-        n = 1;
-    } else if (cp <= 0x7FF) {
+    if (cp < 0) { *out = *s; return; }
+    else if (cp <= 0x7F) { buf[0] = (uint8_t)cp; n = 1; }
+    else if (cp <= 0x7FF) {
         buf[0] = 0xC0 | (uint8_t)(cp >> 6);
         buf[1] = 0x80 | (uint8_t)(cp & 0x3F);
         n = 2;
     } else if (cp <= 0xFFFF) {
-        // Reject surrogates — not valid Unicode scalar values
-        if (cp >= 0xD800 && cp <= 0xDFFF) return s;
+        if (cp >= 0xD800 && cp <= 0xDFFF) { *out = *s; return; }
         buf[0] = 0xE0 | (uint8_t)(cp >> 12);
         buf[1] = 0x80 | (uint8_t)((cp >> 6) & 0x3F);
         buf[2] = 0x80 | (uint8_t)(cp & 0x3F);
@@ -146,272 +609,83 @@ RaskString *rask_string_push_char(RaskString *s, int32_t cp) {
         buf[2] = 0x80 | (uint8_t)((cp >> 6) & 0x3F);
         buf[3] = 0x80 | (uint8_t)(cp & 0x3F);
         n = 4;
-    } else {
-        return s; // invalid codepoint
-    }
-    s = string_cow(s);
-    string_grow(s, s->len + n);
-    memcpy(s->data + s->len, buf, (size_t)n);
-    s->len += n;
-    s->data[s->len] = '\0';
-    return s;
+    } else { *out = *s; return; }
+
+    builder_ensure_heap(out, s);
+    int64_t len = str_len(out);
+    builder_grow(out, len + n);
+    memcpy(out->heap.header + 8 + len, buf, (size_t)n);
+    len += n;
+    out->heap.header[8 + len] = '\0';
+    out->heap.tagged_len = (uint64_t)len | RASK_HEAP_FLAG;
 }
 
-RaskString *rask_string_append(RaskString *s, const RaskString *other) {
-    if (!s || !other || other->len == 0) return s;
-    s = string_cow(s);
-    string_grow(s, s->len + other->len);
-    memcpy(s->data + s->len, other->data, (size_t)other->len);
-    s->len += other->len;
-    s->data[s->len] = '\0';
-    return s;
+void rask_string_append(RaskStr *out, const RaskStr *s, const RaskStr *other) {
+    int64_t olen = str_len(other);
+    if (olen == 0) { *out = *s; return; }
+    const char *od = str_data(other);
+    builder_ensure_heap(out, s);
+    int64_t len = str_len(out);
+    builder_grow(out, len + olen);
+    memcpy(out->heap.header + 8 + len, od, (size_t)olen);
+    len += olen;
+    out->heap.header[8 + len] = '\0';
+    out->heap.tagged_len = (uint64_t)len | RASK_HEAP_FLAG;
 }
 
-RaskString *rask_string_append_cstr(RaskString *s, const char *cstr) {
-    if (!s || !cstr) return s;
+void rask_string_append_cstr(RaskStr *out, const RaskStr *s, const char *cstr) {
+    if (!cstr) { *out = *s; return; }
     int64_t clen = (int64_t)strlen(cstr);
-    if (clen == 0) return s;
-    s = string_cow(s);
-    string_grow(s, s->len + clen);
-    memcpy(s->data + s->len, cstr, (size_t)clen);
-    s->len += clen;
-    s->data[s->len] = '\0';
-    return s;
+    if (clen == 0) { *out = *s; return; }
+    builder_ensure_heap(out, s);
+    int64_t len = str_len(out);
+    builder_grow(out, len + clen);
+    memcpy(out->heap.header + 8 + len, cstr, (size_t)clen);
+    len += clen;
+    out->heap.header[8 + len] = '\0';
+    out->heap.tagged_len = (uint64_t)len | RASK_HEAP_FLAG;
 }
 
-RaskString *rask_string_clone(const RaskString *s) {
-    if (!s) return rask_string_new();
-    if (s->refcount != RASK_RC_SENTINEL) {
-        __atomic_add_fetch(&((RaskString *)s)->refcount, 1, __ATOMIC_RELAXED);
-    }
-    return (RaskString *)s;
-}
-
-int64_t rask_string_eq(const RaskString *a, const RaskString *b) {
-    if (a == b) return 1;
-    if (!a || !b) return 0;
-    if (a->len != b->len) return 0;
-    return memcmp(a->data, b->data, (size_t)a->len) == 0;
-}
-
-int64_t rask_string_byte_at(const RaskString *s, int64_t pos) {
-    if (!s || pos < 0 || pos >= s->len) return 0;
-    return (int64_t)(uint8_t)s->data[pos];
-}
-
-RaskString *rask_string_substr(const RaskString *s, int64_t start, int64_t end) {
-    if (!s) return rask_string_new();
-    if (start < 0) start = 0;
-    if (end > s->len) end = s->len;
-    if (start >= end) return rask_string_new();
-    return rask_string_from_bytes(s->data + start, end - start);
-}
-
-RaskString *rask_string_concat(const RaskString *a, const RaskString *b) {
-    const char *ad = a ? a->data : "";
-    int64_t alen = a ? a->len : 0;
-    const char *bd = b ? b->data : "";
-    int64_t blen = b ? b->len : 0;
-    RaskString *r = (RaskString *)rask_alloc(sizeof(RaskString));
-    r->refcount = 1;
-    r->len = rask_safe_add(alen, blen);
-    r->cap = r->len;
-    r->data = (char *)rask_alloc(rask_safe_add(r->len, 1));
-    if (alen) memcpy(r->data, ad, (size_t)alen);
-    if (blen) memcpy(r->data + alen, bd, (size_t)blen);
-    r->data[r->len] = '\0';
-    return r;
-}
-
-int64_t rask_string_contains(const RaskString *haystack, const RaskString *needle) {
-    const char *h = haystack ? haystack->data : "";
-    const char *n = needle ? needle->data : "";
-    return strstr(h, n) != NULL ? 1 : 0;
-}
-
-RaskString *rask_string_to_lowercase(const RaskString *s) {
-    if (!s || s->len == 0) return rask_string_new();
-    RaskString *r = (RaskString *)rask_alloc(sizeof(RaskString));
-    r->refcount = 1;
-    r->len = s->len;
-    r->cap = s->len;
-    r->data = (char *)rask_alloc(s->len + 1);
-    for (int64_t i = 0; i < s->len; i++) {
-        char c = s->data[i];
-        r->data[i] = (c >= 'A' && c <= 'Z') ? c + 32 : c;
-    }
-    r->data[r->len] = '\0';
-    return r;
-}
-
-int64_t rask_string_starts_with(const RaskString *s, const RaskString *prefix) {
-    if (!prefix || prefix->len == 0) return 1;
-    if (!s || s->len < prefix->len) return 0;
-    return memcmp(s->data, prefix->data, (size_t)prefix->len) == 0 ? 1 : 0;
-}
-
-int64_t rask_string_ends_with(const RaskString *s, const RaskString *suffix) {
-    if (!suffix || suffix->len == 0) return 1;
-    if (!s || s->len < suffix->len) return 0;
-    return memcmp(s->data + s->len - suffix->len, suffix->data, (size_t)suffix->len) == 0 ? 1 : 0;
-}
-
-RaskVec *rask_string_lines(const RaskString *s) {
-    RaskVec *v = rask_vec_new(sizeof(RaskString *));
-    if (!s || s->len == 0) return v;
-    const char *p = s->data;
-    const char *end = s->data + s->len;
-    while (p < end) {
-        const char *nl = (const char *)memchr(p, '\n', (size_t)(end - p));
-        int64_t len = nl ? (int64_t)(nl - p) : (int64_t)(end - p);
-        RaskString *line = rask_string_from_bytes(p, len);
-        rask_vec_push(v, &line);
-        p = nl ? nl + 1 : end;
-    }
-    return v;
-}
-
-RaskString *rask_string_trim(const RaskString *s) {
-    if (!s || s->len == 0) return rask_string_new();
-    const char *start = s->data;
-    const char *end = s->data + s->len;
-    while (start < end && (*start == ' ' || *start == '\t' || *start == '\n' || *start == '\r'))
-        start++;
-    while (end > start && (end[-1] == ' ' || end[-1] == '\t' || end[-1] == '\n' || end[-1] == '\r'))
-        end--;
-    return rask_string_from_bytes(start, (int64_t)(end - start));
-}
-
-RaskVec *rask_string_split(const RaskString *s, const RaskString *sep) {
-    RaskVec *v = rask_vec_new(sizeof(RaskString *));
-    const char *p = s ? s->data : "";
-    int64_t slen = s ? s->len : 0;
-    int64_t sep_len = sep ? sep->len : 0;
-    const char *end = p + slen;
-
-    if (sep_len == 0) {
-        // Split each byte (ASCII character)
-        for (int64_t i = 0; i < slen; i++) {
-            RaskString *c = rask_string_from_bytes(p + i, 1);
-            rask_vec_push(v, &c);
-        }
-        return v;
-    }
-
-    while (p <= end) {
-        const char *found = NULL;
-        if (p < end) {
-            // Manual memmem — find sep in remaining bytes
-            for (const char *q = p; q + sep_len <= end; q++) {
-                if (memcmp(q, sep->data, (size_t)sep_len) == 0) {
-                    found = q;
-                    break;
-                }
-            }
-        }
-        int64_t chunk = found ? (int64_t)(found - p) : (int64_t)(end - p);
-        RaskString *part = rask_string_from_bytes(p, chunk);
-        rask_vec_push(v, &part);
-        if (!found) break;
-        p = found + sep_len;
-    }
-    return v;
-}
-
-RaskVec *rask_string_split_whitespace(const RaskString *s) {
-    RaskVec *v = rask_vec_new(sizeof(RaskString *));
-    if (!s || s->len == 0) return v;
-    const char *p = s->data;
-    const char *end = p + s->len;
-    while (p < end) {
-        // Skip whitespace
-        while (p < end && (*p == ' ' || *p == '\t' || *p == '\n' || *p == '\r'))
-            p++;
-        if (p >= end) break;
-        // Find end of token
-        const char *start = p;
-        while (p < end && *p != ' ' && *p != '\t' && *p != '\n' && *p != '\r')
-            p++;
-        RaskString *tok = rask_string_from_bytes(start, p - start);
-        rask_vec_push(v, &tok);
-    }
-    return v;
-}
-
-RaskString *rask_string_replace(const RaskString *s, const RaskString *from, const RaskString *to) {
-    if (!s) return rask_string_new();
-    if (!from || from->len == 0) return rask_string_clone(s);
-
-    const char *to_data = to ? to->data : "";
-    int64_t to_len = to ? to->len : 0;
-
-    // Count occurrences
-    int64_t count = 0;
-    const char *p = s->data;
-    const char *end = s->data + s->len;
-    while (p + from->len <= end) {
-        if (memcmp(p, from->data, (size_t)from->len) == 0) {
-            count++;
-            p += from->len;
-        } else {
-            p++;
-        }
-    }
-
-    int64_t new_len = rask_safe_add(s->len, rask_safe_mul(count, to_len - from->len));
-    RaskString *r = (RaskString *)rask_alloc(sizeof(RaskString));
-    r->refcount = 1;
-    r->len = new_len;
-    r->cap = new_len;
-    r->data = (char *)rask_alloc(rask_safe_add(new_len, 1));
-
-    char *dst = r->data;
-    p = s->data;
-    while (p < end) {
-        if (p + from->len <= end && memcmp(p, from->data, (size_t)from->len) == 0) {
-            if (to_len) memcpy(dst, to_data, (size_t)to_len);
-            dst += to_len;
-            p += from->len;
-        } else {
-            *dst++ = *p++;
-        }
-    }
-    r->data[new_len] = '\0';
-    return r;
-}
-
-int64_t rask_string_parse_int(const RaskString *s) {
-    if (!s || s->len == 0) return 0;
-    return (int64_t)atoll(s->data);
-}
-
-double rask_string_parse_float(const RaskString *s) {
-    if (!s || s->len == 0) return 0.0;
-    return atof(s->data);
+void rask_string_push_str(RaskStr *out, const RaskStr *s, const RaskStr *other) {
+    rask_string_append(out, s, other);
 }
 
 // ─── Conversion to string ───────────────────────────────────
 
-RaskString *rask_i64_to_string(int64_t val) {
+void rask_i64_to_string(RaskStr *out, int64_t val) {
     char buf[32];
     snprintf(buf, sizeof(buf), "%lld", (long long)val);
-    return rask_string_from(buf);
+    rask_string_from(out, buf);
 }
 
-RaskString *rask_bool_to_string(int64_t val) {
-    return rask_string_from(val ? "true" : "false");
+void rask_bool_to_string(RaskStr *out, int64_t val) {
+    rask_string_from(out, val ? "true" : "false");
 }
 
-RaskString *rask_f64_to_string(double val) {
+void rask_f64_to_string(RaskStr *out, double val) {
     char buf[64];
     snprintf(buf, sizeof(buf), "%g", val);
-    return rask_string_from(buf);
+    rask_string_from(out, buf);
 }
 
-RaskString *rask_char_to_string(int32_t codepoint) {
-    RaskString *s = rask_string_new();
-    s = rask_string_push_char(s, codepoint);
-    return s;
+void rask_char_to_string(RaskStr *out, int32_t codepoint) {
+    RaskStr empty;
+    rask_string_new(&empty);
+    rask_string_push_char(out, &empty, codepoint);
+    // If the push produced a heap string from an empty builder, check if
+    // the result fits in SSO. For single chars (1-4 bytes), it always does,
+    // but the builder always produces heap. Compact to SSO if possible.
+    if (str_is_heap(out)) {
+        int64_t len = str_len(out);
+        if (len <= RASK_SSO_MAX) {
+            const char *d = str_data(out);
+            uint8_t *header = out->heap.header;
+            str_make_sso(out, d, len);
+            // Free the heap allocation
+            uint32_t cap = *(uint32_t *)(header + 4);
+            rask_realloc(header, 8 + cap + 1, 0);
+        }
+    }
 }
 
 // ─── Char predicates ────────────────────────────────────────
@@ -425,18 +699,16 @@ int64_t rask_char_is_ascii(int32_t c) {
 }
 
 int64_t rask_char_is_alphabetic(int32_t c) {
-    // ASCII letters + basic Unicode letter detection
     if ((c >= 'A' && c <= 'Z') || (c >= 'a' && c <= 'z')) return 1;
-    if (c > 127) return 1; // conservative: treat non-ASCII as alphabetic
+    if (c > 127) return 1;
     return 0;
 }
 
 int64_t rask_char_is_numeric(int32_t c) {
     if (c >= '0' && c <= '9') return 1;
-    // Unicode numeric characters (superscripts, fractions, etc.)
-    if (c >= 0x00B2 && c <= 0x00B3) return 1; // ², ³
-    if (c == 0x00B9) return 1; // ¹
-    if (c >= 0x00BC && c <= 0x00BE) return 1; // ¼, ½, ¾
+    if (c >= 0x00B2 && c <= 0x00B3) return 1;
+    if (c == 0x00B9) return 1;
+    if (c >= 0x00BC && c <= 0x00BE) return 1;
     return 0;
 }
 
@@ -482,179 +754,17 @@ int64_t rask_char_eq(int32_t a, int32_t b) {
     return a == b ? 1 : 0;
 }
 
-// ─── Additional string methods ──────────────────────────────
+// ─── Filesystem ─────────────────────────────────────────────
 
-int64_t rask_string_is_empty(const RaskString *s) {
-    return (!s || s->len == 0) ? 1 : 0;
-}
+RaskVec *rask_fs_list_dir(const RaskStr *path) {
+    RaskVec *v = rask_vec_new(16);
+    int64_t plen = str_len(path);
+    if (plen == 0) return v;
 
-RaskString *rask_string_to_uppercase(const RaskString *s) {
-    if (!s) return rask_string_new();
-    RaskString *r = rask_string_from_bytes(s->data, s->len);
-    for (int64_t i = 0; i < r->len; i++) {
-        unsigned char c = (unsigned char)r->data[i];
-        if (c >= 'a' && c <= 'z') r->data[i] = (char)(c - 32);
-    }
-    return r;
-}
-
-// find(haystack, needle) — byte offset of first occurrence, -1 if not found.
-int64_t rask_string_find(const RaskString *haystack, const RaskString *needle) {
-    if (!haystack || !needle) return -1;
-    if (needle->len == 0) return 0;
-    const char *p = strstr(haystack->data, needle->data);
-    if (!p) return -1;
-    return (int64_t)(p - haystack->data);
-}
-
-// rfind(haystack, needle) — byte offset of last occurrence, -1 if not found.
-int64_t rask_string_rfind(const RaskString *haystack, const RaskString *needle) {
-    if (!haystack || !needle) return -1;
-    if (needle->len == 0) return haystack->len;
-    int64_t last = -1;
-    const char *start = haystack->data;
-    while (1) {
-        const char *p = strstr(start, needle->data);
-        if (!p) break;
-        last = (int64_t)(p - haystack->data);
-        start = p + 1;
-    }
-    return last;
-}
-
-// char_at(s, byte_index) — returns the UTF-8 codepoint at byte index.
-int64_t rask_string_char_at(const RaskString *s, int64_t index) {
-    if (!s || index < 0 || index >= s->len) return -1;
-    unsigned char c = (unsigned char)s->data[index];
-    if (c < 0x80) return c;
-    // Simplified UTF-8 decode
-    if ((c & 0xE0) == 0xC0 && index + 1 < s->len) {
-        return ((c & 0x1F) << 6) | (s->data[index + 1] & 0x3F);
-    }
-    if ((c & 0xF0) == 0xE0 && index + 2 < s->len) {
-        return ((c & 0x0F) << 12) | ((s->data[index + 1] & 0x3F) << 6)
-             | (s->data[index + 2] & 0x3F);
-    }
-    if ((c & 0xF8) == 0xF0 && index + 3 < s->len) {
-        return ((c & 0x07) << 18) | ((s->data[index + 1] & 0x3F) << 12)
-             | ((s->data[index + 2] & 0x3F) << 6) | (s->data[index + 3] & 0x3F);
-    }
-    return c;
-}
-
-// repeat(s, count) — returns string repeated count times.
-RaskString *rask_string_repeat(const RaskString *s, int64_t count) {
-    if (!s || count <= 0) return rask_string_new();
-    int64_t total = s->len * count;
-    RaskString *r = (RaskString *)rask_alloc(sizeof(RaskString));
-    r->refcount = 1;
-    r->data = (char *)rask_alloc(total + 1);
-    r->cap = total + 1;
-    r->len = total;
-    for (int64_t i = 0; i < count; i++) {
-        memcpy(r->data + i * s->len, s->data, (size_t)s->len);
-    }
-    r->data[total] = '\0';
-    return r;
-}
-
-// string_reverse(s) — byte-reversed copy (correct for ASCII; multi-byte aware).
-RaskString *rask_string_reverse(const RaskString *s) {
-    if (!s) return rask_string_new();
-    RaskString *r = (RaskString *)rask_alloc(sizeof(RaskString));
-    r->refcount = 1;
-    r->data = (char *)rask_alloc(s->len + 1);
-    r->cap = s->len + 1;
-    r->len = s->len;
-    for (int64_t i = 0; i < s->len; i++) {
-        r->data[i] = s->data[s->len - 1 - i];
-    }
-    r->data[s->len] = '\0';
-    return r;
-}
-
-// trim_start(s) — trim leading whitespace.
-RaskString *rask_string_trim_start(const RaskString *s) {
-    if (!s) return rask_string_new();
-    int64_t start = 0;
-    while (start < s->len && (s->data[start] == ' ' || s->data[start] == '\t'
-           || s->data[start] == '\n' || s->data[start] == '\r')) {
-        start++;
-    }
-    return rask_string_from_bytes(s->data + start, s->len - start);
-}
-
-// trim_end(s) — trim trailing whitespace.
-RaskString *rask_string_trim_end(const RaskString *s) {
-    if (!s) return rask_string_new();
-    int64_t end = s->len;
-    while (end > 0 && (s->data[end - 1] == ' ' || s->data[end - 1] == '\t'
-           || s->data[end - 1] == '\n' || s->data[end - 1] == '\r')) {
-        end--;
-    }
-    return rask_string_from_bytes(s->data, end);
-}
-
-// ── String comparison ──────────────────────────────────────────────
-// Lexicographic compare: returns -1, 0, +1
-int64_t rask_string_compare(const RaskString *a, const RaskString *b) {
-    if (a == b) return 0;
-    const char *ad = a ? a->data : "";
-    int64_t alen = a ? a->len : 0;
-    const char *bd = b ? b->data : "";
-    int64_t blen = b ? b->len : 0;
-    int64_t min_len = alen < blen ? alen : blen;
-    int cmp = memcmp(ad, bd, (size_t)min_len);
-    if (cmp != 0) return cmp < 0 ? -1 : 1;
-    if (alen < blen) return -1;
-    if (alen > blen) return 1;
-    return 0;
-}
-
-int64_t rask_string_lt(const RaskString *a, const RaskString *b) {
-    return rask_string_compare(a, b) < 0;
-}
-int64_t rask_string_gt(const RaskString *a, const RaskString *b) {
-    return rask_string_compare(a, b) > 0;
-}
-int64_t rask_string_le(const RaskString *a, const RaskString *b) {
-    return rask_string_compare(a, b) <= 0;
-}
-int64_t rask_string_ge(const RaskString *a, const RaskString *b) {
-    return rask_string_compare(a, b) >= 0;
-}
-
-// push_str: append another string (builder-only, must be sole owner)
-void rask_string_push_str(RaskString *s, const RaskString *other) {
-    if (!s || !other || other->len == 0) return;
-    // Builder context — must be sole owner. COW via rask_string_append.
-    rask_string_append(s, other);
-}
-
-// chars: return Vec of char codepoints (as i64)
-RaskVec *rask_string_chars(const RaskString *s) {
-    RaskVec *v = rask_vec_new(8);
-    if (!s) return v;
-    for (int64_t i = 0; i < s->len; i++) {
-        int64_t ch = (int64_t)(uint8_t)s->data[i];
-        rask_vec_push(v, &ch);
-    }
-    return v;
-}
-
-// ── Filesystem ─────────────────────────────────────────────────────
-// list_dir: return Vec of filenames in a directory
-RaskVec *rask_fs_list_dir(const RaskString *path) {
-    RaskVec *v = rask_vec_new(8);
-    if (!path) return v;
-
-    // Null-terminate the path
-    char *cpath = (char *)malloc((size_t)(path->len + 1));
-    memcpy(cpath, path->data, (size_t)path->len);
-    cpath[path->len] = '\0';
-
-    DIR *d = opendir(cpath);
-    free(cpath);
+    const char *pd = str_data(path);
+    // str_data returns null-terminated pointer for SSO (zeroed bytes)
+    // and for heap (explicit null). Safe to pass to opendir.
+    DIR *d = opendir(pd);
     if (!d) return v;
 
     struct dirent *entry;
@@ -662,16 +772,16 @@ RaskVec *rask_fs_list_dir(const RaskString *path) {
         if (entry->d_name[0] == '.' && (entry->d_name[1] == '\0' ||
             (entry->d_name[1] == '.' && entry->d_name[2] == '\0')))
             continue;
-        RaskString *name = rask_string_from(entry->d_name);
+        RaskStr name;
+        rask_string_from(&name, entry->d_name);
         rask_vec_push(v, &name);
     }
     closedir(d);
     return v;
 }
 
-// ── Map iteration ──────────────────────────────────────────────────
-// Map_iter: return Vec of (key, value) pairs for iteration
-// Delegates to the map's internal iteration.
+// ─── Map iteration ──────────────────────────────────────────
+
 extern RaskVec *rask_map_entries(const void *map);
 RaskVec *rask_map_iter(const void *map) {
     return rask_map_entries(map);

--- a/compiler/runtime/vec.c
+++ b/compiler/runtime/vec.c
@@ -195,32 +195,44 @@ RaskVec *rask_vec_clone(const RaskVec *src) {
 }
 
 // join(vec_of_strings, separator) — concatenate strings with separator.
-RaskString *rask_vec_join(const RaskVec *src, const RaskString *sep) {
-    RaskString *result = rask_string_new();
-    if (!src || src->len == 0) return result;
+void rask_vec_join(RaskStr *out, const RaskVec *src, const RaskStr *sep) {
+    rask_string_new(out);
+    if (!src || src->len == 0) return;
     for (int64_t i = 0; i < src->len; i++) {
         if (i > 0 && sep) {
-            rask_string_append(result, sep);
+            RaskStr tmp;
+            rask_string_append(&tmp, out, sep);
+            rask_string_free(out);
+            *out = tmp;
         }
-        RaskString *elem = *(RaskString **)(src->data + i * src->elem_size);
-        if (elem) rask_string_append(result, elem);
+        const RaskStr *elem = (const RaskStr *)(src->data + i * src->elem_size);
+        RaskStr tmp;
+        rask_string_append(&tmp, out, elem);
+        rask_string_free(out);
+        *out = tmp;
     }
-    return result;
 }
 
 // join(vec_of_ints, separator) — convert integers to strings and concatenate.
-RaskString *rask_vec_join_i64(const RaskVec *src, const RaskString *sep) {
-    RaskString *result = rask_string_new();
-    if (!src || src->len == 0) return result;
+void rask_vec_join_i64(RaskStr *out, const RaskVec *src, const RaskStr *sep) {
+    rask_string_new(out);
+    if (!src || src->len == 0) return;
     for (int64_t i = 0; i < src->len; i++) {
         if (i > 0 && sep) {
-            rask_string_append(result, sep);
+            RaskStr tmp;
+            rask_string_append(&tmp, out, sep);
+            rask_string_free(out);
+            *out = tmp;
         }
         int64_t val = *(int64_t *)(src->data + i * src->elem_size);
-        RaskString *s = rask_i64_to_string(val);
-        rask_string_append(result, s);
+        RaskStr s;
+        rask_i64_to_string(&s, val);
+        RaskStr tmp;
+        rask_string_append(&tmp, out, &s);
+        rask_string_free(out);
+        rask_string_free(&s);
+        *out = tmp;
     }
-    return result;
 }
 
 // slice(vec, start, end) — returns a new Vec with elements [start..end).


### PR DESCRIPTION
## Summary

Refactor the string implementation from a pointer-based refcounted design to a 16-byte tagged union with small string optimization (SSO). Strings up to 15 bytes are stored inline; longer strings use heap allocation with atomic refcounting. This reduces allocation overhead for short strings and improves cache locality.

## Key Changes

- **New RaskStr type**: 16-byte union with two modes:
  - SSO mode (MSB of byte 15 = 0): inline storage for up to 15 bytes, with a "remaining" byte tracking unused space
  - Heap mode (MSB of byte 15 = 1): pointer to header + tagged length, where header contains atomic refcount and capacity

- **API signature changes**:
  - String constructors now take `RaskStr *out` out-parameter instead of returning a pointer
  - String-producing functions (concat, substr, to_lowercase, etc.) use out-parameters
  - RC operations (free/clone) now take `const RaskStr *` and operate inline on the union

- **Refcounting simplification**:
  - Only heap-mode strings use refcounting; SSO strings have no refcount overhead
  - Sentinel refcount changed from `INT32_MAX` to `UINT32_MAX` for consistency
  - Clone operation is now a simple RC increment for heap strings, no-op for SSO

- **Runtime integration**:
  - Updated all stdlib functions in `runtime.c` to work with new signatures
  - Vec operations (join, etc.) adapted to handle 16-byte string elements
  - File I/O and CLI modules updated to construct strings via out-parameters

- **Codegen support**:
  - Added `StringOutParam` and `DerefStringElement` call adaptations in builder
  - String variables allocated as stack slots (16 bytes) rather than pointers
  - Inline tag checking for RC operations (free/clone only called on heap strings)
  - String assignment uses 16-byte aggregate copy instead of pointer aliasing

- **Helper functions**:
  - Inline accessors: `str_is_heap()`, `str_len()`, `str_data()`, `heap_rc()`, `heap_cap()`
  - Internal constructors: `str_make_sso()`, `str_make_heap()`, `str_make()`

## Implementation Details

- All strings are always null-terminated (SSO unused bytes zeroed, heap data includes null)
- Single contiguous allocation for heap strings: header (8 bytes) + data + null terminator
- Refcount stored as first u32 in heap header; capacity as second u32
- Tagged length uses bit 63 as heap flag to avoid separate mode byte
- String comparison and search operations work uniformly across both modes via inline helpers

https://claude.ai/code/session_01HFE2XAf7m1xAJaZbRSSwr3