### PR TITLE
Add convention registry, binary formats, and resource limits docs

### DIFF
--- a/projects/gdl/GDL-extensions.md
+++ b/projects/gdl/GDL-extensions.md
@@ -220,6 +220,66 @@ mesh_2d	2D collision polygons (line segments, shapes)	Platformer level geometry,
 mesh_3d	3D collision mesh (triangles)	Complex 3D environments
 navmesh	Walkable area graph	Pathfinding for NPCs and AI
 
+### Binary Formats
+
+Layer data blobs are content-addressed, like assets. Each type has a defined binary encoding so clients can parse them without format negotiation.
+
+**Heightmap:**
+```
+Header:
+  width  (u16)  — columns
+  height (u16)  — rows
+  scale  (f32)  — meters per cell (horizontal)
+  y_scale (f32) — meters per unit of elevation
+Data:
+  elevations[width * height] (each f32, row-major)
+```
+Total size: 12 + (width × height × 4) bytes. A 256×256 heightmap is ~256 KB.
+
+**Tilemap 2D:**
+```
+Header:
+  width      (u16) — columns
+  height     (u16) — rows
+  tile_bits  (u8)  — bits per tile ID (8 or 16)
+  layer_count (u8) — number of tile layers (ground, decoration, etc.)
+  _pad       (2 bytes)
+Palette ref:
+  palette    (32 bytes) — SHA-256 hash of tile palette definition
+Data (per layer):
+  tiles[width * height] (each u8 or u16 per tile_bits, row-major)
+```
+Tile ID 0 is always empty/transparent. The palette blob maps tile IDs to names, collision flags, and animation frames — a separate content-addressed asset that multiple tilemaps can share.
+
+**Voxel 3D (chunked):**
+```
+Chunk header:
+  cx, cy, cz (each i16) — chunk coordinates in chunk-space
+  size       (u8)       — cells per edge (typically 16)
+  _pad       (1 byte)
+  palette    (32 bytes) — SHA-256 hash of block palette definition
+Data:
+  blocks[size^3] (each u16, XZY order — x varies fastest, then z, then y)
+```
+Block ID 0 is always air. XZY order optimizes for column-based rendering (vertical slices are contiguous). Each chunk is a separate content-addressed blob. A 16³ chunk with u16 blocks is 8 KB + 40 bytes header.
+
+**Mesh 2D:**
+```
+Header:
+  vertex_count   (u16)
+  segment_count  (u16)
+Vertices:
+  positions[vertex_count] (each 2 × f32 — x, y)
+Segments:
+  indices[segment_count] (each 2 × u16 — start vertex, end vertex)
+  flags[segment_count]   (each u8 — 0x01: one-way-up, 0x02: one-way-down)
+```
+Defines 2D collision geometry as line segments. One-way flags enable platforms you can jump through from below.
+
+**Mesh 3D and Navmesh** use standard glTF binary format (`.glb`) — no custom encoding. glTF is already GPU-ready and well-supported. The content-addressed blob is the `.glb` file.
+
+All integer fields are little-endian. All float fields are IEEE 754 little-endian. Layer blobs carry no version field — the layer `type` in the region description implies the format. If the format ever changes, it becomes a new type name.
+
 Layer data is content-addressed, like assets. Large layers (voxel worlds) are chunked — the client fetches chunks within its viewport. Layer updates arrive through the observation stream:
 
 layer_update	Layer id + changed chunk hashes	Terrain/block modifications

--- a/projects/gdl/GDL.md
+++ b/projects/gdl/GDL.md
@@ -208,7 +208,57 @@ Tagged	`tags: [...]` (string list)	Filter, search, category display
 
 Values are always absolute, never percentages. `health: 30` means 30 units, not 30%. `health` without `health_max` means the maximum is unknown — the client shows the number but can't render a bar. This matters for cross-domain consistency.
 
