### PR TITLE
Implement build_exec capability gating for exec() and exec_output()

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -56,7 +56,7 @@ Hardening for the package ecosystem. Not blocking any examples.
 
 - [ ] **Build script sandbox** — Cross-platform sandbox for dep build scripts (SB1-SB7).
 - [x] **Package signing** — Ed25519 TOFU signing on publish/fetch (SG1-SG7, KM1-KM3, LK8).
-- [ ] **Build exec gating** — `exec()`/`exec_output()` require `build_exec` capability (PM9-PM10).
+- [x] **Build exec gating** — `exec()`/`exec_output()` require `build_exec` capability (PM9-PM10).
 - [x] **Unsafe report command** — CLI command to report all unsafe operations by category.
 
 ---

--- a/compiler/crates/rask-cli/src/commands/build.rs
+++ b/compiler/crates/rask-cli/src/commands/build.rs
@@ -436,6 +436,8 @@ pub fn cmd_build(path: &str, opts: BuildOptions) {
                 extra_objects: Vec::new(),
                 declared_deps: Vec::new(),
                 tool_versions: std::collections::HashMap::new(),
+                // Root package is unrestricted (struct.build/PM9)
+                allowed_capabilities: None,
             };
 
             let mut interp = rask_interp::Interpreter::new();

--- a/compiler/crates/rask-interp/src/build_context.rs
+++ b/compiler/crates/rask-interp/src/build_context.rs
@@ -33,6 +33,10 @@ pub struct BuildState {
     pub declared_deps: Vec<PathBuf>,
     /// Tool version strings recorded for step cache keys.
     pub tool_versions: HashMap<String, String>,
+    /// Allowed capabilities for this build script (struct.build/PM9).
+    /// `None` = unrestricted (root package). `Some(caps)` = only these
+    /// capabilities are permitted (dependency packages).
+    pub allowed_capabilities: Option<Vec<String>>,
 }
 
 impl BuildState {
@@ -94,6 +98,22 @@ fn expect_string_vec(val: &Value, context: &str) -> Result<Vec<String>, String> 
         }
         _ => Err(format!("{}: expected Vec<string>", context)),
     }
+}
+
+/// Check that `build_exec` capability is allowed (struct.build/PM9).
+/// Root packages (allowed_capabilities = None) are always permitted.
+fn check_build_exec(state: &BuildState, method: &str) -> Result<(), String> {
+    if let Some(ref allowed) = state.allowed_capabilities {
+        if !allowed.iter().any(|c| c == "build_exec") {
+            return Err(format!(
+                "[struct.build/PM9]: build_exec capability required\n\
+                 \x20  dependency '{}' build script calls {}() but is not allowed\n\
+                 \x20  add `allow: [\"build_exec\"]` to the dep declaration in build.rk",
+                state.package_name, method,
+            ));
+        }
+    }
+    Ok(())
 }
 
 /// Dispatch a method call on BuildContext.
