### PR TITLE
Add cycle detection, error policies, epochs, and gossip scoring

### DIFF
--- a/projects/allgard/CONSERVATION.md
+++ b/projects/allgard/CONSERVATION.md
@@ -108,6 +108,26 @@ Even if a Transform is technically valid, you can't execute 10,000 transfers per
 
 Physics has the speed of light. We have rate limits.
 
+### Time Window Semantics
+
+**Sliding window, not bucketed.** Rate limits use a sliding window — the count of operations in the last N seconds, not "operations since the start of this minute." Bucketed windows create burst-at-boundary problems: an entity spends its budget at 11:59:59, then again at 12:00:00. Sliding windows prevent this by construction.
+
+**Implementation: sliding window log.** The domain maintains a timestamped log of operations per entity per operation type. To check the rate: count entries in `[now - window, now]`. To keep memory bounded: evict entries older than the window on every check. This is O(n) in the number of operations within the window, which is bounded by the rate limit itself.
+
+**Default windows and rates:**
+
+| Operation type | Window | Default max rate | Rationale |
+|---------------|--------|-----------------|-----------|
+| Transform (mutation) | 1 second | 100/s per entity | Covers game-loop-speed mutations. Most entities won't hit this. |
+| Transform (transfer) | 1 second | 10/s per entity | Transfers are heavier — cross-domain coordination, proof generation. |
+| Grant creation | 1 second | 50/s per entity | Grants are lightweight but shouldn't be spammable. |
+| Grant revocation | 1 second | 50/s per entity | Revocations should never be rate-limited in practice, but a ceiling prevents abuse. |
+| Introduction | 30 days | See Law 7 | Law 7 governs introduction rates with its own parameters. |
+
+**Per-second vs per-window.** Most operation types use a 1-second sliding window because the threat is burst abuse — a runaway script hammering mutations. The window is short enough that normal gameplay never notices it. Introduction uses a 30-day window because the threat is sustained graph manipulation, not bursts.
+
+**Configurable, but must exist.** A domain can raise or lower any rate limit. The runtime rejects configurations without a rate limit for any operation type. Setting a rate to 0 disables that operation type entirely — valid for domains that don't support transfers, for example. Setting a rate to `u32::MAX` is permissive but still technically bounded.
+
 ### Why Not Gas
 
 I considered a gas model (like Ethereum) but rejected it. Gas is UX poison — it makes every action cost something, which kills casual interaction. Rate limits cover the abuse case (no infinite loops, no spam) without burdening normal use.

--- a/projects/allgard/PRIMITIVES.md
+++ b/projects/allgard/PRIMITIVES.md
@@ -97,6 +97,40 @@ This is a Grant from the player to the backup domain — scoped to mirror and re
 
 Without a backup, home domain failure is permanent loss. That's the honest tradeoff. But with a backup, it's a recoverable event — same as a disk failure with a RAID mirror.
 