-Specific property names (`health`, `level`, `hostile`, `locked`, `price`) are **conventions**, not protocol. A game domain uses `health`. An IoT domain uses `temperature`. A project tracker uses `progress`. The protocol defines patterns. Communities define conventions.
+Specific property names are **conventions**, not protocol. A game domain uses `health`. An IoT domain uses `temperature`. A project tracker uses `progress`. The protocol defines patterns. Communities define conventions.
+
+### Initial Convention Registry
+
+These are the starting conventions — properties that clients can recognize and render smartly out of the box. Not exhaustive. Not required. Domains define their own. But if you use `health`, use it like this.
+
+**Bounded numeric (X + X_max → bar)**
+
+| Property | Type | Meaning |
+|----------|------|---------|
+| `health` + `health_max` | int | Hit points. Client renders a bar, typically colored via `color.danger` token. |
+| `energy` + `energy_max` | float | Stamina, mana, fuel — any expendable resource. |
+| `progress` + `progress_max` | int | Task completion, crafting timer, loading state. |
+| `durability` + `durability_max` | int | Equipment wear. |
+| `capacity` + `capacity_max` | int | Container fullness, ammo remaining. |
+
+**State (string → badge/label)**
+
+| Property | Type | Meaning |
+|----------|------|---------|
+| `faction` | string | Affiliation. Client may color-code by faction. |
+| `mood` | string | Emotional state ("hostile", "friendly", "neutral"). |
+| `status` | string | General state ("alive", "dead", "stunned", "sleeping"). |
+
+**Flags (bool → toggle/indicator)**
+
+| Property | Type | Meaning |
+|----------|------|---------|
+| `hostile` | bool | Whether the entity is hostile to the observer. Clients may apply `entity.hostile_tint`. |
+| `locked` | bool | Whether the entity is locked (doors, chests). |
+| `hidden` | bool | Whether the entity is hidden. Clients may reduce opacity or hide the label. |
+| `interactive` | bool | Whether the entity can be interacted with right now. Clients may apply `entity.interactive_highlight`. |
+
+**Numeric (number → display)**
+
+| Property | Type | Meaning |
+|----------|------|---------|
+| `level` | int | Power level, tier, floor number. |
+| `price` | int | Cost in the domain's currency. |
+| `weight` | float | Mass or encumbrance. |
+| `speed` | float | Movement speed multiplier (1.0 = normal). |
+
+**Reference (ref → link/association)**
+
+| Property | Type | Meaning |
+|----------|------|---------|
+| `owner` | ref | Entity that owns this one. |
+| `equipped_by` | ref | Entity that has this equipped. |
+| `contained_in` | ref | Container this entity is inside. |
+
+The pattern matters more than the name. A client that understands bounded numeric renders a bar for `shield` + `shield_max` without ever seeing "shield" in this list. The registry bootstraps recognition; the patterns provide forward compatibility.
 Affordances
 
 Affordances are what make GDL interactive. They answer: "what can I do here?"
@@ -614,6 +664,23 @@ The security model is `<iframe sandbox="allow-scripts">`:
 - No network. CSP: `default-src 'self' blob: data:; connect-src 'none'`. No phone home, no exfiltrate, no external scripts.
 
 Same model as Stripe payment forms, YouTube embeds. Browser-enforced, battle-tested.
+
+### Resource Limits
+
+Sandboxing prevents escape. Resource limits prevent abuse. A panel that mines crypto or allocates 2 GB of ArrayBuffers is sandboxed but still ruins the player's experience.
+
+Clients enforce per-panel resource budgets:
+
+| Resource | Default limit | Notes |
+|----------|--------------|-------|
+| CPU | 50ms per second (5% of one core) | Measured via `performance.now()` deltas or the Performance API. Panels that exceed the budget get throttled — the client suspends the iframe's execution until the next budget window. |
+| Memory | 64 MB heap | Enforced via `Cross-Origin-Embedder-Policy` where available, or monitored via `performance.measureUserAgentSpecificMemory()`. Exceeding = panel killed, fallback text shown. |
+| DOM nodes | 10,000 | Prevents DOM-bombing. Client can poll `document.querySelectorAll('*').length` via a monitoring script injected before the panel loads. Exceeding = panel killed. |
+| Storage | None | No localStorage, no IndexedDB (`sandbox` without `allow-same-origin` already prevents this). |
+
+These are client-enforced defaults, not protocol fields. A client can raise or lower them. A mobile client might set 32 MB memory and 25ms/s CPU. A desktop client might allow 128 MB for a complex crafting panel. The domain doesn't negotiate resource limits — it authors a panel that works within reasonable bounds, the same way a web page doesn't negotiate CPU time with the browser.
+
+When a panel exceeds its budget, the client kills the iframe and shows the panel's `fallback` text. The player sees "Skills: Strength 5, Agility 3, Magic 7" instead of a blank frame. This is the same recovery path as an asset that fails to load — degrade to the simpler representation.
 postMessage Protocol
 
 Panel → Client:

--- a/projects/raido/language/stdlib.md
+++ b/projects/raido/language/stdlib.md
@@ -21,9 +21,9 @@ These are part of the language, not an opt-in module. A Raido VM without these i
 
 `tostring(v)` — converts any value to string.
 
-`tonumber(v)` — string/int → number. Returns nil on failure.
+`int(v)` — string/number → int (truncates). Returns nil on failure.
 
-`toint(v)` — string/number → int (truncates). Returns nil on failure.
+`number(v)` — string/int → number. Returns nil on failure.
 
 `len(v)` — string byte length, array length, or map entry count. TypeError on other types.
 

--- a/projects/raido/vm/architecture.md
+++ b/projects/raido/vm/architecture.md
@@ -69,8 +69,10 @@ Arena is a flat `[u8]` with a bump pointer (`top: u32`). Every object starts wit
 Object header (4 bytes):
   type (u8)   — same as value tag (4=string, 5=array, 6=map, 7=closure)
   _pad (u8)   — reserved, zero
-  size (u16)  — object body size in bytes (max 64 KB per object)
+  size (u16)  — object body size in bytes (max 65535 bytes per object)
 ```
+
+**The `size` field is the hard limit.** A u16 caps every object at 64 KB. The `len` and `cap` fields inside object bodies are u32 for alignment and simplicity, but they can never describe an object that exceeds the header's u16 `size`. An array with `cap` slots totaling more than 65535 bytes of body can't exist — the allocator rejects it with `ArenaExhausted` before writing the header. This is intentional: scripts that need more than 64 KB in a single object are doing something the VM isn't designed for.
 
 All objects are 4-byte aligned. The bump pointer advances by `4 (header) + size`, rounded up to 4-byte alignment.
 
@@ -128,7 +130,20 @@ How it works:
 
 **What's frame-local:** everything above `frame_base` — temporary strings from interpolation, arrays built during the frame, intermediate results.
 
-If a script stores a frame-local value into a global, that value becomes a dangling offset after `frame_end()`. This is a **host bug**, not a VM bug. The rule: don't store frame-local arena objects into persistent state. The VM doesn't enforce this — enforcement would require a write barrier, which contradicts "lightweight." Document it clearly in the host API docs.
+If a script stores a frame-local value into a global, that value becomes a dangling offset after `frame_end()`. This is a **host bug**, not a VM bug. The rule: don't store frame-local arena objects into persistent state.
+
+The VM doesn't enforce this by default — a write barrier on every store contradicts "lightweight." But finding these bugs in production is painful, so the VM supports an optional debug mode:
+
+```rask
+const vm = raido.Vm.new(raido.Config {
+    arena_size: 256.kilobytes(),
+    debug_frame_writes: true,  // off by default
+})
+```
+
+When `debug_frame_writes` is enabled, `SET_GLOBAL` and `SET_UPVALUE` validate that any arena offset in the stored value is below `frame_base`. If the value points above `frame_base` (i.e., into frame-local memory), the VM raises a `FrameStoreViolation` error instead of silently creating a dangling reference.
+
+The cost: one comparison per `SET_GLOBAL` / `SET_UPVALUE` that touches an arena-backed value (tags 4–7). Negligible in debug builds, but not zero — this is why it's off by default. Ship with it off. Debug with it on.
 
 ## Resource Limits
 
@@ -294,7 +309,7 @@ Jumps are relative to the *next* instruction (PC after decode, before jump).
 | Op | Fmt | Semantics |
 |----|-----|-----------|
 | `CALL A B C` | ABC | Call `R[A]` with args `R[A+1..A+B]`. `B` = arg count. Result stored in `R[A]`. Increment call depth. |
-| `TAIL_CALL A B` | ABC | Same as `CALL` but reuses current frame. No call depth increment. |
+| `TAIL_CALL A B` | ABC | Same as `CALL` but reuses current frame. No call depth increment. Compiler constraint: only emitted in tail position (the last expression before `RETURN`). |
 | `RETURN A` | ABx | Return `R[A]` to caller. If `A = 255`, return `nil`. Decrement call depth. Pop frame, restore PC. |
 | `CLOSURE A Bx` | ABx | `R[A] = new closure` from prototype `Bx`. Captures upvalues per prototype's upvalue descriptor list. |
 
@@ -343,6 +358,7 @@ Every runtime error is a `raido.ScriptError` with a `kind` enum and a message st
 | `CoroutineDead` | Resumed a finished coroutine |
 | `ReadOnlyField` | Wrote to a read-only host ref field |
 | `ScriptError` | Raised by `error(msg)` in script code |
+| `FrameStoreViolation` | Stored a frame-local value into persistent state (debug mode only) |
 | `HostError` | Raised by a host function |
 
 All errors carry: kind, message (string), and a stack trace (array of `{file, line, function}` if debug info is present, `{proto_idx, pc_offset}` if not).
@@ -360,3 +376,5 @@ Single-pass compiler. Source → bytecode in one walk. No AST. Same architecture
 5. **Output.** Chunk (see [chunk-format.md](chunk-format.md)).
 
 No AST means no intermediate representation, no memory proportional to source size. The compiler holds the current token, the previous token, and the scope stack. Memory use is O(scope depth), not O(program size).
+
+**Tail call constraint.** The compiler only emits `TAIL_CALL` when a call expression is in tail position — the last expression in a function body, directly before an implicit or explicit `return`. Calls inside `try` blocks, inside operand positions, or before further statements get a regular `CALL`. This is a compile-time structural check, not an optimization heuristic. A `TAIL_CALL` in non-tail position would corrupt the caller's frame, so the compiler must never emit one there.


### PR DESCRIPTION
This PR expands documentation across three projects with concrete specifications for conventions, binary data formats, and resource management.

## Summary
Added comprehensive documentation for GDL property conventions, binary layer format specifications, Raido VM resource limits and debug features, and clarified several implementation details across the codebase.

## Key Changes

**GDL (projects/gdl/GDL.md)**
- Added "Initial Convention Registry" section defining standard property patterns:
  - Bounded numeric properties (health, energy, progress, durability, capacity)
  - State properties (faction, mood, status)
  - Boolean flags (hostile, locked, hidden, interactive)
  - Numeric properties (level, price, weight, speed)
  - Reference properties (owner, equipped_by, contained_in)
- Added "Resource Limits" section documenting per-panel budgets:
  - CPU: 50ms per second (5% of one core)
  - Memory: 64 MB heap default
  - DOM nodes: 10,000 limit
  - Storage: None (sandbox prevents it)
- Clarified that resource limits are client-enforced defaults, not protocol fields

**GDL Extensions (projects/gdl/GDL-extensions.md)**
- Added "Binary Formats" section with detailed specifications for layer data:
  - Heightmap format (u16 width/height, f32 scale, elevation data)
  - Tilemap 2D format (tile bits, layer count, palette hash, tile data)
  - Voxel 3D chunked format (chunk coordinates, block palette, XZY-ordered blocks)
  - Mesh 2D format (vertices, segments with one-way flags)
  - Mesh 3D and Navmesh use standard glTF binary format
- Specified all integer fields as little-endian and floats as IEEE 754

**Raido VM (projects/raido/vm/architecture.md)**
- Clarified object header `size` field: u16 caps every object at 65535 bytes (64 KB)
- Added optional debug mode `debug_frame_writes` to catch frame-local value leaks into persistent state
- Documented the debug mode's validation behavior and negligible performance cost
- Added `FrameStoreViolation` error kind to error enum

**Raido Language (projects/raido/language/stdlib.md)**
- Renamed `tonumber()` → `number()` and `toint()` → `int()` for clarity
- Updated function descriptions to match new names

**Raido Compiler (projects/raido/vm/architecture.md)**
- Added compiler constraint documentation: `TAIL_CALL` only emitted in tail position
- Clarified that tail call constraint is a compile-time structural check, not an optimization heuristic
- Explained why non-tail-position `TAIL_CALL` would corrupt the caller's frame

## Notable Details
- Convention registry emphasizes patterns over specific names — clients recognize bounded numeric properties by structure, not by name
- Resource limits degrade gracefully: panels exceeding budgets show fallback text rather than blank frames
- Binary formats are content-addressed and version-implicit (format determined by layer type)
- Debug frame write validation is opt-in to preserve lightweight VM design in production

https://claude.ai/code/session_013V9nYGtcEGXmBdvqUef7ef