### PR TITLE
Document Raido chunk format versioning and cross-domain verification

### DIFF
--- a/projects/allgard/README.md
+++ b/projects/allgard/README.md
@@ -265,9 +265,35 @@ With it: Domain B re-executes the computation. Bilateral trust becomes bilateral
 
 ### Capability Negotiation
 
-Two domains agree to verifiable transforms during Leden capability negotiation. They agree on a Raido chunk format version. From then on, cross-domain Proofs for scripted transforms include the script hash, inputs, and outputs. The receiving domain re-executes to verify.
+Two domains agree to verifiable transforms during Leden capability negotiation. The `verifiable_transform` extension carries Raido version metadata:
+
+```
+Hello(ext=[verifiable_transform(raido_versions=[1,2], serialization_version=1)])
+Welcome(ext=[verifiable_transform(raido_versions=[1,2], serialization_version=1)])
+```
+
+Both sides advertise which [Raido chunk format versions](../raido/vm/chunk-format.md#version-compatibility) they can execute. The session uses the intersection. From then on, cross-domain Proofs for scripted transforms include the script hash, chunk format version, inputs, and outputs. The receiving domain re-executes to verify.
+
+**Version mismatch.** If the intersection is empty, the domains cannot mechanically verify each other's scripted transforms. They fall back to trust-based verification — Proof structure is checked (signature, causal link) but computation is not re-executed. This carries lower reputation weight. See [chunk format version compatibility](../raido/vm/chunk-format.md#what-happens-version-mismatch-scenarios) for the full breakdown.
+
+**Minting verification is not exempt.** Verifiable minting is mandatory (Conservation Law 1), but it requires version agreement to be mechanical. A domain whose minting scripts use chunk format v2 cannot be mechanically audited by a v1-only partner. The v1 partner can still verify Proof structure, bilateral transfer history, and audit gossip totals — but not re-execute the minting script. This is a real gap. Domains that want full mechanical auditability maintain minting scripts in the oldest version any active trading partner supports, or their partners upgrade.
 
 This is the same pattern as observation in Leden — negotiated, optional, composable. No domain is forced to support general verification. But every domain must support verifiable minting — that's not negotiable.
+
+### Supply Audit Version Metadata
+
+Supply audit entries carry the Raido chunk format version alongside each script hash:
+
+| Field | Type | Purpose |
+|-------|------|---------|
+| `script_hash` | `[u8; 32]` | Content hash of the minting/burning script |
+| `chunk_version` | `uint` | Chunk format version the script was compiled under |
+| `inputs` | `bytes` | Serialized inputs to the script |
+| `outputs` | `bytes` | Claimed outputs |
+
+A verifying domain fetches the script (via Leden content store), checks that its content hash matches, confirms it can execute that chunk version, and re-runs it. If the verifier doesn't support the chunk version, it cannot mechanically verify that entry — but can still cross-check totals against bilateral transfer history and audit gossip.
+
+Historical audit entries remain valid indefinitely. The script hash pins the exact bytecode; the chunk version pins the execution semantics. A verifier needs a VM that supports that version to re-execute. In practice, the set of chunk versions used across the network grows slowly — VMs carry support for all released versions.
 
 ## Prior Art and Differentiation
 

--- a/projects/raido/vm/chunk-format.md
+++ b/projects/raido/vm/chunk-format.md
@@ -80,6 +80,92 @@ const chunk = try vm.compile("script.raido", source)
 const chunk = try vm.load(bytecode_bytes)
 ```
 
+## Version Compatibility
+
+The format version in the chunk header is an integer, starting at 1. It determines bytecode encoding, constant pool layout, and instruction semantics. Two VMs can re-execute each other's chunks only if they agree on the format version.
+
+### Compatibility Matrix
+
+| Relationship | Compatible? | Notes |
+|-------------|-------------|-------|
+| Same version | Yes | Bitwise-identical execution guaranteed |
+| Newer VM, older chunk | Yes, with constraints | VM must include the older version's instruction semantics. Execution uses the chunk's declared version, not the VM's latest. |
+| Older VM, newer chunk | No | `vm.load()` returns `VersionMismatch`. The VM cannot execute instructions it doesn't understand. |
+
+A VM that supports versions 1–3 can load and execute a v1 chunk using v1 semantics. It cannot "upgrade" the chunk — it runs it as-is. This is what makes cross-domain verification work: both sides execute the same bytecode with the same version's rules.
+
+### Version Metadata in Chunks
+
+The chunk header carries:
+
+| Field | Type | Purpose |
+|-------|------|---------|
+| `magic` | `[u8; 4]` | Format identifier (`RADO`) |
+| `version` | `u16` | Chunk format version |
+| `content_hash` | `[u8; 32]` | SHA-256 of bytecode + constants + prototypes |
+
+The version field is checked first during `vm.load()`. If the VM doesn't support that version, it rejects immediately — before reading any other section. This prevents misinterpreting bytecode encoded under unknown rules.
+
+### Cross-Domain Version Agreement
+
+When two domains negotiate verifiable transforms over [Leden](../../leden/), they include Raido version support in the capability negotiation:
+
+```
+Hello(min=1, max=1, ext=[content_store, verifiable_transform])
+Welcome(version=1, ext=[content_store, verifiable_transform])
+```
+
+The `verifiable_transform` extension carries additional parameters during negotiation:
+
+| Parameter | Type | Purpose |
+|-----------|------|---------|
+| `raido_versions` | `array<uint>` | Chunk format versions this domain can execute |
+| `raido_serialization_version` | `uint` | VM serialization format version (for snapshot exchange) |
+
+Both domains compute the intersection of supported versions. Cross-domain Proofs for scripted transforms must use a chunk format version both sides support. If the intersection is empty, verifiable transforms are unavailable for this session — the domains fall back to trust-based verification (Proof structure only, no re-execution).
+
+### What Happens: Version Mismatch Scenarios
+
+**Domain A has a v2 script, Domain B only runs v1.**
+
+B cannot verify A's v2 transform. Three options, in order of preference:
+
+1. **A provides a v1-compatible script.** If the minting logic can be expressed in v1, A maintains both versions. The v1 script has a different content hash — both hashes are registered in A's supply audit as equivalent minting authorities for the same asset type.
+2. **B upgrades.** B deploys a VM that supports v2. This is a software update, not a protocol change.
+3. **Fall back to trust-based.** B accepts A's Proof structurally but cannot mechanically verify the computation. B's trust model accounts for this — unverified transforms carry lower weight in reputation scoring. This is the default when `verifiable_transform` negotiation fails.
+
+No silent degradation. B always knows whether it verified mechanically or accepted on trust. The distinction is recorded in B's local audit log.
+
+**A domain upgrades its minting script from v1 to v2.**
+
+The old v1 script's content hash remains valid for historical audits. Supply audit entries reference the script hash that produced them — a v1 mint stays linked to the v1 script, a v2 mint to the v2 script. Verifying domains fetch the script version that matches each audit entry's hash.
+
+### Script Migration
+
+Old scripts are not migrated. A v1 chunk stays a v1 chunk forever. Its content hash is its identity, and changing the bytecode changes the hash, which breaks the audit trail.
+
+If a domain wants to move from v1 minting logic to v2, it deploys a new script. The new script gets a new content hash. The domain's supply audit records which script hash authorized each mint/burn event. Historical entries remain verifiable against the original script.
+
+This means a verifying domain may need to support older chunk format versions to audit historical mints. In practice, this is bounded — a domain only needs to verify scripts from its active trading partners, and the set of versions in use across the network is small.
+
+### Serialization Compatibility
+
+VM serialization (snapshots) has its own version header, separate from the chunk format version. A snapshot includes:
+
+| Field | Purpose |
+|-------|---------|
+| `serialization_version` | Snapshot format version |
+| `chunk_version` | The chunk format version of the bytecode being executed |
+| `chunk_hash` | Content hash of the bytecode (for re-loading) |
+
+Deserialize rejects unknown serialization versions with `VersionMismatch`. The chunk format version in the snapshot tells the restoring VM which instruction semantics to use — the VM must support that chunk version to resume execution.
+
+**Forward compatibility:** New serialization versions may add fields. Old VMs reject them (unknown version). No attempt to skip unknown fields — the snapshot format is not self-describing.
+
+**Backward compatibility:** A newer VM can deserialize older snapshots if it retains the older serialization logic. Each serialization version is a distinct code path, not a layered extension. This keeps deserialization simple and auditable — no accumulated migration transforms.
+
+**Policy:** Serialization versions are supported for as long as any actively-traded scripts might have snapshots in that format. In practice, the VM ships with support for the current version and the previous one. Domains that need longer support pin their VM version.
+
 ## Debug Sections
 
 Optional. Stripped by default in release, included with a compile flag.

--- a/projects/raido/vm/chunk-format.md
+++ b/projects/raido/vm/chunk-format.md
@@ -142,11 +142,15 @@ The old v1 script's content hash remains valid for historical audits. Supply aud
 
 ### Script Migration
 
-Old scripts are not migrated. A v1 chunk stays a v1 chunk forever. Its content hash is its identity, and changing the bytecode changes the hash, which breaks the audit trail.
+A chunk's content hash is its identity. Changing bytecode changes the hash, which breaks audit references. So migration must be provable — any domain can independently reproduce the translation and verify the output hash.
 
-If a domain wants to move from v1 minting logic to v2, it deploys a new script. The new script gets a new content hash. The domain's supply audit records which script hash authorized each mint/burn event. Historical entries remain verifiable against the original script.
+**When migration works:** version bumps that change encoding or instruction layout but not semantics. A mechanical `v1 → v2` translation is a deterministic function of the input bytecode. Any party can run it and confirm the output matches the claimed new hash.
 
-This means a verifying domain may need to support older chunk format versions to audit historical mints. In practice, this is bounded — a domain only needs to verify scripts from its active trading partners, and the set of versions in use across the network is small.
+**When it doesn't:** version bumps that change instruction semantics. If v2 redefines what an instruction means, there's no mechanical translation. The old script stays at v1; domains that need to verify it must support v1.
+
+**Equivalence registration.** A domain that migrates a script publishes both hashes (old and new) as equivalent minting authorities for the same asset type. Verifying domains confirm equivalence by running the migration themselves. No trust required.
+
+Concrete migration tooling is deferred until the first version bump — the mechanism depends on what actually changes between versions.
 
 ### Serialization Compatibility
 


### PR DESCRIPTION
## Summary

This PR adds comprehensive documentation for Raido chunk format versioning and its role in cross-domain verifiable transforms. It establishes the versioning strategy, compatibility rules, and integration with Allgard's supply audit system.

## Key Changes

- **Chunk Format Versioning** (`chunk-format.md`): Added "Version Compatibility" section covering:
  - Format version semantics and compatibility matrix (same version, newer VM with older chunk, older VM with newer chunk)
  - Version metadata in chunk headers (magic, version, content_hash)
  - Cross-domain version negotiation via Leden capability exchange
  - Version mismatch scenarios and resolution strategies (provide compatible script, upgrade VM, fall back to trust-based verification)
  - Script migration mechanics and equivalence registration
  - Serialization format versioning separate from chunk format versioning
  - Forward/backward compatibility policies for snapshots

- **Allgard Supply Audit Integration** (`allgard/README.md`): Updated capability negotiation and audit documentation:
  - Clarified that `verifiable_transform` extension carries Raido version metadata during Leden negotiation
  - Documented version intersection logic for session compatibility
  - Added explicit note that verifiable minting requires version agreement for mechanical verification
  - Added "Supply Audit Version Metadata" section showing chunk_version field in audit entries
  - Explained how verifiers use chunk version to determine if re-execution is possible

## Notable Details

- **No silent degradation**: Domains always know whether computation was mechanically verified or accepted on trust
- **Content hash as identity**: Script migration is provable only when semantics are preserved; breaking changes require maintaining both versions
- **Audit trail preservation**: Historical entries remain valid indefinitely, pinned by both script hash and chunk version
- **Practical policy**: VMs ship with current and previous serialization versions; domains needing longer support pin their VM version

https://claude.ai/code/session_01WndCc8XLPri7hAmGRWiz6Q