### PR TITLE
Spec session reconnection, revocation flows, and capability GC


### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -266,8 +266,8 @@ Start with [CORE_DESIGN.md](specs/CORE_DESIGN.md). For specs: [specs/README.md](
 | Compiler architecture | IR layers, SSA pipeline, analysis framework, pass manager, CTFE, debug info | [architecture.md](specs/compiler/architecture.md) |
 | Code generation | MIR-based pipeline, Cranelift backend, runtime library | [codegen.md](specs/compiler/codegen.md) |
 | Raido | Independent deterministic scripting VM, 32.32 fixed-point, versioned serialization (lives in repo, not part of Rask) | [raido/](projects/raido/) |
-| Allgard | Orchestration of isolated domains (gards), supervision, location transparency | [allgard/](projects/allgard/) |
-| Leden | Standalone networking/IPC protocol and transport layer, separate crate | [leden/](projects/leden/) |
+| Allgard | Topology, registry, discovery, and health for networks of gards | [allgard/](projects/allgard/) |
+| Leden | Capability-based networking protocol — sessions, capabilities, object references | [leden/](projects/leden/) |
 | Midgard | Virtual world example — uses Raido, Leden, Allgard together | [midgard/](projects/midgard/) |
 
 ### Open

--- a/projects/allgard/README.md
+++ b/projects/allgard/README.md
@@ -1,65 +1,71 @@
 <!-- id: allgard.overview -->
 <!-- status: proposed -->
-<!-- summary: Allgard — orchestration of isolated domains (gards) -->
+<!-- summary: Allgard — topology, registry, and discovery for networks of gards -->
 
 # Allgard
 
-Orchestration layer for gards — isolated domains that communicate through message passing. Uses Leden for transport but is a separate concern.
+The map of the multiverse. Allgard knows what gards exist, where they are, and how to find them. [Leden](../leden/) is the web between them.
 
 ## What's a Gard
 
-An isolated domain. Own state, own lifecycle. Communicates with other gards only through messages over Leden. No shared memory between gards.
+A server process with isolated state. Runs independently, talks to other gards over Leden. Could be a game world region, a microservice, a build worker — whatever. Allgard doesn't care what's inside.
 
-Think of it as: a gard is to Allgard what an actor is to an actor system, what a process is to Erlang's VM, what a service is to a microservice architecture. The isolation boundary.
+Gards are coarse-grained. A gard might contain thousands of entities, its own task scheduler, its own pools. It's a domain, not an object.
 
-The difference from actors: gards are coarser-grained. A gard might contain thousands of entities, its own task scheduler, its own pools. It's a world, not an object.
+## What Allgard Does
 
-## Why Allgard
+Leden gives you point-to-point capability-based communication. But it doesn't answer: what endpoints exist? Where are they? How does a new gard join? How do I know one went down?
 
-Rask's concurrency model (`spawn`, channels, `Shared<T>`) handles parallelism within a single domain well. But structuring a system as multiple isolated domains — where failure in one doesn't crash the others, where domains can be distributed across machines — needs more.
+Allgard fills that gap:
 
-Allgard is that "more." It provides:
+1. **Registry** — what gards exist and where they are. The directory.
+2. **Topology** — how gards relate. Which ones should know about each other at startup. What capabilities they bootstrap with.
+3. **Discovery** — a new gard joins the network and finds the others. An existing gard moves and the others find its new address.
+4. **Health** — is a gard up? Leden detects connection drops. Allgard decides what that means — report it, alert an operator, notify dependent gards.
 
-1. **Isolation** — gards don't share memory. One gard panicking doesn't corrupt another.
-2. **Communication** — typed messages between gards, routed over Leden.
-3. **Lifecycle** — start, stop, restart gards. Supervision strategies.
-4. **Location transparency** — a gard doesn't know (or care) if the other gard is in-process, on another core, or on another machine.
+## What Allgard Does Not Do
 
-## Relationship to Other Components
+- **Communication** — that's Leden. Allgard helps you find the address; Leden handles the session, capabilities, and messages.
+- **Process supervision** — restarting crashed processes is your deployment platform's job (systemd, Docker, Kubernetes). Allgard reports health, it doesn't manage processes.
+- **Application logic** — Allgard doesn't know about game worlds, conservation laws, or Raido VMs. That's Midgard.
+
+## How It Fits Together
 
 ```
-┌──────────────────────────────────────────┐
-│ Allgard (orchestration)                  │
-│  ┌─────────┐  ┌─────────┐  ┌─────────┐  │
-│  │  Gard A  │  │  Gard B  │  │  Gard C  │  │
-│  │ (state,  │  │ (state,  │  │ (state,  │  │
-│  │  tasks)  │  │  tasks)  │  │  tasks)  │  │
-│  └────┬─────┘  └────┬─────┘  └────┬─────┘  │
-│       └──────┬──────┘──────┬──────┘        │
-│              │ Leden (transport)            │
-└──────────────┴─────────────────────────────┘
+┌─────────────────────────────────────────────────┐
+│ Allgard (registry, topology, discovery, health) │
+│                                                 │
+│   "Gard A is at 10.0.1.5:9000"                │
+│   "Gard B is at 10.0.2.3:9000"                │
+│   "Gard C just joined at 10.0.3.1:9000"       │
+│   "Gard A hasn't responded in 30s"             │
+│                                                 │
+├─────────────────────────────────────────────────┤
+│ Leden (protocol, sessions, capabilities)        │
+│                                                 │
+│   Gard A ←──session──→ Gard B                  │
+│   Gard B ←──session──→ Gard C                  │
+│                                                 │
+├─────────────────────────────────────────────────┤
+│ Transport (TCP, QUIC, Unix socket)              │
+└─────────────────────────────────────────────────┘
 ```
 
-- **Leden** — moves bytes. No knowledge of gards.
-- **Allgard** — manages gards, routes messages through Leden.
-- **Raido** — unrelated. Application-specific scripting VM. A gard might host a Raido VM, but that's the application's choice.
+Allgard is DNS + service mesh. Leden is the protocol on the wire.
 
 ## Key Decisions
 
 | Decision | Choice | Rationale |
 |----------|--------|-----------|