+### Key Compromise Propagation
+
+When an Owner's key is compromised, the home domain must propagate revocation to every domain where the Owner has active sessions, outstanding Grants, or leased objects. This is the hardest revocation case — it's time-critical and cross-domain.
+
+**Revocation flow:**
+
+1. **Owner or home domain detects compromise.** The Owner reports a compromised key (out-of-band — new key signed by backup key, admin action, etc.), or the home domain detects anomalous behavior (impossible concurrent sessions, operations from conflicting locations).
+
+2. **Home domain issues `KeyRevocation(owner_id, compromised_key, evidence, new_key)`** to all domains it has bilateral relationships with. This is a broadcast, not targeted — the home domain may not know every domain the Owner visited (Grants can chain through intermediaries). The message includes:
+   - The Owner identity being revoked
+   - The compromised public key
+   - Evidence: signed statement from the backup key, or from the home domain's admin key
+   - The replacement public key (if available) or `null` (Owner disabled pending re-keying)
+
+3. **Receiving domains apply synchronous revocation strategy** (see [Revocation](#revocation)). Key revocation is always synchronous — the strictest strategy, regardless of what was negotiated for other Grant types.
+
+4. **Receiving domains propagate to their trading partners.** If Domain B received a Grant from the compromised Owner and delegated a sub-Grant to Domain C, Domain B revokes the sub-Grant and forwards the `KeyRevocation` to Domain C. Propagation follows the Grant delegation graph.
+
+**Propagation rules:**
+
+| Situation | Action |
+|-----------|--------|
+| Active session from compromised key | Terminate immediately. All in-flight operations rejected. |
+| Outstanding Grants from compromised Owner | Revoke all. Sub-Grants revoked transitively. |
+| Leased objects from compromised Owner | Freeze in place. No mutations allowed until new key confirms or lease expires. Objects return to home domain on lease expiry if no new key is presented. |
+| Objects transferred *to* compromised Owner (completed transfers) | No clawback. Completed transfers are final (Law 4 — sequential history). The compromised key may have already moved them. The home domain's recourse is through the replacement key. |
+| Pending transfers involving compromised Owner | Abort. Escrow releases back to source. |
+
+**Timing.** Key revocation is the one case where I accept the cost of synchronous cross-domain coordination. A compromised key can cause unbounded damage if revocation is eventual. The target: all direct trading partners notified within 5 seconds. Transitive propagation (via Grant delegation chains) adds latency per hop — the depth of the Grant graph determines total propagation time, but each hop is bounded by the synchronous revocation timeout (default: 10s).
+
+**Without a backup key.** If the Owner has no backup key and the home domain's admin issues the revocation, the Owner identity is effectively dead. All Grants revoked, all sessions terminated, leased objects frozen until lease expiry. The Owner must create a new identity and re-establish relationships from scratch. This is intentionally harsh — it incentivizes backup keys.
+
+**Replay protection.** `KeyRevocation` messages include a monotonic sequence number per Owner (stored at the home domain). Receiving domains reject revocations with a sequence number ≤ the last seen revocation for that Owner. This prevents an attacker from replaying an old revocation to disrupt a legitimate key rotation.
+
 ### Owner Wallet
 
 The ultimate fallback: you hold your own proof of ownership locally.

--- a/projects/allgard/TRUST.md
+++ b/projects/allgard/TRUST.md
@@ -130,6 +130,34 @@ This means: a trusted domain that had years of history with an introduction and 
 
 All externally verifiable from transaction records and gossip timestamps. Nothing self-reported.
 
+#### Reference Aggregation Function
+
+Domains can override this with their own scoring, but the runtime ships a default so the system works without configuration.
+
+**Composite reputation score** (0.0–1.0):
+
+```
+score = w_success * success_rate
+      + w_volume  * volume_factor
+      + w_history * history_factor
+      + w_response * response_factor
+```
+
+| Component | Weight | Computation |
+|-----------|--------|-------------|
+| `success_rate` | 0.4 | `1.0 - (failure_count / total_introductions)`. Undefined (0.0) if `total_introductions < 5`. |
+| `volume_factor` | 0.2 | `min(1.0, ln(1 + total_introductions) / ln(1 + 500))`. Logarithmic — 500 introductions saturates the score. Prevents gaming by volume alone. |
+| `history_factor` | 0.2 | `min(1.0, avg_pre_introduction_history_days / 180)`. Saturates at 6 months average. Rewards domains that take time before introducing. |
+| `response_factor` | 0.2 | `1.0 - min(1.0, avg_fraud_response_hours / 48)`. Saturates at 48 hours. Faster fraud response = higher score. Undefined (0.5) if no fraud events. |
+
+**Minimum sample size.** A domain with fewer than 5 total introductions gets a score of `null` — insufficient data, not a score of 0. Domains should treat `null` scores as "unknown" and apply their stranger-level trust defaults, not penalize.
+
+**Decay.** Scores are computed over a rolling 365-day window. Introductions older than a year don't count. A domain that was excellent 3 years ago but inactive since is an unknown, not a trusted entity.
+
+**Why these weights:** Success rate dominates (0.4) because it's the most direct signal. Volume, history depth, and response time split the remaining 0.6 equally — they're supporting evidence that contextualizes the success rate. A 95% success rate over 500 introductions with deep pre-introduction history and fast fraud response is qualitatively different from 95% over 10 introductions with shallow history.
+
+**Override semantics.** A domain can replace this function entirely. The only constraint: the replacement must produce a value in [0.0, 1.0] and must be computed from externally verifiable inputs (the metrics above). A domain that scores reputation using self-reported data is making a local decision — other domains aren't obligated to trust it.
+
 A domain with a 95% success rate over 500 introductions is a reliable introducer. A domain with 3 introductions total tells you nothing. A domain whose last 5 introductions were all fraudulent is actively dangerous. A domain with a 90% success rate but fast response times and long pre-introduction histories is honest but operating in a tough neighborhood.
 
 ### Why Introduce Anyone?
@@ -383,7 +411,31 @@ I initially called this "hard to fix." It's not — because the introduction gra
 
 **Downstream fraud score.** Domains can track not just direct introduction failures, but introduction failures N hops downstream. B's direct introductions might all look clean — but if B's introductions consistently lead to fraud two hops later, that's a measurable anomaly. The transparent graph makes this computable.
 
-The score naturally attenuates with distance — one hop is strong signal, two hops is weaker, three hops is noise. But the cutout pattern specifically creates a two-hop signature that's detectable over repeated attacks.
+#### Attenuation Curve
+
+Accountability decays exponentially with introduction distance. The **downstream fraud attribution weight** for a fraud event at hop distance `d` from the introducer:
+
+```
+weight(d) = { 1.0   if d = 1  (direct introduction)
+            { 0.25  if d = 2  (one intermediary)
+            { 0.0   if d ≥ 3  (too distant to attribute)
+```
+
+**Why these specific values:**
+
+- **1-hop (weight 1.0):** Direct introduction. Full accountability. You vouched for this domain, you own the outcome.
+- **2-hop (weight 0.25):** One intermediary. Detectable as a pattern over multiple incidents, but any single instance is weak signal. The 0.25 weight means a domain needs ~4× the fraud volume at 2 hops to register the same reputation impact as 1-hop fraud. This is the cutout detection zone — a domain consistently 2 hops from fraud is statistically distinguishable from one that's just unlucky.
+- **3+ hops (weight 0.0):** Noise. The introduction graph is too diluted for meaningful attribution. Attempting to score at this distance creates false positives that punish well-connected, honest hubs.
+
+**Computation.** A domain's downstream fraud score is:
+
+```
+downstream_fraud_rate = Σ (weight(d_i) * fraud_severity_i) / total_downstream_introductions
+```
+
+Where `d_i` is the hop distance to each fraud event traced through the domain's introduction chain, and `fraud_severity_i` is normalized to [0.0, 1.0] by the magnitude of the fraud (proportion of conservation law violations relative to the domain's total transaction volume).
+
+**Threshold for action.** A `downstream_fraud_rate` above 0.1 (10% weighted fraud in downstream introductions) is a negative signal in the reputation aggregation. Above 0.3 triggers the same behavioral scrutiny as a low gossip score — trust level cap, introduction pause.
 
 **Single cutout attacks are still undetectable.** One instance of B→C→D where D defrauds doesn't implicate B. That's fine — one instance of anything is indistinguishable from bad luck. The trust model handles fraud as a statistical property, not a per-incident investigation.
 
@@ -416,11 +468,34 @@ What "contribute" means:
 - Propagate fraud reports (with evidence) received from other domains
 - Respond to supply audit queries for asset types the domain mints
 
-**Non-participation is observable and consequential.** A domain that consumes gossip without contributing is detectable — its trading partners ask for observations and get silence. Consequences:
+**Non-participation is observable and consequential.** Detection and enforcement are concrete, not aspirational.
 
-- Trading partners can downgrade the non-contributing domain's trust level
-- Introduction quality scores can factor in gossip participation
-- At the extreme: domains can refuse to trade with non-contributors
+#### Detection Mechanism
+
+Every gossip exchange is a bilateral request-response. The runtime tracks a **gossip participation score** per trading partner:
+
+| Metric | Measurement |
+|--------|-------------|
+| `response_rate` | Fraction of gossip requests that received a valid response within the timeout (default: 30s) |
+| `evidence_rate` | Fraction of responses that included verifiable evidence (Proof hashes, timestamps) vs empty/stub responses |
+| `propagation_rate` | Fraction of fraud reports received from this partner that included forwarded evidence from *their* partners (measures whether they're propagating, not just responding) |
+
+A domain's **gossip score** is: `0.5 * response_rate + 0.3 * evidence_rate + 0.2 * propagation_rate`. Computed per-partner over a 30-day rolling window (same as Law 7).
+
+#### Minimum Consequences
+
+These are runtime defaults, not suggestions. Domains can be stricter.
+
+| Gossip score | Consequence | Automatic? |
+|-------------|-------------|------------|
+| ≥ 0.8 | None — healthy participation | — |
+| 0.5–0.8 | Warning logged. Gossip score included in reputation aggregation (see [Reference Aggregation Function](#reference-aggregation-function)) as a penalty multiplier: `reputation * gossip_score`. | Yes |
+| 0.2–0.5 | Trust level capped at `known` regardless of other signals. Introduction acceptance from this domain paused. Trading continues but under increased scrutiny (pessimistic revocation strategy for all Grants). | Yes |
+| < 0.2 | Trust level downgraded to `stranger`. All pending introductions rejected. Existing Grants remain valid but no new Grants accepted. Trading partner notified with reason code `GossipDutyViolation`. | Yes |
+
+**Recovery.** Scores improve immediately when participation resumes. A domain that starts responding to gossip requests again will see its score climb within one window period. No permanent penalty — the system measures current behavior, not historical grudges.
+
+**Grace period.** New trading relationships start with a gossip score of `null` (no data). The first 7 days of a bilateral relationship are grace — no gossip score penalties apply. After 7 days, the score begins accumulating.
 
 This isn't a new conservation law — it's an enforcement mechanism for the existing ones. The conservation laws are only as strong as the bilateral verification that checks them. Gossip is how that verification scales beyond direct trading partners. Without it, fraud detection is limited to direct bilateral views, which is weaker.
 

--- a/projects/leden/discovery.md
+++ b/projects/leden/discovery.md
@@ -157,6 +157,14 @@ Discovery must not gossip unreachable addresses. A NAT'd endpoint advertises its
 
 STUN/TURN/ICE are heavy. A Leden relay is lighter because it already speaks the protocol — no translation layer.
 
+**Relay security.** A relay sees all traffic between the NAT'd endpoint and its peers. Without protection, a compromised or malicious relay can read, modify, or drop messages. Two requirements:
+
+1. **TLS required on relay sessions.** The session between the NAT'd endpoint and the relay must use TLS (or equivalent transport encryption). This isn't the general "TLS is optional" rule from the transport layer — relay sessions are a special case because the relay is a privileged intermediary. In-process and localhost sessions don't need TLS because there's no intermediary. Relay sessions always have one.
+
+2. **Capability attenuation on relay grants.** The relay receives an attenuated capability for message forwarding — specifically `relay` permission only, not `invoke` or `observe`. The relay can route messages to/from the NAT'd endpoint but cannot call methods on the endpoint's objects, observe its state, or delegate capabilities on its behalf. The relay is a dumb pipe with a narrow permission scope.
+
+**What this doesn't cover:** End-to-end encryption between the NAT'd endpoint and its peers (through the relay). TLS protects NAT'd↔relay and relay↔peer separately, but the relay can still observe cleartext at the application layer. True end-to-end encryption through relays would require encrypting the message payload before it enters the Leden message layer — that's a transport-layer extension, not a protocol requirement. For most deployments, TLS on both hops is sufficient. For high-security deployments, an E2E encryption extension can be negotiated during the handshake.
+
 ## Deferred
 
 - **Gossip protocol tuning.** Fanout, probe interval, suspect timeout, down threshold. All configurable per deployment. Sensible defaults will come from implementation experience, not spec work. Target: 10–1000 endpoints for defaults.

--- a/projects/leden/observation.md
+++ b/projects/leden/observation.md
@@ -109,12 +109,53 @@ Not every observer wants every field. A minimap UI cares about position, not hea
 Filters are specified at subscribe time:
 
 ```
-Observe(object_ref, filter: [position, velocity])
+Observe(object_ref, filter: ["position", "velocity"])
 ```
 
 The server only sends updates matching the filter. This reduces bandwidth and processing on both sides. Filters are optional — omit for "everything."
 
 Filters can be updated on a live observation without unsubscribing and resubscribing. The server applies the new filter immediately.
+
+### Filter Path Expressions
+
+Flat field names work for flat objects. Game entities aren't flat — they have nested structs, arrays, and maps. The filter language supports path expressions for nested access.
+
+**Syntax:**
+
+| Expression | Meaning | Example |
+|------------|---------|---------|
+| `field` | Top-level field | `"health"` |
+| `field.nested` | Nested field access | `"position.x"` |
+| `field[*]` | All elements of an array | `"inventory[*]"` |
+| `field[*].nested` | Nested field in each array element | `"inventory[*].name"` |
+| `field{*}` | All values of a map | `"attributes{*}"` |
+| `field{key}` | Specific map key | `"attributes{strength}"` |
+
+**No wildcards on field names.** `"pos*"` is not valid. Filters select known paths, not patterns. This keeps server-side filtering simple — it's a tree walk, not a regex engine.
+
+**Depth limit:** Paths are limited to 8 segments (dots). Deeper nesting than that is an application design problem, not a filter problem.
+
+**Examples:**
+
+```
+// Game entity — minimap only needs position
+filter: ["position.x", "position.y"]
+
+// Inventory screen — names and quantities, not full item data
+filter: ["inventory[*].name", "inventory[*].quantity"]
+
+// Damage log — health changes only
+filter: ["stats.health"]
+
+// Equipment tooltip — specific slot
+filter: ["equipment{weapon}.name", "equipment{weapon}.damage"]
+```
+
+**Semantics:** A filter path matches if the full path exists in the update. If an update changes `position.x` and `health`, and the filter is `["position.x"]`, the observer receives only the `position.x` change. The `health` change is suppressed.
+
+For array filters, `inventory[*].name` means: if any element's `name` changed, include that element's `name` in the update. Unchanged elements are omitted.
+
+**Invalid paths** are silently ignored at subscribe time (the object's schema may evolve). The server logs a warning for unrecognized paths but doesn't reject the subscription — this prevents breakage when a field is renamed or removed in a later version.
 
 ### Fan-Out
 

--- a/projects/leden/protocol.md
+++ b/projects/leden/protocol.md
@@ -543,15 +543,38 @@ This is rare in practice — most capability graphs are trees, not cyclic. But "
 
 **Strategy: trial deletion.**
 
-Adapted from distributed garbage collection literature. Periodically, the issuer suspects a capability might be in a cycle (heuristic: lease renewed many times but never released, low-weight reference that hasn't been delegated further). The issuer initiates a probe:
+Adapted from distributed garbage collection literature (Lins' weighted trial deletion). The issuer runs a probe when concrete conditions are met — not on every GC pass, and not on a vague heuristic.
 
-1. Issuer sends `GCProbe(capability_id, probe_id)` to the holder
-2. Holder checks if it holds any capabilities back to the issuer (or the issuer's objects)
-3. If yes, it forwards the probe along those capabilities
-4. If the probe returns to the issuer, a cycle is confirmed
-5. The issuer can then break the cycle by forcibly reclaiming one of the capabilities
+**Probe triggers.** A capability becomes a cycle suspect when *any* of these conditions hold:
 
-This is expensive and only triggered by heuristics, not on every GC pass. For most applications, leases alone handle the problem — a leaked cycle that renews leases is a memory leak, but a bounded one that the application can monitor.
+| Trigger | Condition | Rationale |
+|---------|-----------|-----------|
+| **Stale renewal** | Lease renewed ≥ `cycle_suspect_renewals` times (default: 8) without any weight being returned or the capability being released | A healthy reference either gets delegated (splitting weight) or released. Repeated renewal with no other activity suggests it's held only because something holds it back. |
+| **Low residual weight** | Remaining weight ≤ `cycle_suspect_weight_floor` (default: 1, i.e., the minimum non-zero weight) and the capability has been alive for ≥ 2 lease periods | Weight has been split down to the minimum — all delegations have happened, nobody released. If the minimum-weight holder is still renewing, it's either actively used or part of a cycle. |
+| **Mutual reference** | The issuer discovers it also holds a capability issued by the *same endpoint* that holds this one | Direct evidence of a potential two-node cycle. Doesn't confirm a cycle (the capabilities might reference different objects), but it's the strongest trigger. |
+
+When a capability becomes suspect, it enters a **cooldown period** of one lease interval before probing. If the capability is released or weight is returned during cooldown, the suspicion clears. This avoids probing capabilities that are about to be collected normally.
+
+**Probe protocol:**
+
+1. Issuer sends `GCProbe(capability_id, probe_id, ttl)` to the holder. The `ttl` starts at `cycle_probe_max_hops` (default: 8) and decrements at each hop — prevents probes from wandering indefinitely in large graphs.
+2. Holder checks if it holds any capabilities back to the issuer (matching the issuer's endpoint identity).
+3. If yes, it forwards the probe along those capabilities (decrementing `ttl`).
+4. If the probe returns to the issuer, a cycle is confirmed.
+5. If `ttl` reaches 0 without returning, the probe is dropped. The capability remains suspect and can be re-probed after another cooldown.
+
+**Cycle breaking.** When a cycle is confirmed, the issuer forcibly reclaims the probed capability by sending `Reclaim(capability_id, reason: CycleDetected)`. The holder treats this as a revocation — any operations through that capability fail with `CapabilityReclaimed`. The holder can re-acquire via a sturdy reference if the object still exists.
+
+**Configurable parameters:**
+
+| Parameter | Default | Constraints |
+|-----------|---------|-------------|
+| `cycle_suspect_renewals` | 8 | ≥ 2 |
+| `cycle_suspect_weight_floor` | 1 | ≥ 1 |
+| `cycle_probe_max_hops` | 8 | ≥ 2, ≤ 32 |
+| `cycle_probe_cooldown` | 1 lease interval | ≥ 1 lease interval |
+
+Defaults are conservative — they delay probing long enough that normal usage patterns won't trigger it, but catch genuine cycles within a few lease periods.
 
 **Pragmatic reality:** Most deployments won't hit cycles. Leases are the primary GC mechanism. Weight-based counting is the fast path. Cycle detection is a safety net for long-running servers with complex capability graphs.
 
@@ -703,15 +726,77 @@ The open question from before, now answered. When an endpoint goes down while ho
 
 The default is `fail`. You opt into `retry` or `expire` when you know the semantics justify it. No silent hangs.
 
+### Per-Promise Error Policies
+
+Resolution policies control what happens when the *endpoint* fails. Error policies control what happens when the *call itself* fails — the endpoint is fine, but the operation returned an error.
+
+Error policies are set per-promise at call time, alongside the resolution policy:
+
+| Policy | Behavior | Use when |
+|--------|----------|----------|
+| `propagate` | Reject the promise with the received error. Downstream pipelined promises break. | Default. Caller handles errors explicitly. |
+| `retry(max, backoff)` | Re-send the call up to `max` times with exponential backoff (base interval × 2^attempt, capped at backoff cap). | Transient failures on idempotent operations. |
+| `fallback(value)` | Resolve the promise with a fallback value instead of rejecting. Downstream pipeline continues. | Non-critical lookups where a default is acceptable. |
+
+**`retry` details:**
+
+| Parameter | Default | Constraints |
+|-----------|---------|-------------|
+| `max` | 3 | 1–16 |
+| `backoff_base` | 100ms | ≥ 10ms |
+| `backoff_cap` | 5s | ≥ `backoff_base` |
+
+Only retries errors where `retryable = true` in the error response (see Error Codes). Non-retryable errors (`PermissionDenied`, `InvalidArgument`, `CapabilityRevoked`) reject immediately regardless of retry policy. The server sets `retryable` — the protocol doesn't guess.
+
+**`fallback` details:**
+
+The fallback value must be type-compatible with the expected response. This is not protocol-enforced (the protocol doesn't know application types) — it's a caller responsibility. A type mismatch in the fallback is an application bug, not a protocol error.
+
+Fallback does *not* suppress the error silently. The promise resolves with the fallback value, but the original error is logged as a warning on the caller side and included in the resolution metadata (accessible via `promise.error()` even after successful resolution).
+
+**Interaction with resolution policies:**
+
+Error policies apply to errors received while the endpoint is live. If the endpoint goes down, the resolution policy takes over. They compose cleanly:
+
+- `retry` error policy + `retry` resolution policy: retry the call on error, and also retry on reconnect.
+- `fallback` error policy + `fail` resolution policy: use fallback on application errors, but reject immediately if the endpoint itself dies.
+- `propagate` error policy + `expire` resolution policy: no retries, but reject on deadline if the endpoint is slow.
+
+### Promise Epochs
+
+A session reconnection creates ambiguity: was a response received just before disconnection for the *original* call, or for a *retried* call after reconnection? Without versioning, a stale response from the old session can be mistaken for a fresh one.
+
+Every session has a monotonically increasing **epoch** counter, starting at 1. The epoch increments on every successful reconnection (after the Hello/Welcome handshake completes). Each outbound call is tagged with the session epoch at send time. Responses carry the epoch they were produced in.
+
+```
+Session connects:     epoch = 1
+Call A sent:          epoch = 1
+   ... disconnect ...
+Session reconnects:   epoch = 2
+Call A retried:       epoch = 2
+Response arrives:     epoch = 1  ← stale, discard
+Response arrives:     epoch = 2  ← fresh, accept
+```
+
+**Rules:**
+
+1. Responses with an epoch older than the promise's current epoch are discarded silently.
+2. For `retry` resolution policy: the retried call is tagged with the new epoch. Only responses matching the new epoch are accepted.
+3. For `fail` resolution policy: no retry happens, so epoch mismatch is impossible — the promise was already rejected before the new epoch started.
+4. For `expire` resolution policy: same as `fail` — if the promise survived to the new epoch, it's checked against its deadline first. If still valid, it behaves like `retry`.
+
+The epoch is a `uint32` carried in the message header (see [wire-format.md](wire-format.md)). It doesn't need to be large — a session that reconnects 4 billion times has bigger problems.
+
 ### Error Handling at Session Boundaries
 
 When a session drops and reconnects:
 
-1. Capabilities survive (sturdy references, already specified).
-2. Pending promises with `fail` policy are rejected immediately.
-3. Pending promises with `retry` policy are re-sent automatically on reconnect.
-4. Pending promises with `expire` policy are rejected if past their deadline.
-5. Active observations (see observation.md) are re-established from the last known state.
+1. Session epoch increments.
+2. Capabilities survive (sturdy references, already specified).
+3. Pending promises with `fail` policy are rejected immediately.
+4. Pending promises with `retry` policy are re-sent with the new epoch.
+5. Pending promises with `expire` policy are rejected if past their deadline, otherwise re-sent with new epoch.
+6. Active observations (see observation.md) are re-established from the last known state.
 
 The caller doesn't need to track which promises were in-flight. The session handles it.
 

--- a/projects/leden/wire-format.md
+++ b/projects/leden/wire-format.md
@@ -251,6 +251,7 @@ Each sturdy reference in the `sturdy_refs` array is a MessagePack map:
 | 3 | method | string | Method name |
 | 4 | args | bytes | MessagePack-encoded arguments |
 | 5 | pipeline | optional array | Pipelined call chain (see below) |
+| 6 | epoch | optional uint | Session epoch (see [protocol.md](protocol.md#promise-epochs)). Omit for epoch 1. |
 
 Each pipeline entry:
 
@@ -267,6 +268,7 @@ Each pipeline entry:
 | 1 | id | uint | Request ID (matches Call) |
 | 2 | value | bytes | MessagePack-encoded return value |
 | 3 | caps | optional array\<bytes\> | Capability references included in the return value |
+| 4 | epoch | optional uint | Session epoch the response was produced in |
 
 ### Error (0x12)
 
@@ -398,7 +400,7 @@ Each peer entry:
 | 1 | id | uint | Request ID |
 | 2 | object_ref | bytes | Object or promise reference |
 | 3 | credits | uint | Initial backpressure credits |
-| 4 | filter | optional array\<string\> | Field names to include |
+| 4 | filter | optional array\<string\> | Path expressions to include (see [observation.md](observation.md#filter-path-expressions)) |
 
 ### Update (0x51)
 
@@ -433,7 +435,7 @@ Each observation entry uses the same fields as Observe (minus `type`):
 |-------|------|------|-------|
 | 0 | object_ref | bytes | |
 | 1 | credits | uint | |
-| 2 | filter | optional array\<string\> | |
+| 2 | filter | optional array\<string\> | Path expressions (see [observation.md](observation.md#filter-path-expressions)) |
 
 ### UnobserveBatch (0x54)
 


### PR DESCRIPTION
## Summary

This PR adds four major protocol features to improve reliability and observability across the Leden and Allgard systems:

1. **Cycle detection in garbage collection** — Replaces vague heuristics with concrete, measurable triggers for detecting capability cycles
2. **Per-promise error policies** — Allows callers to specify retry and fallback behavior for application-level errors, separate from endpoint failures
3. **Session epochs** — Prevents stale response confusion during reconnection by versioning calls and responses
4. **Gossip participation scoring** — Makes non-participation in fraud reporting observable and consequential with concrete metrics and enforcement

## Key Changes

### Garbage Collection (protocol.md)
- Replaced heuristic-based cycle detection with three concrete triggers: stale renewal count, low residual weight, and mutual references
- Added cooldown period before probing to avoid unnecessary work on capabilities about to be collected
- Introduced `ttl` parameter to probe protocol to prevent infinite wandering in large graphs
- Added configurable parameters table with sensible defaults and constraints
- Clarified cycle breaking via `Reclaim` message with `CycleDetected` reason

### Error Handling (protocol.md)
- New section on per-promise error policies (`propagate`, `retry`, `fallback`)
- `retry` policy includes configurable max attempts and exponential backoff with caps
- `fallback` policy allows resolution with default values while logging original errors
- Clarified interaction between error policies (application-level) and resolution policies (endpoint-level)
- Added detailed `retry` parameter table with constraints

### Session Epochs (protocol.md)
- Every session has monotonically increasing epoch counter starting at 1
- Epoch increments on successful reconnection
- Each outbound call tagged with session epoch; responses carry epoch they were produced in
- Stale responses (older epoch than promise's current epoch) discarded silently
- Prevents confusion between original and retried calls across reconnections
- Updated wire format to include optional `epoch` field in Call and Response messages

### Observation Filters (observation.md)
- Added filter path expression syntax for nested field access
- Supports dot notation (`field.nested`), array wildcards (`field[*]`), and map access (`field{key}`)
- Depth limit of 8 segments to prevent pathological nesting
- Invalid paths silently ignored with warning logged
- Examples provided for common game entity patterns

### Gossip Participation (TRUST.md)
- New reference aggregation function with composite reputation score (0.0–1.0)
- Four weighted components: success rate (0.4), volume factor (0.2), history factor (0.2), response factor (0.2)
- Minimum sample size of 5 introductions; insufficient data returns `null` not 0
- 365-day rolling window with decay for old data
- New downstream fraud attribution with attenuation curve: 1.0 weight at 1-hop, 0.25 at 2-hop, 0.0 at 3+ hops
- Concrete gossip participation metrics: response rate, evidence rate, propagation rate
- Automatic enforcement with four tiers: healthy (≥0.8), warning (0.5–0.8), capped trust (0.2–0.5), downgraded (< 0.2)
- 7-day grace period for new trading relationships before gossip scoring applies
- Recovery is immediate when participation resumes

### Key Compromise Propagation (PRIMITIVES.md)
- New section on cross-domain key revocation flow
- Home domain broadcasts `KeyRevocation` to all trading partners with evidence and replacement key
- Synchronous revocation strategy applied regardless of negotiated strategy
- Propagation follows Grant delegation graph
- Replay protection via monotonic sequence numbers per Owner
- Timing target: 5 seconds to direct partners, additional latency per hop for transitive propagation

### Rate Limiting (CONSERVATION.md)
- Clarified sliding window semantics (not bucketed) to prevent burst-at-boundary issues
- Implementation guidance: timestamped log with O(n) check bounded by rate limit
- Default rate limits table for Transform (100/s mutations, 10/s transfers), Grants (50/s), Introductions (Law

https://claude.ai/code/session_01TZAypHvWbbAdV5GzF7Cm1K