@@ -187,6 +207,7 @@ pub fn call_method(
 
         "exec" => {
             // exec(program: string, args: [string]) -> () or Error
+            check_build_exec(state, "exec")?;
             if args.len() != 2 {
                 return Err(format!("exec expects 2 args, got {}", args.len()));
             }
@@ -208,6 +229,7 @@ pub fn call_method(
 
         "exec_output" => {
             // exec_output(program: string, args: [string]) -> string or Error
+            check_build_exec(state, "exec_output")?;
             if args.len() != 2 {
                 return Err(format!("exec_output expects 2 args, got {}", args.len()));
             }
@@ -490,4 +512,123 @@ fn matches_glob(pattern: &str, name: &str) -> bool {
         return name.starts_with(prefix);
     }
     pattern == name
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn make_state(allowed_capabilities: Option<Vec<String>>) -> BuildState {
+        BuildState {
+            package_name: "test-dep".into(),
+            package_version: "1.0.0".into(),
+            package_dir: PathBuf::from("/tmp"),
+            profile: "debug".into(),
+            target: "x86_64-linux".into(),
+            host: "x86_64-linux".into(),
+            gen_dir: PathBuf::from("/tmp/rask-test-gen"),
+            out_dir: PathBuf::from("/tmp/rask-test-out"),
+            step_cache_dir: None,
+            link_libraries: vec![],
+            link_search_paths: vec![],
+            extra_objects: vec![],
+            declared_deps: vec![],
+            tool_versions: HashMap::new(),
+            allowed_capabilities,
+        }
+    }
+
+    fn str_val(s: &str) -> Value {
+        Value::String(Arc::new(Mutex::new(s.to_string())))
+    }
+
+    fn empty_vec() -> Value {
+        Value::Vec(Arc::new(Mutex::new(vec![])))
+    }
+
+    // PM9: exec() blocked without build_exec capability
+    #[test]
+    fn exec_blocked_without_build_exec() {
+        let mut state = make_state(Some(vec![]));
+        let result = call_method(&mut state, "exec", vec![str_val("echo"), empty_vec()]);
+        assert!(result.is_err());
+        let err = result.unwrap_err();
+        assert!(err.contains("build_exec"), "should mention build_exec: {}", err);
+        assert!(err.contains("PM9"), "should cite PM9: {}", err);
+        assert!(err.contains("test-dep"), "should name the package: {}", err);
+    }
+
+    // PM9: exec_output() blocked without build_exec capability
+    #[test]
+    fn exec_output_blocked_without_build_exec() {
+        let mut state = make_state(Some(vec!["net".into(), "read".into()]));
+        let result = call_method(&mut state, "exec_output", vec![str_val("echo"), empty_vec()]);
+        assert!(result.is_err());
+        let err = result.unwrap_err();
+        assert!(err.contains("build_exec"));
+        assert!(err.contains("exec_output"), "should name the method: {}", err);
+    }
+
+    // PM9: exec() allowed with build_exec capability
+    #[test]
+    fn exec_allowed_with_build_exec() {
+        let mut state = make_state(Some(vec!["build_exec".into()]));
+        let result = call_method(&mut state, "exec", vec![str_val("echo"), empty_vec()]);
+        assert!(result.is_ok(), "should succeed with build_exec: {:?}", result);
+    }
+
+    // PM9: exec_output() allowed with build_exec capability
+    #[test]
+    fn exec_output_allowed_with_build_exec() {
+        let mut state = make_state(Some(vec!["build_exec".into()]));
+        let result = call_method(&mut state, "exec_output", vec![str_val("echo"), empty_vec()]);
+        assert!(result.is_ok(), "should succeed with build_exec: {:?}", result);
+    }
+
+    // PM9: Root package (None) is always unrestricted
+    #[test]
+    fn root_package_unrestricted() {
+        let mut state = make_state(None);
+        let result = call_method(&mut state, "exec", vec![str_val("echo"), empty_vec()]);
+        assert!(result.is_ok(), "root package should always work: {:?}", result);
+    }
+
+    // PM10: Structured APIs don't require build_exec
+    #[test]
+    fn structured_apis_no_capability_needed() {
+        let mut state = make_state(Some(vec![]));
+
+        // link_library — pure state accumulation
+        let result = call_method(&mut state, "link_library", vec![str_val("ssl")]);
+        assert!(result.is_ok(), "link_library needs no capability: {:?}", result);
+
+        // link_search_path — pure state accumulation
+        let result = call_method(&mut state, "link_search_path", vec![str_val("/usr/lib")]);
+        assert!(result.is_ok(), "link_search_path needs no capability: {:?}", result);
+
+        // env — read-only
+        let result = call_method(&mut state, "env", vec![str_val("HOME")]);
+        assert!(result.is_ok(), "env needs no capability: {:?}", result);
+
+        // warning — stderr only
+        let result = call_method(&mut state, "warning", vec![str_val("test")]);
+        assert!(result.is_ok(), "warning needs no capability: {:?}", result);
+
+        // find_program — read-only PATH search
+        let result = call_method(&mut state, "find_program", vec![str_val("nonexistent-xyz")]);
+        assert!(result.is_ok(), "find_program needs no capability: {:?}", result);
+
+        // is_cross_compiling — pure computation
+        let result = call_method(&mut state, "is_cross_compiling", vec![]);
+        assert!(result.is_ok(), "is_cross_compiling needs no capability: {:?}", result);
+    }
+
+    // PM9: Error message includes actionable fix
+    #[test]
+    fn error_message_includes_fix() {
+        let mut state = make_state(Some(vec![]));
+        let err = call_method(&mut state, "exec", vec![str_val("echo"), empty_vec()]).unwrap_err();
+        assert!(err.contains(r#"add `allow: ["build_exec"]`"#), "should suggest fix: {}", err);
+        assert!(err.contains("build.rk"), "should mention build.rk: {}", err);
+    }
 }

--- a/specs/structure/build.md
+++ b/specs/structure/build.md
@@ -755,7 +755,7 @@ func build(ctx: BuildContext) -> () or Error {
 | Conditional compilation (CC1-CC2) | Implemented |
 | Cross-compilation toolchain (XT1-XT8) | Not started |
 | Build script sandbox (SB1-SB7) | Not started |
-| Build exec gating (PM9-PM10) | Not started |
+| Build exec gating (PM9-PM10) | Implemented |
 | Package signing (SG1-SG7, KM1-KM3) | Implemented |
 
 ### See Also


### PR DESCRIPTION
## Summary
Implements PM9-PM10 capability gating for build script execution methods. Dependency packages can now only call `exec()` and `exec_output()` if explicitly granted the `build_exec` capability, while root packages remain unrestricted.

## Key Changes

- **Added `allowed_capabilities` field** to `BuildState` struct to track permitted capabilities per package:
  - `None` = unrestricted (root package)
  - `Some(caps)` = only listed capabilities allowed (dependency packages)

- **Implemented `check_build_exec()` validation function** that:
  - Permits all operations for root packages (allowed_capabilities = None)
  - Blocks `exec()` and `exec_output()` for dependencies without `build_exec` capability
  - Provides actionable error messages citing PM9 and suggesting the fix

- **Guarded execution methods** with capability checks:
  - `exec()` now calls `check_build_exec()` before execution
  - `exec_output()` now calls `check_build_exec()` before execution
  - Structured APIs (link_library, env, find_program, etc.) remain unrestricted

- **Added comprehensive test suite** covering:
  - Blocking exec/exec_output without capability
  - Allowing exec/exec_output with capability
  - Root package unrestricted access
  - Structured APIs requiring no capability
  - Error message quality and actionability

- **Updated build command** to initialize root package with `allowed_capabilities: None`

- **Updated specification** to mark PM9-PM10 as implemented

## Implementation Details

The capability check is minimal and non-invasive—only `exec()` and `exec_output()` are gated, as these are the only methods that perform arbitrary system operations. All other BuildContext methods (state accumulation, environment queries, program discovery) remain available to all packages regardless of capabilities.

Error messages include the package name, method name, and a concrete fix suggestion for the build.rk manifest.

https://claude.ai/code/session_012uXQ6c6MEF15fWM5GkKykN