### PR TITLE
WDP: resolve all open questions, add panels and prediction

### DIFF
--- a/projects/gdl/GDL-style.md
+++ b/projects/gdl/GDL-style.md
@@ -1,22 +1,22 @@
-World Description Style
-<!-- id: midgard.wds --> <!-- status: proposed --> <!-- summary: Visual identity and theming system for WDP — design tokens, structured hints, and CSS stylesheets -->
+Gard Description Style
+<!-- id: gdl.style --> <!-- status: proposed --> <!-- summary: Visual identity and theming system for GDL — design tokens, structured hints, and CSS stylesheets -->
 
-WDS is WDP's CSS. WDP describes what exists — structure, entities, affordances. WDS describes how it should feel — colors, atmosphere, lighting, sound palette, typography, entity treatment. Separate specs because they evolve independently and have different implementer audiences.
+GDL-style is GDL's CSS. GDL describes what exists — structure, entities, affordances. GDL-style describes how it should feel — colors, atmosphere, lighting, sound palette, typography, entity treatment. Separate specs because they evolve independently and have different implementer audiences.
 
-Without WDS, WDP is the pre-CSS internet. Content exists. Visual identity doesn't. A horror dungeon and a fairy forest render with the same client defaults. Walking through a cross-domain portal feels like nothing because both sides look identical. Domain authors have no way to express creative intent beyond text descriptions and per-entity appearance hints.
+Without GDL-style, GDL is the pre-CSS internet. Content exists. Visual identity doesn't. A horror dungeon and a fairy forest render with the same client defaults. Walking through a cross-domain portal feels like nothing because both sides look identical. Domain authors have no way to express creative intent beyond text descriptions and per-entity appearance hints.
 
-CSS solved this for documents. WDS solves it for worlds. But WDS is not CSS — CSS styles text, boxes, and layout. WDS styles lighting, atmosphere, color language, entity treatment, and sound. Different medium, different tool.
+CSS solved this for documents. GDL-style solves it for worlds. But GDL-style is not CSS — CSS styles text, boxes, and layout. GDL-style styles lighting, atmosphere, color language, entity treatment, and sound. Different medium, different tool.
 Why Not Just CSS
 
-I considered making the entire style system CSS with custom properties and WDP-specific selectors. Three problems:
+I considered making the entire style system CSS with custom properties and GDL-specific selectors. Three problems:
 
 1. CSS has no concept of fog density, ambient light color, or shadow intensity. You'd need custom properties for all of them, which makes CSS a transport format for non-CSS data. At that point it's not CSS anymore — it's key-value pairs wearing CSS syntax.
 
-2. CSS selectors are overkill. WDS doesn't need `.creature[data-hostile="true"]:nth-child(2n+1)`. It needs "hostile creatures get a red tint." Flat token namespaces (`entity.hostile_tint: #ff2200`) are simpler to author, simpler to parse, and impossible to create specificity bugs with.
+2. CSS selectors are overkill. GDL-style doesn't need `.creature[data-hostile="true"]:nth-child(2n+1)`. It needs "hostile creatures get a red tint." Flat token namespaces (`entity.hostile_tint: #ff2200`) are simpler to author, simpler to parse, and impossible to create specificity bugs with.
 
 3. CSS is still needed — for panels and web client UI. If the whole style system were CSS, you'd mix world-styling custom properties with actual layout CSS in one file. Keeping them separate means domain authors know exactly what goes where: tokens for world feel, CSS for panel/UI appearance.
 
-The architecture: tokens + hints (WDS, client-agnostic) and stylesheets (CSS, for web clients). Tokens are the real design system. CSS is a bonus layer.
+The architecture: tokens + hints (GDL-style, client-agnostic) and stylesheets (CSS, for web clients). Tokens are the real design system. CSS is a bonus layer.
 Design Tokens
 
 Tokens are named values that express visual identity. They're the bridge between "what the domain wants" and "what the client renders." Every client type can consume tokens — a text client maps color tokens to ANSI terminal colors, a 2D client maps them to sprite tinting, a 3D client maps them to shader uniforms.
@@ -96,7 +96,7 @@ Color:
 - Text client → ANSI terminal colors (color.danger → red, color.success → green)
 - 2D client → sprite tinting, UI palette, overlay colors
 - 3D client → material uniforms, UI palette, post-processing color grading
-- Web client → CSS custom properties (--wdp-color-primary, etc.)
+- Web client → CSS custom properties (--gdl-color-primary, etc.)
 
 Atmosphere:
 - Text client → ignored (mood comes from description text)
@@ -199,45 +199,45 @@ Clients that support CSS automatically expose tokens as custom properties:
 
     :root {
       /* Auto-generated from theme tokens */
-      --wdp-color-primary: #2a1a0e;
-      --wdp-color-secondary: #5c3a1e;
-      --wdp-color-accent: #8b6914;
-      --wdp-color-surface: #1a1a1a;
-      --wdp-color-background: #0d0d0d;
-      --wdp-color-text: #c4a882;
-      --wdp-color-danger: #8b2500;
-      --wdp-color-success: #2e5a1e;
-      --wdp-type-heading: serif;
-      --wdp-type-body: serif;
-      --wdp-type-ui: sans-serif;
-      /* ... all tokens mapped to --wdp-{namespace}-{name} */
+      --gdl-color-primary: #2a1a0e;
+      --gdl-color-secondary: #5c3a1e;
+      --gdl-color-accent: #8b6914;
+      --gdl-color-surface: #1a1a1a;
+      --gdl-color-background: #0d0d0d;
+      --gdl-color-text: #c4a882;
+      --gdl-color-danger: #8b2500;
+      --gdl-color-success: #2e5a1e;
+      --gdl-type-heading: serif;
+      --gdl-type-body: serif;
+      --gdl-type-ui: sans-serif;
+      /* ... all tokens mapped to --gdl-{namespace}-{name} */
     }
 
-The mapping is mechanical: `color.primary` → `--wdp-color-primary`. `atmosphere.fog_density` → `--wdp-atmosphere-fog-density`. Dots become hyphens. The `--wdp-` prefix prevents collisions with the client's own custom properties.
+The mapping is mechanical: `color.primary` → `--gdl-color-primary`. `atmosphere.fog_density` → `--gdl-atmosphere-fog-density`. Dots become hyphens. The `--gdl-` prefix prevents collisions with the client's own custom properties.
 
 The domain's stylesheet builds on these. It doesn't re-declare the palette — it references the tokens:
 
