### PR TITLE
Redesign capability delegation to use per-event tokens instead of HMAC chains

### DIFF
--- a/projects/leden/protocol.md
+++ b/projects/leden/protocol.md
@@ -257,161 +257,79 @@ A sturdy reference is what you store to prove you held a capability. It contains
 | `issuer` | endpoint identity | Who created the original capability |
 | `object_id` | opaque | Which object this grants access to |
 | `permissions` | bitfield | What operations are allowed (after attenuation) |
-| `nonce` | 256-bit | Unique, unguessable — proves this was issued, not fabricated |
-| `delegation_path` | endpoint identity[] | Plaintext delegation path — who delegated to whom |
-| `delegation_chain` | hash chain | HMAC-SHA256 verification of the delegation path |
+| `token` | 256-bit | Unique, unguessable — identifies this specific delegation event |
 | `expiry` | optional timestamp | When this sturdy ref becomes invalid (if time-limited) |
 
-The `nonce` is critical. Without it, anyone who knows the object_id could fabricate a sturdy reference. The issuer generates the nonce and stores it — when a client presents a sturdy ref, the issuer checks the nonce against its records.
+The `token` is unique per delegation event — not per capability. When the issuer creates a capability, the first holder gets a token. When that holder delegates, the new holder gets a different token. Each token maps to exactly one node in the issuer's delegation tree.
 
-The `delegation_path` and `delegation_chain` together identify and verify the delegation path. The path provides plaintext identities for tree lookup; the chain provides cryptographic tamper detection. The algorithm and verification procedure are specified below.
+### Delegation Verification
 
