### PR TITLE
Document Pin elimination in async state machines

### DIFF
--- a/specs/CORE_DESIGN.md
+++ b/specs/CORE_DESIGN.md
@@ -263,6 +263,8 @@ No lifetime annotations needed. Function signatures are simple. Reasoning about 
 
 **Concrete benefit — relocatable state:** Because user-visible types contain only owned values and integer handles (never pointers), pool state can be serialized, memory-mapped, and sent across processes without pointer fixup. Handles survive round-trips because they're integers, not addresses. See `mem.relocatable` for the full specification.
 
+**Concrete benefit — no Pin in async:** State machines from spawn closures only hold owned values (closures can't capture borrows cross-task — mem.closures/SL2). Self-referential futures are impossible by construction, so `Pin` is unnecessary. Tasks are plain movable values. See conc.runtime/T1.
+
 **The fundamental choice:** I trade "hold a reference to data owned elsewhere" for "hold a handle/key/index to data in a collection." The former requires tracking lifetimes; the latter requires explicit indirection. I think the explicitness is worth it.
 
 ### Comptime Limitations

--- a/specs/concurrency/runtime.md
+++ b/specs/concurrency/runtime.md
@@ -39,7 +39,7 @@ Task<T> {
     waker: Mutex<Option<Waker>>,        // Reactor wake-up handle
     cancel_flag: AtomicBool,            // Cooperative cancellation (CN1)
     ensure_hooks: Mutex<Vec<EnsureHook>>, // Resource cleanup (mem.resources/R4)
-    future: Pin<Box<dyn Future<Output = T>>>, // Compiler-generated state machine
+    future: Box<dyn Future<Output = T>>,  // State machine — no Pin needed (see T3-NOTE)
     spawn_location: (&'static str, u32), // (file, line) for debug traces
 }
 ```
@@ -163,6 +163,8 @@ impl Future for State {
     }
 }
 ```
+
+> **T3-NOTE: No Pin required.** Rask's "no storable references" rule (CORE_DESIGN.md §3) means state machine variants only hold owned values — `IoFuture<File>`, `File`, `Vec<u8>` in the example above. No self-referential pointers. In Rust, `Pin` exists because async state machines can hold references to their own fields. Rask closures passed to `spawn` can only capture owned or Copy values (mem.closures/SL2), so the generated state machine can never reference itself. The `future` field in T1 is a plain `Box`, not `Pin<Box>`.
 
 **Current interpreter:** No state machine transform. Closures execute on real OS thread stacks. Full transform planned for compiled version.
 


### PR DESCRIPTION
## Summary
This PR clarifies the design rationale for why Rask's async state machines don't require `Pin`, adding explicit documentation to both the runtime specification and core design document.

## Key Changes
- **runtime.md (T1):** Updated the `future` field comment from `Pin<Box<dyn Future<Output = T>>>` to `Box<dyn Future<Output = T>>` with a reference to the new T3-NOTE explaining why Pin is unnecessary
- **runtime.md:** Added T3-NOTE section explaining that Rask's "no storable references" rule (CORE_DESIGN.md §3) prevents self-referential state machines, making Pin redundant
- **CORE_DESIGN.md (§3):** Added a new concrete benefit explaining that spawn closures can only capture owned/Copy values, making self-referential futures impossible by construction

## Implementation Details
The change is purely documentation—no code behavior changes. The key insight is that Rask's closure capture restrictions (mem.closures/SL2) guarantee state machines only hold owned values, never references to their own fields. Since `Pin` exists specifically to handle self-referential async state machines in standard Rust, it becomes unnecessary under Rask's constraints. This is a natural consequence of the existing "no storable references" design principle, now made explicit for clarity.

https://claude.ai/code/session_01G2Mh689rAA9xiAHywNyeZ7