-| Isolation | No shared memory between gards | Failure isolation. Distribution transparency. |
-| Communication | Message passing over Leden | Decoupled from transport. Same API local or remote. |
-| Granularity | Coarse — a gard is a domain, not an object | Actors are too fine-grained for game worlds, service boundaries. |
-| Supervision | Restart strategies per gard | Erlang got this right. |
-| Packaging | Separate crate (`allgard`) | Not every program needs domain orchestration. |
+| Scope | Registry, topology, discovery, health | Everything between "I have a protocol" and "I have a running system." |
+| Not process management | Delegate to OS/infra | Reinventing systemd is not the goal. |
+| Packaging | Separate crate (`allgard`) | Many Leden users won't need managed topology. |
+| Granularity | Coarse — gards are servers, not objects | Fine-grained actors don't need a registry. Server processes do. |
 
 ## Open Questions
 
-- **Gard definition syntax.** Declarative? Programmatic? Both?
-- **Message routing.** Direct addressing? Topics/channels? Broadcast?
-- **Supervision strategies.** One-for-one, one-for-all, rest-for-one? Custom?
-- **Hot migration.** Can a gard be serialized and moved to another machine? If so, what are the constraints?
-- **Backpressure.** Per-gard mailbox limits? What happens on overflow?
-
-Inter-gard communication (bootstrap, introduction, capability model) is handled by [Leden](../leden/).
+- **Registry implementation.** Central registry gard? Gossip protocol? Static config file? Probably all three for different scales.
+- **Topology definition.** Declarative manifest? Programmatic API? How do you describe "these 5 gards form a cluster, this one is standalone"?
+- **Health semantics.** What's the contract? Heartbeat interval? What does "unhealthy" mean — just report it, or trigger topology changes?
+- **Dynamic membership.** Gards joining and leaving at runtime. How does the registry propagate changes? Eventually consistent is fine, but what's the consistency window?
+- **Migration.** Can a gard's address change (move to a different machine) without breaking existing Leden sessions? Sturdy references help — reconnect and re-present credentials. But the registry needs to know the new address.

--- a/projects/leden/README.md
+++ b/projects/leden/README.md
@@ -90,13 +90,12 @@ See [protocol.md](protocol.md) for full specification of each layer.
 
 | Spec | What it covers |
 |------|----------------|
-| [protocol.md](protocol.md) | Full protocol layer specification, operations, persistence, serialization |
+| [protocol.md](protocol.md) | Layers, operations, persistence, version negotiation, error model |
 | [content.md](content.md) | Content-addressed blob storage, lazy fetching, chunking |
+| [observation.md](observation.md) | Push-based observation of object state changes |
 
 ## Open Questions
 
-- **Discovery.** How do endpoints find each other? Static config? DNS? Multicast? Or leave that to the layer above?
-- **Flow control.** Credit-based or window-based?
+- **Discovery.** How do endpoints find each other? Static config? DNS? Multicast? Or leave that to Allgard?
 - **Wire format.** MessagePack, Cap'n Proto, FlatBuffers, Protocol Buffers? Must have schema evolution, compact binary, cross-language support, existing tooling.
 - **Capability GC.** Distributed garbage collection via reference counting with cycle detection (from E). Needs specification.
-- **Promise resolution on endpoint failure.** Timeout and error, retry on reconnect, or propagate failure? Probably all three depending on context.

--- a/projects/leden/README.md
+++ b/projects/leden/README.md
@@ -90,7 +90,7 @@ See [protocol.md](protocol.md) for full specification of each layer.
 
 | Spec | What it covers |
 |------|----------------|
-| [protocol.md](protocol.md) | Layers, operations, persistence, version negotiation, error model |
+| [protocol.md](protocol.md) | Layers, operations, persistence, reconnection, capability lifecycle, version negotiation, error model |
 | [content.md](content.md) | Content-addressed blob storage, lazy fetching, chunking |
 | [observation.md](observation.md) | Push-based observation of object state changes |
 
@@ -98,4 +98,3 @@ See [protocol.md](protocol.md) for full specification of each layer.
 
 - **Discovery.** How do endpoints find each other? Static config? DNS? Multicast? Or leave that to Allgard?
 - **Wire format.** MessagePack, Cap'n Proto, FlatBuffers, Protocol Buffers? Must have schema evolution, compact binary, cross-language support, existing tooling.
-- **Capability GC.** Distributed garbage collection via reference counting with cycle detection (from E). Needs specification.

--- a/projects/leden/README.md
+++ b/projects/leden/README.md
@@ -91,6 +91,7 @@ See [protocol.md](protocol.md) for full specification of each layer.
 | Spec | What it covers |
 |------|----------------|
 | [protocol.md](protocol.md) | Full protocol layer specification, operations, persistence, serialization |
+| [content.md](content.md) | Content-addressed blob storage, lazy fetching, chunking |
 
 ## Open Questions
 