-    .wdp-panel {
-      background: var(--wdp-color-surface);
-      color: var(--wdp-color-text);
-      font-family: var(--wdp-type-body, serif);
-      border: 1px solid var(--wdp-color-accent);
+    .gdl-panel {
+      background: var(--gdl-color-surface);
+      color: var(--gdl-color-text);
+      font-family: var(--gdl-type-body, serif);
+      border: 1px solid var(--gdl-color-accent);
     }
 
-    .wdp-health-bar {
-      background: var(--wdp-color-danger);
+    .gdl-health-bar {
+      background: var(--gdl-color-danger);
       border-radius: 2px;
     }
 
-    .wdp-affordance-button {
-      background: var(--wdp-color-surface);
-      color: var(--wdp-color-accent);
-      border: 1px solid var(--wdp-color-accent);
+    .gdl-affordance-button {
+      background: var(--gdl-color-surface);
+      color: var(--gdl-color-accent);
+      border: 1px solid var(--gdl-color-accent);
     }
 
-    .wdp-affordance-button:hover {
-      background: var(--wdp-color-accent);
-      color: var(--wdp-color-surface);
+    .gdl-affordance-button:hover {
+      background: var(--gdl-color-accent);
+      color: var(--gdl-color-surface);
     }
 
 If the domain changes its tokens (e.g., a day/night cycle shifts color.primary), the CSS custom properties update automatically and the stylesheet's var() references resolve to the new values. No stylesheet swap needed for token-driven changes.
@@ -246,21 +246,21 @@ Well-Known CSS Classes
 Clients that render HTML-based UI should expose these classes on their elements. Domain stylesheets target them to style the client's built-in chrome.
 
 Class	Element	Purpose
-.wdp-panel	Panel container	Wraps each domain panel
-.wdp-health-bar	Health indicator	Bar showing health/health_max ratio
-.wdp-health-bar-fill	Health fill	Inner element sized to health/health_max
-.wdp-entity-label	Name label	Entity name overlay in graphical clients
-.wdp-entity-label--hostile	Hostile variant	Label on hostile entities (additional class)
-.wdp-affordance-button	Action button	Clickable affordance trigger
-.wdp-affordance-menu	Menu container	Groups affordances by category
-.wdp-affordance-group	Category group	One affordance category within the menu
-.wdp-region-name	Region title	Current region's name display
-.wdp-ambient-overlay	Screen overlay	Full-screen mood/atmosphere tinting layer
-.wdp-toast	Notification	Transient messages (damage numbers, pickups)
+.gdl-panel	Panel container	Wraps each domain panel
+.gdl-health-bar	Health indicator	Bar showing health/health_max ratio
+.gdl-health-bar-fill	Health fill	Inner element sized to health/health_max
+.gdl-entity-label	Name label	Entity name overlay in graphical clients
+.gdl-entity-label--hostile	Hostile variant	Label on hostile entities (additional class)
+.gdl-affordance-button	Action button	Clickable affordance trigger
+.gdl-affordance-menu	Menu container	Groups affordances by category
+.gdl-affordance-group	Category group	One affordance category within the menu
+.gdl-region-name	Region title	Current region's name display
+.gdl-ambient-overlay	Screen overlay	Full-screen mood/atmosphere tinting layer
+.gdl-toast	Notification	Transient messages (damage numbers, pickups)
 
 The client is not required to apply domain styles to its own UI. But clients that do get the portal-transition effect: walk into a new domain and the entire UI shifts color and feel. This is the key experience that makes cross-domain travel feel coherent rather than jarring.
 
-Modifier classes follow BEM-lite convention: `.wdp-entity-label--hostile`, `.wdp-affordance-button--disabled`, `.wdp-panel--collapsed`. Domains can target these for state-specific styling.
+Modifier classes follow BEM-lite convention: `.gdl-entity-label--hostile`, `.gdl-affordance-button--disabled`, `.gdl-panel--collapsed`. Domains can target these for state-specific styling.
 Stylesheet Constraints
 
 - No JavaScript. No `<script>`, no event handlers, no `expression()`, no `-moz-binding`.
@@ -315,7 +315,7 @@ Text client:
 Web client:
 - Injects all tokens as CSS custom properties on :root
 - Applies stylesheet directly to page
-- Uses .wdp-* classes on its UI elements
+- Uses .gdl-* classes on its UI elements
 - Gets portal-transition effect: region change → new tokens → CSS custom properties update → instant UI recolor via var() references
 - Panels inherit styling automatically via the CSS cascade
 - Result: the domain's visual identity permeates every pixel of the client
@@ -323,7 +323,7 @@ Resolved
 
 Tokens over selectors. I considered CSS-like selectors for targeting entities (`creature[hostile=true] { tint: red }`). Flat namespaced tokens are simpler. No specificity bugs. No parsing complexity. Domain authors write `entity.hostile_tint: #ff2200` instead of learning a selector language. The tradeoff is less precision — you can't target "hostile creatures of level > 10 in this specific room." But that level of granularity belongs in per-entity appearance, not in the theme.
 
-Separate spec from WDP. CSS is a separate spec from HTML. They evolved independently with different versioning, complexity budgets, and implementer communities. WDS changes more frequently than WDP — new token categories, new mood terms, stylesheet feature additions. Keeping them separate means WDP implementations are complete without WDS (use client defaults), and WDS can evolve without forcing WDP revisions.
+Separate spec from GDL. CSS is a separate spec from HTML. They evolved independently with different versioning, complexity budgets, and implementer communities. GDL-style changes more frequently than GDL — new token categories, new mood terms, stylesheet feature additions. Keeping them separate means GDL implementations are complete without GDL-style (use client defaults), and GDL-style can evolve without forcing GDL revisions.
 
 Three-level cascade is enough. I considered adding a fourth level (union themes — a domain union defines shared visual standards). Not worth the complexity. If a union wants visual consistency, its member domains use the same domain-level tokens. The cascade doesn't need to know about unions.
 
@@ -334,7 +334,7 @@ Open Questions
 
 Token animation. Should tokens support transition hints? `atmosphere.ambient_intensity: 0.5 [transition: 2s]` would tell the client to smoothly interpolate over 2 seconds instead of snapping. The domain can fake this by sending multiple updates, but that's chattier. A built-in transition hint is cleaner — but adds complexity to the token format. For now, domains send incremental updates and clients interpolate at their own rate.
 
-Audio token depth. The sound.* namespace is shallow — ambient layer, music mood, footstep style. Real audio design needs more: reverb presets, distance attenuation curves, environmental occlusion hints, music crossfade behavior. Should this stay shallow (simple, most domains don't need it) or get its own sub-spec (complex, but enables rich audio experiences)? Leaning toward keeping it shallow in WDS and deferring deep audio to a future extension.
+Audio token depth. The sound.* namespace is shallow — ambient layer, music mood, footstep style. Real audio design needs more: reverb presets, distance attenuation curves, environmental occlusion hints, music crossfade behavior. Should this stay shallow (simple, most domains don't need it) or get its own sub-spec (complex, but enables rich audio experiences)? Leaning toward keeping it shallow in GDL-style and deferring deep audio to a future extension.
 
 Accessibility overrides. The client's accessibility settings should always win over domain themes. A domain that sets `contrast: low` shouldn't override a user's high-contrast mode. The cascade should probably be: domain → region → entity → USER (always wins). But this means the client needs to know which tokens map to accessibility-relevant settings. Not specified yet.
 

--- a/projects/gdl/GDL.md
+++ b/projects/gdl/GDL.md
@@ -1,16 +1,16 @@
-World Description Protocol
-<!-- id: midgard.wdp --> <!-- status: proposed --> <!-- summary: Content schema for describing virtual world state over Leden -->
+Gard Description Language
+<!-- id: gds --> <!-- status: proposed --> <!-- summary: Content schema for describing gard state over Leden -->
 
-WDP is Midgard's "HTML" — the content schema that tells a client what the world looks like and how to interact with it. Domains send structured descriptions. Clients decide how to render them. A text client shows room descriptions. A 2D client draws tiles. A 3D client builds a scene. Same data, different presentations.
+GDL is the content schema that tells a client what a gard looks like and how to interact with it. Domains send structured descriptions. Clients decide how to render them. A text client shows room descriptions. A 2D client draws tiles. A 3D client builds a scene. Same data, different presentations.
 
-WDP is not a protocol. It's a content schema that rides on Leden, the same way HTML rides on HTTP. Leden handles sessions, capabilities, observation, and content delivery. WDP defines what's inside the payloads.
+GDL is not a protocol. It's a content schema that rides on Leden, the same way HTML rides on HTTP. Leden handles sessions, capabilities, observation, and content delivery. GDL defines what's inside the payloads.
 Why This Exists
 
-The Midgard stack has logic (Raido), trust (Allgard), and transport (Leden). It doesn't have a way to describe what the world looks like.
+The stack has logic (Raido), trust (Allgard), and transport (Leden). It doesn't have a way to describe what a gard looks like.
 
-Without WDP, every domain invents its own scene format. Clients need per-domain rendering code. Cross-domain travel becomes "load a completely different game." The federation model works at the object level (swords transfer) but fails at the experience level (the player sees nothing coherent).
+Without GDL, every domain invents its own scene format. Clients need per-domain rendering code. Cross-domain travel becomes "load a completely different game." The federation model works at the object level (swords transfer) but fails at the experience level (the player sees nothing coherent).
 
-WDP is the common language between domain and client. A domain describes its world in WDP. A client that speaks WDP can render any domain, the same way a browser that speaks HTML can render any website.
+GDL is the common language between domain and client. A domain describes its world in GDL. A client that speaks GDL can render any domain, the same way a browser that speaks HTML can render any website.
 Design Principles
 
 These come from studying what worked and what didn't across 30 years of world description formats.
@@ -18,17 +18,17 @@ These come from studying what worked and what didn't across 30 years of world de
 
 The single most important rule. If a client receives a property it doesn't recognize, it skips it. If a domain sends an entity kind the client hasn't seen before, the client falls back to the kind's category. Unknown fields are preserved, never rejected.
 
-This is how HTML survived 30 years of evolution. Browsers that don't know <video> render the fallback content inside the tags. WDP clients that don't know a "flamebrand" render it as a generic item. Forward compatibility is non-negotiable.
+This is how HTML survived 30 years of evolution. Browsers that don't know <video> render the fallback content inside the tags. GDL clients that don't know a "flamebrand" render it as a generic item. Forward compatibility is non-negotiable.
 2. Description Is Not Behavior
 
-WDP describes what exists — structure, properties, appearance. Raido scripts define what happens — combat, crafting, physics. VRML tried to combine scene description with behavioral wiring and paid for it with implementation complexity that killed adoption. X3D inherited the same mistake.
+GDL describes what exists — structure, properties, appearance. Raido scripts define what happens — combat, crafting, physics. VRML tried to combine scene description with behavioral wiring and paid for it with implementation complexity that killed adoption. X3D inherited the same mistake.
 
-The boundary is sharp: WDP says "there's a goblin here with 30 health." Raido says "when attacked, subtract damage from health." The client renders the description. The domain runs the behavior. They don't mix.
+The boundary is sharp: GDL says "there's a goblin here with 30 health." Raido says "when attacked, subtract damage from health." The client renders the description. The domain runs the behavior. They don't mix.
 3. Description Is Not Rendering
 
-WDP carries semantic descriptions, not rendering instructions. "A weathered oak door with iron bands" — not vertex buffers, not sprite coordinates, not CSS. The client decides how to present it. A text client prints the description. A 3D client assembles a door from its built-in asset library. A client with GenAI generates one on the fly.
+GDL carries semantic descriptions, not rendering instructions. "A weathered oak door with iron bands" — not vertex buffers, not sprite coordinates, not CSS. The client decides how to present it. A text client prints the description. A 3D client assembles a door from its built-in asset library. A client with GenAI generates one on the fly.
 
-Second Life got this right with parametric prims — 50 bytes of shape parameters instead of megabytes of mesh data. glTF got it right for transmission (GPU-ready buffers). WDP sits one level higher: semantic description that any renderer can interpret.
+Second Life got this right with parametric prims — 50 bytes of shape parameters instead of megabytes of mesh data. glTF got it right for transmission (GPU-ready buffers). GDL sits one level higher: semantic description that any renderer can interpret.
 4. Progressive Enhancement, Not Multiple Representations
 
 The domain sends one description. Richer clients extract more from it. A text client uses name and description. A 2D client adds position and appearance.shape. A 3D client adds appearance.assets for custom models. Same payload, different extraction depths.
@@ -36,10 +36,10 @@ The domain sends one description. Richer clients extract more from it. A text cl
 This is HTML's model. One document, many renderers. Not "here's the text version, here's the 2D version, here's the 3D version." That doesn't scale — domains would need to author three descriptions for every entity.
 5. Optimize for the Consumer
 
-glTF's tagline is "the JPEG of 3D." It succeeded by optimizing for the renderer, not the authoring tool. WDP optimizes for the client, not the domain. Descriptions are structured for fast parsing, progressive extraction, and incremental updates. The domain does extra work once; thousands of clients benefit.
+glTF's tagline is "the JPEG of 3D." It succeeded by optimizing for the renderer, not the authoring tool. GDL optimizes for the client, not the domain. Descriptions are structured for fast parsing, progressive extraction, and incremental updates. The domain does extra work once; thousands of clients benefit.
 6. The Simpler System Wins
 
-HTTP beat CORBA. JSON beat XML. HTML beat SGML. In every case, the simpler format won because more people could implement it correctly. A WDP client should be buildable in a weekend. The minimum viable client is a text renderer that prints names, descriptions, and affordance menus. Everything beyond that is progressive enhancement.
+HTTP beat CORBA. JSON beat XML. HTML beat SGML. In every case, the simpler format won because more people could implement it correctly. A GDL client should be buildable in a weekend. The minimum viable client is a text renderer that prints names, descriptions, and affordance menus. Everything beyond that is progressive enhancement.
 Core Model
 
 Eight concepts: regions, entities, affordances, appearance, panels, themes, spatial layers, and input streams.
@@ -47,7 +47,7 @@ Regions
 
 A region is a spatial container. It's the "page" — the top-level context that a client loads and renders. A dungeon room, a forest clearing, a city block, a spaceship interior. Regions connect to other regions through portals.
 
-A region is a Leden object. Observing it gives you WDP content — a snapshot of the region's current state, followed by a delta stream of changes.
+A region is a Leden object. Observing it gives you GDL content — a snapshot of the region's current state, followed by a delta stream of changes.
 
 Region:
   name: "The Rusty Anchor"
@@ -75,7 +75,7 @@ name	Yes	Display name
 description	Yes	Text description — the universal fallback
 spatial	No	How positions work (see below)
 ambient	No	Environmental properties
-theme	No	Visual identity and mood (see WDS)
+theme	No	Visual identity and mood (see GDL-style)
 layers	No	Dense spatial data — terrain, tilemaps, voxels, collision geometry
 physics	No	Physics parameters for client-side simulation
 comfort	No	Immersive comfort hints (locomotion modes, vignette settings)
@@ -171,11 +171,11 @@ Well-known properties let clients build smart UIs without domain-specific code. 
 Property semantics convention: numeric properties that represent a bounded value use `X` + `X_max` naming. Values are always absolute, never percentages. `health: 30` means 30 hit points, not 30%. `health` without `health_max` means the maximum is unknown — the client shows the number but can't render a bar. This matters for cross-domain consistency: two domains using `health` to mean different things (absolute vs. percentage vs. armor-adjusted) would break the smart UI promise.
 Affordances
 
-Affordances are what make WDP interactive. They answer: "what can I do here?"
+Affordances are what make GDL interactive. They answer: "what can I do here?"
 
-This is HATEOAS applied to virtual worlds. In REST, the server response tells you what actions are available via links and forms. In WDP, the entity description tells you what actions are available via affordances. The client doesn't need compiled-in knowledge of what's possible — the domain tells it, per entity, right now.
+This is HATEOAS applied to virtual worlds. In REST, the server response tells you what actions are available via links and forms. In GDL, the entity description tells you what actions are available via affordances. The client doesn't need compiled-in knowledge of what's possible — the domain tells it, per entity, right now.
 
-LambdaMOO discovered this in 1990: verbs live on objects and are discovered at runtime. "Take ball" works because the ball has a take verb. WDP formalizes the same pattern.
+LambdaMOO discovered this in 1990: verbs live on objects and are discovered at runtime. "Take ball" works because the ball has a take verb. GDL formalizes the same pattern.
 
 Affordance:
   verb: "attack"
@@ -290,7 +290,7 @@ Assets are content-addressed blobs in Leden's content store. The client fetches 
 If the client can't fetch an asset (network issue, unsupported format), it falls back to hints. If no hints, it falls back to kind + description. The layers degrade gracefully. Always.
 Panels
 
-Some domain UI doesn't map to entities in a region — skill trees, faction reputation, crafting grids, build mode toolbars, quest logs. These aren't world description. But punting them to "each domain builds custom UI" defeats the whole point of WDP.
+Some domain UI doesn't map to entities in a region — skill trees, faction reputation, crafting grids, build mode toolbars, quest logs. These aren't world description. But punting them to "each domain builds custom UI" defeats the whole point of GDL.
 
 I decided to use HTML. Not invent a new UI description language — the web already has one with 30 years of tooling, accessibility support, and rendering engines. A panel is a sandboxed HTML fragment that a domain sends for non-spatial UI.
 
@@ -311,9 +311,9 @@ fallback	Yes	Plain text summary — always renderable
 content_type	Yes	MIME type of the content (text/html for now)
 content	Yes	Content-addressed blob reference
 
-The content is sandboxed HTML/CSS — no JavaScript, no external resources. Think HTML email, not a web app. The domain authors a self-contained fragment. The client renders it in an iframe with sandbox restrictions or shadow DOM. Interaction flows through WDP affordances embedded in the HTML as data attributes, not through JS event handlers.
+The content is sandboxed HTML/CSS — no JavaScript, no external resources. Think HTML email, not a web app. The domain authors a self-contained fragment. The client renders it in an iframe with sandbox restrictions or shadow DOM. Interaction flows through GDL affordances embedded in the HTML as data attributes, not through JS event handlers.
 
-A text client renders the fallback string. A web-based client renders the HTML natively. A native client can use a lightweight HTML renderer or fall back to the text. Same progressive enhancement as everything else in WDP.
+A text client renders the fallback string. A web-based client renders the HTML natively. A native client can use a lightweight HTML renderer or fall back to the text. Same progressive enhancement as everything else in GDL.
 
 Why HTML and not a structured schema: I considered a custom layout language. But any layout language rich enough for skill trees and crafting grids would end up being a bad version of HTML. CSS already solves layout. HTML already has form elements. Screen readers already understand both. The alternative is years of design work to build something worse than what exists.
 
@@ -331,12 +331,12 @@ Panel interaction convention: clickable elements in panel HTML use data attribut
 
 The client listens for click events on elements with `data-wdp-verb`, extracts the parameters (any attribute starting with `data-wdp-param-`), and calls the referenced Leden method. The domain receives the call and validates. Results come back through panel_update in the observation stream.
 
-This means panel HTML is a layout and display concern. Interactivity is WDP's job — the client IS the JavaScript runtime. CSS handles hover states, transitions, and visual feedback. The domain authors HTML the same way you'd author an HTML email with a few clickable buttons.
+This means panel HTML is a layout and display concern. Interactivity is GDL's job — the client IS the JavaScript runtime. CSS handles hover states, transitions, and visual feedback. The domain authors HTML the same way you'd author an HTML email with a few clickable buttons.
 Theme
 
-Regions carry a theme field for visual identity — the domain's way of saying "this place should feel like this." The full theme system is specified separately in [WDS.md](WDS.md) (World Description Style), the same way CSS is a separate spec from HTML. They evolve independently: WDP's structure is stable, styling evolves fast. A WDP implementation is complete without WDS — it just uses client defaults.
+Regions carry a theme field for visual identity — the domain's way of saying "this place should feel like this." The full theme system is specified separately in [GDL-style.md](GDL-style.md), the same way CSS is a separate spec from HTML. They evolve independently: GDL's structure is stable, styling evolves fast. A GDL implementation is complete without GDL-style — it just uses client defaults.
 
-Brief summary of what WDS provides:
+Brief summary of what GDL-style provides:
 
 - Design tokens. Flat key-value pairs (`color.primary: #2a1a0e`, `atmosphere.fog_density: 0.4`, `entity.hostile_tint: #ff2200`) that every client type can map to its rendering system. Text clients map colors to ANSI. 3D clients map atmosphere tokens to shaders. No selector syntax, no specificity bugs.
 
@@ -346,7 +346,7 @@ Brief summary of what WDS provides:
 
 - Three-level cascade. Domain → region → entity. Domain is the brand. Region is the scene. Entity is the individual. Last writer wins.
 
-See [WDS.md](WDS.md) for the full design: token categories, cascade rules, stylesheet constraints, security model, and per-client-type consumption examples.
+See [GDL-style.md](GDL-style.md) for the full design: token categories, cascade rules, stylesheet constraints, security model, and per-client-type consumption examples.
 Fidelity Negotiation
 
 The client declares what it can handle. The domain uses this to tailor its descriptions.
@@ -389,10 +389,10 @@ client_viewport:
   center: [120, 85]
   radius: 25
 
-The viewport is a circle (center + radius) regardless of spatial model. The domain sends entities within the radius, plus a buffer for smooth scrolling. Entity enter/exit deltas fire as entities cross the viewport boundary, not the region boundary. This is how WDP scales to large regions without sending 10,000 entities on initial snapshot.
+The viewport is a circle (center + radius) regardless of spatial model. The domain sends entities within the radius, plus a buffer for smooth scrolling. Entity enter/exit deltas fire as entities cross the viewport boundary, not the region boundary. This is how GDL scales to large regions without sending 10,000 entities on initial snapshot.
 Integration with Leden
 
-WDP is a content schema. Leden is the protocol. Here's how they compose.
+GDL is a content schema. Leden is the protocol. Here's how they compose.
 Session Setup
 
     Client connects to domain's bootstrap address (Leden Layer 0-1)
@@ -405,7 +405,7 @@ Region Entry
 
     Client receives a region object reference (from greeter, from a portal, from another region)
     Client calls Observe(region_ref) (Leden observation)
-    Domain responds with a region snapshot — the full WDP region description
+    Domain responds with a region snapshot — the full GDL region description
     Client renders the region
     Observation stream begins — client receives deltas
 
@@ -420,7 +420,7 @@ entity_update	Ref + changed fields	Entity properties change
 affordance_update	Ref + new affordance list	Available actions change
 ambient_update	Changed ambient fields	Environment changes
 panel_update	Panel id + new content hash	Domain UI changes
-theme_update	Changed tokens and/or hints	Visual identity changes (see WDS)
+theme_update	Changed tokens and/or hints	Visual identity changes (see GDL-style)
 layer_update	Layer id + changed chunk hashes	Terrain/block modifications
 
 These map directly to Leden observation deltas. The region object is the publisher. Subscribed clients are the observers. Leden handles fan-out, backpressure, sequence numbering, and reconnection.
@@ -459,11 +459,11 @@ For real-time interaction (movement, combat), the round-trip through "affordance
 
 Affordances with `predicted: true` tell the client it can apply the expected result locally before the server confirms. The client acts on the optimistic result immediately and reconciles when the authoritative update arrives through the observation stream.
 
-What the client predicts is the client's problem. WDP doesn't carry prediction logic — that would violate "description is not behavior." The `predicted` flag is permission: "this action's effect is predictable enough that you should try." A movement affordance is predictable. A "open mysterious chest" affordance is not.
+What the client predicts is the client's problem. GDL doesn't carry prediction logic — that would violate "description is not behavior." The `predicted` flag is permission: "this action's effect is predictable enough that you should try." A movement affordance is predictable. A "open mysterious chest" affordance is not.
 
 If the server result differs from the prediction, the client snaps to the authoritative state. Smooth reconciliation (interpolation, rollback) is a client rendering concern. The domain sends truth. The client makes it feel good.
 
-This is the same model every multiplayer game uses. The difference is that WDP makes it opt-in per affordance rather than a global client assumption. A domain with deterministic physics marks movement as predicted. A domain with complex server-side logic marks nothing as predicted. The client adapts.
+This is the same model every multiplayer game uses. The difference is that GDL makes it opt-in per affordance rather than a global client assumption. A domain with deterministic physics marks movement as predicted. A domain with complex server-side logic marks nothing as predicted. The client adapts.
 Input Streams
 
 Affordances model discrete actions: "attack", "open door", "move to [5, 3]". Some interactions are continuous high-frequency data that doesn't fit the request-response pattern: player movement (gamepad stick at 60Hz), mouse aim, VR head/hand pose at 90Hz. Issuing an affordance call per input frame is too heavyweight — that's 90 method calls per second per tracked point.
@@ -548,7 +548,7 @@ Layers also carry physics-relevant data. A platformer's mesh_2d layer defines co
 Spatial layers don't replace entities. The terrain is a layer. The goblin standing on the terrain is an entity. A tree might be either — a decorative tree in a forest is part of a layer, a specific tree the player can chop down is an entity. The domain decides the boundary.
 Physics Parameters
 
-Some domains need clients to run local physics — platformers, racing, VR hand interaction, any game where frame-precise movement matters. "Description is not behavior" means WDP doesn't carry physics logic. But physics parameters (gravity, friction, collision rules) are description — they describe the physical properties of the space, not what happens in it.
+Some domains need clients to run local physics — platformers, racing, VR hand interaction, any game where frame-precise movement matters. "Description is not behavior" means GDL doesn't carry physics logic. But physics parameters (gravity, friction, collision rules) are description — they describe the physical properties of the space, not what happens in it.
 
 Regions can declare physics parameters:
 
@@ -635,7 +635,7 @@ Affordance:
 
 Haptic fields are hints. VR clients with haptic controllers apply them. All other clients ignore them. A text client rendering a proximity affordance shows it as a regular menu item.
 
-Immersive clients are just clients. They render WDP regions, observe entities, call affordance methods. The immersive extensions (input streams, proximity mode, physics, comfort, haptics) are all progressive enhancements. A domain that sends them works fine with a non-immersive client — the extensions are ignored. A VR client connecting to a non-immersive domain works fine too — it uses standard 3D rendering and falls back to menu-based affordances.
+Immersive clients are just clients. They render GDL regions, observe entities, call affordance methods. The immersive extensions (input streams, proximity mode, physics, comfort, haptics) are all progressive enhancements. A domain that sends them works fine with a non-immersive client — the extensions are ignored. A VR client connecting to a non-immersive domain works fine too — it uses standard 3D rendering and falls back to menu-based affordances.
 Progressive Rendering Example
 
 The same region data, four clients:
@@ -676,31 +676,31 @@ Same tavern, but you're standing in it. Head tracking renders the scene at 90Hz 
 
 Uses: everything above + orientation, input streams (head, hands), physics parameters, proximity affordances, haptic hints, comfort settings
 
-Same WDP payload. Zero domain-specific client code.
+Same GDL payload. Zero domain-specific client code.
 The Vocabulary
 
-WDP defines mechanisms (kinds, shapes, materials, categories). The initial terms are listed above in their respective sections. The vocabulary is extensible without protocol changes — new terms are just new strings. Clients that don't recognize a term fall back to the category or ignore it.
+GDL defines mechanisms (kinds, shapes, materials, categories). The initial terms are listed above in their respective sections. The vocabulary is extensible without protocol changes — new terms are just new strings. Clients that don't recognize a term fall back to the category or ignore it.
 
 Over time, commonly-used terms will become de facto standards. When 200 domains all use shape: humanoid, that's a standard. No committee needed. The same way HTML elements standardized through browser adoption, not W3C edicts (the edicts came after).
 
-Domain unions (from the existing Midgard design) accelerate vocabulary convergence. A union of 50 domains that all agree on the same entity types, appearance hints, and affordance verbs creates a pocket of perfect interop. WDP doesn't need to know unions exist — it just sees consistent vocabulary use.
+Domain unions (from the Allgard federation model) accelerate vocabulary convergence. A union of 50 domains that all agree on the same entity types, appearance hints, and affordance verbs creates a pocket of perfect interop. GDL doesn't need to know unions exist — it just sees consistent vocabulary use.
 What This Doesn't Cover
 
-Client UI chrome. WDP describes the world and domain panels, not the client's own interface. Health bars, minimaps, hotkey bindings, settings screens — these are client concerns. The client builds its chrome from entity data (health from properties, minimap from region layout) and its own preferences. Domain-specific UI (skill trees, crafting grids) goes through panels.
+Client UI chrome. GDL describes the world and domain panels, not the client's own interface. Health bars, minimaps, hotkey bindings, settings screens — these are client concerns. The client builds its chrome from entity data (health from properties, minimap from region layout) and its own preferences. Domain-specific UI (skill trees, crafting grids) goes through panels.
 
-Physics simulation. WDP provides physics parameters (gravity, friction, collision rules) and spatial layers (collision geometry). The client runs local physics against these. But the physics engine itself is the client's choice — WDP doesn't specify simulation algorithms, integrator types, or solver iterations. Two clients simulating the same parameters may produce slightly different results. The domain is authoritative; clients predict and reconcile.
+Physics simulation. GDL provides physics parameters (gravity, friction, collision rules) and spatial layers (collision geometry). The client runs local physics against these. But the physics engine itself is the client's choice — GDL doesn't specify simulation algorithms, integrator types, or solver iterations. Two clients simulating the same parameters may produce slightly different results. The domain is authoritative; clients predict and reconcile.
 
-Animation. WDP doesn't describe skeletal rigs or animation state machines. The posture hint covers coarse state ("crouching", "attacking", "idle"). Smooth animation is the client's problem, driven by posture changes in the observation stream.
+Animation. GDL doesn't describe skeletal rigs or animation state machines. The posture hint covers coarse state ("crouching", "attacking", "idle"). Smooth animation is the client's problem, driven by posture changes in the observation stream.
 
-Audio design. WDP carries ambient properties and sound asset references. Spatial audio mixing, music systems, and sound design are client-side. The domain says "there's a fire here." The client decides what fire sounds like.
+Audio design. GDL carries ambient properties and sound asset references. Spatial audio mixing, music systems, and sound design are client-side. The domain says "there's a fire here." The client decides what fire sounds like.
 
-Scripting. No behavior in the description. Ever. Raido handles scripting. WDP handles description. The boundary is load-bearing.
+Scripting. No behavior in the description. Ever. Raido handles scripting. GDL handles description. The boundary is load-bearing.
 
-Entity internals. WDP describes what an entity looks like from outside. Its internal state machine, its Raido scripts, its capabilities graph — all opaque. The domain exposes what it wants through properties and affordances.
+Entity internals. GDL describes what an entity looks like from outside. Its internal state machine, its Raido scripts, its capabilities graph — all opaque. The domain exposes what it wants through properties and affordances.
 
-Data validation. WDP doesn't specify validation rules. A domain might send `health: 50, health_max: 30` or a position outside the region's bounds. Domains are responsible for consistency. Clients should be tolerant — display what you can, clamp out-of-bounds values, don't crash on contradictions. Postel's law: be conservative in what you send, liberal in what you accept.
+Data validation. GDL doesn't specify validation rules. A domain might send `health: 50, health_max: 30` or a position outside the region's bounds. Domains are responsible for consistency. Clients should be tolerant — display what you can, clamp out-of-bounds values, don't crash on contradictions. Postel's law: be conservative in what you send, liberal in what you accept.
 
-Panel security. Panels are sandboxed: no JavaScript, no external resource loading. Clients render panels in sandboxed iframes (`sandbox="allow-same-origin"`) with a Content-Security-Policy that blocks external fetches. A malicious domain cannot use panels to exfiltrate data, track users, or escape the sandbox. For stylesheet security, see [WDS.md](WDS.md).
+Panel security. Panels are sandboxed: no JavaScript, no external resource loading. Clients render panels in sandboxed iframes (`sandbox="allow-same-origin"`) with a Content-Security-Policy that blocks external fetches. A malicious domain cannot use panels to exfiltrate data, track users, or escape the sandbox. For stylesheet security, see [GDL-style.md](GDL-style.md).
 Resolved
 
 Regions are not entities. A region is a container. Entities are contents. Regions have metadata (name, description, ambient, spatial model). Entities have affordances and appearance. Mixing them creates ambiguity about what "observing an entity" means vs. "observing a region." Clean separation.
@@ -711,7 +711,7 @@ One spatial model per region. A region doesn't present itself differently to dif
 
 Affordances over methods. The client doesn't call entity methods directly. It discovers affordances, which contain method references. This indirection is the key to client-domain decoupling. A domain can change its internal method structure without breaking clients — it just updates the affordance's method field. Clients never hardcode method names.
 
-No inheritance in the entity model. USD and Roblox use class hierarchies. ECS uses composition. WDP uses composition — an entity is a bag of kind + properties + affordances + appearance. No "class GenericSword with subclass Flamebrand." Inheritance creates coupling between entity definitions that breaks across domain boundaries. Composition lets two domains agree on individual properties without agreeing on a type hierarchy.
+No inheritance in the entity model. USD and Roblox use class hierarchies. ECS uses composition. GDL uses composition — an entity is a bag of kind + properties + affordances + appearance. No "class GenericSword with subclass Flamebrand." Inheritance creates coupling between entity definitions that breaks across domain boundaries. Composition lets two domains agree on individual properties without agreeing on a type hierarchy.
 
 Content-addressed assets, not URLs. Assets are identified by content hash, not location. This means: deduplication across domains is free, integrity verification is free, and caching is trivial. Two domains that independently use the same goblin sprite share the content hash. The client fetches it once. This falls directly out of Leden's content store.
 
@@ -723,20 +723,20 @@ Observation has three tiers. Region observation for structural changes (entity a
 
 Domain-specific UI uses HTML panels. Domains send sandboxed HTML/CSS fragments for non-spatial UI (skill trees, crafting grids, faction screens). No JavaScript, no external resources. Web clients render natively, text clients show a plain text fallback. I chose HTML over a custom schema because any layout language rich enough for real UI would end up being a bad version of HTML. See the Panels section above.
 
-Visual identity is a separate spec (WDS). Design tokens for world styling, CSS stylesheets for panels and web UI, three-level cascade (domain → region → entity). Separated from WDP because styling evolves faster than structure and has a different implementer audience. A WDP implementation is complete without WDS. See [WDS.md](WDS.md).
+Visual identity is a separate spec (GDL-style). Design tokens for world styling, CSS stylesheets for panels and web UI, three-level cascade (domain → region → entity). Separated from GDL because styling evolves faster than structure and has a different implementer audience. A GDL implementation is complete without GDL-style. See [GDL-style.md](GDL-style.md).
 
 VR/AR/XR is supported through general-purpose extensions, not a VR-specific protocol. Entity orientation, input streams (continuous client→server data), proximity affordances, spatial layers (dense geometry), physics parameters, and immersive fidelity fields. All are progressive enhancements — a VR client connecting to a non-VR domain works fine (menu affordances, no hand physics), and a non-VR client connecting to a VR domain works fine (ignores input stream endpoints, uses instant/targeted affordances). The immersive capabilities are the same mechanisms needed for platformers, racing games, and any real-time physics game.
 
 Dense worlds use spatial layers. Tilemaps, voxel chunks, heightmaps, and collision meshes sit alongside entities in a region. Entities are sparse (things you interact with). Layers are dense (the world itself). A Minecraft chunk is a voxel layer. A platformer level is a mesh_2d layer. A terrain system is a heightmap layer. Layers are content-addressed and chunked for viewport-based streaming.
 
-Large regions use viewport filtering. The client reports its viewport (center + radius), and the domain only sends entities within that area. Entity enter/exit deltas fire at the viewport boundary. This scales WDP to open-world regions without dumping 10,000 entities on initial snapshot.
+Large regions use viewport filtering. The client reports its viewport (center + radius), and the domain only sends entities within that area. Entity enter/exit deltas fire at the viewport boundary. This scales GDL to open-world regions without dumping 10,000 entities on initial snapshot.
 Deferred
 
-    Wire format. Binary vs text. Depends on Leden's wire format decision. WDP is a schema — the encoding is separate.
+    Wire format. Binary vs text. Depends on Leden's wire format decision. GDL is a schema — the encoding is separate.
     Vocabulary registry. A formal list of kinds, shapes, materials, and categories with semantic definitions. Needed before implementation, not before design.
     LOD (Level of Detail). Distant entities could be sent with less detail. The mechanism exists (fidelity negotiation + filtered observation), but the specific LOD policy is implementation-level.
     Accessibility. Screen reader hints, colorblind palettes, motor-impairment interaction modes. Important, but a layer on top of the base protocol, not a change to it.
-    Versioning. WDP will evolve. Version negotiation should follow Leden's model (version handshake at session start, backward-compatible additions don't require version bumps). Details after v1 is stable.
-    Entity visibility. Fog of war needs a visibility field on entities: visible, last_known (stale data with timestamp), hidden. The domain controls which entities the client knows about. last_known entities carry stale data that the client renders differently (grayed out, question mark). Deferred because most Midgard use cases don't need fog of war, and the viewport filtering mechanism handles the common case of "don't show what's far away."
-    Event streams. WDP is state (current properties), not events (what happened). A combat log needs "player X hit boss for 500 damage with Fireball" — that's an event, not a state change. A parallel event channel alongside the observation stream would carry happenings. Deferred because panels can show a combat log (updated via panel_update), which covers the common case without a new concept.
-    Time-sequenced content. Rhythm games and cutscenes need pre-loaded event sequences with precise timestamps. The observation model is push-based (server sends updates as they happen), not time-indexed. This is a fundamentally different content type — probably a separate spec rather than a WDP extension. Deferred.
+    Versioning. GDL will evolve. Version negotiation should follow Leden's model (version handshake at session start, backward-compatible additions don't require version bumps). Details after v1 is stable.
+    Entity visibility. Fog of war needs a visibility field on entities: visible, last_known (stale data with timestamp), hidden. The domain controls which entities the client knows about. last_known entities carry stale data that the client renders differently (grayed out, question mark). Deferred because most use cases don't need fog of war, and the viewport filtering mechanism handles the common case of "don't show what's far away."
+    Event streams. GDL is state (current properties), not events (what happened). A combat log needs "player X hit boss for 500 damage with Fireball" — that's an event, not a state change. A parallel event channel alongside the observation stream would carry happenings. Deferred because panels can show a combat log (updated via panel_update), which covers the common case without a new concept.
+    Time-sequenced content. Rhythm games and cutscenes need pre-loaded event sequences with precise timestamps. The observation model is push-based (server sends updates as they happen), not time-indexed. This is a fundamentally different content type — probably a separate spec rather than a GDL extension. Deferred.

--- a/projects/gdl/README.md
+++ b/projects/gdl/README.md
@@ -1,0 +1,22 @@
+# GDL — Gard Description Language
+
+Content schema for describing gards (interactive spatial environments) over [Leden](../leden/).
+
+GDL is to Leden what HTML is to HTTP. Leden handles transport, capabilities, and observation. GDL defines what's inside the payloads — regions, entities, affordances, appearance, spatial layers, input streams.
+
+## Specs
+
+| Spec | What |
+|------|------|
+| [GDL.md](GDL.md) | Content schema — regions, entities, affordances, appearance, panels, spatial layers, input streams, physics |
+| [GDL-style.md](GDL-style.md) | Style system — design tokens, structured hints, CSS stylesheets. GDL's CSS. |
+
+## Stack
+
+| Layer | Project |
+|-------|---------|
+| VM / scripting | [Raido](../raido/) |
+| Federation / trust | [Allgard](../allgard/) |
+| Transport / capabilities | [Leden](../leden/) |
+| **Content / style** | **GDL** |
+| Example application | [Midgard](../midgard/) |

--- a/projects/midgard/WDP.md
+++ b/projects/midgard/WDP.md
@@ -327,54 +327,19 @@ The client listens for click events on elements with `data-wdp-verb`, extracts t
 This means panel HTML is a layout and display concern. Interactivity is WDP's job — the client IS the JavaScript runtime. CSS handles hover states, transitions, and visual feedback. The domain authors HTML the same way you'd author an HTML email with a few clickable buttons.
 Theme
 
-This is WDP's CSS moment. Without it, every domain renders with the client's default style — the same way every website looked the same in 1993. The domain author creates a horror dungeon, but the client's built-in bright sprite set turns it into a cartoon. Content exists. Visual identity doesn't.
+Regions carry a theme field for visual identity — the domain's way of saying "this place should feel like this." The full theme system is specified separately in [WDS.md](WDS.md) (World Description Style), the same way CSS is a separate spec from HTML. They evolve independently: WDP's structure is stable, styling evolves fast. A WDP implementation is complete without WDS — it just uses client defaults.
 
-Theme lives on regions, not domains, because different regions in the same domain can have different moods (bright overworld, dark dungeon, underwater temple). It's the domain's way of saying "this place should feel like this."
+Brief summary of what WDS provides:
 
-theme:
-  mood: gritty
-  palette: [#2a1a0e, #5c3a1e, #8b6914, #1a1a1a]
-  saturation: low
-  contrast: high
-  epoch: medieval
-  density: cluttered
-  stylesheet: sha256:ef9a01...
+- Design tokens. Flat key-value pairs (`color.primary: #2a1a0e`, `atmosphere.fog_density: 0.4`, `entity.hostile_tint: #ff2200`) that every client type can map to its rendering system. Text clients map colors to ANSI. 3D clients map atmosphere tokens to shaders. No selector syntax, no specificity bugs.
 
-Theme fields:
-Field	Required	Purpose
-mood	No	Emotional register — hint vocabulary below
-palette	No	Region color palette — client uses for tinting, UI accent, sprite selection
-saturation	No	low, medium, high — client adjusts post-processing or sprite selection
-contrast	No	low, medium, high — lighting contrast guidance
-epoch	No	Time period hint — medieval, futuristic, modern, ancient, alien, ...
-density	No	How full the space feels — sparse, normal, cluttered, dense
-stylesheet	No	Content-addressed CSS blob for the region's panel styling and UI hints
+- Structured hints. Coarse mood signals (`mood: gritty`, `epoch: medieval`, `saturation: low`) for clients that don't want to parse individual tokens. A simple client picks a preset from mood + epoch.
 
-Mood vocabulary:
-Mood	Guidance
-gritty	Dark, rough, dangerous. Muted colors, harsh lighting.
-whimsical	Light, playful, colorful. Rounded shapes, bright palette.
-serene	Calm, peaceful. Soft colors, gentle lighting, low contrast.
-ominous	Threatening, foreboding. Deep shadows, unsettling palette.
-epic	Grand, dramatic. High contrast, saturated colors, sweeping scale.
-mundane	Ordinary, everyday. Natural colors, neutral lighting.
-alien	Strange, unfamiliar. Unusual palette, unexpected shapes.
+- CSS stylesheet. Content-addressed CSS blob for panel styling and web client UI theming. Domain stylesheets reference tokens via CSS custom properties (`var(--wdp-color-primary)`). Walking through a portal shifts the entire client's UI palette.
 
-A text client ignores the theme entirely — mood comes from the description text. A 2D client uses palette for tinting and mood to pick between sprite set variants (if it has them). A 3D client applies palette to post-processing, mood to lighting presets, saturation/contrast to shaders.
+- Three-level cascade. Domain → region → entity. Domain is the brand. Region is the scene. Entity is the individual. Last writer wins.
 
-The stylesheet field is where CSS comes in. It's a content-addressed CSS blob that the domain can provide for clients that support it. The stylesheet can:
-
-- Style the domain's panels (colors, fonts, layout refinements)
-- Provide CSS custom properties that the client can apply to its own UI chrome: `--wdp-primary`, `--wdp-secondary`, `--wdp-accent`, `--wdp-bg`, `--wdp-text`, `--wdp-danger`, `--wdp-success`
-- Suggest UI treatment via well-known classes: `.wdp-health-bar`, `.wdp-entity-label`, `.wdp-affordance-button`
-
-The client is not required to apply the stylesheet. It's a hint, like everything else. A text client ignores it. A web-based client can adopt the custom properties to tint its UI to match the domain's visual identity. A native client can extract the custom properties and map them to its own theming system.
-
-This is CSS's original promise: content and presentation separated, but presentation exists. Without it, WDP is HTML circa 1993 — every page looks like the browser's default.
-
-One stylesheet per region means: walking through a portal can shift the entire client's color scheme. The horror dungeon portal fades to dark reds and deep shadows. The fairy forest portal shifts to greens and dappled light. The client's UI chrome follows the domain's visual identity without domain-specific code.
-
-Security: Same restrictions as panel HTML. No `url()` to external resources. No `@import`. Only `data:` URIs and content-addressed `sha256:` references. The client validates the CSS before applying it.
+See [WDS.md](WDS.md) for the full design: token categories, cascade rules, stylesheet constraints, security model, and per-client-type consumption examples.
 Fidelity Negotiation
 
 The client declares what it can handle. The domain uses this to tailor its descriptions.
@@ -446,6 +411,7 @@ entity_update	Ref + changed fields	Entity properties change
 affordance_update	Ref + new affordance list	Available actions change
 ambient_update	Changed ambient fields	Environment changes
 panel_update	Panel id + new content hash	Domain UI changes
+theme_update	Changed tokens and/or hints	Visual identity changes (see WDS)
 
 These map directly to Leden observation deltas. The region object is the publisher. Subscribed clients are the observers. Leden handles fan-out, backpressure, sequence numbering, and reconnection.
 
@@ -546,7 +512,7 @@ Entity internals. WDP describes what an entity looks like from outside. Its inte
 
 Data validation. WDP doesn't specify validation rules. A domain might send `health: 50, health_max: 30` or a position outside the region's bounds. Domains are responsible for consistency. Clients should be tolerant — display what you can, clamp out-of-bounds values, don't crash on contradictions. Postel's law: be conservative in what you send, liberal in what you accept.
 
-Panel and stylesheet security. Panels and theme stylesheets are sandboxed: no JavaScript, no external resource loading, no `@import`, no CSS `url()` except `data:` URIs and content-addressed `sha256:` references. Clients must enforce this — render panels in sandboxed iframes (`sandbox="allow-same-origin"`) with a Content-Security-Policy that blocks external fetches. Theme stylesheets are validated before application. A malicious domain cannot use panels or stylesheets to exfiltrate data, track users, or escape the sandbox.
+Panel security. Panels are sandboxed: no JavaScript, no external resource loading. Clients render panels in sandboxed iframes (`sandbox="allow-same-origin"`) with a Content-Security-Policy that blocks external fetches. A malicious domain cannot use panels to exfiltrate data, track users, or escape the sandbox. For stylesheet security, see [WDS.md](WDS.md).
 Resolved
 
 Regions are not entities. A region is a container. Entities are contents. Regions have metadata (name, description, ambient, spatial model). Entities have affordances and appearance. Mixing them creates ambiguity about what "observing an entity" means vs. "observing a region." Clean separation.
@@ -569,7 +535,7 @@ Observation has three tiers. Region observation for structural changes (entity a
 
 Domain-specific UI uses HTML panels. Domains send sandboxed HTML/CSS fragments for non-spatial UI (skill trees, crafting grids, faction screens). No JavaScript, no external resources. Web clients render natively, text clients show a plain text fallback. I chose HTML over a custom schema because any layout language rich enough for real UI would end up being a bad version of HTML. See the Panels section above.
 
-Visual identity uses region themes. Mood, palette, saturation, contrast, epoch, density — plus an optional CSS stylesheet for panel styling and UI custom properties. This is WDP's CSS moment: without it, every domain renders in the client's default style regardless of the domain author's creative intent. Theme is a hint layer, like appearance hints on entities. Clients apply what they can. Text clients ignore it. Web clients adopt CSS custom properties. 3D clients map mood/palette to post-processing. See the Theme section above.
+Visual identity is a separate spec (WDS). Design tokens for world styling, CSS stylesheets for panels and web UI, three-level cascade (domain → region → entity). Separated from WDP because styling evolves faster than structure and has a different implementer audience. A WDP implementation is complete without WDS. See [WDS.md](WDS.md).
 
 Large regions use viewport filtering. The client reports its viewport (center + radius), and the domain only sends entities within that area. Entity enter/exit deltas fire at the viewport boundary. This scales WDP to open-world regions without dumping 10,000 entities on initial snapshot.
 Deferred

--- a/projects/midgard/WDP.md
+++ b/projects/midgard/WDP.md
@@ -42,7 +42,7 @@ glTF's tagline is "the JPEG of 3D." It succeeded by optimizing for the renderer,
 HTTP beat CORBA. JSON beat XML. HTML beat SGML. In every case, the simpler format won because more people could implement it correctly. A WDP client should be buildable in a weekend. The minimum viable client is a text renderer that prints names, descriptions, and affordance menus. Everything beyond that is progressive enhancement.
 Core Model
 
-Four concepts: regions, entities, affordances, and appearance.
+Five concepts: regions, entities, affordances, appearance, and panels.
 Regions
 
 A region is a spatial container. It's the "page" — the top-level context that a client loads and renders. A dungeon room, a forest clearing, a city block, a spaceship interior. Regions connect to other regions through portals.
@@ -74,6 +74,7 @@ Model	Positions	Use case
 continuous_3d { bounds }	[x, y, z] floats	Full 3D worlds
 continuous_2d { bounds }	[x, y] floats	Top-down or side-view
 grid_2d { width, height }	[col, row] integers	Tile-based games
+hex { width, height }	[q, r] axial integers	Strategy games, hex-based worlds
 graph	Named locations	Text adventures, node-based maps
 abstract	None	Inventories, conversations, menus
 
@@ -115,9 +116,9 @@ creature	Living entity — player, NPC, monster, animal	Name + description
 item	Portable object — sword, potion, tool, material	Name + "you could pick this up"
 structure	Fixed construction — wall, door, chest, table, building	Name + part of environment
 terrain	Ground/environment — grass, water, stone, lava	Background/floor
-portal	Navigation point — door, gate, path, teleporter	Directional prompt
+portal	Navigation point — door, gate, path, teleporter	Directional prompt (+ transition hint)
 effect	Transient phenomenon — fire, mist, spell, sound	Flavor text
-marker	Abstract point — spawn, waypoint, boundary	Hidden or minimal
+marker	Abstract point — spawn, waypoint, boundary	Not rendered. Editor/debug mode may visualize
 container	Holds other entities — chest, bag, shelf	Name + "contains things"
 vehicle	Rideable/enterable transport	Name + description
 
@@ -152,6 +153,8 @@ price	item	Trade value
 owner_name	any	Display name of the owner
 
 Well-known properties let clients build smart UIs without domain-specific code. A client sees health and health_max on a creature and renders a health bar. No domain-specific plugin needed.
+
+Property semantics convention: numeric properties that represent a bounded value use `X` + `X_max` naming. Values are always absolute, never percentages. `health: 30` means 30 hit points, not 30%. `health` without `health_max` means the maximum is unknown — the client shows the number but can't render a bar. This matters for cross-domain consistency: two domains using `health` to mean different things (absolute vs. percentage vs. armor-adjusted) would break the smart UI promise.
 Affordances
 
 Affordances are what make WDP interactive. They answer: "what can I do here?"
@@ -183,6 +186,7 @@ params	No	Inputs the action needs
 range	No	Maximum distance for this action
 method	Yes	Leden method reference to call
 conditions	No	Client-side hints about requirements
+predicted	No	Whether the client can apply the result optimistically
 
 Categories (how the client groups/renders affordances):
 Category	Rendering hint	Examples
@@ -268,13 +272,45 @@ appearance:
 Assets are content-addressed blobs in Leden's content store. The client fetches what it needs based on its rendering capability. A text client fetches nothing. A 2D client fetches the sprite. A 3D client fetches the model. Asset format is encoded in the blob's metadata (stored with the content hash).
 
 If the client can't fetch an asset (network issue, unsupported format), it falls back to hints. If no hints, it falls back to kind + description. The layers degrade gracefully. Always.
+Panels
+
+Some domain UI doesn't map to entities in a region — skill trees, faction reputation, crafting grids, build mode toolbars, quest logs. These aren't world description. But punting them to "each domain builds custom UI" defeats the whole point of WDP.
+
+I decided to use HTML. Not invent a new UI description language — the web already has one with 30 years of tooling, accessibility support, and rendering engines. A panel is a sandboxed HTML fragment that a domain sends for non-spatial UI.
+
+Panel:
+  id: "skill_tree"
+  label: "Skills"
+  category: character
+  fallback: "Strength: 5, Agility: 3, Magic: 7"
+  content_type: text/html
+  content: sha256:abc123...
+
+Panel fields:
+Field	Required	Purpose
+id	Yes	Stable identifier for the panel
+label	Yes	Human-readable name
+category	Yes	Grouping hint (character, inventory, social, craft, quest, system)
+fallback	Yes	Plain text summary — always renderable
+content_type	Yes	MIME type of the content (text/html for now)
+content	Yes	Content-addressed blob reference
+
+The content is sandboxed HTML/CSS — no JavaScript, no external resources. Think HTML email, not a web app. The domain authors a self-contained fragment. The client renders it in an iframe with sandbox restrictions or shadow DOM. Interaction flows through WDP affordances embedded in the HTML as data attributes, not through JS event handlers.
+
+A text client renders the fallback string. A web-based client renders the HTML natively. A native client can use a lightweight HTML renderer or fall back to the text. Same progressive enhancement as everything else in WDP.
+
+Why HTML and not a structured schema: I considered a custom layout language. But any layout language rich enough for skill trees and crafting grids would end up being a bad version of HTML. CSS already solves layout. HTML already has form elements. Screen readers already understand both. The alternative is years of design work to build something worse than what exists.
+
+Panels are delivered through the observation stream like everything else. A panel_update delta carries a new content hash when the domain changes the panel's contents. The client fetches the new blob and re-renders.
+
+Panels are not entities. They don't have positions, affordances, or appearance. They're a parallel content channel for structured information that lives outside the spatial world. A domain can send zero panels (pure world interaction) or many (complex RPG with character sheets, quest logs, faction standings).
 Fidelity Negotiation
 
 The client declares what it can handle. The domain uses this to tailor its descriptions.
 
 This is HTTP's Accept header applied to world description. The client says what it supports. The domain picks the best match.
 
-Fidelity is declared once at session start, during Leden bootstrap:
+Fidelity is declared at session start during Leden bootstrap, and can be renegotiated mid-session via a `fidelity_update` message. A client that switches from windowed to fullscreen, or a mobile client that rotates orientation, sends an updated fidelity declaration. The domain adjusts what it sends going forward — no snapshot reset needed, just different filtering on the delta stream.
 
 client_fidelity:
   rendering: [text, tiles_2d, scene_3d]
@@ -291,6 +327,7 @@ asset_formats	What asset formats the client can load
 interaction	Input methods available
 audio	Whether the client can play audio
 spatial_preference	Preferred spatial model (domain may override)
+panels	Whether the client can render HTML panels (bool)
 
 The domain uses fidelity to:
 
@@ -329,6 +366,7 @@ entity_exit	Entity ref	Entity leaves region
 entity_update	Ref + changed fields	Entity properties change
 affordance_update	Ref + new affordance list	Available actions change
 ambient_update	Changed ambient fields	Environment changes
+panel_update	Panel id + new content hash	Domain UI changes
 
 These map directly to Leden observation deltas. The region object is the publisher. Subscribed clients are the observers. Leden handles fan-out, backpressure, sequence numbering, and reconnection.
 
@@ -337,6 +375,12 @@ For high-frequency updates (entity movement), the client can observe individual 
 Observe(entity_ref, filter: [position])
 
 This gives position-only updates at high frequency without the overhead of full entity deltas. The region observation handles add/remove (low frequency). Individual observations handle property changes (high frequency).
+
+For regions with many entities, the client can also filter at the region level:
+
+Observe(region_ref, entity_filter: [position])
+
+This gives position updates for all entities in the region as a single subscription, instead of requiring one observation per entity. The region observation handles structural changes (add/remove), the region-level filter handles bulk property streaming (all positions), and individual entity observations handle detailed per-entity tracking. Three tiers, matching different update frequencies.
 
 Coalescing strategy: Game entities should use coalesce-on-backpressure. The client wants the latest position, not every position along the path. This is configured on the domain side — Leden's observation backpressure model handles it.
 Interaction Execution
@@ -352,6 +396,17 @@ When the player selects an affordance:
 The client never calls domain-specific APIs. It calls the method that the affordance told it to call. New domain features are new affordances on entities — the client discovers and renders them without code changes. This is the HATEOAS guarantee.
 
 Error handling: If the method call fails (insufficient permissions, out of range, invalid state), the domain returns a structured error through the Leden promise. The client displays it. The affordance's conditions field helps the client avoid common errors proactively (graying out "attack" when out of range), but the domain always validates server-side.
+Client-Side Prediction
+
+For real-time interaction (movement, combat), the round-trip through "affordance → Leden method → observation update" adds perceptible latency. Without prediction, everything feels like 200ms input lag.
+
+Affordances with `predicted: true` tell the client it can apply the expected result locally before the server confirms. The client acts on the optimistic result immediately and reconciles when the authoritative update arrives through the observation stream.
+
+What the client predicts is the client's problem. WDP doesn't carry prediction logic — that would violate "description is not behavior." The `predicted` flag is permission: "this action's effect is predictable enough that you should try." A movement affordance is predictable. A "open mysterious chest" affordance is not.
+
+If the server result differs from the prediction, the client snaps to the authoritative state. Smooth reconciliation (interpolation, rollback) is a client rendering concern. The domain sends truth. The client makes it feel good.
+
+This is the same model every multiplayer game uses. The difference is that WDP makes it opt-in per affordance rather than a global client assumption. A domain with deterministic physics marks movement as predicted. A domain with complex server-side logic marks nothing as predicted. The client adapts.
 Progressive Rendering Example
 
 The same region data, three clients:
@@ -396,7 +451,7 @@ Over time, commonly-used terms will become de facto standards. When 200 domains 
 Domain unions (from the existing Midgard design) accelerate vocabulary convergence. A union of 50 domains that all agree on the same entity types, appearance hints, and affordance verbs creates a pocket of perfect interop. WDP doesn't need to know unions exist — it just sees consistent vocabulary use.
 What This Doesn't Cover
 
-UI layout. WDP describes the world, not the client's interface. Health bars, minimaps, quest trackers, inventory screens — these are client concerns. The client builds UI from entity data (health from properties, minimap from region layout, inventory from a container entity's contents).
+Client UI chrome. WDP describes the world and domain panels, not the client's own interface. Health bars, minimaps, hotkey bindings, settings screens — these are client concerns. The client builds its chrome from entity data (health from properties, minimap from region layout) and its own preferences. Domain-specific UI (skill trees, crafting grids) goes through panels.
 
 Physics. WDP doesn't describe collision volumes, rigid body properties, or physics constraints. If a domain needs physics-aware clients, it uses well-known properties (solid: true, mass: 5.0) and the client interprets them. Full physics simulation is domain-side (Raido).
 
@@ -420,15 +475,14 @@ Affordances over methods. The client doesn't call entity methods directly. It di
 No inheritance in the entity model. USD and Roblox use class hierarchies. ECS uses composition. WDP uses composition — an entity is a bag of kind + properties + affordances + appearance. No "class GenericSword with subclass Flamebrand." Inheritance creates coupling between entity definitions that breaks across domain boundaries. Composition lets two domains agree on individual properties without agreeing on a type hierarchy.
 
 Content-addressed assets, not URLs. Assets are identified by content hash, not location. This means: deduplication across domains is free, integrity verification is free, and caching is trivial. Two domains that independently use the same goblin sprite share the content hash. The client fetches it once. This falls directly out of Leden's content store.
-Open Questions
 
-Entity relationships. An NPC might be "in a group with" other NPCs. A sword might be "equipped by" a character. A chair might be "part of" a table set. Should WDP express relationships between entities, or is that just properties (equipped_by: <ref>)? Flecs-style entity relationships are powerful but add complexity. Properties might be enough for v1.
+Entity relationships are properties for v1. `equipped_by: <ref>`, `contained_in: <ref>`, `group: <ref>`. Flecs-style first-class relationships are powerful but add complexity that isn't justified yet. Properties handle the common cases (equipment, containment, grouping). If the pattern proves too limiting, relationships can be promoted to a first-class concept later. Going the other direction — removing a relationship system — is painful.
 
-Region transitions. When a player enters a portal, what does the client experience? Instant swap (region A disappears, region B appears)? Gradual transition (both regions visible briefly)? The domain might want to control this. Should portals have transition hints (transition: fade, transition: walk, transition: instant)?
+Portal transitions are domain-controlled. Portals carry a `transition` hint: `instant` (default), `fade`, `walk`, or `loading`. The client renders what it can — a text client ignores transitions entirely, a graphical client uses the hint to drive its transition animation. The domain decides the experience; the client decides the presentation. Without this, every client guesses differently and cross-domain travel feels jarring.
 
-Observation granularity. The current model is: observe the region for add/remove, observe individual entities for property changes. Is this the right split? For a region with 500 entities, the client might want "observe all entities with position changes" as a single subscription instead of 500 individual ones. Leden's ObserveBatch handles the wire-level cost, but the conceptual model might need a "region-level property filter."
+Observation has three tiers. Region observation for structural changes (entity add/remove). Region-level property filter for bulk streaming (`Observe(region_ref, entity_filter: [position])` gives position updates for all entities as one subscription). Individual entity observation for detailed per-entity tracking. This avoids the 500-subscriptions problem without changing Leden's observation model — region-level filters are just a filtered view over the region's delta stream.
 
-Domain-specific UI. Some domains need UI that doesn't map to entities — a skill tree, a faction reputation screen, a build mode toolbar. These aren't world description. Should WDP punt on these entirely (domain provides a custom UI layer, client renders it as a webview or ignores it)? Or should there be a lightweight "panel" concept in WDP for structured non-spatial information?
+Domain-specific UI uses HTML panels. Domains send sandboxed HTML/CSS fragments for non-spatial UI (skill trees, crafting grids, faction screens). No JavaScript, no external resources. Web clients render natively, text clients show a plain text fallback. I chose HTML over a custom schema because any layout language rich enough for real UI would end up being a bad version of HTML. See the Panels section above.
 Deferred
 
     Wire format. Binary vs text. Depends on Leden's wire format decision. WDP is a schema — the encoding is separate.

--- a/projects/midgard/WDP.md
+++ b/projects/midgard/WDP.md
@@ -42,7 +42,7 @@ glTF's tagline is "the JPEG of 3D." It succeeded by optimizing for the renderer,
 HTTP beat CORBA. JSON beat XML. HTML beat SGML. In every case, the simpler format won because more people could implement it correctly. A WDP client should be buildable in a weekend. The minimum viable client is a text renderer that prints names, descriptions, and affordance menus. Everything beyond that is progressive enhancement.
 Core Model
 
-Five concepts: regions, entities, affordances, appearance, and panels.
+Six concepts: regions, entities, affordances, appearance, panels, and themes.
 Regions
 
 A region is a spatial container. It's the "page" — the top-level context that a client loads and renders. A dungeon room, a forest clearing, a city block, a spaceship interior. Regions connect to other regions through portals.
@@ -59,6 +59,14 @@ Region:
     lighting: dim
     sound: tavern_murmur
     temperature: warm
+  theme:
+    mood: gritty
+    palette: [#2a1a0e, #5c3a1e, #8b6914, #1a1a1a]
+    saturation: low
+    contrast: high
+    epoch: medieval
+    density: cluttered
+    stylesheet: sha256:ef9a01...
   entities: [...]
 
 Region fields:
@@ -67,6 +75,7 @@ name	Yes	Display name
 description	Yes	Text description — the universal fallback
 spatial	No	How positions work (see below)
 ambient	No	Environmental properties
+theme	No	Visual identity and mood (see Theme below)
 entities	Yes	Things in the region
 
 Spatial models:
@@ -304,6 +313,68 @@ Why HTML and not a structured schema: I considered a custom layout language. But
 Panels are delivered through the observation stream like everything else. A panel_update delta carries a new content hash when the domain changes the panel's contents. The client fetches the new blob and re-renders.
 
 Panels are not entities. They don't have positions, affordances, or appearance. They're a parallel content channel for structured information that lives outside the spatial world. A domain can send zero panels (pure world interaction) or many (complex RPG with character sheets, quest logs, faction standings).
+
+Panel interaction convention: clickable elements in panel HTML use data attributes that the client intercepts and translates to affordance calls:
+
+    <button data-wdp-verb="unlock_skill"
+            data-wdp-param-skill="fireball"
+            data-wdp-method="<leden_method_ref>">
+      Learn Fireball
+    </button>
+
+The client listens for click events on elements with `data-wdp-verb`, extracts the parameters (any attribute starting with `data-wdp-param-`), and calls the referenced Leden method. The domain receives the call and validates. Results come back through panel_update in the observation stream.
+
+This means panel HTML is a layout and display concern. Interactivity is WDP's job — the client IS the JavaScript runtime. CSS handles hover states, transitions, and visual feedback. The domain authors HTML the same way you'd author an HTML email with a few clickable buttons.
+Theme
+
+This is WDP's CSS moment. Without it, every domain renders with the client's default style — the same way every website looked the same in 1993. The domain author creates a horror dungeon, but the client's built-in bright sprite set turns it into a cartoon. Content exists. Visual identity doesn't.
+
+Theme lives on regions, not domains, because different regions in the same domain can have different moods (bright overworld, dark dungeon, underwater temple). It's the domain's way of saying "this place should feel like this."
+
+theme:
+  mood: gritty
+  palette: [#2a1a0e, #5c3a1e, #8b6914, #1a1a1a]
+  saturation: low
+  contrast: high
+  epoch: medieval
+  density: cluttered
+  stylesheet: sha256:ef9a01...
+
+Theme fields:
+Field	Required	Purpose
+mood	No	Emotional register — hint vocabulary below
+palette	No	Region color palette — client uses for tinting, UI accent, sprite selection
+saturation	No	low, medium, high — client adjusts post-processing or sprite selection
+contrast	No	low, medium, high — lighting contrast guidance
+epoch	No	Time period hint — medieval, futuristic, modern, ancient, alien, ...
+density	No	How full the space feels — sparse, normal, cluttered, dense
+stylesheet	No	Content-addressed CSS blob for the region's panel styling and UI hints
+
+Mood vocabulary:
+Mood	Guidance
+gritty	Dark, rough, dangerous. Muted colors, harsh lighting.
+whimsical	Light, playful, colorful. Rounded shapes, bright palette.
+serene	Calm, peaceful. Soft colors, gentle lighting, low contrast.
+ominous	Threatening, foreboding. Deep shadows, unsettling palette.
+epic	Grand, dramatic. High contrast, saturated colors, sweeping scale.
+mundane	Ordinary, everyday. Natural colors, neutral lighting.
+alien	Strange, unfamiliar. Unusual palette, unexpected shapes.
+
+A text client ignores the theme entirely — mood comes from the description text. A 2D client uses palette for tinting and mood to pick between sprite set variants (if it has them). A 3D client applies palette to post-processing, mood to lighting presets, saturation/contrast to shaders.
+
+The stylesheet field is where CSS comes in. It's a content-addressed CSS blob that the domain can provide for clients that support it. The stylesheet can:
+
+- Style the domain's panels (colors, fonts, layout refinements)
+- Provide CSS custom properties that the client can apply to its own UI chrome: `--wdp-primary`, `--wdp-secondary`, `--wdp-accent`, `--wdp-bg`, `--wdp-text`, `--wdp-danger`, `--wdp-success`
+- Suggest UI treatment via well-known classes: `.wdp-health-bar`, `.wdp-entity-label`, `.wdp-affordance-button`
+
+The client is not required to apply the stylesheet. It's a hint, like everything else. A text client ignores it. A web-based client can adopt the custom properties to tint its UI to match the domain's visual identity. A native client can extract the custom properties and map them to its own theming system.
+
+This is CSS's original promise: content and presentation separated, but presentation exists. Without it, WDP is HTML circa 1993 — every page looks like the browser's default.
+
+One stylesheet per region means: walking through a portal can shift the entire client's color scheme. The horror dungeon portal fades to dark reds and deep shadows. The fairy forest portal shifts to greens and dappled light. The client's UI chrome follows the domain's visual identity without domain-specific code.
+
+Security: Same restrictions as panel HTML. No `url()` to external resources. No `@import`. Only `data:` URIs and content-addressed `sha256:` references. The client validates the CSS before applying it.
 Fidelity Negotiation
 
 The client declares what it can handle. The domain uses this to tailor its descriptions.
@@ -337,6 +408,14 @@ The domain uses fidelity to:
     Pick asset formats. If the client supports glTF, reference glTF assets. If only PNG, reference sprites.
 
 Fidelity is a declaration, not a negotiation. The domain reads it and adapts. No back-and-forth. If the domain can't serve the client's capabilities at all (a 3D-only domain with a text-only client), it says so at bootstrap and the client can disconnect gracefully.
+
+For large regions (cities, open worlds), the client also reports its viewport — the spatial area it's currently displaying. The domain uses the viewport to decide which entities to include in the observation stream. A client showing a 20x15 tile area of a 500x500 city only receives entities within (and slightly beyond) that viewport. The client sends viewport updates as it scrolls or moves the camera.
+
+client_viewport:
+  center: [120, 85]
+  radius: 25
+
+The viewport is a circle (center + radius) regardless of spatial model. The domain sends entities within the radius, plus a buffer for smooth scrolling. Entity enter/exit deltas fire as entities cross the viewport boundary, not the region boundary. This is how WDP scales to large regions without sending 10,000 entities on initial snapshot.
 Integration with Leden
 
 WDP is a content schema. Leden is the protocol. Here's how they compose.
@@ -383,6 +462,8 @@ Observe(region_ref, entity_filter: [position])
 This gives position updates for all entities in the region as a single subscription, instead of requiring one observation per entity. The region observation handles structural changes (add/remove), the region-level filter handles bulk property streaming (all positions), and individual entity observations handle detailed per-entity tracking. Three tiers, matching different update frequencies.
 
 Coalescing strategy: Game entities should use coalesce-on-backpressure. The client wants the latest position, not every position along the path. This is configured on the domain side — Leden's observation backpressure model handles it.
+
+Tick rate: The region snapshot includes a `tick_rate` field (updates per second) so the client can calibrate interpolation. A turn-based domain sends `tick_rate: 0` (event-driven, no interpolation needed). A real-time action domain sends `tick_rate: 20` (the client interpolates between position updates at 20Hz). The client renders at its own frame rate — tick rate is about the domain's update frequency, not the client's display refresh.
 Interaction Execution
 
 When the player selects an affordance:
@@ -462,6 +543,10 @@ Audio design. WDP carries ambient properties and sound asset references. Spatial
 Scripting. No behavior in the description. Ever. Raido handles scripting. WDP handles description. The boundary is load-bearing.
 
 Entity internals. WDP describes what an entity looks like from outside. Its internal state machine, its Raido scripts, its capabilities graph — all opaque. The domain exposes what it wants through properties and affordances.
+
+Data validation. WDP doesn't specify validation rules. A domain might send `health: 50, health_max: 30` or a position outside the region's bounds. Domains are responsible for consistency. Clients should be tolerant — display what you can, clamp out-of-bounds values, don't crash on contradictions. Postel's law: be conservative in what you send, liberal in what you accept.
+
+Panel and stylesheet security. Panels and theme stylesheets are sandboxed: no JavaScript, no external resource loading, no `@import`, no CSS `url()` except `data:` URIs and content-addressed `sha256:` references. Clients must enforce this — render panels in sandboxed iframes (`sandbox="allow-same-origin"`) with a Content-Security-Policy that blocks external fetches. Theme stylesheets are validated before application. A malicious domain cannot use panels or stylesheets to exfiltrate data, track users, or escape the sandbox.
 Resolved
 
 Regions are not entities. A region is a container. Entities are contents. Regions have metadata (name, description, ambient, spatial model). Entities have affordances and appearance. Mixing them creates ambiguity about what "observing an entity" means vs. "observing a region." Clean separation.
@@ -483,6 +568,10 @@ Portal transitions are domain-controlled. Portals carry a `transition` hint: `in
 Observation has three tiers. Region observation for structural changes (entity add/remove). Region-level property filter for bulk streaming (`Observe(region_ref, entity_filter: [position])` gives position updates for all entities as one subscription). Individual entity observation for detailed per-entity tracking. This avoids the 500-subscriptions problem without changing Leden's observation model — region-level filters are just a filtered view over the region's delta stream.
 
 Domain-specific UI uses HTML panels. Domains send sandboxed HTML/CSS fragments for non-spatial UI (skill trees, crafting grids, faction screens). No JavaScript, no external resources. Web clients render natively, text clients show a plain text fallback. I chose HTML over a custom schema because any layout language rich enough for real UI would end up being a bad version of HTML. See the Panels section above.
+
+Visual identity uses region themes. Mood, palette, saturation, contrast, epoch, density — plus an optional CSS stylesheet for panel styling and UI custom properties. This is WDP's CSS moment: without it, every domain renders in the client's default style regardless of the domain author's creative intent. Theme is a hint layer, like appearance hints on entities. Clients apply what they can. Text clients ignore it. Web clients adopt CSS custom properties. 3D clients map mood/palette to post-processing. See the Theme section above.
+
+Large regions use viewport filtering. The client reports its viewport (center + radius), and the domain only sends entities within that area. Entity enter/exit deltas fire at the viewport boundary. This scales WDP to open-world regions without dumping 10,000 entities on initial snapshot.
 Deferred
 
     Wire format. Binary vs text. Depends on Leden's wire format decision. WDP is a schema — the encoding is separate.

--- a/projects/midgard/WDP.md
+++ b/projects/midgard/WDP.md
@@ -42,7 +42,7 @@ glTF's tagline is "the JPEG of 3D." It succeeded by optimizing for the renderer,
 HTTP beat CORBA. JSON beat XML. HTML beat SGML. In every case, the simpler format won because more people could implement it correctly. A WDP client should be buildable in a weekend. The minimum viable client is a text renderer that prints names, descriptions, and affordance menus. Everything beyond that is progressive enhancement.
 Core Model
 
-Six concepts: regions, entities, affordances, appearance, panels, and themes.
+Eight concepts: regions, entities, affordances, appearance, panels, themes, spatial layers, and input streams.
 Regions
 
 A region is a spatial container. It's the "page" — the top-level context that a client loads and renders. A dungeon room, a forest clearing, a city block, a spaceship interior. Regions connect to other regions through portals.
@@ -75,7 +75,11 @@ name	Yes	Display name
 description	Yes	Text description — the universal fallback
 spatial	No	How positions work (see below)
 ambient	No	Environmental properties
-theme	No	Visual identity and mood (see Theme below)
+theme	No	Visual identity and mood (see WDS)
+layers	No	Dense spatial data — terrain, tilemaps, voxels, collision geometry
+physics	No	Physics parameters for client-side simulation
+comfort	No	Immersive comfort hints (locomotion modes, vignette settings)
+tick_rate	No	Server update frequency in Hz (0 = event-driven)
 entities	Yes	Things in the region
 
 Spatial models:
@@ -115,6 +119,7 @@ kind	Yes	Category from the vocabulary
 name	Yes	Display name
 description	Yes	Text description — always the fallback
 position	No	Location within the region's spatial model
+orientation	No	Facing direction — [qx, qy, qz, qw] quaternion, or degrees for 2D
 properties	No	Key-value extensible data
 affordances	No	What you can do with/to this entity
 appearance	No	Rendering hints and asset references
@@ -216,6 +221,8 @@ instant	One action, immediate result	Take item, attack, go north
 targeted	Select a target first	Attack which enemy, give to whom
 dialog	Multi-step structured interaction	Trade negotiation, crafting recipe selection
 continuous	Ongoing action with a duration	Channel spell, hold position, follow
+proximity	Triggered by spatial closeness	Pick up nearby item, open door you're standing at, grab object in reach
+batch	One action applied to multiple entities	Command selected units, loot all nearby items
 
 For dialog mode, the affordance includes a schema — a structured form definition that the client renders as UI:
 
@@ -364,6 +371,8 @@ interaction	Input methods available
 audio	Whether the client can play audio
 spatial_preference	Preferred spatial model (domain may override)
 panels	Whether the client can render HTML panels (bool)
+immersive	VR/AR/XR capabilities (see Immersive Capabilities)
+physics	Whether the client can run local physics simulation (bool)
 
 The domain uses fidelity to:
 
@@ -412,6 +421,7 @@ affordance_update	Ref + new affordance list	Available actions change
 ambient_update	Changed ambient fields	Environment changes
 panel_update	Panel id + new content hash	Domain UI changes
 theme_update	Changed tokens and/or hints	Visual identity changes (see WDS)
+layer_update	Layer id + changed chunk hashes	Terrain/block modifications
 
 These map directly to Leden observation deltas. The region object is the publisher. Subscribed clients are the observers. Leden handles fan-out, backpressure, sequence numbering, and reconnection.
 
@@ -454,9 +464,181 @@ What the client predicts is the client's problem. WDP doesn't carry prediction l
 If the server result differs from the prediction, the client snaps to the authoritative state. Smooth reconciliation (interpolation, rollback) is a client rendering concern. The domain sends truth. The client makes it feel good.
 
 This is the same model every multiplayer game uses. The difference is that WDP makes it opt-in per affordance rather than a global client assumption. A domain with deterministic physics marks movement as predicted. A domain with complex server-side logic marks nothing as predicted. The client adapts.
+Input Streams
+
+Affordances model discrete actions: "attack", "open door", "move to [5, 3]". Some interactions are continuous high-frequency data that doesn't fit the request-response pattern: player movement (gamepad stick at 60Hz), mouse aim, VR head/hand pose at 90Hz. Issuing an affordance call per input frame is too heavyweight — that's 90 method calls per second per tracked point.
+
+Input streams are a lightweight client→server channel for continuous positional data. The client publishes. The domain subscribes. Other clients observe the result through the normal entity observation stream.
+
+The player entity has input stream endpoints declared by the domain:
+
+input_streams:
+  - id: position
+    type: pose_3d       # [x, y, z, qx, qy, qz, qw]
+    rate: 20            # domain wants 20Hz updates from client
+  - id: head
+    type: pose_3d
+    rate: 90
+  - id: left_hand
+    type: pose_3d
+    rate: 90
+  - id: right_hand
+    type: pose_3d
+    rate: 90
+  - id: aim
+    type: direction_2d  # [yaw, pitch]
+    rate: 60
+
+Input stream fields:
+Field	Required	Purpose
+id	Yes	Stream identifier
+type	Yes	Data type: pose_3d, position_3d, position_2d, direction_2d, float, bool
+rate	Yes	Maximum update rate the domain accepts (Hz)
+
+The client sends input at the requested rate (or lower if it can't keep up). The domain processes input server-side and publishes the authoritative result to other observers through entity_update deltas. The client that sent the input applies it locally (predicted) and reconciles on the authoritative update.
+
+Input streams are Leden observation in reverse: the client is the publisher, the domain is the observer. They use the same coalescing and backpressure model — if the domain can't keep up, it gets the latest value, not a queue of stale frames.
+
+A VR client with head + two hand tracking sends three pose streams. The domain receives them, validates (prevent teleportation hacks, enforce physics), and fans out the result to other players through the normal observation stream. Other clients see the VR player's avatar moving its head and hands.
+
+A non-VR client with a gamepad sends one position stream (stick movement) and maybe one aim stream (right stick or mouse). A text client sends no input streams — it uses discrete movement affordances. The domain adapts to what the client provides.
+
+Input streams don't replace affordances. Moving around is an input stream. Attacking is an affordance. Aiming is an input stream. Pulling the trigger is an affordance. Streams handle continuous state. Affordances handle discrete events. They compose.
+Spatial Layers
+
+Entities work for sparse worlds — 20 things in a tavern, 200 in a battlefield. Dense worlds break this model. A Minecraft chunk is 65,536 blocks. A platformer level is collision geometry. A terrain system is a heightmap. These aren't entities — they're bulk spatial data.
+
+Spatial layers sit alongside entities in a region. A layer is a typed array of spatial data that the client renders as background/environment. Entities exist ON TOP of layers.
+
+Region:
+  name: "Crystal Caverns"
+  spatial: continuous_3d { bounds: [256, 64, 256] }
+  layers:
+    - id: terrain
+      type: heightmap
+      resolution: [256, 256]
+      data: sha256:abc123...
+    - id: blocks
+      type: voxel_3d
+      chunk_size: 16
+      palette: sha256:def456...   # block type definitions
+      chunks: [sha256:111..., sha256:222..., ...]
+    - id: collision
+      type: mesh_2d
+      data: sha256:789abc...
+  entities: [...]
+
+Layer types:
+Type	Data	Use case
+heightmap	2D grid of elevation values	Terrain in 3D worlds
+tilemap_2d	2D grid of tile IDs + tile palette	Platformers, top-down games, pixel art worlds
+voxel_3d	3D grid of block IDs + block palette	Minecraft-style voxel worlds
+mesh_2d	2D collision polygons (line segments, shapes)	Platformer level geometry, walls, slopes
+mesh_3d	3D collision mesh (triangles)	Complex 3D environments
+navmesh	Walkable area graph	Pathfinding for NPCs and AI
+
+Layer data is content-addressed, like assets. Large layers (voxel worlds) are chunked — the client fetches chunks within its viewport. Layer updates arrive through the observation stream:
+
+layer_update	Layer id + changed chunk hashes	Terrain/block modifications
+
+A text client ignores layers entirely — it uses entity descriptions. A 2D client renders tilemap_2d layers as background tiles. A 3D client renders heightmaps, voxel chunks, and collision meshes. Progressive enhancement, as always.
+
+Layers also carry physics-relevant data. A platformer's mesh_2d layer defines collision geometry — slopes, one-way platforms, moving platform paths. The client can run local physics against the layer data for predicted movement. The domain validates authoritatively.
+
+Spatial layers don't replace entities. The terrain is a layer. The goblin standing on the terrain is an entity. A tree might be either — a decorative tree in a forest is part of a layer, a specific tree the player can chop down is an entity. The domain decides the boundary.
+Physics Parameters
+
+Some domains need clients to run local physics — platformers, racing, VR hand interaction, any game where frame-precise movement matters. "Description is not behavior" means WDP doesn't carry physics logic. But physics parameters (gravity, friction, collision rules) are description — they describe the physical properties of the space, not what happens in it.
+
+Regions can declare physics parameters:
+
+physics:
+  gravity: [0, -9.8, 0]
+  drag: 0.01
+  move_speed: 5.0
+  jump_velocity: 8.0
+  friction: 0.3
+  collision: layers    # collide against spatial layers
+
+Physics fields:
+Field	Purpose
+gravity	Gravitational acceleration vector
+drag	Air/fluid resistance factor
+move_speed	Base movement speed (domain-defined units)
+jump_velocity	Initial jump velocity (0 = no jumping)
+friction	Surface friction coefficient
+collision	What the player collides with: layers, entities, both, none
+
+These are parameters, not a physics engine. The client plugs them into whatever physics system it uses — Unity's Rigidbody, a custom Verlet integrator, a simple Euler step. The domain provides the constants. The client provides the simulation. The domain validates the result.
+
+Entities that participate in physics carry physics-relevant properties:
+
+properties:
+  solid: true
+  mass: 5.0
+  friction: 0.8       # surface override
+  bouncy: 0.3
+  kinematic: true      # moves but isn't pushed by others
+
+A VR client uses physics parameters + spatial layers to simulate hand interaction locally: the hand collides with objects, objects have mass and friction, the client predicts the physical result and sends it to the domain for validation. Without physics parameters, VR interaction would require a server round-trip for every hand movement against every object. That's 200ms input lag on touching a table. Unacceptable.
+
+A text client ignores physics parameters. A 2D client might use gravity + friction for simple character movement. A 3D client uses the full set. A VR client adds hand physics on top. Progressive enhancement.
+Immersive Capabilities
+
+VR, AR, and spatial computing clients declare their capabilities through the fidelity system. The domain adapts what it sends.
+
+client_fidelity:
+  rendering: [scene_3d]
+  immersive:
+    type: vr
+    tracking: [head, hands]
+    room_scale: true
+    controllers: [hand_tracking, touch]
+    refresh_rate: 90
+  max_entities: 200
+  asset_formats: [gltf, ogg]
+
+Immersive fidelity fields:
+Field	Purpose
+type	vr, ar, xr, or spatial — what kind of immersive display
+tracking	What the client tracks: head, hands, body, eyes, face
+room_scale	Whether the client has room-scale tracking (vs. seated/standing)
+controllers	Input types: hand_tracking, touch, gamepad, wand, gaze
+refresh_rate	Display refresh rate — affects tick rate and input stream expectations
+
+The domain uses immersive fidelity to:
+
+- Set up input streams. A VR client with hand tracking gets head + left_hand + right_hand input stream endpoints. A seated VR client gets head only.
+- Mark proximity affordances. Objects in a VR domain get `mode: proximity` affordances with appropriate ranges (0.3m for grabbing, 1.0m for interacting).
+- Send comfort metadata. The region includes comfort hints:
+
+comfort:
+  locomotion: [teleport, smooth, snap_turn]
+  vignette_on_move: true
+  seated_mode: supported
+
+- Choose appropriate spatial model. VR domains use continuous_3d. The domain can reject clients without 3D support at bootstrap.
+
+Comfort is a domain declaration, not a client request. The domain says "I support teleport and smooth locomotion." The client picks which one to use based on user preference. The domain doesn't need to know — both result in the same position input stream, just with different positional patterns (discrete jumps vs. smooth movement).
+
+Haptic feedback: affordances can carry a `haptic` field:
+
+Affordance:
+  verb: "grab"
+  mode: proximity
+  range: 0.3
+  predicted: true
+  haptic:
+    pattern: pulse
+    intensity: 0.5
+    duration: 50
+
+Haptic fields are hints. VR clients with haptic controllers apply them. All other clients ignore them. A text client rendering a proximity affordance shows it as a regular menu item.
+
+Immersive clients are just clients. They render WDP regions, observe entities, call affordance methods. The immersive extensions (input streams, proximity mode, physics, comfort, haptics) are all progressive enhancements. A domain that sends them works fine with a non-immersive client — the extensions are ignored. A VR client connecting to a non-immersive domain works fine too — it uses standard 3D rendering and falls back to menu-based affordances.
 Progressive Rendering Example
 
-The same region data, three clients:
+The same region data, four clients:
 Text Client
 
 === The Rusty Anchor ===
@@ -488,6 +670,12 @@ Builds a tavern interior from built-in assets (shape hints for walls, bar, stool
 
 Uses: everything above + appearance.assets, appearance.material, appearance.scale, spatial audio
 
+VR Client
+
+Same tavern, but you're standing in it. Head tracking renders the scene at 90Hz from your eye position. Barkeep Marta has a 3D model (appearance.assets.model) or a procedural humanoid assembled from shape + scale + material hints. Reaching toward the Dusty Bottle triggers its proximity affordance — your hand enters the 0.3m grab range and the client highlights it. Squeeze to grab (affordance call with predicted: true), the bottle follows your hand locally while the server confirms. Spatial audio: Marta's voice comes from her position, tavern murmur is ambient. Candlelight is a volumetric light source from the effect entity.
+
+Uses: everything above + orientation, input streams (head, hands), physics parameters, proximity affordances, haptic hints, comfort settings
+
 Same WDP payload. Zero domain-specific client code.
 The Vocabulary
 
@@ -500,7 +688,7 @@ What This Doesn't Cover
 
 Client UI chrome. WDP describes the world and domain panels, not the client's own interface. Health bars, minimaps, hotkey bindings, settings screens — these are client concerns. The client builds its chrome from entity data (health from properties, minimap from region layout) and its own preferences. Domain-specific UI (skill trees, crafting grids) goes through panels.
 
-Physics. WDP doesn't describe collision volumes, rigid body properties, or physics constraints. If a domain needs physics-aware clients, it uses well-known properties (solid: true, mass: 5.0) and the client interprets them. Full physics simulation is domain-side (Raido).
+Physics simulation. WDP provides physics parameters (gravity, friction, collision rules) and spatial layers (collision geometry). The client runs local physics against these. But the physics engine itself is the client's choice — WDP doesn't specify simulation algorithms, integrator types, or solver iterations. Two clients simulating the same parameters may produce slightly different results. The domain is authoritative; clients predict and reconcile.
 
 Animation. WDP doesn't describe skeletal rigs or animation state machines. The posture hint covers coarse state ("crouching", "attacking", "idle"). Smooth animation is the client's problem, driven by posture changes in the observation stream.
 
@@ -537,6 +725,10 @@ Domain-specific UI uses HTML panels. Domains send sandboxed HTML/CSS fragments f
 
 Visual identity is a separate spec (WDS). Design tokens for world styling, CSS stylesheets for panels and web UI, three-level cascade (domain → region → entity). Separated from WDP because styling evolves faster than structure and has a different implementer audience. A WDP implementation is complete without WDS. See [WDS.md](WDS.md).
 
+VR/AR/XR is supported through general-purpose extensions, not a VR-specific protocol. Entity orientation, input streams (continuous client→server data), proximity affordances, spatial layers (dense geometry), physics parameters, and immersive fidelity fields. All are progressive enhancements — a VR client connecting to a non-VR domain works fine (menu affordances, no hand physics), and a non-VR client connecting to a VR domain works fine (ignores input stream endpoints, uses instant/targeted affordances). The immersive capabilities are the same mechanisms needed for platformers, racing games, and any real-time physics game.
+
+Dense worlds use spatial layers. Tilemaps, voxel chunks, heightmaps, and collision meshes sit alongside entities in a region. Entities are sparse (things you interact with). Layers are dense (the world itself). A Minecraft chunk is a voxel layer. A platformer level is a mesh_2d layer. A terrain system is a heightmap layer. Layers are content-addressed and chunked for viewport-based streaming.
+
 Large regions use viewport filtering. The client reports its viewport (center + radius), and the domain only sends entities within that area. Entity enter/exit deltas fire at the viewport boundary. This scales WDP to open-world regions without dumping 10,000 entities on initial snapshot.
 Deferred
 
@@ -545,3 +737,6 @@ Deferred
     LOD (Level of Detail). Distant entities could be sent with less detail. The mechanism exists (fidelity negotiation + filtered observation), but the specific LOD policy is implementation-level.
     Accessibility. Screen reader hints, colorblind palettes, motor-impairment interaction modes. Important, but a layer on top of the base protocol, not a change to it.
     Versioning. WDP will evolve. Version negotiation should follow Leden's model (version handshake at session start, backward-compatible additions don't require version bumps). Details after v1 is stable.
+    Entity visibility. Fog of war needs a visibility field on entities: visible, last_known (stale data with timestamp), hidden. The domain controls which entities the client knows about. last_known entities carry stale data that the client renders differently (grayed out, question mark). Deferred because most Midgard use cases don't need fog of war, and the viewport filtering mechanism handles the common case of "don't show what's far away."
+    Event streams. WDP is state (current properties), not events (what happened). A combat log needs "player X hit boss for 500 damage with Fireball" — that's an event, not a state change. A parallel event channel alongside the observation stream would carry happenings. Deferred because panels can show a combat log (updated via panel_update), which covers the common case without a new concept.
+    Time-sequenced content. Rhythm games and cutscenes need pre-loaded event sequences with precise timestamps. The observation model is push-based (server sends updates as they happen), not time-indexed. This is a fundamentally different content type — probably a separate spec rather than a WDP extension. Deferred.

--- a/projects/midgard/WDS.md
+++ b/projects/midgard/WDS.md
@@ -1,0 +1,341 @@
+World Description Style
+<!-- id: midgard.wds --> <!-- status: proposed --> <!-- summary: Visual identity and theming system for WDP — design tokens, structured hints, and CSS stylesheets -->
+
+WDS is WDP's CSS. WDP describes what exists — structure, entities, affordances. WDS describes how it should feel — colors, atmosphere, lighting, sound palette, typography, entity treatment. Separate specs because they evolve independently and have different implementer audiences.
+
+Without WDS, WDP is the pre-CSS internet. Content exists. Visual identity doesn't. A horror dungeon and a fairy forest render with the same client defaults. Walking through a cross-domain portal feels like nothing because both sides look identical. Domain authors have no way to express creative intent beyond text descriptions and per-entity appearance hints.
+
+CSS solved this for documents. WDS solves it for worlds. But WDS is not CSS — CSS styles text, boxes, and layout. WDS styles lighting, atmosphere, color language, entity treatment, and sound. Different medium, different tool.
+Why Not Just CSS
+
+I considered making the entire style system CSS with custom properties and WDP-specific selectors. Three problems:
+
+1. CSS has no concept of fog density, ambient light color, or shadow intensity. You'd need custom properties for all of them, which makes CSS a transport format for non-CSS data. At that point it's not CSS anymore — it's key-value pairs wearing CSS syntax.
+
+2. CSS selectors are overkill. WDS doesn't need `.creature[data-hostile="true"]:nth-child(2n+1)`. It needs "hostile creatures get a red tint." Flat token namespaces (`entity.hostile_tint: #ff2200`) are simpler to author, simpler to parse, and impossible to create specificity bugs with.
+
+3. CSS is still needed — for panels and web client UI. If the whole style system were CSS, you'd mix world-styling custom properties with actual layout CSS in one file. Keeping them separate means domain authors know exactly what goes where: tokens for world feel, CSS for panel/UI appearance.
+
+The architecture: tokens + hints (WDS, client-agnostic) and stylesheets (CSS, for web clients). Tokens are the real design system. CSS is a bonus layer.
+Design Tokens
+
+Tokens are named values that express visual identity. They're the bridge between "what the domain wants" and "what the client renders." Every client type can consume tokens — a text client maps color tokens to ANSI terminal colors, a 2D client maps them to sprite tinting, a 3D client maps them to shader uniforms.
+
+Tokens are flat key-value pairs with dotted namespaces. No selector syntax. No cascade complexity. A domain author can write them in five minutes.
+
+theme:
+  tokens:
+    # Color language
+    color.primary: #2a1a0e
+    color.secondary: #5c3a1e
+    color.accent: #8b6914
+    color.surface: #1a1a1a
+    color.background: #0d0d0d
+    color.text: #c4a882
+    color.danger: #8b2500
+    color.success: #2e5a1e
+    color.warning: #8b6914
+
+    # Atmosphere
+    atmosphere.fog_color: #1a1008
+    atmosphere.fog_density: 0.4
+    atmosphere.ambient_color: #3a2a1a
+    atmosphere.ambient_intensity: 0.3
+    atmosphere.shadow_intensity: 0.8
+    atmosphere.sky_color: #0a0a0a
+    atmosphere.sky_intensity: 0.1
+
+    # Entity treatment
+    entity.hostile_tint: #ff2200
+    entity.friendly_tint: #44aa44
+    entity.interactive_highlight: #ffcc00
+    entity.selected_outline: #ffffff
+    entity.damaged_overlay: #880000
+
+    # Kind defaults — override per-entity appearance
+    kind.creature.label_color: #c4a882
+    kind.item.highlight: #8b6914
+    kind.portal.glow_color: #4488ff
+    kind.portal.glow_intensity: 0.6
+    kind.structure.label_visible: false
+    kind.terrain.label_visible: false
+
+    # Typography
+    type.heading: serif
+    type.body: serif
+    type.ui: sans-serif
+
+    # Sound palette
+    sound.ambient_layer: sha256:aa11bb...
+    sound.music_mood: dark_ambient
+    sound.interaction: stone_click
+    sound.footstep: wood_creak
+
+  # Structured hints (see below)
+  mood: gritty
+  epoch: medieval
+  saturation: low
+  contrast: high
+  density: cluttered
+
+  # CSS stylesheet for panels and web clients
+  stylesheet: sha256:ef9a01...
+Token Categories
+
+Category	Namespace	Purpose
+Color language	color.*	Domain's palette — primary, secondary, accent, surface, danger, etc.
+Atmosphere	atmosphere.*	Lighting, fog, sky, shadows — the environmental feel
+Entity treatment	entity.*	Visual treatment of entity states — hostile, selected, damaged, interactive
+Kind defaults	kind.<kind>.*	Default appearance per entity kind — label visibility, glow, highlight
+Typography	type.*	Font family hints by role — heading, body, UI
+Sound palette	sound.*	Ambient layers, music mood, interaction sounds, footstep style
+
+How each client type maps each category:
+
+Color:
+- Text client → ANSI terminal colors (color.danger → red, color.success → green)
+- 2D client → sprite tinting, UI palette, overlay colors
+- 3D client → material uniforms, UI palette, post-processing color grading
+- Web client → CSS custom properties (--wdp-color-primary, etc.)
+
+Atmosphere:
+- Text client → ignored (mood comes from description text)
+- 2D client → screen-space fog overlay, global brightness, sky color
+- 3D client → fog shader, skybox, shadow maps, ambient light, volumetrics
+- Web client → CSS filters on game canvas, overlay layers
+
+Entity treatment:
+- Text client → prefix markers ([!] for hostile, [*] for interactive)
+- 2D client → outline colors, tint overlays, highlight animations
+- 3D client → outline shaders, fresnel effects, particle highlights
+- Web client → CSS classes toggled on entity DOM elements
+
+Kind defaults:
+- All clients → fallback appearance when entity has no explicit appearance hints
+- Overridable per-entity by the entity's own appearance field
+- kind.structure.label_visible: false means structure names hidden by default (reduce clutter)
+
+Typography:
+- Text client → ignored (terminal font)
+- 2D/3D client → font selection for entity labels, UI text
+- Web client → CSS font-family on UI elements
+
+Sound:
+- Text client → ignored
+- Audio-capable client → ambient audio layer, music selection, interaction sound effects
+- sound.music_mood is a vocabulary term; the client maps it to its music library
+Token Value Types
+
+Type	Example	Notes
+color	#2a1a0e, #ff2200	Hex RGB. Alpha via #RRGGBBAA. Clients map to their color space.
+float	0.4, 0.8	0.0–1.0 for intensities/densities. Unbounded for scale/size.
+bool	true, false	Visibility flags, toggles.
+string	serif, dark_ambient	Vocabulary terms. Clients map to their asset/font libraries.
+ref	sha256:aa11bb...	Content-addressed blob reference (for sound layers, textures).
+Cascade
+
+Tokens cascade from domain → region → entity. Three levels, strict precedence, no specificity.
+
+A domain declares its global identity at session start (returned by the greeter alongside the initial region). Every region inherits domain tokens. A region's theme overrides specific tokens. An entity's appearance hints override everything for that entity.
+
+domain_theme:
+  tokens:
+    color.primary: #2a1a0e
+    color.accent: #8b6914
+    atmosphere.fog_density: 0.2
+    # ... domain-wide identity
+
+region_theme:
+  tokens:
+    atmosphere.fog_density: 0.8    # this dungeon is foggier
+    atmosphere.ambient_intensity: 0.1  # and darker
+    # color.primary: inherited from domain
+
+entity appearance:
+  palette: [#ff0000]  # this specific entity overrides its kind default
+
+The domain level is the brand. The region level is the scene. The entity level is the individual. Last writer wins. Entity beats region. Region beats domain. No complex specificity rules.
+
+A domain with 50 regions doesn't repeat its color palette 50 times. It defines it once. Dark dungeons override atmosphere tokens. The bright overworld overrides them differently. Individual entities stand out when they need to.
+
+Token inheritance is merge, not replace. A region that sets `atmosphere.fog_density: 0.8` inherits all other domain tokens unchanged. Only the explicitly overridden tokens change.
+Structured Hints
+
+Alongside tokens, themes carry structured mood hints. These are coarser than tokens — high-level signals for clients that don't want to interpret individual token values.
+
+Field	Values	Purpose
+mood	gritty, whimsical, serene, ominous, epic, mundane, alien, sacred, decayed, mechanical	Emotional register — the single most useful hint
+epoch	medieval, futuristic, modern, ancient, alien, steampunk, mythic, ...	Time period — drives asset selection, font choice, sound design
+saturation	low, medium, high	Color intensity guidance
+contrast	low, medium, high	Lighting contrast guidance
+density	sparse, normal, cluttered, dense	How full the space feels
+
+These are shortcuts. A client that fully supports tokens can ignore structured hints — they're derivable from token values. A simpler client that doesn't parse tokens can use mood + epoch to pick a preset. "Gritty medieval" → dark, muted rendering. "Whimsical futuristic" → bright, neon. The structured hints are the minimum viable theme for clients that don't want the full token system.
+
+Structured hints also cascade (domain → region), same as tokens.
+
+Mood vocabulary:
+Mood	Guidance
+gritty	Dark, rough, dangerous. Muted colors, harsh lighting, worn textures.
+whimsical	Light, playful, colorful. Rounded shapes, bright palette, bouncy feel.
+serene	Calm, peaceful. Soft colors, gentle lighting, low contrast, slow ambient.
+ominous	Threatening, foreboding. Deep shadows, desaturated, unsettling sound.
+epic	Grand, dramatic. High contrast, saturated, sweeping scale, orchestral.
+mundane	Ordinary, everyday. Natural colors, neutral lighting, realistic.
+alien	Strange, unfamiliar. Non-standard palette, asymmetric, dissonant sound.
+sacred	Reverent, holy. Gold accents, soft glow, echo, vertical emphasis.
+decayed	Abandoned, rotting. Desaturated, broken geometry, organic overtones.
+mechanical	Industrial, precise. Metal palette, rhythmic sound, grid alignment.
+Stylesheets
+
+The theme's stylesheet field is a content-addressed CSS blob. This is actual CSS — the same language web developers already know. It handles two things that tokens can't: panel layout and web client UI treatment.
+
+Purpose 1: Panel styling. Panels are HTML fragments. Without a stylesheet, they render in the client's default style — a horror domain's skill tree gets cheerful blue buttons. The stylesheet gives panels visual identity: colors, fonts, spacing, borders that match the domain's mood.
+
+Purpose 2: Client UI theming. Web-capable clients can adopt the stylesheet's CSS custom properties for their own UI chrome. When the player walks through a portal, health bars, menus, and overlays shift to match the new domain's palette.
+Token-to-CSS Bridge
+
+Clients that support CSS automatically expose tokens as custom properties:
+
+    :root {
+      /* Auto-generated from theme tokens */
+      --wdp-color-primary: #2a1a0e;
+      --wdp-color-secondary: #5c3a1e;
+      --wdp-color-accent: #8b6914;
+      --wdp-color-surface: #1a1a1a;
+      --wdp-color-background: #0d0d0d;
+      --wdp-color-text: #c4a882;
+      --wdp-color-danger: #8b2500;
+      --wdp-color-success: #2e5a1e;
+      --wdp-type-heading: serif;
+      --wdp-type-body: serif;
+      --wdp-type-ui: sans-serif;
+      /* ... all tokens mapped to --wdp-{namespace}-{name} */
+    }
+
+The mapping is mechanical: `color.primary` → `--wdp-color-primary`. `atmosphere.fog_density` → `--wdp-atmosphere-fog-density`. Dots become hyphens. The `--wdp-` prefix prevents collisions with the client's own custom properties.
+
+The domain's stylesheet builds on these. It doesn't re-declare the palette — it references the tokens:
+
+    .wdp-panel {
+      background: var(--wdp-color-surface);
+      color: var(--wdp-color-text);
+      font-family: var(--wdp-type-body, serif);
+      border: 1px solid var(--wdp-color-accent);
+    }
+
+    .wdp-health-bar {
+      background: var(--wdp-color-danger);
+      border-radius: 2px;
+    }
+
+    .wdp-affordance-button {
+      background: var(--wdp-color-surface);
+      color: var(--wdp-color-accent);
+      border: 1px solid var(--wdp-color-accent);
+    }
+
+    .wdp-affordance-button:hover {
+      background: var(--wdp-color-accent);
+      color: var(--wdp-color-surface);
+    }
+
+If the domain changes its tokens (e.g., a day/night cycle shifts color.primary), the CSS custom properties update automatically and the stylesheet's var() references resolve to the new values. No stylesheet swap needed for token-driven changes.
+Well-Known CSS Classes
+
+Clients that render HTML-based UI should expose these classes on their elements. Domain stylesheets target them to style the client's built-in chrome.
+
+Class	Element	Purpose
+.wdp-panel	Panel container	Wraps each domain panel
+.wdp-health-bar	Health indicator	Bar showing health/health_max ratio
+.wdp-health-bar-fill	Health fill	Inner element sized to health/health_max
+.wdp-entity-label	Name label	Entity name overlay in graphical clients
+.wdp-entity-label--hostile	Hostile variant	Label on hostile entities (additional class)
+.wdp-affordance-button	Action button	Clickable affordance trigger
+.wdp-affordance-menu	Menu container	Groups affordances by category
+.wdp-affordance-group	Category group	One affordance category within the menu
+.wdp-region-name	Region title	Current region's name display
+.wdp-ambient-overlay	Screen overlay	Full-screen mood/atmosphere tinting layer
+.wdp-toast	Notification	Transient messages (damage numbers, pickups)
+
+The client is not required to apply domain styles to its own UI. But clients that do get the portal-transition effect: walk into a new domain and the entire UI shifts color and feel. This is the key experience that makes cross-domain travel feel coherent rather than jarring.
+
+Modifier classes follow BEM-lite convention: `.wdp-entity-label--hostile`, `.wdp-affordance-button--disabled`, `.wdp-panel--collapsed`. Domains can target these for state-specific styling.
+Stylesheet Constraints
+
+- No JavaScript. No `<script>`, no event handlers, no `expression()`, no `-moz-binding`.
+- No external resources. No `@import`, no `url()` pointing to external hosts.
+- Content references only. `url()` values must be `data:` URIs or `sha256:` content-addressed references (resolved through Leden's content store).
+- No layout hijacking. Clients may reject or sandbox properties that change their layout structure: `position: fixed/absolute`, `z-index` above client-reserved range, `display: none` on critical UI, `pointer-events: none` on interactive elements. The stylesheet styles appearance, not structure.
+- Size limit. 64KB maximum. Enough for comprehensive theming. Too small for embedded fonts or image data URIs (those go in the content store as assets).
+- Scoping. Clients should scope domain stylesheets to prevent cross-domain style leaks. When the player has panels from two domains visible, each domain's stylesheet applies only to its own panels. CSS `@scope` or shadow DOM provides this.
+
+Clients validate stylesheets before applying. Parse the CSS, strip disallowed properties, verify all url() references. A malicious domain cannot use a stylesheet to exfiltrate data, track users, overlay misleading UI, or escape sandboxing.
+Theme Updates
+
+Themes can change during a session. A day/night cycle shifts atmosphere tokens. An event tints the region red. A quest completion changes the mood from ominous to serene.
+
+Theme changes arrive through the observation stream as a `theme_update` delta on the region:
+Update	Payload	When
+theme_update	Changed tokens and/or hints	Region visual identity changes
+
+Token updates are partial — only changed tokens are sent. The client merges them with the current token set. This enables smooth transitions: the domain sends `atmosphere.ambient_intensity: 0.1` → `0.5` over several updates to simulate dawn.
+
+Stylesheet changes send a new content hash. The client fetches the new blob and re-applies. Stylesheet swaps are infrequent (portal transitions, major events), not per-frame.
+How Clients Consume Themes — Full Example
+
+The same theme applied by four client types:
+
+Text client:
+- Maps color.danger → ANSI red for hostile creature names
+- Maps entity.hostile_tint → a [!] prefix on hostile entities
+- Uses mood ("gritty") to adjust description framing: "you sense danger" vs. neutral listing
+- Ignores atmosphere, typography, sound, stylesheet entirely
+- Result: the horror dungeon FEELS different through word choice, even in text
+
+2D tile client:
+- Maps color.* to UI palette and sprite tinting
+- Maps atmosphere.fog_density → screen-space fog overlay (dark gradient from edges)
+- Maps atmosphere.ambient_intensity → global brightness multiplier
+- Maps kind.portal.glow_color → portal tile animation tint
+- Maps sound.ambient_layer → background audio loop
+- Uses mood + epoch to select sprite set variant (if multiple available)
+- Applies stylesheet to any HTML panels it renders
+- Result: same tiles, but the color grading and atmosphere make it feel like a dungeon
+
+3D client:
+- Maps color.* to material tints and UI palette
+- Maps atmosphere.* directly to fog shader, skybox color, shadow map intensity, ambient light
+- Maps entity.* to outline/highlight shader parameters
+- Maps kind.* to default material/glow when entities lack custom appearance
+- Maps sound.* to spatial audio: ambient layer, reverb preset, footstep sound selection
+- Applies stylesheet to HUD panels (typically HTML overlays in the 3D engine)
+- Result: full atmospheric rendering — fog, lighting, color grading, spatial audio, all from tokens
+
+Web client:
+- Injects all tokens as CSS custom properties on :root
+- Applies stylesheet directly to page
+- Uses .wdp-* classes on its UI elements
+- Gets portal-transition effect: region change → new tokens → CSS custom properties update → instant UI recolor via var() references
+- Panels inherit styling automatically via the CSS cascade
+- Result: the domain's visual identity permeates every pixel of the client
+Resolved
+
+Tokens over selectors. I considered CSS-like selectors for targeting entities (`creature[hostile=true] { tint: red }`). Flat namespaced tokens are simpler. No specificity bugs. No parsing complexity. Domain authors write `entity.hostile_tint: #ff2200` instead of learning a selector language. The tradeoff is less precision — you can't target "hostile creatures of level > 10 in this specific room." But that level of granularity belongs in per-entity appearance, not in the theme.
+
+Separate spec from WDP. CSS is a separate spec from HTML. They evolved independently with different versioning, complexity budgets, and implementer communities. WDS changes more frequently than WDP — new token categories, new mood terms, stylesheet feature additions. Keeping them separate means WDP implementations are complete without WDS (use client defaults), and WDS can evolve without forcing WDP revisions.
+
+Three-level cascade is enough. I considered adding a fourth level (union themes — a domain union defines shared visual standards). Not worth the complexity. If a union wants visual consistency, its member domains use the same domain-level tokens. The cascade doesn't need to know about unions.
+
+Structured hints AND tokens, not OR. Some people will say "just use tokens" or "just use mood hints." Both camps are wrong. Tokens give precise control for capable clients. Structured hints give useful signals for simple clients that don't want to parse 40 tokens. A text client benefits from `mood: ominous` even though it ignores every token. A 3D client benefits from `atmosphere.fog_density: 0.4` even though `mood: gritty` is too vague for its renderer.
+
+CSS for panels, tokens for worlds. The stylesheet handles document-like concerns (panel layout, fonts, borders). Tokens handle world-like concerns (fog, lighting, entity treatment). Mixing them in one system would mean CSS parsing is required for atmosphere rendering, which kills the "buildable in a weekend" promise for simple clients.
+Open Questions
+
+Token animation. Should tokens support transition hints? `atmosphere.ambient_intensity: 0.5 [transition: 2s]` would tell the client to smoothly interpolate over 2 seconds instead of snapping. The domain can fake this by sending multiple updates, but that's chattier. A built-in transition hint is cleaner — but adds complexity to the token format. For now, domains send incremental updates and clients interpolate at their own rate.
+
+Audio token depth. The sound.* namespace is shallow — ambient layer, music mood, footstep style. Real audio design needs more: reverb presets, distance attenuation curves, environmental occlusion hints, music crossfade behavior. Should this stay shallow (simple, most domains don't need it) or get its own sub-spec (complex, but enables rich audio experiences)? Leaning toward keeping it shallow in WDS and deferring deep audio to a future extension.
+
+Accessibility overrides. The client's accessibility settings should always win over domain themes. A domain that sets `contrast: low` shouldn't override a user's high-contrast mode. The cascade should probably be: domain → region → entity → USER (always wins). But this means the client needs to know which tokens map to accessibility-relevant settings. Not specified yet.
+
+Theme previews on portals. When the client is near a portal, should it receive the destination region's theme in advance? This would enable pre-loading assets and showing a visual preview of what's on the other side (color bleeding through the portal, for instance). Adds bandwidth but makes transitions smoother.


### PR DESCRIPTION
- Add HTML panels for domain-specific UI (skill trees, crafting, etc.)
- Add client-side prediction model for real-time affordances
- Add hex spatial model, region-level property filters
- Tighten well-known property semantics (absolute values, X/X_max convention)
- Make fidelity renegotiable mid-session
- Resolve: entity relationships as properties, portal transitions, observation granularity

https://claude.ai/code/session_01BF9AEzQjJADMJKSTqdM9aE