-### Delegation Chain Cryptography
-
-A sturdy ref carries a plaintext delegation path (for tree lookup) and an HMAC chain (to prevent path substitution). The issuer's delegation tree is the authoritative record; the chain cryptographically binds the sturdy ref to a specific path through that tree.
-
-#### Design Rationale
-
-The issuer maintains a delegation tree — the authoritative record of every delegation event. That tree is the real security boundary. The delegation chain in the sturdy ref serves two purposes:
-
-1. **Path identification.** The chain tells the issuer which delegation path the presenter claims. Without it, the issuer would need to search for a path from root to the presenter's identity. With indexed storage (keyed by nonce + holder) this is fast, but the chain makes the claim explicit — no ambiguity when a holder appears at multiple points in the tree.
-
-2. **Path binding (prevents path substitution).** The plaintext path alone is vulnerable to substitution: if the same capability has been delegated through multiple paths, a low-privilege holder could swap their path for a higher-privilege path that also exists in the tree. The HMAC chain binds each step's parameters (permissions, weight, identities) to the specific delegation event. The issuer recomputes the HMAC using values from the tree, so a substituted path produces a different hash — caught at step 3. This is a real attack, not defense-in-depth.
-
-#### Algorithm: HMAC-SHA256 Chain
-
-Each link in the chain is an HMAC-SHA256 computed over the delegation context, keyed with a secret derived from the capability's nonce. The chain is an ordered array of 32-byte link hashes, one per delegation step.
-
-**Root link** (issuer creates the original capability):
-
-```
-link_key  = HMAC-SHA256(key: nonce, data: "leden-delegation-v1")
-link_0    = HMAC-SHA256(key: link_key, data: issuer_id || object_id || permissions || weight || holder_id)
-```
-
-The root link binds the capability to a specific holder and weight. `holder_id` is the endpoint identity of the first recipient. `weight` is the initial weight assigned at creation.
-
-**Delegation link** (holder delegates to a new recipient):
-
-```
-link_n    = HMAC-SHA256(key: link_{n-1}, data: delegator_id || recipient_id || permissions_n || weight_n)
-```
-
-Each subsequent link is keyed with the *previous link's hash*. This chains the links cryptographically — you can't produce link_n without knowing link_{n-1}.
-
-The inputs to each delegation link:
-- `delegator_id` — endpoint identity of the entity delegating
-- `recipient_id` — endpoint identity of the entity receiving
-- `permissions_n` — the permission bitfield *after* any attenuation at this step
-- `weight_n` — the weight assigned to the recipient at this step
-
-**Concatenation encoding.** The `||` operator means length-prefixed concatenation: each field is encoded as a 2-byte big-endian length followed by the field bytes. Fixed-size fields (permissions as u64, weight as u64) are encoded as 8 bytes big-endian with no length prefix. This prevents ambiguity attacks where field boundaries are shifted.
-
-**The sturdy ref carries two parallel arrays:**
-- `delegation_path: [holder_id_0, holder_id_1, ..., holder_id_n]` — plaintext endpoint identities, one per delegation step (including the original holder)
-- `delegation_chain: [link_0, link_1, ..., link_n]` — HMAC hashes, one per step
-
-The path tells the issuer which tree nodes to look up. The chain lets the issuer verify the path wasn't tampered with. Both are needed — the chain is opaque (32-byte hashes), so without the plaintext path the issuer can't locate the corresponding delegation records.
-
-#### Nonce Visibility
-
-Every holder has the nonce (it's in the sturdy ref). A holder can compute `link_key` and produce chain links with arbitrary inputs. **The HMAC chain alone does not prevent forgery** — a holder who fabricates links referencing nonexistent delegations is caught by the tree lookup (step 3.2), not by the HMAC comparison.
-
-What the HMAC *does* prevent: path substitution. A holder who modifies `delegation_path` to point to a different (valid) delegation is caught because the HMAC was computed over the original path's parameters.
-
-The nonce proves "the issuer created this capability" (step 1). The path identifies the delegation route (step 3.1). The chain binds those claims together cryptographically (step 3.5). The tree confirms everything actually happened (step 3.2). All four are needed.
-
-#### Introduction and Delegation Recording
-
-When A introduces B to C's object, the delegation chain gains a new link — but the issuer (C) hasn't recorded this delegation yet. This is resolved by a two-phase introduction:
-
-1. A sends `Introduce(capability, recipient=B, attenuation)` to C (the issuer).
-2. C validates A's capability, records the delegation (A → B) in its tree, computes the new chain link, and builds a sturdy ref for B.
-3. C responds to A with an `IntroduceResult` containing the token (B's sturdy ref).
-4. A forwards the token to B.
-5. B presents the token to C to establish a direct session.
-
-The issuer computes the chain link — not A. A doesn't need to know the chain construction algorithm. C is the authority on its own tree and the only entity that can produce valid chain links (because it controls which delegations are recorded).
-
-The issuer always learns about the delegation *before* the new holder can use it.
-
-#### Example
-
-```
-Issuer I creates capability for object O, nonce N, grants to A (permissions=0x07, weight=512):
-  I computes: link_key = HMAC-SHA256(N, "leden-delegation-v1")
-  I computes: link_0   = HMAC-SHA256(link_key, I || O || 0x07 || 512 || A)
-  A's sturdy ref: delegation_path = [A], delegation_chain = [link_0]
-
-A delegates to B (attenuates to permissions=0x03, weight=256):
-  A sends Introduce to I. I computes:
-  link_1   = HMAC-SHA256(link_0, A || B || 0x03 || 256)
-  B's sturdy ref: delegation_path = [A, B], delegation_chain = [link_0, link_1]
-
-B delegates to C (no attenuation, weight=128):
-  B sends Introduce to I. I computes:
-  link_2   = HMAC-SHA256(link_1, B || C || 0x03 || 128)
-  C's sturdy ref: delegation_path = [A, B, C], delegation_chain = [link_0, link_1, link_2]
-```
+The delegation tree is the security boundary. Each node in the tree records: recipient identity, permissions, weight, revocation status, and parent node. The token is a lookup key into this tree.
 
 #### Verification Procedure
 
 When an endpoint receives a sturdy reference (during re-attachment, introduction, or any capability claim), it performs these steps in order. Any failure rejects the reference.
 
-**Step 1: Nonce lookup.** Look up the nonce in the issuer's persistent capability store. If not found → reject with `InvalidNonce`. This proves the capability was actually issued, not fabricated.
+**Step 1: Token lookup.** Look up the token in the issuer's persistent store. If not found → reject with `InvalidToken`. This proves the delegation event actually happened.
 
-**Step 2: Reconstruct the root link.** Compute `link_key` and `link_0` from the stored nonce, the issuer's own identity, the object_id, the original permissions, and the original holder_id (all stored by the issuer when the capability was created). Compare against `delegation_chain[0]`. If mismatch → reject with `InvalidChain`.
+**Step 2: Check presenter.** The tree node's `recipient` must match the endpoint presenting the sturdy reference. If mismatch → reject with `HolderMismatch`.
 
-**Step 3: Walk the delegation tree.** The issuer maintains a delegation tree recording every delegation event (who delegated to whom, with what permissions and weight). For each delegation step `i` from 1 to N:
+**Step 3: Check revocation.** Walk from the tree node up to the root, checking each ancestor's revocation status. If any ancestor is revoked → reject with `CapabilityRevoked`. (Revocation cascades — revoking a parent revokes all descendants.)
 
-1. Use `delegation_path[i-1]` (delegator) and `delegation_path[i]` (recipient) to look up the delegation record in the tree
-2. If the record doesn't exist → reject with `InvalidChain` (claimed delegation never happened)
-3. If the record is revoked → reject with `CapabilityRevoked`
-4. Recompute `link_i = HMAC-SHA256(link_{i-1}, delegator_id || recipient_id || permissions_i || weight_i)` using values from the tree record
-5. Compare against `delegation_chain[i]`. If mismatch → reject with `InvalidChain`
+**Step 4: Permission and expiry checks.** Verify the permissions in the sturdy ref are no broader than the tree node's permissions (can only narrow). Check expiry.
 
-**Step 4: Check terminal holder.** `delegation_path[N]` (the last entry) must match the endpoint presenting the sturdy reference. If mismatch → reject with `HolderMismatch` (the ref belongs to someone else).
+**Step 5: Accept.** Re-issue a live capability with the verified permissions and a fresh lease.
 
-**Step 5: Permission and expiry checks.** Verify the permissions in the sturdy ref match the most-attenuated permissions in the chain (can only narrow). Check expiry. Check revocation status.
+#### Example
 
-**Step 6: Accept.** Re-issue a live capability with the verified permissions and a fresh lease.
+```
+Issuer I creates capability for object O, grants to A (permissions=0x07, weight=512):
+  I generates token_A, stores tree node: {recipient=A, permissions=0x07, weight=512, parent=root}
+  A's sturdy ref: {issuer=I, object_id=O, token=token_A, expiry=none}
+
+A delegates to B (attenuates to permissions=0x03, weight=256):
+  A sends Introduce to I. I generates token_B, stores tree node:
+    {recipient=B, permissions=0x03, weight=256, parent=node_A}
+  B's sturdy ref: {issuer=I, object_id=O, token=token_B, expiry=none}
+
+B delegates to C (no attenuation, weight=128):
+  B sends Introduce to I. I generates token_C, stores tree node:
+    {recipient=C, permissions=0x03, weight=128, parent=node_B}
+  C's sturdy ref: {issuer=I, object_id=O, token=token_C, expiry=none}
+```
+
+When C presents their sturdy ref:
+1. Look up token_C → find tree node (recipient=C, permissions=0x03, parent=node_B)
+2. Presenter is C, recipient is C → match
+3. Walk up: node_B not revoked, node_A not revoked, root not revoked → ok
+4. Permissions 0x03 ≤ 0x03 → ok
+5. Accept, issue live capability
 
 #### Security Properties
 
-Security comes from *three mechanisms working together*: the nonce (proves issuance), the chain (commits to a delegation path), and the tree (authoritative record of what actually happened). No single mechanism is sufficient alone.
+**Forgery resistance.** Tokens are 256-bit, randomly generated by the issuer. An attacker can't guess a valid token. A holder's token maps to one specific tree node — knowing it reveals nothing about other tokens.
 
-**Forgery resistance.** An external attacker (no sturdy ref) cannot guess the 256-bit nonce, so they can't pass step 1. A holder who has the nonce can compute arbitrary chain links, but cannot forge delegation events in the issuer's tree. Any fabricated chain references a path that doesn't exist in the tree — rejected at step 3.
+**Path substitution resistance.** Each delegation event has its own token. A holder with a low-privilege delegation can't claim a high-privilege path because they don't have the token for it. Unlike a shared nonce + chain design, there's no shared secret that could be used to forge claims about other paths.
 
-**Link-dropping resistance.** Each link is keyed with the previous link's hash. Removing link_i from the chain means link_{i+1} was keyed with a value the attacker can't reproduce without link_i. Even if the attacker could somehow produce a valid-looking shortened chain, the issuer recomputes the full chain from its tree — the chain length must match the tree depth for this delegation path.
+**Impersonation resistance.** Step 2 checks that the presenter matches the tree node's recipient. Stealing someone's sturdy ref requires obtaining their token, which is only transmitted once (from issuer to delegator to recipient).
 
-**Impersonation resistance.** Each link encodes the delegator_id and recipient_id. If an attacker substitutes their own identity for either, the HMAC changes. The issuer cross-references against its delegation tree — the identities must match recorded delegation events. Additionally, step 4 checks that the presenter matches the terminal recipient.
+**Permission escalation resistance.** Step 4 checks the claimed permissions against the tree. Widening fails. The tree records the exact permissions for each delegation event.
 
-**Path substitution resistance.** When the same capability has multiple delegation paths (e.g., A→B with permissions=0x07, A→C with permissions=0x03), a holder could modify their `delegation_path` to point to a higher-privilege path that exists in the tree. The HMAC prevents this: the issuer recomputes each link using the tree's recorded values for the claimed path. A substituted path produces different HMAC inputs → mismatch at step 3.
+**Replay after revocation.** Step 3 walks the tree upward, checking every ancestor. Revoking any node in the chain invalidates all descendants. No window — the tree is the authoritative state.
 
-**Permission escalation resistance.** Each link includes the permission bitfield. Widening permissions changes the HMAC input, producing a different hash that won't match the issuer's recomputation. The issuer also independently enforces that permissions can only narrow along the chain (step 5).
+**Link-dropping resistance.** Not applicable. There's no chain to drop. The tree itself encodes the full delegation path. The holder doesn't carry path information — the issuer reconstructs it from the tree node's parent pointers.
 
-**Replay resistance.** A revoked delegation's entry in the issuer's tree is marked as revoked. Presenting a sturdy ref whose chain passes through a revoked delegation fails at step 3 — the issuer checks revocation status for each delegation record during the tree walk. The chain itself doesn't prevent replay; the tree does.
+#### Why Not HMAC Chains
 
-#### Why HMAC, Not Signatures
+An earlier design used a shared nonce per capability with HMAC-SHA256 chains linking delegation steps. That approach had compounding problems:
 
-Digital signatures (Ed25519, etc.) would let anyone verify the chain without contacting the issuer. That's not what we want. The issuer is *always* the verifier — it's the endpoint hosting the object. Third parties don't need to verify chains independently; they present them to the issuer for verification.
+1. Every holder had the nonce, so any holder could compute valid-looking chain links. The chain alone didn't prevent forgery — the tree had to do that too.
+2. The chain was opaque hashes, so verification needed a parallel plaintext path array for tree lookup — two fields doing one job.
+3. Path substitution attacks required the HMAC to bind each link to its specific delegation parameters. The HMAC was compensating for the shared nonce's weakness.
 
-HMAC is simpler, faster, and doesn't require a PKI. Each endpoint already has a persistent identity, but that identity doesn't need to be a signing key for delegation purposes. The nonce-derived key is sufficient.
+Per-delegation tokens eliminate all three problems. The token is secret (only the issuer and the specific recipient know it), maps directly to a tree node (no search needed), and can't be used to claim a different delegation (no shared secrets between delegation events).
 
-If a future extension needs third-party-verifiable delegation (e.g., for offline verification in partitioned networks), that's a separate mechanism. Don't over-engineer the common path.
-
-#### Wire Format
-
-The sturdy ref carries two parallel arrays:
-
-```
-delegation_path:  [bytes, bytes, ..., bytes]     -- endpoint identities
-delegation_chain: [bin(32), bin(32), ..., bin(32)] -- HMAC-SHA256 hashes
-```
-
-Both arrays must have the same length, at least 1. The original recipient's sturdy ref has one entry in each. A zero-length array is invalid.
-
-Chain length is bounded by the delegation tree depth. Implementations should reject chains longer than a configurable maximum (default: 32 links). Deeper delegation trees indicate either a design problem or an attack.
+The cost: one 256-bit token stored per delegation event, instead of one per capability. Since the issuer already stores a tree node per delegation event, this adds 32 bytes per node — negligible.
 
 ### Re-attachment Flow
 
@@ -453,9 +371,8 @@ Each sturdy ref is validated independently. Some may succeed while others fail. 
 | `CapabilityRevoked` | Revoked while you were disconnected |
 | `CapabilityExpired` | Time limit passed |
 | `ObjectNotFound` | Object was destroyed |
-| `InvalidNonce` | Nonce doesn't match records — forged or corrupted ref |
-| `InvalidChain` | Delegation chain doesn't match issuer's delegation tree |
-| `HolderMismatch` | Presenter doesn't match the terminal recipient in the chain |
+| `InvalidToken` | Token doesn't match records — forged or corrupted ref |
+| `HolderMismatch` | Presenter doesn't match the token's recorded recipient |
 | `IssuerMismatch` | This server didn't issue this ref |
 
 ### Batching
@@ -466,7 +383,7 @@ Each sturdy ref is validated independently. Some may succeed while others fail. 
 
 **Revoked during disconnection.** The client gets `CapabilityRevoked` in the reattach result. Clean — you find out immediately on reconnect, not when you try to use it.
 
-**Server restarted too.** The server reconstructs its capability table from its persistent store. Sturdy refs are designed for this — the nonce and delegation chain are verifiable without in-memory state.
+**Server restarted too.** The server reconstructs its capability table from its persistent store. Sturdy refs are designed for this — the token maps to a persisted tree node, no in-memory state needed.
 
 **Partial re-attachment.** Some refs succeed, some fail. The client gets a complete picture in one response and decides how to handle failures (request new capabilities from another source, degrade gracefully, etc.).
 
@@ -484,10 +401,10 @@ How capabilities are born, shared, and cleaned up. The full picture.
 
 Capabilities are created by the endpoint that hosts the object. When the greeter (bootstrap) grants a capability, or when an object method returns a reference to another object, a new capability is minted:
 
-1. Issuer generates a unique `nonce` and stores it
+1. Issuer generates a unique 256-bit `token` for this delegation event
 2. Issuer assigns a `weight` (for reference counting — see GC below)
-3. Issuer records the holder in the delegation tree
-4. Holder receives a live capability (in-session) + a sturdy reference (for persistence)
+3. Issuer records the holder, permissions, weight, and token in the delegation tree
+4. Holder receives a live capability (in-session) + a sturdy reference containing the token (for persistence)
 
 ### Delegation
 
@@ -522,7 +439,7 @@ B is done: Release(weight=512) → Issuer, total returned = 1024 = original
 All weight returned → capability can be garbage collected.
 ```
 
-When all weight has been returned, no one holds a reference. The issuer cleans up the capability — removes it from the delegation tree, frees the nonce, reclaims any associated resources.
+When all weight has been returned, no one holds a reference. The issuer cleans up the capability — removes it from the delegation tree, frees the tokens, reclaims any associated resources.
 
 ### Lease-Based Expiry
 

--- a/projects/leden/protocol.md
+++ b/projects/leden/protocol.md
@@ -258,16 +258,17 @@ A sturdy reference is what you store to prove you held a capability. It contains
 | `object_id` | opaque | Which object this grants access to |
 | `permissions` | bitfield | What operations are allowed (after attenuation) |
 | `nonce` | 256-bit | Unique, unguessable — proves this was issued, not fabricated |
-| `delegation_chain` | hash chain | Cryptographic proof of the delegation path from issuer |
+| `delegation_path` | endpoint identity[] | Plaintext delegation path — who delegated to whom |
+| `delegation_chain` | hash chain | HMAC-SHA256 verification of the delegation path |
 | `expiry` | optional timestamp | When this sturdy ref becomes invalid (if time-limited) |
 
 The `nonce` is critical. Without it, anyone who knows the object_id could fabricate a sturdy reference. The issuer generates the nonce and stores it — when a client presents a sturdy ref, the issuer checks the nonce against its records.
 
-The `delegation_chain` is a hash chain linking this sturdy ref back to the original capability through every delegation step. The algorithm and verification procedure are specified below.
+The `delegation_path` and `delegation_chain` together identify and verify the delegation path. The path provides plaintext identities for tree lookup; the chain provides cryptographic tamper detection. The algorithm and verification procedure are specified below.
 
 ### Delegation Chain Cryptography
 
-The delegation chain is the security backbone of capability transfer. It prevents three attacks: forgery (inventing a capability from scratch), link-dropping (skipping intermediate delegators to claim broader authority), and impersonation (pretending a different endpoint delegated to you).
+A sturdy ref carries a plaintext delegation path (for tree lookup) and an HMAC chain (to prevent path substitution). The issuer's delegation tree is the authoritative record; the chain cryptographically binds the sturdy ref to a specific path through that tree.
 
 #### Design Rationale
 
@@ -275,7 +276,7 @@ The issuer maintains a delegation tree — the authoritative record of every del
 
 1. **Path identification.** The chain tells the issuer which delegation path the presenter claims. Without it, the issuer would need to search for a path from root to the presenter's identity. With indexed storage (keyed by nonce + holder) this is fast, but the chain makes the claim explicit — no ambiguity when a holder appears at multiple points in the tree.
 
-2. **Tamper detection (defense-in-depth).** A simpler design would use a plaintext `delegation_path: [endpoint_id, ...]`. The HMAC chain adds cryptographic tamper detection: if the tree lookup code has a bug that accepts a modified path, the HMAC mismatch catches it. The cost is 32 bytes per link and one HMAC per step during verification. I think that's worth it for a security boundary.
+2. **Path binding (prevents path substitution).** The plaintext path alone is vulnerable to substitution: if the same capability has been delegated through multiple paths, a low-privilege holder could swap their path for a higher-privilege path that also exists in the tree. The HMAC chain binds each step's parameters (permissions, weight, identities) to the specific delegation event. The issuer recomputes the HMAC using values from the tree, so a substituted path produces a different hash — caught at step 3. This is a real attack, not defense-in-depth.
 
 #### Algorithm: HMAC-SHA256 Chain
 
@@ -306,13 +307,19 @@ The inputs to each delegation link:
 
 **Concatenation encoding.** The `||` operator means length-prefixed concatenation: each field is encoded as a 2-byte big-endian length followed by the field bytes. Fixed-size fields (permissions as u64, weight as u64) are encoded as 8 bytes big-endian with no length prefix. This prevents ambiguity attacks where field boundaries are shifted.
 
-**The delegation chain in the sturdy ref is the full array `[link_0, link_1, ..., link_n]`.**
+**The sturdy ref carries two parallel arrays:**
+- `delegation_path: [holder_id_0, holder_id_1, ..., holder_id_n]` — plaintext endpoint identities, one per delegation step (including the original holder)
+- `delegation_chain: [link_0, link_1, ..., link_n]` — HMAC hashes, one per step
+
+The path tells the issuer which tree nodes to look up. The chain lets the issuer verify the path wasn't tampered with. Both are needed — the chain is opaque (32-byte hashes), so without the plaintext path the issuer can't locate the corresponding delegation records.
 
 #### Nonce Visibility
 
-Every holder has the nonce (it's in the sturdy ref). A holder can compute `link_key` and produce chain links with arbitrary inputs. **The HMAC chain alone does not prevent forgery.** Only the issuer should compute links, but the protocol doesn't enforce this cryptographically — enforcement comes from the issuer's delegation tree. A holder who fabricates extra chain links would reference delegation events that don't exist in the tree, and verification rejects it at step 3.
+Every holder has the nonce (it's in the sturdy ref). A holder can compute `link_key` and produce chain links with arbitrary inputs. **The HMAC chain alone does not prevent forgery** — a holder who fabricates links referencing nonexistent delegations is caught by the tree lookup (step 3.2), not by the HMAC comparison.
 
-The nonce proves "the issuer created this capability" (step 1). The chain says "this is my delegation path" (steps 2-3). The tree proves "that path actually happened." All three are needed.
+What the HMAC *does* prevent: path substitution. A holder who modifies `delegation_path` to point to a different (valid) delegation is caught because the HMAC was computed over the original path's parameters.
+
+The nonce proves "the issuer created this capability" (step 1). The path identifies the delegation route (step 3.1). The chain binds those claims together cryptographically (step 3.5). The tree confirms everything actually happened (step 3.2). All four are needed.
 
 #### Introduction and Delegation Recording
 
@@ -334,17 +341,17 @@ The issuer always learns about the delegation *before* the new holder can use it
 Issuer I creates capability for object O, nonce N, grants to A (permissions=0x07, weight=512):
   I computes: link_key = HMAC-SHA256(N, "leden-delegation-v1")
   I computes: link_0   = HMAC-SHA256(link_key, I || O || 0x07 || 512 || A)
-  A's sturdy ref: delegation_chain = [link_0]
+  A's sturdy ref: delegation_path = [A], delegation_chain = [link_0]
 
 A delegates to B (attenuates to permissions=0x03, weight=256):
   A sends Introduce to I. I computes:
   link_1   = HMAC-SHA256(link_0, A || B || 0x03 || 256)
-  B's sturdy ref: delegation_chain = [link_0, link_1]
+  B's sturdy ref: delegation_path = [A, B], delegation_chain = [link_0, link_1]
 
 B delegates to C (no attenuation, weight=128):
   B sends Introduce to I. I computes:
   link_2   = HMAC-SHA256(link_1, B || C || 0x03 || 128)
-  C's sturdy ref: delegation_chain = [link_0, link_1, link_2]
+  C's sturdy ref: delegation_path = [A, B, C], delegation_chain = [link_0, link_1, link_2]
 ```
 
 #### Verification Procedure
@@ -357,12 +364,13 @@ When an endpoint receives a sturdy reference (during re-attachment, introduction
 
 **Step 3: Walk the delegation tree.** The issuer maintains a delegation tree recording every delegation event (who delegated to whom, with what permissions and weight). For each delegation step `i` from 1 to N:
 
-1. Look up the delegation record for step `i` in the tree (keyed by parent holder + recipient)
-2. Recompute `link_i = HMAC-SHA256(link_{i-1}, delegator_id || recipient_id || permissions_i || weight_i)`
-3. Compare against `delegation_chain[i]`
-4. If mismatch → reject with `InvalidChain`
+1. Use `delegation_path[i-1]` (delegator) and `delegation_path[i]` (recipient) to look up the delegation record in the tree
+2. If the record doesn't exist → reject with `InvalidChain` (claimed delegation never happened)
+3. If the record is revoked → reject with `CapabilityRevoked`
+4. Recompute `link_i = HMAC-SHA256(link_{i-1}, delegator_id || recipient_id || permissions_i || weight_i)` using values from the tree record
+5. Compare against `delegation_chain[i]`. If mismatch → reject with `InvalidChain`
 
-**Step 4: Check terminal holder.** The final link's `recipient_id` must match the endpoint presenting the sturdy reference. If mismatch → reject with `HolderMismatch` (the ref belongs to someone else).
+**Step 4: Check terminal holder.** `delegation_path[N]` (the last entry) must match the endpoint presenting the sturdy reference. If mismatch → reject with `HolderMismatch` (the ref belongs to someone else).
 
 **Step 5: Permission and expiry checks.** Verify the permissions in the sturdy ref match the most-attenuated permissions in the chain (can only narrow). Check expiry. Check revocation status.
 
@@ -378,6 +386,8 @@ Security comes from *three mechanisms working together*: the nonce (proves issua
 
 **Impersonation resistance.** Each link encodes the delegator_id and recipient_id. If an attacker substitutes their own identity for either, the HMAC changes. The issuer cross-references against its delegation tree — the identities must match recorded delegation events. Additionally, step 4 checks that the presenter matches the terminal recipient.
 
+**Path substitution resistance.** When the same capability has multiple delegation paths (e.g., A→B with permissions=0x07, A→C with permissions=0x03), a holder could modify their `delegation_path` to point to a higher-privilege path that exists in the tree. The HMAC prevents this: the issuer recomputes each link using the tree's recorded values for the claimed path. A substituted path produces different HMAC inputs → mismatch at step 3.
+
 **Permission escalation resistance.** Each link includes the permission bitfield. Widening permissions changes the HMAC input, producing a different hash that won't match the issuer's recomputation. The issuer also independently enforces that permissions can only narrow along the chain (step 5).
 
 **Replay resistance.** A revoked delegation's entry in the issuer's tree is marked as revoked. Presenting a sturdy ref whose chain passes through a revoked delegation fails at step 3 — the issuer checks revocation status for each delegation record during the tree walk. The chain itself doesn't prevent replay; the tree does.
@@ -392,13 +402,14 @@ If a future extension needs third-party-verifiable delegation (e.g., for offline
 
 #### Wire Format
 
-The `delegation_chain` field in a sturdy reference is encoded as a MessagePack array of bin-32 values (each 32 bytes, one HMAC-SHA256 output per link):
+The sturdy ref carries two parallel arrays:
 
 ```
-delegation_chain: [bin(32), bin(32), ..., bin(32)]
+delegation_path:  [bytes, bytes, ..., bytes]     -- endpoint identities
+delegation_chain: [bin(32), bin(32), ..., bin(32)] -- HMAC-SHA256 hashes
 ```
 
-The original recipient's sturdy ref contains `[link_0]`. A zero-length chain is invalid — every sturdy ref has at least the root link.
+Both arrays must have the same length, at least 1. The original recipient's sturdy ref has one entry in each. A zero-length array is invalid.
 
 Chain length is bounded by the delegation tree depth. Implementations should reject chains longer than a configurable maximum (default: 32 links). Deeper delegation trees indicate either a design problem or an attack.
 

--- a/projects/leden/protocol.md
+++ b/projects/leden/protocol.md
@@ -262,7 +262,112 @@ A sturdy reference is what you store to prove you held a capability. It contains
 
 The `nonce` is critical. Without it, anyone who knows the object_id could fabricate a sturdy reference. The issuer generates the nonce and stores it — when a client presents a sturdy ref, the issuer checks the nonce against its records.
 
-The `delegation_chain` is a hash chain linking this sturdy ref back to the original capability through every delegation step. C can verify that B's ref chains back through A to the issuer without contacting A.
+The `delegation_chain` is a hash chain linking this sturdy ref back to the original capability through every delegation step. The algorithm and verification procedure are specified below.
+
+### Delegation Chain Cryptography
+
+The delegation chain is the security backbone of capability transfer. It prevents three attacks: forgery (inventing a capability from scratch), link-dropping (skipping intermediate delegators to claim broader authority), and impersonation (pretending a different endpoint delegated to you).
+
+#### Algorithm: HMAC-SHA256 Chain
+
+Each link in the chain is an HMAC-SHA256 computed over the delegation context, keyed with a secret derived from the capability's nonce. The chain is an ordered array of 32-byte link hashes, one per delegation step.
+
+**Root link** (issuer creates the original capability):
+
+```
+link_key  = HMAC-SHA256(key: nonce, data: "leden-delegation-v1")
+link_0    = HMAC-SHA256(key: link_key, data: issuer_id || object_id || permissions || weight || holder_id)
+```
+
+The root link binds the capability to a specific holder and weight. `holder_id` is the endpoint identity of the first recipient. `weight` is the initial weight assigned at creation.
+
+**Delegation link** (holder delegates to a new recipient):
+
+```
+link_n    = HMAC-SHA256(key: link_{n-1}, data: delegator_id || recipient_id || permissions_n || weight_n)
+```
+
+Each subsequent link is keyed with the *previous link's hash*. This chains the links cryptographically — you can't produce link_n without knowing link_{n-1}.
+
+The inputs to each delegation link:
+- `delegator_id` — endpoint identity of the entity delegating
+- `recipient_id` — endpoint identity of the entity receiving
+- `permissions_n` — the permission bitfield *after* any attenuation at this step
+- `weight_n` — the weight assigned to the recipient at this step
+
+**Concatenation encoding.** The `||` operator means length-prefixed concatenation: each field is encoded as a 2-byte big-endian length followed by the field bytes. Fixed-size fields (permissions as u64, weight as u64) are encoded as 8 bytes big-endian with no length prefix. This prevents ambiguity attacks where field boundaries are shifted.
+
+**The delegation chain in the sturdy ref is the full array `[link_0, link_1, ..., link_n]`.**
+
+#### Example
+
+```
+Issuer I creates capability for object O, nonce N, grants to A (permissions=0x07, weight=512):
+  link_key = HMAC-SHA256(N, "leden-delegation-v1")
+  link_0   = HMAC-SHA256(link_key, I || O || 0x07 || 512 || A)
+  A's sturdy ref: delegation_chain = [link_0]
+
+A delegates to B (attenuates to permissions=0x03, weight=256):
+  link_1   = HMAC-SHA256(link_0, A || B || 0x03 || 256)
+  B's sturdy ref: delegation_chain = [link_0, link_1]
+
+B delegates to C (no attenuation, weight=128):
+  link_2   = HMAC-SHA256(link_1, B || C || 0x03 || 128)
+  C's sturdy ref: delegation_chain = [link_0, link_1, link_2]
+```
+
+#### Verification Procedure
+
+When an endpoint receives a sturdy reference (during re-attachment, introduction, or any capability claim), it performs these steps in order. Any failure rejects the reference.
+
+**Step 1: Nonce lookup.** Look up the nonce in the issuer's persistent capability store. If not found → reject with `InvalidNonce`. This proves the capability was actually issued, not fabricated.
+
+**Step 2: Reconstruct the root link.** Compute `link_key` and `link_0` from the stored nonce, the issuer's own identity, the object_id, the original permissions, and the original holder_id (all stored by the issuer when the capability was created). Compare against `delegation_chain[0]`. If mismatch → reject with `InvalidChain`.
+
+**Step 3: Walk the delegation tree.** The issuer maintains a delegation tree recording every delegation event (who delegated to whom, with what permissions and weight). For each delegation step `i` from 1 to N:
+
+1. Look up the delegation record for step `i` in the tree (keyed by parent holder + recipient)
+2. Recompute `link_i = HMAC-SHA256(link_{i-1}, delegator_id || recipient_id || permissions_i || weight_i)`
+3. Compare against `delegation_chain[i]`
+4. If mismatch → reject with `InvalidChain`
+
+**Step 4: Check terminal holder.** The final link's `recipient_id` must match the endpoint presenting the sturdy reference. If mismatch → reject with `IssuerMismatch` (the ref belongs to someone else).
+
+**Step 5: Permission and expiry checks.** Verify the permissions in the sturdy ref match the most-attenuated permissions in the chain (can only narrow). Check expiry. Check revocation status.
+
+**Step 6: Accept.** Re-issue a live capability with the verified permissions and a fresh lease.
+
+#### Security Properties
+
+**Forgery resistance.** An attacker who doesn't know the nonce cannot compute `link_key`, and therefore cannot produce a valid `link_0`. The nonce is 256-bit, randomly generated, and never transmitted in cleartext outside the original sturdy reference. HMAC-SHA256 is a PRF — knowing the output doesn't reveal the key.
+
+**Link-dropping resistance.** Each link is keyed with the previous link's hash. Removing link_i from the chain means link_{i+1} was keyed with a value the attacker can't reproduce without link_i. The issuer recomputes the full chain from its delegation tree during verification — any gap is detected at step 3.
+
+**Impersonation resistance.** Each link encodes the delegator_id and recipient_id. If an attacker substitutes their own identity for either, the HMAC changes. The issuer cross-references against its delegation tree — the identities must match recorded delegation events.
+
+**Permission escalation resistance.** Each link includes the permission bitfield. Widening permissions changes the HMAC input, producing a different hash that won't match the issuer's recomputation. The issuer also independently enforces that permissions can only narrow along the chain (step 5).
+
+**Replay resistance.** The chain includes weight values, which are unique per delegation event (weight is halved, recorded by the issuer). Replaying a sturdy ref from a revoked delegation fails at step 3 because the issuer's tree marks that delegation as revoked.
+
+#### Why HMAC, Not Signatures
+
+Digital signatures (Ed25519, etc.) would let anyone verify the chain without contacting the issuer. That's not what we want. The issuer is *always* the verifier — it's the endpoint hosting the object. Third parties don't need to verify chains independently; they present them to the issuer for verification.
+
+HMAC is simpler, faster, and doesn't require a PKI. Each endpoint already has a persistent identity, but that identity doesn't need to be a signing key for delegation purposes. The nonce-derived key is sufficient.
+
+If a future extension needs third-party-verifiable delegation (e.g., for offline verification in partitioned networks), that's a separate mechanism. Don't over-engineer the common path.
+
+#### Wire Format
+
+The `delegation_chain` field in a sturdy reference is encoded as a MessagePack array of bin-32 values (each 32 bytes, one HMAC-SHA256 output per link):
+
+```
+delegation_chain: [bin(32), bin(32), ..., bin(32)]
+```
+
+The original recipient's sturdy ref contains `[link_0]`. A zero-length chain is invalid — every sturdy ref has at least the root link.
+
+Chain length is bounded by the delegation tree depth. Implementations should reject chains longer than a configurable maximum (default: 32 links). Deeper delegation trees indicate either a design problem or an attack.
 
 ### Re-attachment Flow
 
@@ -305,6 +410,7 @@ Each sturdy ref is validated independently. Some may succeed while others fail. 
 | `CapabilityExpired` | Time limit passed |
 | `ObjectNotFound` | Object was destroyed |
 | `InvalidNonce` | Nonce doesn't match records — forged or corrupted ref |
+| `InvalidChain` | Delegation chain doesn't match issuer's delegation tree |
 | `IssuerMismatch` | This server didn't issue this ref |
 
 ### Batching

--- a/projects/leden/protocol.md
+++ b/projects/leden/protocol.md
@@ -80,13 +80,14 @@ The most important distributed operation. Without this, every cross-endpoint int
 Scenario: A wants to give B access to an object on C.
 
 1. A holds a capability to the object (from C)
-2. A creates an **introduction** — a new capability scoped for B, referencing the object
-3. A sends the introduction to B over their existing session
-4. B presents the introduction to C, establishing a direct session
-5. C validates the introduction (checks it chains back to a valid delegation from A)
-6. B now has a direct capability to the object on C
+2. A sends `Introduce(capability, recipient=B, attenuation)` to C (the issuer)
+3. C records the delegation (A → B) in its tree, computes the new chain link, and responds with an introduction token (a sturdy ref for B)
+4. A forwards the token to B over their existing session
+5. B presents the token to C, establishing a direct session
+6. C validates the token (see Delegation Chain Cryptography, Verification Procedure)
+7. B now has a direct capability to the object on C
 
-A is out of the loop. B and C communicate directly. Introductions fan out — the introducer doesn't become a bottleneck.
+A is out of the loop after step 4. B and C communicate directly. The issuer (C) always learns about the delegation before B can use it — no gap between delegation and tree recording.
 
 This is a **named protocol operation** (`Introduce`), not an implicit side effect of delegation. Important enough for first-class status.
 
@@ -268,6 +269,14 @@ The `delegation_chain` is a hash chain linking this sturdy ref back to the origi
 
 The delegation chain is the security backbone of capability transfer. It prevents three attacks: forgery (inventing a capability from scratch), link-dropping (skipping intermediate delegators to claim broader authority), and impersonation (pretending a different endpoint delegated to you).
 
+#### Design Rationale
+
+The issuer maintains a delegation tree — the authoritative record of every delegation event. That tree is the real security boundary. The delegation chain in the sturdy ref serves two purposes:
+
+1. **Path identification.** The chain tells the issuer which delegation path the presenter claims. Without it, the issuer would need to search for a path from root to the presenter's identity. With indexed storage (keyed by nonce + holder) this is fast, but the chain makes the claim explicit — no ambiguity when a holder appears at multiple points in the tree.
+
+2. **Tamper detection (defense-in-depth).** A simpler design would use a plaintext `delegation_path: [endpoint_id, ...]`. The HMAC chain adds cryptographic tamper detection: if the tree lookup code has a bug that accepts a modified path, the HMAC mismatch catches it. The cost is 32 bytes per link and one HMAC per step during verification. I think that's worth it for a security boundary.
+
 #### Algorithm: HMAC-SHA256 Chain
 
 Each link in the chain is an HMAC-SHA256 computed over the delegation context, keyed with a secret derived from the capability's nonce. The chain is an ordered array of 32-byte link hashes, one per delegation step.
@@ -299,19 +308,41 @@ The inputs to each delegation link:
 
 **The delegation chain in the sturdy ref is the full array `[link_0, link_1, ..., link_n]`.**
 
+#### Nonce Visibility
+
+Every holder has the nonce (it's in the sturdy ref). A holder can compute `link_key` and produce chain links with arbitrary inputs. **The HMAC chain alone does not prevent forgery.** Only the issuer should compute links, but the protocol doesn't enforce this cryptographically — enforcement comes from the issuer's delegation tree. A holder who fabricates extra chain links would reference delegation events that don't exist in the tree, and verification rejects it at step 3.
+
+The nonce proves "the issuer created this capability" (step 1). The chain says "this is my delegation path" (steps 2-3). The tree proves "that path actually happened." All three are needed.
+
+#### Introduction and Delegation Recording
+
+When A introduces B to C's object, the delegation chain gains a new link — but the issuer (C) hasn't recorded this delegation yet. This is resolved by a two-phase introduction:
+
+1. A sends `Introduce(capability, recipient=B, attenuation)` to C (the issuer).
+2. C validates A's capability, records the delegation (A → B) in its tree, computes the new chain link, and builds a sturdy ref for B.
+3. C responds to A with an `IntroduceResult` containing the token (B's sturdy ref).
+4. A forwards the token to B.
+5. B presents the token to C to establish a direct session.
+
+The issuer computes the chain link — not A. A doesn't need to know the chain construction algorithm. C is the authority on its own tree and the only entity that can produce valid chain links (because it controls which delegations are recorded).
+
+The issuer always learns about the delegation *before* the new holder can use it.
+
 #### Example
 
 ```
 Issuer I creates capability for object O, nonce N, grants to A (permissions=0x07, weight=512):
-  link_key = HMAC-SHA256(N, "leden-delegation-v1")
-  link_0   = HMAC-SHA256(link_key, I || O || 0x07 || 512 || A)
+  I computes: link_key = HMAC-SHA256(N, "leden-delegation-v1")
+  I computes: link_0   = HMAC-SHA256(link_key, I || O || 0x07 || 512 || A)
   A's sturdy ref: delegation_chain = [link_0]
 
 A delegates to B (attenuates to permissions=0x03, weight=256):
+  A sends Introduce to I. I computes:
   link_1   = HMAC-SHA256(link_0, A || B || 0x03 || 256)
   B's sturdy ref: delegation_chain = [link_0, link_1]
 
 B delegates to C (no attenuation, weight=128):
+  B sends Introduce to I. I computes:
   link_2   = HMAC-SHA256(link_1, B || C || 0x03 || 128)
   C's sturdy ref: delegation_chain = [link_0, link_1, link_2]
 ```
@@ -331,7 +362,7 @@ When an endpoint receives a sturdy reference (during re-attachment, introduction
 3. Compare against `delegation_chain[i]`
 4. If mismatch → reject with `InvalidChain`
 
-**Step 4: Check terminal holder.** The final link's `recipient_id` must match the endpoint presenting the sturdy reference. If mismatch → reject with `IssuerMismatch` (the ref belongs to someone else).
+**Step 4: Check terminal holder.** The final link's `recipient_id` must match the endpoint presenting the sturdy reference. If mismatch → reject with `HolderMismatch` (the ref belongs to someone else).
 
 **Step 5: Permission and expiry checks.** Verify the permissions in the sturdy ref match the most-attenuated permissions in the chain (can only narrow). Check expiry. Check revocation status.
 
@@ -339,15 +370,17 @@ When an endpoint receives a sturdy reference (during re-attachment, introduction
 
 #### Security Properties
 
-**Forgery resistance.** An attacker who doesn't know the nonce cannot compute `link_key`, and therefore cannot produce a valid `link_0`. The nonce is 256-bit, randomly generated, and never transmitted in cleartext outside the original sturdy reference. HMAC-SHA256 is a PRF — knowing the output doesn't reveal the key.
+Security comes from *three mechanisms working together*: the nonce (proves issuance), the chain (commits to a delegation path), and the tree (authoritative record of what actually happened). No single mechanism is sufficient alone.
 
-**Link-dropping resistance.** Each link is keyed with the previous link's hash. Removing link_i from the chain means link_{i+1} was keyed with a value the attacker can't reproduce without link_i. The issuer recomputes the full chain from its delegation tree during verification — any gap is detected at step 3.
+**Forgery resistance.** An external attacker (no sturdy ref) cannot guess the 256-bit nonce, so they can't pass step 1. A holder who has the nonce can compute arbitrary chain links, but cannot forge delegation events in the issuer's tree. Any fabricated chain references a path that doesn't exist in the tree — rejected at step 3.
 
-**Impersonation resistance.** Each link encodes the delegator_id and recipient_id. If an attacker substitutes their own identity for either, the HMAC changes. The issuer cross-references against its delegation tree — the identities must match recorded delegation events.
+**Link-dropping resistance.** Each link is keyed with the previous link's hash. Removing link_i from the chain means link_{i+1} was keyed with a value the attacker can't reproduce without link_i. Even if the attacker could somehow produce a valid-looking shortened chain, the issuer recomputes the full chain from its tree — the chain length must match the tree depth for this delegation path.
+
+**Impersonation resistance.** Each link encodes the delegator_id and recipient_id. If an attacker substitutes their own identity for either, the HMAC changes. The issuer cross-references against its delegation tree — the identities must match recorded delegation events. Additionally, step 4 checks that the presenter matches the terminal recipient.
 
 **Permission escalation resistance.** Each link includes the permission bitfield. Widening permissions changes the HMAC input, producing a different hash that won't match the issuer's recomputation. The issuer also independently enforces that permissions can only narrow along the chain (step 5).
 
-**Replay resistance.** The chain includes weight values, which are unique per delegation event (weight is halved, recorded by the issuer). Replaying a sturdy ref from a revoked delegation fails at step 3 because the issuer's tree marks that delegation as revoked.
+**Replay resistance.** A revoked delegation's entry in the issuer's tree is marked as revoked. Presenting a sturdy ref whose chain passes through a revoked delegation fails at step 3 — the issuer checks revocation status for each delegation record during the tree walk. The chain itself doesn't prevent replay; the tree does.
 
 #### Why HMAC, Not Signatures
 
@@ -411,6 +444,7 @@ Each sturdy ref is validated independently. Some may succeed while others fail. 
 | `ObjectNotFound` | Object was destroyed |
 | `InvalidNonce` | Nonce doesn't match records — forged or corrupted ref |
 | `InvalidChain` | Delegation chain doesn't match issuer's delegation tree |
+| `HolderMismatch` | Presenter doesn't match the terminal recipient in the chain |
 | `IssuerMismatch` | This server didn't issue this ref |
 
 ### Batching
@@ -446,11 +480,14 @@ Capabilities are created by the endpoint that hosts the object. When the greeter
 
 ### Delegation
 
-When A delegates a capability to B:
+Delegation uses the same `Introduce` / `IntroduceResult` message pair regardless of whether A and B share a session with the issuer or not:
 
-1. A's capability weight is split — A keeps half, B gets half
-2. The delegation is recorded in the issuer's delegation tree (for revocation cascading)
-3. B receives a new capability with A in its delegation chain
+1. A sends `Introduce(capability, recipient=B)` to the issuer
+2. The issuer splits A's weight — A keeps half, B gets half
+3. The issuer records the delegation (A → B) in its delegation tree
+4. The issuer computes the new chain link and builds B's sturdy ref
+5. The issuer responds with `IntroduceResult(token=B's sturdy ref)`
+6. A forwards the token to B
 
 Weight splitting is how the issuer tracks outstanding references without centralized reference counting. The original weight (e.g., 1024) is halved at each delegation. When delegations return their weight (via `Release`), the issuer can determine when all references are accounted for.
 

--- a/projects/leden/protocol.md
+++ b/projects/leden/protocol.md
@@ -262,6 +262,8 @@ A sturdy reference is what you store to prove you held a capability. It contains
 
 The `token` is unique per delegation event — not per capability. When the issuer creates a capability, the first holder gets a token. When that holder delegates, the new holder gets a different token. Each token maps to exactly one node in the issuer's delegation tree.
 
+**The token is not the in-session capability ID.** Live capabilities have session-scoped IDs used in Call messages. If the token were reused as the capability ID, anyone who observes a Call on an unencrypted transport could construct a sturdy ref. The token must only appear in sturdy references and in the issuer's persistent store — never in Call, Return, or other session messages.
+
 ### Delegation Verification
 
 The delegation tree is the security boundary. Each node in the tree records: recipient identity, permissions, weight, revocation status, and parent node. The token is a lookup key into this tree.
@@ -272,13 +274,15 @@ When an endpoint receives a sturdy reference (during re-attachment, introduction
 
 **Step 1: Token lookup.** Look up the token in the issuer's persistent store. If not found → reject with `InvalidToken`. This proves the delegation event actually happened.
 
-**Step 2: Check presenter.** The tree node's `recipient` must match the endpoint presenting the sturdy reference. If mismatch → reject with `HolderMismatch`.
+**Step 2: Check object.** The sturdy ref's `object_id` must match the tree node's object. If mismatch → reject with `ObjectNotFound`. (The token is the real lookup key, but a mismatched object_id means the ref was tampered with or corrupted.)
 
-**Step 3: Check revocation.** Walk from the tree node up to the root, checking each ancestor's revocation status. If any ancestor is revoked → reject with `CapabilityRevoked`. (Revocation cascades — revoking a parent revokes all descendants.)
+**Step 3: Check presenter.** The tree node's `recipient` must match the endpoint presenting the sturdy reference. If mismatch → reject with `HolderMismatch`.
 
-**Step 4: Permission and expiry checks.** Verify the permissions in the sturdy ref are no broader than the tree node's permissions (can only narrow). Check expiry.
+**Step 4: Check revocation.** Walk from the tree node up to the root, checking each ancestor's revocation status. If any ancestor is revoked → reject with `CapabilityRevoked`. (Revocation cascades — revoking a parent revokes all descendants.)
 
-**Step 5: Accept.** Re-issue a live capability with the verified permissions and a fresh lease.
+**Step 5: Permission and expiry checks.** Verify the permissions in the sturdy ref are no broader than the tree node's permissions (can only narrow). Check expiry.
+
+**Step 6: Accept.** Re-issue a live capability with the verified permissions and a fresh lease.
 
 #### Example
 
@@ -299,11 +303,12 @@ B delegates to C (no attenuation, weight=128):
 ```
 
 When C presents their sturdy ref:
-1. Look up token_C → find tree node (recipient=C, permissions=0x03, parent=node_B)
-2. Presenter is C, recipient is C → match
-3. Walk up: node_B not revoked, node_A not revoked, root not revoked → ok
-4. Permissions 0x03 ≤ 0x03 → ok
-5. Accept, issue live capability
+1. Look up token_C → find tree node (recipient=C, permissions=0x03, object=O, parent=node_B)
+2. Claimed object_id=O matches tree node's object=O → ok
+3. Presenter is C, recipient is C → match
+4. Walk up: node_B not revoked, node_A not revoked, root not revoked → ok
+5. Permissions 0x03 ≤ 0x03 → ok
+6. Accept, issue live capability
 
 #### Security Properties
 

--- a/projects/leden/wire-format.md
+++ b/projects/leden/wire-format.md
@@ -196,6 +196,15 @@ Each message is a MessagePack map. Field IDs are permanent — once assigned, ne
 | 3 | recipient | bytes | Endpoint identity of the intended recipient |
 | 4 | attenuation | optional uint | Permission bitfield for the narrowed capability |
 
+### IntroduceResult (0x09)
+
+| Field | Name | Type | Notes |
+|-------|------|------|-------|
+| 0 | type | uint | `0x09` |
+| 1 | id | uint | Request ID (matches Introduce) |
+| 2 | token | bytes | Encoded sturdy reference for the recipient to present |
+| 3 | error | optional uint | Error code if introduction failed |
+
 ### Reattach (0x07)
 
 | Field | Name | Type | Notes |
@@ -509,7 +518,8 @@ Error codes from protocol.md, encoded as uint:
 | 10 | MalformedMessage |
 | 11 | InvalidNonce |
 | 12 | InvalidChain |
-| 13 | IssuerMismatch |
+| 13 | HolderMismatch |
+| 14 | IssuerMismatch |
 | 0x1000+ | Application(n - 0x1000) |
 
 Application error codes start at 0x1000 to leave room for future protocol-defined codes.

--- a/projects/leden/wire-format.md
+++ b/projects/leden/wire-format.md
@@ -238,10 +238,11 @@ Each sturdy reference in the `sturdy_refs` array is a MessagePack map:
 | 1 | object_id | bytes | Object this capability grants access to |
 | 2 | permissions | uint | Permission bitfield (after attenuation) |
 | 3 | nonce | bin(32) | 256-bit nonce proving issuance |
-| 4 | delegation_chain | array\<bin(32)\> | HMAC-SHA256 link hashes, one per delegation step |
-| 5 | expiry | optional uint | Unix timestamp (seconds), absent if no expiry |
+| 4 | delegation_path | array\<bytes\> | Endpoint identities, one per delegation step (including original holder) |
+| 5 | delegation_chain | array\<bin(32)\> | HMAC-SHA256 link hashes, one per delegation step |
+| 6 | expiry | optional uint | Unix timestamp (seconds), absent if no expiry |
 
-The `delegation_chain` array has at least one entry (the root link). Maximum length is implementation-defined (recommended: 32).
+`delegation_path` and `delegation_chain` must have the same length, at least 1. Maximum length is implementation-defined (recommended: 32).
 
 ### Call (0x10)
 

--- a/projects/leden/wire-format.md
+++ b/projects/leden/wire-format.md
@@ -219,6 +219,21 @@ Each entry in `results`:
 | 0 | capability | optional bytes | Live capability, if successful |
 | 1 | error | optional uint | Error code, if failed |
 
+### Sturdy Reference Encoding
+
+Each sturdy reference in the `sturdy_refs` array is a MessagePack map:
+
+| Field | Name | Type | Notes |
+|-------|------|------|-------|
+| 0 | issuer | bytes | Endpoint identity of the original issuer |
+| 1 | object_id | bytes | Object this capability grants access to |
+| 2 | permissions | uint | Permission bitfield (after attenuation) |
+| 3 | nonce | bin(32) | 256-bit nonce proving issuance |
+| 4 | delegation_chain | array\<bin(32)\> | HMAC-SHA256 link hashes, one per delegation step |
+| 5 | expiry | optional uint | Unix timestamp (seconds), absent if no expiry |
+
+The `delegation_chain` array has at least one entry (the root link). Maximum length is implementation-defined (recommended: 32).
+
 ### Call (0x10)
 
 | Field | Name | Type | Notes |
@@ -492,6 +507,9 @@ Error codes from protocol.md, encoded as uint:
 | 8 | Timeout |
 | 9 | VersionMismatch |
 | 10 | MalformedMessage |
+| 11 | InvalidNonce |
+| 12 | InvalidChain |
+| 13 | IssuerMismatch |
 | 0x1000+ | Application(n - 0x1000) |
 
 Application error codes start at 0x1000 to leave room for future protocol-defined codes.

--- a/projects/leden/wire-format.md
+++ b/projects/leden/wire-format.md
@@ -237,12 +237,8 @@ Each sturdy reference in the `sturdy_refs` array is a MessagePack map:
 | 0 | issuer | bytes | Endpoint identity of the original issuer |
 | 1 | object_id | bytes | Object this capability grants access to |
 | 2 | permissions | uint | Permission bitfield (after attenuation) |
-| 3 | nonce | bin(32) | 256-bit nonce proving issuance |
-| 4 | delegation_path | array\<bytes\> | Endpoint identities, one per delegation step (including original holder) |
-| 5 | delegation_chain | array\<bin(32)\> | HMAC-SHA256 link hashes, one per delegation step |
-| 6 | expiry | optional uint | Unix timestamp (seconds), absent if no expiry |
-
-`delegation_path` and `delegation_chain` must have the same length, at least 1. Maximum length is implementation-defined (recommended: 32).
+| 3 | token | bin(32) | 256-bit, unique per delegation event |
+| 4 | expiry | optional uint | Unix timestamp (seconds), absent if no expiry |
 
 ### Call (0x10)
 
@@ -517,10 +513,9 @@ Error codes from protocol.md, encoded as uint:
 | 8 | Timeout |
 | 9 | VersionMismatch |
 | 10 | MalformedMessage |
-| 11 | InvalidNonce |
-| 12 | InvalidChain |
-| 13 | HolderMismatch |
-| 14 | IssuerMismatch |
+| 11 | InvalidToken |
+| 12 | HolderMismatch |
+| 13 | IssuerMismatch |
 | 0x1000+ | Application(n - 0x1000) |
 
 Application error codes start at 0x1000 to leave room for future protocol-defined codes.


### PR DESCRIPTION
## Summary

This PR fundamentally redesigns the capability delegation and verification system in the Leden protocol. The previous HMAC chain-based approach is replaced with a simpler, more secure per-delegation-event token model backed by an issuer-maintained delegation tree.

## Key Changes

**Protocol Design (protocol.md)**
- Restructured the `Introduce` operation to be issuer-centric: the introducer (A) now sends the request to the issuer (C), not directly to the recipient (B). The issuer generates the token and responds, then A forwards it to B.
- Replaced the `nonce` field in sturdy references with a `token` field (256-bit, unique per delegation event, not per capability)
- Completely rewrote the "Delegation Verification" section with a new 6-step verification procedure:
  1. Token lookup in persistent store
  2. Object ID validation
  3. Presenter identity check (HolderMismatch)
  4. Revocation cascade walk
  5. Permission and expiry checks
  6. Live capability re-issuance
- Added detailed security analysis explaining why per-delegation tokens eliminate forgery, path substitution, and impersonation attacks
- Removed the "Why Not HMAC Chains" section explaining the limitations of the previous design (shared nonce, opaque hashes, path substitution complexity)
- Updated capability lifecycle documentation to reflect token generation and tree-based delegation recording
- Changed error codes: `InvalidNonce` → `InvalidToken`, added `HolderMismatch`

**Wire Format (wire-format.md)**
- Added `IntroduceResult (0x09)` message type with fields: type, id, token, error
- Added "Sturdy Reference Encoding" section documenting the wire format with fields: issuer, object_id, permissions, token (bin(32)), expiry
- Updated error code table to include `InvalidToken (11)`, `HolderMismatch (12)`, `IssuerMismatch (13)`

## Notable Implementation Details

- **Token uniqueness**: Each delegation event gets its own token, not shared across holders. This prevents any holder from computing valid-looking claims about other delegation paths.
- **Tree-based verification**: The issuer maintains a persistent delegation tree where each node records recipient, permissions, weight, revocation status, and parent. Verification walks this tree without needing the holder to provide path information.
- **Session vs. persistence separation**: Tokens only appear in sturdy references and the issuer's persistent store—never in live Call/Return messages. This prevents observers on unencrypted transports from constructing forged sturdy refs.
- **Weight splitting**: Delegation still uses weight halving for reference counting, but now the issuer controls the entire process rather than relying on chain-based verification.
- **Revocation cascading**: Revoking any node in the delegation tree immediately invalidates all descendants via the parent pointer walk in Step 4 of verification.

https://claude.ai/code/session_017hbeTLooSZTSuqgDeVQBvH