--- a/projects/leden/content.md
+++ b/projects/leden/content.md
@@ -1,0 +1,131 @@
+<!-- id: leden.content -->
+<!-- status: proposed -->
+<!-- summary: Content-addressed blob storage and lazy fetching -->
+
+# Content Store
+
+How Leden handles data behind references. The problem: object references are small, but the data they point to can be arbitrarily large. A reference to a 3D model shouldn't force you to download 50MB just to hold it.
+
+## The Split
+
+Every piece of data in the system is either a **reference** or a **blob**.
+
+| Thing | Size | Identity | Mutability |
+|-------|------|----------|------------|
+| **Reference** | Tiny (hash + metadata) | Content-addressed | Immutable (new content = new hash) |
+| **Blob** | Arbitrary | Hash of content | Immutable |
+
+References travel through the capability protocol (Layer 2-3). Blobs travel through the content store. Holding a reference does not require having the blob. You fetch the blob when you need it.
+
+## Content Addressing
+
+Blob identity is the hash of the content. This gives you:
+
+- **Deduplication** — two endpoints storing the same data have the same hash. Free.
+- **Integrity** — fetch a blob, hash it, compare. Tampered = wrong hash. Free.
+- **Unforgeability** — can't construct a valid hash without having the content. Same property capabilities rely on.
+- **Immutability** — changing content changes the hash, which means it's a different blob. There's no "update in place."
+
+Hash algorithm is a protocol decision (SHA-256 is the obvious default). Must be fixed per protocol version — mixed hashes are a nightmare.
+
+## Fetching
+
+A content fetch is a request: "give me the bytes for this hash." The response is either the bytes or "I don't have it."
+
+```
+Endpoint A                          Endpoint B
+    |                                   |
+    |  ContentRequest(hash)             |
+    |──────────────────────────────────>|
+    |                                   |
+    |  ContentResponse(bytes)           |
+    |<──────────────────────────────────|
+    |                                   |
+```
+
+This fits into Leden's existing promise model. A content fetch returns a promise. The promise resolves to bytes (or an error). You can pipeline operations on the result — "fetch this blob, then decode field X from it" is one round trip, not two.
+
+### Chunking
+
+Large blobs are split into fixed-size chunks (e.g. 256KB). Each chunk is independently content-addressed. A blob's hash is the hash of its chunk list (a Merkle tree).
+
+Why:
+- **Resumable transfers** — network drops, you pick up where you left off
+- **Parallel fetching** — request chunks from multiple sources simultaneously
+- **Partial fetching** — if you only need the first 1MB of a 50MB blob, fetch those chunks
+- **Dedup at chunk level** — two blobs that share a common prefix share chunks
+
+### Sources
+
+A blob doesn't have a single canonical location. Any endpoint that has it can serve it. This means:
+
+- **Origin** — the endpoint that created the blob. Always has it (unless it's been garbage collected).
+- **Cache** — any endpoint that fetched it previously and hasn't evicted it.
+- **Peer** — another endpoint that happens to have it. Fetch from whoever's closest.
+
+The protocol doesn't mandate a specific resolution strategy. An endpoint can ask the origin, ask known peers, or use a separate discovery mechanism. The content store defines the fetch operation; routing is policy.
+
+## Pinning and Eviction
+
+Endpoints decide what to keep locally. The content store doesn't force replication.
+
+- **Pin** — "I want this blob to stay local." Prevents eviction.
+- **Evict** — "I don't need this anymore." Frees local storage. The blob still exists elsewhere.
+- **Cache** — "Keep this around if there's room, evict if storage is tight." LRU or whatever.
+
+This is entirely local policy. The protocol doesn't dictate storage strategy. A resource-constrained embedded device might cache nothing. A game server might pin all assets for its active region. A CDN might cache everything.
+
+## Relationship to Object Layer
+
+Layer 3 (Object) deals with references, method calls, and promises. The content store is how references resolve to actual data.
+
+An object reference contains:
+- Capability token (Layer 2) — authority to interact
+- Type information (Layer 3) — what methods/interface
+- Content hash (Content Store) — where the data lives
+
+The first two are always present in the reference. The content hash is a pointer — you follow it when you need the bytes.
+
+```
+┌──────────────────────────────────────────┐
+│  3. Object        References, calls      │
+│     └── content hash ──→ Content Store   │
+├──────────────────────────────────────────┤
+│  2. Capability    Authority, delegation  │
+├──────────────────────────────────────────┤
+│  1. Session       Multiplexing, reconnect│
+├──────────────────────────────────────────┤
+│  0. Transport     TCP, QUIC, etc.        │
+└──────────────────────────────────────────┘
+```
+
+The content store isn't a fifth layer — it's a service that Layer 3 uses. Objects reference blobs. The content store resolves those references to bytes.
+
+## Mutable State vs. Immutable Assets
+
+Important distinction. Not everything is a blob.
+
+| | Mutable state | Immutable asset |
+|-|---------------|-----------------|
+| **Example** | HP=50, position=(3,7) | 3D mesh, texture, audio |
+| **Changes?** | Yes, via Transforms | Never (new content = new blob) |
+| **Where?** | Hosting domain, in memory | Content store, fetched on demand |
+| **Size** | Small (usually) | Anything |
+| **Replication** | Only to authorized parties | Anyone with the hash |
+
+An object might have both: mutable state (managed through the capability protocol) and references to immutable assets (resolved through the content store). The sword's HP is mutable state. The sword's 3D model is an immutable blob.
+
+## What This Doesn't Cover
+
+- **Blob discovery across unconnected endpoints.** If A has a blob and B wants it, but A and B have no session, how does B find A? That's Allgard's job (or a DHT, or static config).
+- **Encryption at rest.** The content store deals with bytes. Encrypting them before storage is application policy.
+- **Garbage collection.** When no reference points to a blob, it can be cleaned up. Distributed GC is already an open problem in the protocol spec — content blobs inherit that problem.
+- **Streaming.** Live audio/video is not content-addressed (it doesn't exist yet). That's a different protocol concern.
+
+## Open Questions
+
+- **Hash algorithm.** SHA-256 is the default. BLAKE3 is faster. Does performance matter enough at the protocol level, or is this a transport optimization?
+- **Chunk size.** 256KB is a guess. Too small = too many chunks = overhead. Too large = poor dedup, no partial fetch benefit. Needs benchmarking.
+- **Manifest format.** How does the chunk list / Merkle tree get serialized? This is wire format, tied to the serialization decision in the protocol spec.
+- **Cross-endpoint cache coordination.** Should endpoints advertise what blobs they have? Or is "just ask and see" good enough? Advertising scales poorly. Asking has latency.
+- **Content types.** Should the content store know about types (image, mesh, script), or is everything opaque bytes with type info in the object reference? Leaning opaque — keep the store simple.

--- a/projects/leden/observation.md
+++ b/projects/leden/observation.md
@@ -1,0 +1,148 @@
+<!-- id: leden.observation -->
+<!-- status: proposed -->
+<!-- summary: Push-based observation of object state changes -->
+
+# Observation
+
+How Leden handles "notify me when this changes." Without this, every real-time system built on Leden is polling. Polling over a network is wrong — you have a persistent session, use it.
+
+## The Problem
+
+The protocol has request/response (method calls) and chained operations (promise pipelining). Both are pull-based: the caller asks, the responder answers. But most real-time systems need push:
+
+- Game state changes → update all observers
+- Inventory changes → update the UI
+- Health monitoring → alert when something drops
+- Collaborative editing → sync between participants
+
+Polling is the obvious workaround, and it's bad in every way: wastes bandwidth, adds latency (you see changes on the next poll, not when they happen), and scales poorly (N observers × M objects × poll frequency = too many messages).
+
+## Design
+
+Observation is a protocol-level operation, not something each object implements ad hoc. This is important — backpressure, reconnection, and capability gating are protocol concerns.
+
+### Core Operations
+
+| Operation | Direction | Purpose |
+|-----------|-----------|---------|
+| `Observe(object_ref)` | Client → Server | "Notify me of changes to this object" |
+| `Update(observation_id, payload)` | Server → Client | "This object changed, here's what happened" |
+| `Unobserve(observation_id)` | Client → Server | "Stop notifying me" |
+
+That's it. Three operations. Everything else is policy on top.
+
+### Capability Gating
+
+You can only observe objects you have a capability for. Observation isn't a separate permission by default — if you can read an object, you can observe it. But capabilities can be attenuated to exclude observation:
+
+```
+Full capability:     read + write + observe
+Attenuated:          read + write              (no push updates)
+Further attenuated:  read                      (no write, no push)
+```
+
+This matters for load control. A high-traffic object might have thousands of readers but only dozens of observers. The object's host can issue read-only capabilities to most clients and observe-capable ones to the few that need real-time updates.
+
+### What Gets Sent
+
+The server decides what an update contains. The protocol defines the envelope (observation_id + payload), not the contents. Two strategies:
+
+**Deltas** — "field X changed from A to B." Small. Efficient. Requires the observer to maintain state and apply deltas in order.
+
+**Snapshots** — "here's the entire current state." Larger. Simpler. The observer doesn't need to track history.
+
+The right choice depends on the object. A game entity with 20 fields where one changes per tick → delta. An observer that just reconnected and missed 500 updates → snapshot. Most objects will use deltas for normal operation and snapshots for catch-up.
+
+The protocol carries a **sequence number** on every update. This lets the observer detect gaps (missed updates during a network blip) and request a snapshot to resync.
+
+```
+Update(id=7, seq=142, delta: {health: 50 → 43})
+Update(id=7, seq=143, delta: {position: (3,7) → (4,7)})
+   ... network blip, seq 144-148 lost ...
+Update(id=7, seq=149, delta: {health: 43 → 30})
+   observer detects gap, requests resync
+Update(id=7, seq=149, snapshot: {health: 30, position: (6,8), ...})
+```
+
+### Backpressure
+
+A fast-changing object shouldn't overwhelm a slow observer. Credit-based flow control:
+
+1. Observer grants N credits when subscribing (e.g., 10).
+2. Each update consumes one credit.
+3. When credits hit zero, the server stops sending updates to that observer.
+4. Observer grants more credits when it's ready (e.g., after processing a batch).
+
+When backpressured, the server has options:
+
+| Strategy | Behavior | When |
+|----------|----------|------|
+| **Buffer** | Queue updates, send when credits arrive | Short bursts, observer will catch up |
+| **Coalesce** | Merge pending updates into one snapshot | Observer is slow, intermediate states don't matter |
+| **Drop** | Discard old updates, send latest | Real-time systems where stale data is worse than gaps |
+
+The object decides the strategy. A stock ticker drops stale prices. A chat log buffers. A game entity coalesces — you want the latest position, not every position along the path.
+
+### Multiplexing
+
+One session, many observations. Each observation is a logical stream within the session's multiplexing (Layer 1). No per-observation connection overhead.
+
+An observer watching 200 objects in a game region has 200 observations over one session. The session's backpressure applies globally (the transport can only carry so much), and per-observation credits apply locally (a chatty object doesn't starve a quiet one).
+
+### Session Reconnection
+
+When a session drops and reconnects:
+
+1. The server remembers active observations (tied to the session's sturdy reference).
+2. On reconnect, observations resume automatically.
+3. The server sends a snapshot for each observation to resync (the observer may have missed updates during the gap).
+4. Normal delta flow continues from the snapshot's sequence number.
+
+The observer doesn't re-subscribe manually. This falls out of Leden's session-capability decoupling — the session reconnects, capabilities re-attach, observations resume.
+
+If the observer was down long enough that the server evicted its observation state, the observer gets an `ObservationExpired` error and must re-subscribe. This is the server's eviction policy, not a protocol rule.
+
+### Filtered Observation
+
+Not every observer wants every field. A minimap UI cares about position, not health. A damage log cares about health changes, not position.
+
+Filters are specified at subscribe time:
+
+```
+Observe(object_ref, filter: [position, velocity])
+```
+
+The server only sends updates matching the filter. This reduces bandwidth and processing on both sides. Filters are optional — omit for "everything."
+
+Filters can be updated on a live observation without unsubscribing and resubscribing. The server applies the new filter immediately.
+
+### Fan-Out
+
+One object, many observers. The server is responsible for fan-out — sending updates to all observers of an object. This is a server-side scaling concern, not a protocol concern.
+
+The protocol intentionally doesn't specify how the server manages fan-out internally. It could be a simple loop, a pub/sub bus, or a dedicated broadcast tree. The protocol only cares about the per-observer stream.
+
+However: fan-out is where observation gets expensive. An object with 10,000 observers sending 60 updates/second is 600,000 messages/second. The protocol provides the tools to manage this (backpressure, coalescing, filtering), but the server must be smart about it. This is an implementation concern, not a spec problem.
+
+## Observation Is an Extension
+
+Observation is negotiated during the version handshake as an extension (see protocol.md, Version Negotiation). Not every endpoint needs it. A build system using Leden for RPC doesn't need push updates. A game server does.
+
+```
+Hello(min=1, max=1, ext=[observation])
+Welcome(version=1, ext=[observation])
+```
+
+If the server doesn't support observation, `Observe` calls return `MethodNotFound`. The client falls back to polling or decides it can't operate.
+
+## What This Doesn't Cover
+
+- **Derived observations.** "Notify me when any object in this collection changes." That's application logic — the application observes the collection and decides what to forward.
+- **Cross-endpoint observation relay.** Observer on A wants to watch an object on B, routed through C. The protocol handles this through capability delegation — C introduces A to B, A observes directly. No relay.
+- **Observation persistence.** Should observations survive endpoint restarts? Currently: no. Observations are session-scoped. Sturdy references let you re-establish them, but they don't auto-resume across restarts. This might be wrong for some use cases — open to revisiting.
+
+## Open Questions
+
+- **Observation on promises.** Can you observe the result of a promise that hasn't resolved yet? "When this promise resolves, start observing the result." Feels natural with promise pipelining, but adds complexity — the observation can't start until the promise resolves, so there's a gap.
+- **Observation groups.** Subscribe to many objects in one operation. Reduces round trips for "I just entered a region with 200 entities." Probably worth doing, but the semantics of partial failure (3 of 200 fail) need thought.
+- **Server-initiated observation.** Currently observation is client-pull ("I want to watch this"). Should the server be able to push an observation onto a client? "You're in this region now, here are the objects you should be watching." Capability model says no — the client decides what it observes. But it's a common pattern.

--- a/projects/leden/protocol.md
+++ b/projects/leden/protocol.md
@@ -108,6 +108,97 @@ Strategies by risk level (per-capability policy, not global):
 | Pessimistic | High-value operations | Liveness check before honoring |
 | Synchronous | Critical operations | Don't complete until revocation status confirmed |
 
+#### Revocation Message Types
+
+| Message | Direction | Fields | Purpose |
+|---------|-----------|--------|---------|
+| `Revoke` | Revoker → Issuer | `capability_id` | "I want this capability dead" |
+| `RevocationNotice` | Issuer → All holders | `capability_id`, `reason` | "This capability is no longer valid" |
+| `RevocationAck` | Holder → Issuer | `capability_id` | "Acknowledged, I've stopped using it" |
+| `CheckRevocation` | Holder → Issuer | `capability_id` | "Is this still valid?" |
+| `RevocationStatus` | Issuer → Holder | `capability_id`, `valid: bool` | "Yes/no" |
+
+The issuer is the authoritative source for revocation status. It maintains a revocation log — an append-only record of which capabilities were revoked and when.
+
+#### Optimistic Flow
+
+```
+A (revoker)              Issuer              B (holder)
+    |                      |                     |
+    |  Revoke(cap_id)      |                     |
+    |─────────────────────>|                     |
+    |                      | mark revoked        |
+    |                      |                     |
+    |                      | RevocationNotice    |
+    |                      |────────────────────>|
+    |                      |                     | stop using cap
+    |                      |                     |
+```
+
+No synchronization. B might use the capability between "mark revoked" and receiving the notice. That's accepted — the application reconciles later (e.g., undo the operation, compensate).
+
+Best for: read operations, low-value writes, anything where "oops, they saw one more update" is fine.
+
+#### Pessimistic Flow
+
+```
+B (holder)              Issuer
+    |                      |
+    | (wants to use cap)   |
+    | CheckRevocation(id)  |
+    |─────────────────────>|
+    |                      |
+    | RevocationStatus     |
+    |<─────────────────────|
+    |                      |
+    | (proceed or abort)   |
+```
+
+Extra round trip every time B wants to use the capability. Expensive but safe. No window of vulnerability.
+
+The cost is real: one additional RTT per operation. For a 100ms link, that's 100ms added to every call. Use this only when the consequence of using a revoked capability is worse than the latency.
+
+Best for: financial operations, permission changes, anything where "used a revoked capability" is a serious problem.
+
+**Caching:** To reduce the cost, B can cache the status for a short TTL. The TTL trades freshness for latency. A 1-second cache on a 100ms link means at most 1 second of stale status instead of checking every time. The issuer can also push `RevocationNotice` to invalidate caches.
+
+#### Synchronous Flow
+
+```
+A (revoker)              Issuer              B (holder)
+    |                      |                     |
+    |  Revoke(cap_id)      |                     |
+    |─────────────────────>|                     |
+    |                      | RevocationNotice    |
+    |                      |────────────────────>|
+    |                      |                     |
+    |                      |    RevocationAck    |
+    |                      |<────────────────────|
+    |                      |                     |
+    |  Revoked(confirmed)  | all acks received   |
+    |<─────────────────────|                     |
+```
+
+The revoker blocks until all holders have acknowledged. No operations on the capability succeed during this window — the issuer queues them until revocation is confirmed.
+
+This is the slowest strategy. If one holder is unreachable, the revoker blocks. Needs a timeout: if not all acks arrive within the deadline, the revocation is forced and any in-flight operations from unresponsive holders will get `CapabilityRevoked` when they eventually arrive.
+
+Best for: security-critical revocation (revoking a compromised key), administrative operations.
+
+#### Delegated Revocation
+
+When A delegates a capability to B, and B delegates to C, revocation must cascade:
+
+```
+A revokes the original capability
+→ B's derived capability is automatically revoked
+  → C's derived capability is automatically revoked
+```
+
+The issuer tracks the delegation tree. `RevocationNotice` is sent to all nodes in the tree. A holder doesn't need to explicitly revoke derived capabilities — revoking the parent revokes all descendants.
+
+This is why the delegation chain matters for introduction (Layer 2). The issuer must track "who delegated to whom" to propagate revocation correctly.
+
 ### Promise Pipelining
 
 Send a message to the result of a message that hasn't resolved yet.
@@ -149,6 +240,170 @@ A sturdy reference is NOT a capability — it's a *claim* that you once held one
 | Capabilities | Yes | Sturdy references, stored by holder |
 | Sessions | No | Rebuilt on reconnection |
 | Promises | Depends | Resolved = just values. Pending may be lost on restart. |
+
+---
+
+## Session Reconnection
+
+The concrete flow for "transport dropped, reconnect and get my capabilities back."
+
+### Sturdy Reference Structure
+
+A sturdy reference is what you store to prove you held a capability. It contains:
+
+| Field | Type | Purpose |
+|-------|------|---------|
+| `issuer` | endpoint identity | Who created the original capability |
+| `object_id` | opaque | Which object this grants access to |
+| `permissions` | bitfield | What operations are allowed (after attenuation) |
+| `nonce` | 256-bit | Unique, unguessable — proves this was issued, not fabricated |
+| `delegation_chain` | hash chain | Cryptographic proof of the delegation path from issuer |
+| `expiry` | optional timestamp | When this sturdy ref becomes invalid (if time-limited) |
+
+The `nonce` is critical. Without it, anyone who knows the object_id could fabricate a sturdy reference. The issuer generates the nonce and stores it — when a client presents a sturdy ref, the issuer checks the nonce against its records.
+
+The `delegation_chain` is a hash chain linking this sturdy ref back to the original capability through every delegation step. C can verify that B's ref chains back through A to the issuer without contacting A.
+
+### Re-attachment Flow
+
+```
+Client                                Server (Issuer)
+   |                                     |
+   |  (transport reconnects)             |
+   |                                     |
+   |  Hello(...)                         |
+   |────────────────────────────────────>|
+   |                                     |
+   |  Welcome(...)                       |
+   |<────────────────────────────────────|
+   |                                     |
+   |  Reattach(sturdy_refs=[...])        |
+   |────────────────────────────────────>|
+   |                                     |
+   |  ReattachResult(results=[           |
+   |    {ref: r1, cap: <live cap>},      |
+   |    {ref: r2, cap: <live cap>},      |
+   |    {ref: r3, err: Revoked},         |
+   |  ])                                 |
+   |<────────────────────────────────────|
+   |                                     |
+   |  (resume operations with live caps) |
+```
+
+### Re-attachment Message Types
+
+| Message | Direction | Fields | Purpose |
+|---------|-----------|--------|---------|
+| `Reattach` | Client → Server | `sturdy_refs[]` | "Here are my claims, give me live capabilities" |
+| `ReattachResult` | Server → Client | `results[]` | Per-ref: live capability or error |
+
+Each sturdy ref is validated independently. Some may succeed while others fail. Possible errors per ref:
+
+| Error | Meaning |
+|-------|---------|
+| `CapabilityRevoked` | Revoked while you were disconnected |
+| `CapabilityExpired` | Time limit passed |
+| `ObjectNotFound` | Object was destroyed |
+| `InvalidNonce` | Nonce doesn't match records — forged or corrupted ref |
+| `IssuerMismatch` | This server didn't issue this ref |
+
+### Batching
+
+`Reattach` takes an array, not a single ref, deliberately. A client reconnecting to a game server might need to re-attach 50 capabilities (world objects, chat channels, inventory). One message, one response. No per-ref round trip.
+
+### Edge Cases
+
+**Revoked during disconnection.** The client gets `CapabilityRevoked` in the reattach result. Clean — you find out immediately on reconnect, not when you try to use it.
+
+**Server restarted too.** The server reconstructs its capability table from its persistent store. Sturdy refs are designed for this — the nonce and delegation chain are verifiable without in-memory state.
+
+**Partial re-attachment.** Some refs succeed, some fail. The client gets a complete picture in one response and decides how to handle failures (request new capabilities from another source, degrade gracefully, etc.).
+
+**Observations.** Active observations are re-established automatically after successful re-attachment (see observation.md). The server sends a snapshot for each to resync state.
+
+**Pending promises.** Handled by the error model's resolution policies (see Error Model). `fail` promises were already rejected. `retry` promises are re-sent. `expire` promises are checked against their deadlines.
+
+---
+
+## Capability Lifecycle
+
+How capabilities are born, shared, and cleaned up. The full picture.
+
+### Creation
+
+Capabilities are created by the endpoint that hosts the object. When the greeter (bootstrap) grants a capability, or when an object method returns a reference to another object, a new capability is minted:
+
+1. Issuer generates a unique `nonce` and stores it
+2. Issuer assigns a `weight` (for reference counting — see GC below)
+3. Issuer records the holder in the delegation tree
+4. Holder receives a live capability (in-session) + a sturdy reference (for persistence)
+
+### Delegation
+
+When A delegates a capability to B:
+
+1. A's capability weight is split — A keeps half, B gets half
+2. The delegation is recorded in the issuer's delegation tree (for revocation cascading)
+3. B receives a new capability with A in its delegation chain
+
+Weight splitting is how the issuer tracks outstanding references without centralized reference counting. The original weight (e.g., 1024) is halved at each delegation. When delegations return their weight (via `Release`), the issuer can determine when all references are accounted for.
+
+### Release and GC
+
+When a holder no longer needs a capability:
+
+| Message | Direction | Fields | Purpose |
+|---------|-----------|--------|---------|
+| `Release` | Holder → Issuer | `capability_id`, `weight` | "I'm done, here's my weight back" |
+
+```
+A creates cap with weight 1024, gives to B
+B delegates to C: B keeps 512, C gets 512
+C delegates to D: C keeps 256, D gets 256
+
+D is done: Release(weight=256) → Issuer, total returned = 256
+C is done: Release(weight=256) → Issuer, total returned = 512
+B is done: Release(weight=512) → Issuer, total returned = 1024 = original
+
+All weight returned → capability can be garbage collected.
+```
+
+When all weight has been returned, no one holds a reference. The issuer cleans up the capability — removes it from the delegation tree, frees the nonce, reclaims any associated resources.
+
+### Lease-Based Expiry
+
+Weight-based GC has a problem: what if a holder crashes and never sends `Release`? The weight is lost. The capability is pinned forever.
+
+Solution: **leases**. Every capability has a lease duration. The holder must periodically renew the lease. If the lease expires, the issuer reclaims the weight and treats the capability as released.
+
+| Message | Direction | Fields | Purpose |
+|---------|-----------|--------|---------|
+| `Renew` | Holder → Issuer | `capability_id` | "I'm still here, extend my lease" |
+| `LeaseExpired` | Issuer → Holder | `capability_id` | "Your lease expired, capability reclaimed" (best-effort) |
+
+Lease duration is set by the issuer when the capability is created. Short leases (seconds) for high-churn objects. Long leases (minutes) for stable references. The holder renews at half the lease interval to avoid races.
+
+If a session reconnects after a lease expired, re-attachment with the sturdy ref will re-issue the capability with a fresh lease — no permanent loss.
+
+### Cycle Detection
+
+The hard problem. A holds a cap to B, B holds a cap to A. Neither releases. Weights never return. Without intervention, both are pinned forever.
+
+This is rare in practice — most capability graphs are trees, not cyclic. But "rare" isn't "impossible," and memory leaks in long-running servers are serious.
+
+**Strategy: trial deletion.**
+
+Adapted from distributed garbage collection literature. Periodically, the issuer suspects a capability might be in a cycle (heuristic: lease renewed many times but never released, low-weight reference that hasn't been delegated further). The issuer initiates a probe:
+
+1. Issuer sends `GCProbe(capability_id, probe_id)` to the holder
+2. Holder checks if it holds any capabilities back to the issuer (or the issuer's objects)
+3. If yes, it forwards the probe along those capabilities
+4. If the probe returns to the issuer, a cycle is confirmed
+5. The issuer can then break the cycle by forcibly reclaiming one of the capabilities
+
+This is expensive and only triggered by heuristics, not on every GC pass. For most applications, leases alone handle the problem — a leaked cycle that renews leases is a memory leak, but a bounded one that the application can monitor.
+
+**Pragmatic reality:** Most deployments won't hit cycles. Leases are the primary GC mechanism. Weight-based counting is the fast path. Cycle detection is a safety net for long-running servers with complex capability graphs.
 
 ---
 
@@ -322,8 +577,4 @@ Candidates: MessagePack, Cap'n Proto, FlatBuffers, Protocol Buffers. Decision de
 
 ## Open Design Problems
 
-1. **Session-capability decoupling mechanics.** Sessions and capabilities are separate (unlike CapTP). But the protocol flow for "re-attach capability to new session after reconnect" via sturdy references needs concrete message types.
-
-2. **Distributed revocation latency.** The optimistic/pessimistic/synchronous strategy per capability is right in principle. Needs concrete message types and flows for each.
-
-3. **Capability GC.** When no one holds a reference, the capability should be cleaned up. Distributed reference counting with cycle detection (from E). Needs specification.
+None currently. All previously open problems (session-capability decoupling, distributed revocation flows, capability GC) have been specified above.

--- a/projects/leden/protocol.md
+++ b/projects/leden/protocol.md
@@ -152,6 +152,161 @@ A sturdy reference is NOT a capability — it's a *claim* that you once held one
 
 ---
 
+## Version Negotiation
+
+The first thing two endpoints do. Before capabilities, before bootstrap, before anything — agree on what protocol version to speak.
+
+### Handshake
+
+Happens at Layer 1 (Session establishment), immediately after transport connects.
+
+```
+Client                                Server
+   |                                     |
+   |  Hello(min=1, max=3, ext=[...])     |
+   |────────────────────────────────────>|
+   |                                     |
+   |  Welcome(version=3, ext=[...])      |
+   |<────────────────────────────────────|
+   |                                     |
+   |  (session established, proceed      |
+   |   to bootstrap)                     |
+```
+
+Or if incompatible:
+
+```
+Client                                Server
+   |                                     |
+   |  Hello(min=4, max=5, ext=[...])     |
+   |────────────────────────────────────>|
+   |                                     |
+   |  Incompatible(server_min=1,         |
+   |               server_max=3)         |
+   |<────────────────────────────────────|
+   |                                     |
+   |  (connection closed)                |
+```
+
+The server picks the highest version both sides support. If there's no overlap, the connection fails with a clear error that tells the client what versions the server does support. No guessing.
+
+### Version Semantics
+
+**Major versions** — breaking changes. New major = new protocol. Old and new cannot interoperate without explicit support from both sides.
+
+**Minor versions** — additive only. New message types, new optional fields, new extensions. Old endpoints ignore what they don't understand. A v1.3 endpoint can talk to a v1.1 endpoint — the v1.1 side just won't use the new features.
+
+This means: deploy new servers first (they support old + new minor), clients upgrade at their pace.
+
+### Extensions
+
+Not everything belongs in the core protocol. Extensions are optional features negotiated during the handshake.
+
+```
+Hello(min=1, max=1, ext=[content_store, observation, compression_lz4])
+Welcome(version=1, ext=[content_store, observation])
+```
+
+Both sides advertise what they support. The session uses the intersection. The content store (content.md) and observation (observation.md) are extensions — not every endpoint needs them.
+
+Extensions have their own versioning. `content_store_v2` is a different extension from `content_store_v1`. Keeps the negotiation flat and simple.
+
+### What This Prevents
+
+- **Silent incompatibility.** You find out immediately, not three messages in when something doesn't parse.
+- **Forced lockstep upgrades.** Minor versions are backward-compatible. You don't need to upgrade the entire fleet at once.
+- **Feature creep in core.** Extensions keep optional features out of the base protocol. An embedded device running bare Leden doesn't pay for observation support it doesn't need.
+
+---
+
+## Error Model
+
+Every protocol needs to answer: what happens when things go wrong?
+
+### Error Levels
+
+| Level | Where | Example | Handled by |
+|-------|-------|---------|------------|
+| Transport | Layer 0 | Connection dropped | Session reconnection (Layer 1) |
+| Protocol | Layer 1-2 | Malformed message, invalid session token | Session termination or reset |
+| Capability | Layer 2 | Revoked capability, permission denied | Error response to caller |
+| Application | Layer 3 | Method failed, object not found | Error response with details |
+
+Transport and protocol errors are infrastructure — the endpoint handles them or dies. Capability and application errors are the interesting ones because they propagate to the caller and interact with promises.
+
+### Error Structure
+
+Every error has three parts:
+
+| Field | Type | Purpose |
+|-------|------|---------|
+| `code` | enum | Machine-readable category. Protocol-defined set + application extension. |
+| `message` | string | Human-readable explanation. For logs and debugging, not for branching on. |
+| `data` | optional bytes | Structured detail. Application-specific. Opaque to the protocol. |
+
+### Protocol Error Codes
+
+These are the errors the protocol itself defines. Applications can extend with their own codes in the `Application` range.
+
+| Code | Meaning |
+|------|---------|
+| `CapabilityRevoked` | The capability was revoked between issuance and use |
+| `CapabilityExpired` | Time-limited capability past its expiry |
+| `PermissionDenied` | Capability doesn't grant this operation |
+| `ObjectNotFound` | The referenced object doesn't exist (or was destroyed) |
+| `MethodNotFound` | The object doesn't support this method |
+| `RateLimited` | Too many requests. Backpressure at the application level. |
+| `EndpointUnavailable` | The hosting endpoint is unreachable |
+| `Timeout` | No response within the deadline |
+| `VersionMismatch` | Incompatible protocol version (from handshake) |
+| `MalformedMessage` | Message doesn't parse |
+| `Application(u32)` | Application-defined. The protocol routes it but doesn't interpret it. |
+
+### Promise Rejection
+
+This is the critical part. Promises are first-class in the protocol (promise pipelining). When a promise can't be fulfilled, it's **rejected** — and rejection propagates.
+
+```
+A calls B.method1() → promise P1
+A calls P1.method2() → promise P2  (pipelined)
+A calls P2.method3() → promise P3  (pipelined)
+
+B.method1() fails with PermissionDenied:
+  P1 = Rejected(PermissionDenied)
+  P2 = Rejected(PermissionDenied)   ← automatic
+  P3 = Rejected(PermissionDenied)   ← automatic
+```
+
+The error from the root cause propagates through the entire pipeline. The caller gets the original error, not "P2 failed because P1 failed." No wrapping, no nesting — the root cause flows through.
+
+This is E's "broken promise" semantics. A broken promise infects everything that depends on it. Simple and correct.
+
+### Promise Resolution on Endpoint Failure
+
+The open question from before, now answered. When an endpoint goes down while holding pending promises, the behavior depends on the promise's **resolution policy**, set at creation time:
+
+| Policy | Behavior | Use when |
+|--------|----------|----------|
+| `fail` | Reject with `EndpointUnavailable` after timeout | Default. Fast feedback. Most RPCs. |
+| `retry` | Hold pending, retry when session reconnects | Idempotent operations where you'd rather wait than fail. |
+| `expire` | Reject with `Timeout` after a deadline | Time-sensitive operations. "If this doesn't complete in 5s, I don't want it." |
+
+The default is `fail`. You opt into `retry` or `expire` when you know the semantics justify it. No silent hangs.
+
+### Error Handling at Session Boundaries
+
+When a session drops and reconnects:
+
+1. Capabilities survive (sturdy references, already specified).
+2. Pending promises with `fail` policy are rejected immediately.
+3. Pending promises with `retry` policy are re-sent automatically on reconnect.
+4. Pending promises with `expire` policy are rejected if past their deadline.
+5. Active observations (see observation.md) are re-established from the last known state.
+
+The caller doesn't need to track which promises were in-flight. The session handles it.
+
+---
+
 ## Serialization
 
 The wire format is undecided. Requirements:
@@ -171,6 +326,4 @@ Candidates: MessagePack, Cap'n Proto, FlatBuffers, Protocol Buffers. Decision de
 
 2. **Distributed revocation latency.** The optimistic/pessimistic/synchronous strategy per capability is right in principle. Needs concrete message types and flows for each.
 
-3. **Promise resolution on endpoint failure.** If an endpoint goes down while holding pending promises, what happens? Timeout and error, retry on reconnect, or propagate failure. Probably context-dependent.
-
-4. **Capability GC.** When no one holds a reference, the capability should be cleaned up. Distributed reference counting with cycle detection (from E). Needs specification.
+3. **Capability GC.** When no one holds a reference, the capability should be cleaned up. Distributed reference counting with cycle detection (from E). Needs specification.

--- a/projects/midgard/README.md
+++ b/projects/midgard/README.md
@@ -8,8 +8,8 @@ Midgard is an application — it uses the infrastructure projects, it doesn't de
 
 | Project | Role in Midgard |
 |---------|----------------|
-| **Allgard** | Each world region is a gard. Isolation, supervision, location transparency. |
-| **Leden** | Transport between gards — whether same machine or across a network. |
+| **Allgard** | Each world region is a gard. Registry knows which regions exist and where. Discovery lets new regions join. |
+| **Leden** | The protocol between gards — sessions, capabilities, object references. |
 | **Raido** | User-generated content. Entity scripts, modding, NPC AI. Sandboxed, deterministic, serializable. |
 
 ## Core Model


### PR DESCRIPTION

Closes all three remaining open design problems in the Leden
protocol spec.

Session reconnection: sturdy reference structure (nonce, delegation
chain, permissions, expiry), Reattach/ReattachResult message flow,
batched re-attachment for efficiency, edge cases (revoked during
disconnect, server restart, partial re-attachment).

Revocation flows: concrete message types for all three strategies.
Optimistic: RevocationNotice, no synchronization, reconcile later.
Pessimistic: CheckRevocation/RevocationStatus round trip per use,
with optional TTL caching. Synchronous: RevocationNotice + ack from
all holders, revoker blocks until confirmed. Delegated revocation
cascades through the delegation tree automatically.

Capability lifecycle and GC: weight-based reference counting (split
on delegation, return on release), lease-based expiry (handles
crashed holders that never release), trial deletion for cycle
detection (heuristic-triggered, expensive, safety net for long-
running servers).

https://claude.ai/code/session_01FUErNvjVTJ5Lr3qkpwCU3