### PR TITLE
Differential test system and smart assert messages

### DIFF
--- a/compiler/crates/rask-cli/src/commands/compile.rs
+++ b/compiler/crates/rask-cli/src/commands/compile.rs
@@ -500,6 +500,11 @@ pub fn compile_tests_to_object(
         None, rask_codegen::BuildMode::Debug,
     )?;
 
+    // Set line map so assert messages include correct line:col
+    if let (Some(src_file), Some(lm)) = (source_file, line_map.as_ref()) {
+        codegen.set_debug_context(src_file, lm.clone());
+    }
+
     gen_functions(&mut codegen, &mir_functions)?;
 
     // Generate the test runner entry point

--- a/compiler/crates/rask-cli/src/commands/compile.rs
+++ b/compiler/crates/rask-cli/src/commands/compile.rs
@@ -329,38 +329,51 @@ pub fn extract_tests(decls: &mut Vec<Decl>, filter: Option<&str>) -> Vec<(String
     let mut test_fns = Vec::new();
 
     for decl in decls.iter() {
-        if let DeclKind::Test(t) = &decl.kind {
-            if let Some(pat) = filter {
-                if !t.name.contains(pat) {
-                    continue;
+        match &decl.kind {
+            DeclKind::Test(t) => {
+                if let Some(pat) = filter {
+                    if !t.name.contains(pat) {
+                        continue;
+                    }
                 }
-            }
-            let fn_name = format!("__test_{}", tests.len());
-            tests.push((t.name.clone(), fn_name.clone()));
-            test_fns.push(Decl {
-                id: decl.id,
-                kind: DeclKind::Fn(FnDecl {
-                    name: fn_name,
-                    type_params: vec![],
-                    params: vec![],
-                    ret_ty: None,
-                    context_clauses: vec![],
-                    body: t.body.clone(),
-                    is_pub: false,
-                    is_private: false,
-                    is_comptime: false,
-                    is_unsafe: false,
-                    abi: None,
-                    attrs: vec![],
-                    doc: None,
+                let fn_name = format!("__test_{}", tests.len());
+                tests.push((t.name.clone(), fn_name.clone()));
+                test_fns.push(Decl {
+                    id: decl.id,
+                    kind: DeclKind::Fn(FnDecl {
+                        name: fn_name,
+                        type_params: vec![],
+                        params: vec![],
+                        ret_ty: None,
+                        context_clauses: vec![],
+                        body: t.body.clone(),
+                        is_pub: false,
+                        is_private: false,
+                        is_comptime: false,
+                        is_unsafe: false,
+                        abi: None,
+                        attrs: vec![],
+                        doc: None,
+                        span: decl.span,
+                    }),
                     span: decl.span,
-                }),
-                span: decl.span,
-            });
+                });
+            }
+            // @test functions — include as tests, keep the original function too
+            DeclKind::Fn(f) if f.attrs.iter().any(|a| a == "test") && f.params.is_empty() => {
+                if let Some(pat) = filter {
+                    if !f.name.contains(pat) {
+                        continue;
+                    }
+                }
+                tests.push((f.name.clone(), f.name.clone()));
+            }
+            _ => {}
         }
     }
 
-    // Remove test decls and user's main() — the runner replaces main
+    // Remove test decls and user's main() — the runner replaces main.
+    // Keep @test functions since they're callable from other code.
     decls.retain(|d| {
         !matches!(&d.kind, DeclKind::Test(_))
             && !matches!(&d.kind, DeclKind::Fn(f) if f.name == "main")

--- a/compiler/crates/rask-cli/src/commands/run.rs
+++ b/compiler/crates/rask-cli/src/commands/run.rs
@@ -388,8 +388,19 @@ fn display_test_results(stdout: &str, path: &str, format: Format) {
 fn parse_json_str<'a>(s: &'a str, key: &str) -> Option<&'a str> {
     let pat = format!("\"{}\":\"", key);
     let start = s.find(&pat)? + pat.len();
-    let end = s[start..].find('"')? + start;
-    Some(&s[start..end])
+    // Walk past escaped characters to find the real closing quote
+    let bytes = s[start..].as_bytes();
+    let mut i = 0;
+    while i < bytes.len() {
+        if bytes[i] == b'\\' {
+            i += 2; // skip escaped char
+        } else if bytes[i] == b'"' {
+            return Some(&s[start..start + i]);
+        } else {
+            i += 1;
+        }
+    }
+    None
 }
 
 fn parse_json_i64(s: &str, key: &str) -> Option<i64> {

--- a/compiler/crates/rask-cli/src/commands/specs.rs
+++ b/compiler/crates/rask-cli/src/commands/specs.rs
@@ -9,7 +9,7 @@ use std::process;
 use crate::output;
 
 pub fn cmd_test_specs(path: Option<&str>) {
-    use rask_spec_test::{extract_tests, run_test_with_config, extract_deps, check_staleness, RunConfig, TestSummary};
+    use rask_spec_test::{extract_tests, has_rk_tests, run_test_with_config, run_rk_test_file, extract_deps, check_staleness, RunConfig, TestSummary};
 
     let specs_dir = path.unwrap_or("specs");
     let specs_path = Path::new(specs_dir);
@@ -34,9 +34,12 @@ pub fn cmd_test_specs(path: Option<&str>) {
     let mut all_results = Vec::new();
     let mut all_deps = Vec::new();
 
-    let md_files = collect_md_files(specs_path);
-    summary.files = md_files.len();
+    let all_files = collect_test_files(specs_path);
+    let md_files: Vec<_> = all_files.iter().filter(|p| p.extension().map_or(false, |e| e == "md")).collect();
+    let rk_files: Vec<_> = all_files.iter().filter(|p| p.extension().map_or(false, |e| e == "rk")).collect();
+    summary.files = all_files.len();
 
+    // Run markdown spec tests
     for md_path in &md_files {
         let content = match fs::read_to_string(md_path) {
             Ok(c) => c,
@@ -61,40 +64,68 @@ pub fn cmd_test_specs(path: Option<&str>) {
 
         for test in tests {
             let result = run_test_with_config(test, &config);
-            summary.add(&result);
+            print_result(&result, &mut summary, &mut all_results);
+        }
+        println!();
+    }
 
-            let status = if result.passed {
-                output::status_pass()
-            } else {
-                output::status_fail()
-            };
-
-            // Show interpreter result
-            let native_suffix = match &result.native_result {
-                Some(nr) if nr.passed => format!("  native:{}", "ok".green()),
-                Some(nr) => format!("  native:{}", "FAIL".red().bold()),
-                None => String::new(),
-            };
-
-            println!(
-                "  {} line {}: {:?} - {}{}",
-                status,
-                result.test.line.to_string().dimmed(),
-                result.test.expectation,
-                result.message,
-                native_suffix,
-            );
-
-            // Show native failure details inline
-            if let Some(nr) = &result.native_result {
-                if !nr.passed {
-                    println!("       {} {}", "native:".red(), nr.message);
-                }
+    // Run .rk test files (files with `test "..." { ... }` blocks)
+    let mut rk_results: Vec<rask_spec_test::RkTestResult> = Vec::new();
+    for rk_path in &rk_files {
+        let content = match fs::read_to_string(rk_path) {
+            Ok(c) => c,
+            Err(e) => {
+                eprintln!("{}: reading {}: {}", output::error_label(), output::file_path(&rk_path.display().to_string()), e);
+                continue;
             }
+        };
 
-            if !result.passed || result.native_result.as_ref().map_or(false, |n| !n.passed) {
-                all_results.push(result);
+        if !has_rk_tests(&content) {
+            continue;
+        }
+
+        println!("{}", output::file_path(&rk_path.display().to_string()));
+        let rk_result = run_rk_test_file(rk_path, &content, &config);
+
+        // Display results
+        let interp_status = if rk_result.interp_ok() {
+            format!("interp: {}/{} {}", rk_result.interp_passed, rk_result.interp_total, "ok".green())
+        } else {
+            format!("interp: {}/{} {}", rk_result.interp_passed, rk_result.interp_total, "FAIL".red().bold())
+        };
+
+        let native_status = match (rk_result.native_passed, rk_result.native_total) {
+            (Some(p), Some(t)) if p == t && t > 0 => {
+                format!("  native: {}/{} {}", p, t, "ok".green())
             }
+            (Some(p), Some(t)) => {
+                format!("  native: {}/{} {}", p, t, "FAIL".red().bold())
+            }
+            _ => String::new(),
+        };
+
+        println!("  {} {}{}", if rk_result.interp_ok() { output::status_pass() } else { output::status_fail() }, interp_status, native_status);
+
+        // Show failures
+        for f in &rk_result.interp_failures {
+            println!("       {} {}", "interp:".red(), f);
+        }
+        for f in &rk_result.native_failures {
+            println!("       {} {}", "native:".red(), f);
+        }
+
+        // Update summary
+        summary.total += rk_result.interp_total;
+        summary.passed += rk_result.interp_passed;
+        summary.failed += rk_result.interp_total - rk_result.interp_passed;
+        if let (Some(np), Some(nt)) = (rk_result.native_passed, rk_result.native_total) {
+            summary.native_total += nt;
+            summary.native_passed += np;
+            summary.native_failed += nt - np;
+        }
+
+        if !rk_result.interp_ok() || !rk_result.native_ok() {
+            rk_results.push(rk_result);
         }
         println!();
     }
@@ -152,6 +183,38 @@ pub fn cmd_test_specs(path: Option<&str>) {
         }
     }
 
+    // .rk file failures
+    if !rk_results.is_empty() {
+        let rk_interp_fails: Vec<_> = rk_results.iter().filter(|r| !r.interp_ok()).collect();
+        let rk_native_fails: Vec<_> = rk_results.iter().filter(|r| r.interp_ok() && !r.native_ok()).collect();
+
+        if !rk_interp_fails.is_empty() {
+            println!("\n{}", "Failed .rk test files (interpreter):".red().bold());
+            for r in &rk_interp_fails {
+                println!("  {} {} ({}/{})", output::status_fail(), output::file_path(&r.path.display().to_string()), r.interp_passed, r.interp_total);
+                for f in &r.interp_failures {
+                    println!("       {}", f);
+                }
+            }
+        }
+
+        if !rk_native_fails.is_empty() {
+            println!("\n{}", "Native codegen failures in .rk files (interp passed):".yellow().bold());
+            for r in &rk_native_fails {
+                println!(
+                    "  {} {} (native: {}/{})",
+                    "!".yellow().bold(),
+                    output::file_path(&r.path.display().to_string()),
+                    r.native_passed.unwrap_or(0),
+                    r.native_total.unwrap_or(0),
+                );
+                for f in &r.native_failures {
+                    println!("       {}", f);
+                }
+            }
+        }
+    }
+
     // Staleness check — find project root (where .git lives)
     if !all_deps.is_empty() {
         let project_root = find_project_root(specs_path);
@@ -181,6 +244,56 @@ pub fn cmd_test_specs(path: Option<&str>) {
     }
 }
 
+/// Print a single test result and update summary/failure tracking.
+fn print_result(
+    result: &rask_spec_test::TestResult,
+    summary: &mut rask_spec_test::TestSummary,
+    all_results: &mut Vec<rask_spec_test::TestResult>,
+) {
+    summary.add(result);
+
+    let status = if result.passed {
+        output::status_pass()
+    } else {
+        output::status_fail()
+    };
+
+    let native_suffix = match &result.native_result {
+        Some(nr) if nr.passed => format!("  native:{}", "ok".green()),
+        Some(_nr) => format!("  native:{}", "FAIL".red().bold()),
+        None => String::new(),
+    };
+
+    println!(
+        "  {} line {}: {:?} - {}{}",
+        status,
+        result.test.line.to_string().dimmed(),
+        result.test.expectation,
+        result.message,
+        native_suffix,
+    );
+
+    if let Some(nr) = &result.native_result {
+        if !nr.passed {
+            println!("       {} {}", "native:".red(), nr.message);
+        }
+    }
+
+    if !result.passed || result.native_result.as_ref().map_or(false, |n| !n.passed) {
+        // Clone the test result for failure tracking
+        all_results.push(rask_spec_test::TestResult {
+            test: result.test.clone(),
+            passed: result.passed,
+            message: result.message.clone(),
+            native_result: result.native_result.as_ref().map(|n| rask_spec_test::NativeResult {
+                passed: n.passed,
+                message: n.message.clone(),
+                actual_output: n.actual_output.clone(),
+            }),
+        });
+    }
+}
+
 /// Walk up from a path to find the project root (directory containing .git).
 fn find_project_root(start: &Path) -> Option<PathBuf> {
     let mut dir = if start.is_file() {
@@ -198,12 +311,15 @@ fn find_project_root(start: &Path) -> Option<PathBuf> {
     }
 }
 
-/// Recursively collect all .md files in a directory.
-fn collect_md_files(dir: &Path) -> Vec<PathBuf> {
+/// Recursively collect all .md and .rk files in a directory.
+fn collect_test_files(dir: &Path) -> Vec<PathBuf> {
     let mut files = Vec::new();
 
-    if dir.is_file() && dir.extension().map(|e| e == "md").unwrap_or(false) {
-        files.push(dir.to_path_buf());
+    if dir.is_file() {
+        let ext = dir.extension().and_then(|e| e.to_str());
+        if matches!(ext, Some("md") | Some("rk")) {
+            files.push(dir.to_path_buf());
+        }
         return files;
     }
 
@@ -211,9 +327,12 @@ fn collect_md_files(dir: &Path) -> Vec<PathBuf> {
         for entry in entries.flatten() {
             let path = entry.path();
             if path.is_dir() {
-                files.extend(collect_md_files(&path));
-            } else if path.extension().map(|e| e == "md").unwrap_or(false) {
-                files.push(path);
+                files.extend(collect_test_files(&path));
+            } else {
+                let ext = path.extension().and_then(|e| e.to_str());
+                if matches!(ext, Some("md") | Some("rk")) {
+                    files.push(path);
+                }
             }
         }
     }

--- a/compiler/crates/rask-cli/src/commands/specs.rs
+++ b/compiler/crates/rask-cli/src/commands/specs.rs
@@ -9,7 +9,7 @@ use std::process;
 use crate::output;
 
 pub fn cmd_test_specs(path: Option<&str>) {
-    use rask_spec_test::{extract_tests, run_test, extract_deps, check_staleness, TestSummary};
+    use rask_spec_test::{extract_tests, run_test_with_config, extract_deps, check_staleness, RunConfig, TestSummary};
 
     let specs_dir = path.unwrap_or("specs");
     let specs_path = Path::new(specs_dir);
@@ -17,6 +17,17 @@ pub fn cmd_test_specs(path: Option<&str>) {
     if !specs_path.exists() {
         eprintln!("{}: specs directory not found: {}", output::error_label(), output::file_path(specs_dir));
         process::exit(1);
+    }
+
+    // Find the rask binary for native compilation tests.
+    // Use current executable since we ARE the rask binary.
+    let rask_binary = std::env::current_exe().ok();
+    let config = RunConfig {
+        rask_binary: rask_binary.clone(),
+    };
+
+    if rask_binary.is_none() {
+        eprintln!("{}: could not determine rask binary path, native tests will be skipped", "warn".yellow().bold());
     }
 
     let mut summary = TestSummary::default();
@@ -49,7 +60,7 @@ pub fn cmd_test_specs(path: Option<&str>) {
         println!("{}", output::file_path(&md_path.display().to_string()));
 
         for test in tests {
-            let result = run_test(test);
+            let result = run_test_with_config(test, &config);
             summary.add(&result);
 
             let status = if result.passed {
@@ -57,22 +68,39 @@ pub fn cmd_test_specs(path: Option<&str>) {
             } else {
                 output::status_fail()
             };
+
+            // Show interpreter result
+            let native_suffix = match &result.native_result {
+                Some(nr) if nr.passed => format!("  native:{}", "ok".green()),
+                Some(nr) => format!("  native:{}", "FAIL".red().bold()),
+                None => String::new(),
+            };
+
             println!(
-                "  {} line {}: {:?} - {}",
+                "  {} line {}: {:?} - {}{}",
                 status,
                 result.test.line.to_string().dimmed(),
                 result.test.expectation,
-                result.message
+                result.message,
+                native_suffix,
             );
 
-            if !result.passed {
+            // Show native failure details inline
+            if let Some(nr) = &result.native_result {
+                if !nr.passed {
+                    println!("       {} {}", "native:".red(), nr.message);
+                }
+            }
+
+            if !result.passed || result.native_result.as_ref().map_or(false, |n| !n.passed) {
                 all_results.push(result);
             }
         }
         println!();
     }
 
-    println!("{}", output::separator(50));
+    // Summary
+    println!("{}", output::separator(60));
     println!(
         "{} files, {} tests, {}, {}",
         summary.files,
@@ -80,17 +108,47 @@ pub fn cmd_test_specs(path: Option<&str>) {
         output::passed_count(summary.passed),
         output::failed_count(summary.failed)
     );
+    if summary.native_total > 0 {
+        let native_label = if summary.native_failed > 0 {
+            format!("{}/{} native passed", summary.native_passed, summary.native_total).yellow()
+        } else {
+            format!("{}/{} native passed", summary.native_passed, summary.native_total).green()
+        };
+        println!("{}", native_label);
+    }
 
-    if summary.failed > 0 {
-        println!("\n{}", "Failed tests:".red().bold());
-        for result in &all_results {
-            println!(
-                "  {} {}:{} - {}",
-                output::status_fail(),
-                output::file_path(&result.test.path.display().to_string()),
-                result.test.line,
-                result.message
-            );
+    if !all_results.is_empty() {
+        // Separate interp failures from native-only failures
+        let interp_fails: Vec<_> = all_results.iter().filter(|r| !r.passed).collect();
+        let native_only_fails: Vec<_> = all_results.iter()
+            .filter(|r| r.passed && r.native_result.as_ref().map_or(false, |n| !n.passed))
+            .collect();
+
+        if !interp_fails.is_empty() {
+            println!("\n{}", "Failed tests:".red().bold());
+            for result in &interp_fails {
+                println!(
+                    "  {} {}:{} - {}",
+                    output::status_fail(),
+                    output::file_path(&result.test.path.display().to_string()),
+                    result.test.line,
+                    result.message
+                );
+            }
+        }
+
+        if !native_only_fails.is_empty() {
+            println!("\n{}", "Native codegen failures (interp passed):".yellow().bold());
+            for result in &native_only_fails {
+                let nr = result.native_result.as_ref().unwrap();
+                println!(
+                    "  {} {}:{} - {}",
+                    "!".yellow().bold(),
+                    output::file_path(&result.test.path.display().to_string()),
+                    result.test.line,
+                    nr.message,
+                );
+            }
         }
     }
 

--- a/compiler/crates/rask-codegen/src/builder.rs
+++ b/compiler/crates/rask-codegen/src/builder.rs
@@ -31,8 +31,11 @@ struct CodegenCtx<'a> {
     block_map: &'a HashMap<BlockId, Block>,
     build_mode: BuildMode,
     source_file: Option<&'a str>,
+    line_map: Option<&'a rask_ast::LineMap>,
     current_line: u32,
     current_col: u32,
+    /// Byte offset of the current MIR statement being lowered
+    current_span_start: u32,
     ret_ty: &'a MirType,
     is_main: bool,
     adapt_table: &'a HashMap<String, (ArgAdapt, RetAdapt)>,
@@ -93,6 +96,9 @@ pub struct FunctionBuilder<'a> {
     current_line: u32,
     current_col: u32,
 
+    /// Line map for converting byte offsets → line:col
+    line_map: Option<&'a rask_ast::LineMap>,
+
     /// Table-driven call adaptation (populated from dispatch::stdlib_entries)
     adapt_table: HashMap<String, (ArgAdapt, RetAdapt)>,
 }
@@ -129,8 +135,14 @@ impl<'a> FunctionBuilder<'a> {
             stack_slot_map: HashMap::new(),
             current_line: 0,
             current_col: 0,
+            line_map: None,
             adapt_table: crate::dispatch::build_adapt_table(),
         })
+    }
+
+    /// Set the line map for converting byte offsets to line:col in assert messages.
+    pub fn set_line_map(&mut self, line_map: &'a rask_ast::LineMap) {
+        self.line_map = Some(line_map);
     }
 
     /// Build the Cranelift IR from MIR.
@@ -239,8 +251,10 @@ impl<'a> FunctionBuilder<'a> {
             block_map: &self.block_map,
             build_mode: self.build_mode,
             source_file: self.mir_fn.source_file.as_deref(),
+            line_map: self.line_map,
             current_line: self.current_line,
             current_col: self.current_col,
+            current_span_start: 0,
             ret_ty: &self.mir_fn.ret_ty,
             is_main: self.mir_fn.name == "main",
             adapt_table: &self.adapt_table,
@@ -261,6 +275,13 @@ impl<'a> FunctionBuilder<'a> {
             // Lower statements
             for stmt in &mir_block.statements {
                 Self::apply_srcloc(&mut builder, stmt.span);
+                ctx.current_span_start = stmt.span.start as u32;
+                // Update line:col from span if we have a line map
+                if let Some(lm) = ctx.line_map {
+                    let (line, col) = lm.offset_to_line_col(stmt.span.start);
+                    ctx.current_line = line as u32;
+                    ctx.current_col = col as u32;
+                }
                 Self::lower_stmt(&mut builder, stmt, &ctx)?;
             }
 
@@ -286,8 +307,10 @@ impl<'a> FunctionBuilder<'a> {
 
             let cleanup_ctx = CodegenCtx {
                 source_file: None,
+                line_map: None,
                 current_line: 0,
                 current_col: 0,
+                current_span_start: 0,
                 ..ctx
             };
             // Emit cleanup statements from each block in the chain
@@ -1005,11 +1028,9 @@ impl<'a> FunctionBuilder<'a> {
                 }
             } else if func.name == "assert_fail" {
                 // MIR already handled branching; this is the fail path.
-                // If a message arg is provided, pass it through.
+                // If a message arg is provided, pass it as raw C string pointer.
                 if !args.is_empty() {
-                    let msg_val = Self::lower_operand_typed(
-                        builder, &args[0], Some(types::I64), ctx,
-                    )?;
+                    let msg_val = Self::lower_operand_as_cstr(builder, &args[0], ctx)?;
                     if let Some(file_str) = ctx.source_file {
                         if let (Some(func_ref), Some(gv)) = (
                             ctx.func_refs.get("assert_fail_msg_at"),
@@ -1053,7 +1074,7 @@ impl<'a> FunctionBuilder<'a> {
                 if args.len() >= 3 {
                     let left_val = Self::lower_operand_typed(builder, &args[0], Some(types::I64), ctx)?;
                     let right_val = Self::lower_operand_typed(builder, &args[1], Some(types::I64), ctx)?;
-                    let op_val = Self::lower_operand_typed(builder, &args[2], Some(types::I64), ctx)?;
+                    let op_val = Self::lower_operand_as_cstr(builder, &args[2], ctx)?;
                     if let Some(file_str) = ctx.source_file {
                         if let (Some(func_ref), Some(gv)) = (
                             ctx.func_refs.get("assert_fail_cmp_i64"),
@@ -1069,9 +1090,9 @@ impl<'a> FunctionBuilder<'a> {
             } else if func.name == "assert_fail_cmp_str" {
                 // Comparison assert failure with string values: args = [left, right, op_str]
                 if args.len() >= 3 {
-                    let left_val = Self::lower_operand_typed(builder, &args[0], Some(types::I64), ctx)?;
-                    let right_val = Self::lower_operand_typed(builder, &args[1], Some(types::I64), ctx)?;
-                    let op_val = Self::lower_operand_typed(builder, &args[2], Some(types::I64), ctx)?;
+                    let left_val = Self::lower_operand_as_cstr(builder, &args[0], ctx)?;
+                    let right_val = Self::lower_operand_as_cstr(builder, &args[1], ctx)?;
+                    let op_val = Self::lower_operand_as_cstr(builder, &args[2], ctx)?;
                     if let Some(file_str) = ctx.source_file {
                         if let (Some(func_ref), Some(gv)) = (
                             ctx.func_refs.get("assert_fail_cmp_str"),
@@ -2586,6 +2607,23 @@ impl<'a> FunctionBuilder<'a> {
         Ok(builder.ins().iconst(types::I64, 0))
     }
 
+    /// Lower a MIR operand to a raw C string pointer (for runtime functions
+    /// that take `const char*`). For MirConst::String, returns the data section
+    /// pointer directly instead of constructing a Rask string object.
+    fn lower_operand_as_cstr(
+        builder: &mut ClifFunctionBuilder,
+        op: &MirOperand,
+        ctx: &CodegenCtx,
+    ) -> CodegenResult<Value> {
+        if let MirOperand::Constant(MirConst::String(s)) = op {
+            if let Some(gv) = ctx.string_globals.get(s.as_str()) {
+                return Ok(builder.ins().global_value(types::I64, *gv));
+            }
+        }
+        // Fallback: treat as i64 (pointer)
+        Self::lower_operand_typed(builder, op, Some(types::I64), ctx)
+    }
+
     fn lower_operand_typed(
         builder: &mut ClifFunctionBuilder,
         op: &MirOperand,
@@ -2626,7 +2664,12 @@ impl<'a> FunctionBuilder<'a> {
                         }
                     }
                     MirConst::Bool(b) => {
-                        Ok(builder.ins().iconst(types::I8, if *b { 1 } else { 0 }))
+                        let ty = if matches!(expected_ty, Some(t) if t.is_int() && t != types::I8) {
+                            expected_ty.unwrap()
+                        } else {
+                            types::I8
+                        };
+                        Ok(builder.ins().iconst(ty, if *b { 1 } else { 0 }))
                     }
                     MirConst::Char(c) => {
                         Ok(builder.ins().iconst(types::I32, *c as i64))

--- a/compiler/crates/rask-codegen/src/builder.rs
+++ b/compiler/crates/rask-codegen/src/builder.rs
@@ -1005,8 +1005,31 @@ impl<'a> FunctionBuilder<'a> {
                 }
             } else if func.name == "assert_fail" {
                 // MIR already handled branching; this is the fail path.
-                // Use location-aware variant when source info is available.
-                if let Some(file_str) = ctx.source_file {
+                // If a message arg is provided, pass it through.
+                if !args.is_empty() {
+                    let msg_val = Self::lower_operand_typed(
+                        builder, &args[0], Some(types::I64), ctx,
+                    )?;
+                    if let Some(file_str) = ctx.source_file {
+                        if let (Some(func_ref), Some(gv)) = (
+                            ctx.func_refs.get("assert_fail_msg_at"),
+                            ctx.string_globals.get(file_str),
+                        ) {
+                            let file_ptr = builder.ins().global_value(types::I64, *gv);
+                            let line_val = builder.ins().iconst(types::I32, ctx.current_line as i64);
+                            let col_val = builder.ins().iconst(types::I32, ctx.current_col as i64);
+                            builder.ins().call(*func_ref, &[msg_val, file_ptr, line_val, col_val]);
+                        } else {
+                            let assert_fn = ctx.func_refs.get("assert_fail")
+                                .ok_or_else(|| CodegenError::FunctionNotFound("assert_fail".into()))?;
+                            builder.ins().call(*assert_fn, &[]);
+                        }
+                    } else {
+                        let assert_fn = ctx.func_refs.get("assert_fail")
+                            .ok_or_else(|| CodegenError::FunctionNotFound("assert_fail".into()))?;
+                        builder.ins().call(*assert_fn, &[]);
+                    }
+                } else if let Some(file_str) = ctx.source_file {
                     if let (Some(func_ref), Some(gv)) = (
                         ctx.func_refs.get("assert_fail_at"),
                         ctx.string_globals.get(file_str),
@@ -1024,6 +1047,42 @@ impl<'a> FunctionBuilder<'a> {
                     let assert_fn = ctx.func_refs.get("assert_fail")
                         .ok_or_else(|| CodegenError::FunctionNotFound("assert_fail".into()))?;
                     builder.ins().call(*assert_fn, &[]);
+                }
+            } else if func.name == "assert_fail_cmp_i64" {
+                // Comparison assert failure with i64 values: args = [left, right, op_str]
+                if args.len() >= 3 {
+                    let left_val = Self::lower_operand_typed(builder, &args[0], Some(types::I64), ctx)?;
+                    let right_val = Self::lower_operand_typed(builder, &args[1], Some(types::I64), ctx)?;
+                    let op_val = Self::lower_operand_typed(builder, &args[2], Some(types::I64), ctx)?;
+                    if let Some(file_str) = ctx.source_file {
+                        if let (Some(func_ref), Some(gv)) = (
+                            ctx.func_refs.get("assert_fail_cmp_i64"),
+                            ctx.string_globals.get(file_str),
+                        ) {
+                            let file_ptr = builder.ins().global_value(types::I64, *gv);
+                            let line_val = builder.ins().iconst(types::I32, ctx.current_line as i64);
+                            let col_val = builder.ins().iconst(types::I32, ctx.current_col as i64);
+                            builder.ins().call(*func_ref, &[left_val, right_val, op_val, file_ptr, line_val, col_val]);
+                        }
+                    }
+                }
+            } else if func.name == "assert_fail_cmp_str" {
+                // Comparison assert failure with string values: args = [left, right, op_str]
+                if args.len() >= 3 {
+                    let left_val = Self::lower_operand_typed(builder, &args[0], Some(types::I64), ctx)?;
+                    let right_val = Self::lower_operand_typed(builder, &args[1], Some(types::I64), ctx)?;
+                    let op_val = Self::lower_operand_typed(builder, &args[2], Some(types::I64), ctx)?;
+                    if let Some(file_str) = ctx.source_file {
+                        if let (Some(func_ref), Some(gv)) = (
+                            ctx.func_refs.get("assert_fail_cmp_str"),
+                            ctx.string_globals.get(file_str),
+                        ) {
+                            let file_ptr = builder.ins().global_value(types::I64, *gv);
+                            let line_val = builder.ins().iconst(types::I32, ctx.current_line as i64);
+                            let col_val = builder.ins().iconst(types::I32, ctx.current_col as i64);
+                            builder.ins().call(*func_ref, &[left_val, right_val, op_val, file_ptr, line_val, col_val]);
+                        }
+                    }
                 }
             } else if func.name == "panic_unwrap" {
                 // MIR already handled branching; this is the panic path.

--- a/compiler/crates/rask-codegen/src/module.rs
+++ b/compiler/crates/rask-codegen/src/module.rs
@@ -839,6 +839,9 @@ impl CodeGenerator {
             &self.internal_fns,
             self.build_mode,
         )?;
+        if let Some(lm) = &self.line_map {
+            builder.set_line_map(lm);
+        }
         builder.build()?;
 
         // Temporary: dump CLIF IR for debugging

--- a/compiler/crates/rask-codegen/src/module.rs
+++ b/compiler/crates/rask-codegen/src/module.rs
@@ -274,6 +274,49 @@ impl CodeGenerator {
             self.func_ids.insert("assert_fail_at".to_string(), id);
         }
 
+        // assert_fail_msg_at(msg: ptr, file: ptr, line: i32, col: i32) -> void
+        {
+            let mut sig = self.module.make_signature();
+            sig.params.push(AbiParam::new(types::I64)); // msg ptr
+            sig.params.push(AbiParam::new(types::I64)); // file ptr
+            sig.params.push(AbiParam::new(types::I32)); // line
+            sig.params.push(AbiParam::new(types::I32)); // col
+            let id = self.module
+                .declare_function("rask_assert_fail_msg_at", Linkage::Import, &sig)
+                .map_err(|e| CodegenError::CraneliftError(e.to_string()))?;
+            self.func_ids.insert("assert_fail_msg_at".to_string(), id);
+        }
+
+        // assert_fail_cmp_i64(left: i64, right: i64, op: ptr, file: ptr, line: i32, col: i32)
+        {
+            let mut sig = self.module.make_signature();
+            sig.params.push(AbiParam::new(types::I64)); // left
+            sig.params.push(AbiParam::new(types::I64)); // right
+            sig.params.push(AbiParam::new(types::I64)); // op str ptr
+            sig.params.push(AbiParam::new(types::I64)); // file ptr
+            sig.params.push(AbiParam::new(types::I32)); // line
+            sig.params.push(AbiParam::new(types::I32)); // col
+            let id = self.module
+                .declare_function("rask_assert_fail_cmp_i64", Linkage::Import, &sig)
+                .map_err(|e| CodegenError::CraneliftError(e.to_string()))?;
+            self.func_ids.insert("assert_fail_cmp_i64".to_string(), id);
+        }
+
+        // assert_fail_cmp_str(left: ptr, right: ptr, op: ptr, file: ptr, line: i32, col: i32)
+        {
+            let mut sig = self.module.make_signature();
+            sig.params.push(AbiParam::new(types::I64)); // left str ptr
+            sig.params.push(AbiParam::new(types::I64)); // right str ptr
+            sig.params.push(AbiParam::new(types::I64)); // op str ptr
+            sig.params.push(AbiParam::new(types::I64)); // file ptr
+            sig.params.push(AbiParam::new(types::I32)); // line
+            sig.params.push(AbiParam::new(types::I32)); // col
+            let id = self.module
+                .declare_function("rask_assert_fail_cmp_str", Linkage::Import, &sig)
+                .map_err(|e| CodegenError::CraneliftError(e.to_string()))?;
+            self.func_ids.insert("assert_fail_cmp_str".to_string(), id);
+        }
+
         // pool_get_checked(pool: i64, handle: i64, file: ptr, line: i32, col: i32) -> ptr
         {
             let mut sig = self.module.make_signature();

--- a/compiler/crates/rask-interp/src/interp/eval_expr.rs
+++ b/compiler/crates/rask-interp/src/interp/eval_expr.rs
@@ -10,6 +10,97 @@ use crate::value::{ModuleKind, PoolTask, ThreadHandleInner, ThreadPoolInner, Typ
 
 use super::{Interpreter, RuntimeDiagnostic, RuntimeError};
 
+/// Map comparison method names back to operator symbols.
+fn comparison_op_symbol(method: &str) -> Option<&'static str> {
+    match method {
+        "eq" => Some("=="),
+        "lt" => Some("<"),
+        "gt" => Some(">"),
+        "le" => Some("<="),
+        "ge" => Some(">="),
+        _ => None,
+    }
+}
+
+/// Build a descriptive failure message for assert/check.
+///
+/// After desugaring, `a == b` becomes `a.eq(b)` and `a != b` becomes
+/// `!a.eq(b)`. This function recognizes both forms and re-evaluates the
+/// operands to show actual values in the error message.
+fn build_comparison_message(interp: &mut Interpreter, condition: &Expr, prefix: &str) -> String {
+    match &condition.kind {
+        // Desugared comparison: a.eq(b), a.lt(b), etc.
+        ExprKind::MethodCall { object, method, args, .. }
+            if args.len() == 1 && comparison_op_symbol(method).is_some() =>
+        {
+            let op_str = comparison_op_symbol(method).unwrap();
+            let left_val = interp.eval_expr(object).ok();
+            let right_val = interp.eval_expr(&args[0].expr).ok();
+            match (left_val, right_val) {
+                (Some(l), Some(r)) => format!("{}: {} {} {} (left: {}, right: {})", prefix, l, op_str, r, l, r),
+                _ => prefix.to_string(),
+            }
+        }
+        // Desugared != : !(a.eq(b))
+        ExprKind::Unary { op: UnaryOp::Not, operand } => {
+            match &operand.kind {
+                ExprKind::MethodCall { object, method, args, .. }
+                    if method == "eq" && args.len() == 1 =>
+                {
+                    let left_val = interp.eval_expr(object).ok();
+                    let right_val = interp.eval_expr(&args[0].expr).ok();
+                    match (left_val, right_val) {
+                        (Some(l), Some(r)) => format!("{}: {} != {} (left: {}, right: {})", prefix, l, r, l, r),
+                        _ => prefix.to_string(),
+                    }
+                }
+                _ => {
+                    let val = interp.eval_expr(operand).ok();
+                    match val {
+                        Some(v) => format!("{}: !({}) — value was {}", prefix, v, v),
+                        None => prefix.to_string(),
+                    }
+                }
+            }
+        }
+        // Pre-desugar Binary (in case desugar was skipped, e.g. spec test runner)
+        ExprKind::Binary { op, left, right } if matches!(op,
+            BinOp::Eq | BinOp::Ne | BinOp::Lt | BinOp::Gt | BinOp::Le | BinOp::Ge
+        ) => {
+            let op_str = match op {
+                BinOp::Eq => "==",
+                BinOp::Ne => "!=",
+                BinOp::Lt => "<",
+                BinOp::Gt => ">",
+                BinOp::Le => "<=",
+                BinOp::Ge => ">=",
+                _ => unreachable!(),
+            };
+            let left_val = interp.eval_expr(left).ok();
+            let right_val = interp.eval_expr(right).ok();
+            match (left_val, right_val) {
+                (Some(l), Some(r)) => format!("{}: {} {} {} (left: {}, right: {})", prefix, l, op_str, r, l, r),
+                _ => prefix.to_string(),
+            }
+        }
+        // is pattern: assert x is Some
+        ExprKind::IsPattern { expr, pattern, .. } => {
+            let pat_name = match pattern {
+                rask_ast::expr::Pattern::Constructor { name, .. } => name.as_str(),
+                rask_ast::expr::Pattern::Ident(n) => n.as_str(),
+                rask_ast::expr::Pattern::Wildcard => "_",
+                _ => "pattern",
+            };
+            let val = interp.eval_expr(expr).ok();
+            match val {
+                Some(v) => format!("{}: {} is not {}", prefix, v, pat_name),
+                None => prefix.to_string(),
+            }
+        }
+        _ => prefix.to_string(),
+    }
+}
+
 impl Interpreter {
     pub(crate) fn eval_expr(&mut self, expr: &Expr) -> Result<Value, RuntimeDiagnostic> {
         match &expr.kind {
@@ -1243,7 +1334,7 @@ impl Interpreter {
                         let v = self.eval_expr(msg_expr)?;
                         format!("{}", v)
                     } else {
-                        "assertion failed".to_string()
+                        build_comparison_message(self, condition, "assertion failed")
                     };
                     Err(RuntimeDiagnostic::new(RuntimeError::AssertionFailed(msg), expr.span))
                 }
@@ -1258,7 +1349,7 @@ impl Interpreter {
                         let v = self.eval_expr(msg_expr)?;
                         format!("{}", v)
                     } else {
-                        "check failed".to_string()
+                        build_comparison_message(self, condition, "check failed")
                     };
                     Err(RuntimeDiagnostic::new(RuntimeError::CheckFailed(msg), expr.span))
                 }

--- a/compiler/crates/rask-mir/src/lower/expr.rs
+++ b/compiler/crates/rask-mir/src/lower/expr.rs
@@ -18,6 +18,45 @@ use rask_ast::{
     token::{FloatSuffix, IntSuffix},
 };
 
+/// Detect comparison patterns in assert conditions for smart failure messages.
+///
+/// Returns `Some((left_expr, right_expr, op_str, is_string))` if the condition
+/// is a desugared comparison. After desugar: `a == b` → `a.eq(b)`,
+/// `a != b` → `!(a.eq(b))`, `a < b` → `a.lt(b)`, etc.
+fn extract_assert_comparison(condition: &Expr) -> Option<(&Expr, &Expr, &'static str, bool)> {
+    match &condition.kind {
+        // Desugared comparison: a.eq(b), a.lt(b), etc.
+        ExprKind::MethodCall { object, method, args, .. } if args.len() == 1 => {
+            let op_str = match method.as_str() {
+                "eq" => "==",
+                "lt" => "<",
+                "gt" => ">",
+                "le" => "<=",
+                "ge" => ">=",
+                _ => return None,
+            };
+            let is_string = matches!(&object.kind, ExprKind::String(_))
+                || matches!(&object.kind, ExprKind::Ident(_));
+            // Conservative: assume i64 unless obviously a string literal
+            let is_string = matches!(&object.kind, ExprKind::String(_))
+                || matches!(&args[0].expr.kind, ExprKind::String(_));
+            Some((object.as_ref(), &args[0].expr, op_str, is_string))
+        }
+        // Desugared !=: !(a.eq(b))
+        ExprKind::Unary { op: UnaryOp::Not, operand } => {
+            if let ExprKind::MethodCall { object, method, args, .. } = &operand.kind {
+                if method == "eq" && args.len() == 1 {
+                    let is_string = matches!(&object.kind, ExprKind::String(_))
+                        || matches!(&args[0].expr.kind, ExprKind::String(_));
+                    return Some((object.as_ref(), &args[0].expr, "!=", is_string));
+                }
+            }
+            None
+        }
+        _ => None,
+    }
+}
+
 /// Resolve primitive type associated constants (e.g. i64.MAX, i32.MIN).
 fn primitive_type_constant(type_name: &str, field: &str) -> Option<TypedOperand> {
     let (val, ty) = match (type_name, field) {
@@ -2560,32 +2599,70 @@ impl<'a> MirLowerer<'a> {
 
             // Assert
             ExprKind::Assert { condition, message } => {
-                let (cond_op, _) = self.lower_expr(condition)?;
-                let ok_block = self.builder.create_block();
-                let fail_block = self.builder.create_block();
+                // Detect comparison patterns for smart failure messages.
+                // After desugaring, `a == b` → `a.eq(b)`, `a != b` → `!a.eq(b)`.
+                let cmp_info = if message.is_none() {
+                    extract_assert_comparison(condition)
+                } else {
+                    None
+                };
 
-                self.builder.terminate(MirTerminator::dummy(MirTerminatorKind::Branch {
-                    cond: cond_op,
-                    then_block: ok_block,
-                    else_block: fail_block,
-                }));
+                if let Some((left_expr, right_expr, op_str, is_string)) = cmp_info {
+                    // Lower both sides first to capture their values
+                    let (left_op, _) = self.lower_expr(left_expr)?;
+                    let (right_op, _) = self.lower_expr(right_expr)?;
 
-                self.builder.switch_to_block(fail_block);
+                    // Now lower the full condition
+                    let (cond_op, _) = self.lower_expr(condition)?;
+                    let ok_block = self.builder.create_block();
+                    let fail_block = self.builder.create_block();
 
-                let mut args = Vec::new();
-                if let Some(msg) = message {
-                    let (msg_op, _) = self.lower_expr(msg)?;
-                    args.push(msg_op);
+                    self.builder.terminate(MirTerminator::dummy(MirTerminatorKind::Branch {
+                        cond: cond_op,
+                        then_block: ok_block,
+                        else_block: fail_block,
+                    }));
+
+                    self.builder.switch_to_block(fail_block);
+                    let op_const = MirOperand::Constant(MirConst::String(op_str.to_string()));
+                    let fail_fn = if is_string { "assert_fail_cmp_str" } else { "assert_fail_cmp_i64" };
+                    self.builder.push_stmt(MirStmt::dummy(MirStmtKind::Call {
+                        dst: None,
+                        func: FunctionRef::internal(fail_fn.to_string()),
+                        args: vec![left_op, right_op, op_const],
+                    }));
+                    self.builder.terminate(MirTerminator::dummy(MirTerminatorKind::Unreachable));
+
+                    self.builder.switch_to_block(ok_block);
+                    Ok((MirOperand::Constant(MirConst::Bool(true)), MirType::Bool))
+                } else {
+                    // Generic path: lower condition, pass optional message
+                    let (cond_op, _) = self.lower_expr(condition)?;
+                    let ok_block = self.builder.create_block();
+                    let fail_block = self.builder.create_block();
+
+                    self.builder.terminate(MirTerminator::dummy(MirTerminatorKind::Branch {
+                        cond: cond_op,
+                        then_block: ok_block,
+                        else_block: fail_block,
+                    }));
+
+                    self.builder.switch_to_block(fail_block);
+                    let mut args = Vec::new();
+                    if let Some(msg) = message {
+                        let (msg_op, _) = self.lower_expr(msg)?;
+                        args.push(msg_op);
+                    }
+                    self.builder.push_stmt(MirStmt::dummy(MirStmtKind::Call {
+                        dst: None,
+                        func: FunctionRef::internal("assert_fail".to_string()),
+                        args,
+                    }));
+                    self.builder.terminate(MirTerminator::dummy(MirTerminatorKind::Unreachable));
+
+                    self.builder.switch_to_block(ok_block);
+                    Ok((MirOperand::Constant(MirConst::Bool(true)), MirType::Bool))
                 }
-                self.builder.push_stmt(MirStmt::dummy(MirStmtKind::Call {
-                    dst: None,
-                    func: FunctionRef::internal("assert_fail".to_string()),
-                    args,
-                }));
-                self.builder.terminate(MirTerminator::dummy(MirTerminatorKind::Unreachable));
-
-                self.builder.switch_to_block(ok_block);
-                Ok((MirOperand::Constant(MirConst::Bool(true)), MirType::Bool))
             }
 
             // Check (like assert but continues)

--- a/compiler/crates/rask-mir/src/lower/expr.rs
+++ b/compiler/crates/rask-mir/src/lower/expr.rs
@@ -57,6 +57,23 @@ fn extract_assert_comparison(condition: &Expr) -> Option<(&Expr, &Expr, &'static
     }
 }
 
+/// Extract pattern name from an `is` pattern in an assert condition.
+/// Returns the pattern name as a string for the failure message.
+fn extract_assert_is_pattern(condition: &Expr) -> Option<String> {
+    use rask_ast::expr::Pattern;
+    match &condition.kind {
+        ExprKind::IsPattern { pattern, .. } => {
+            let name = match pattern {
+                Pattern::Constructor { name, .. } => name.clone(),
+                Pattern::Ident(n) => n.clone(),
+                _ => return None,
+            };
+            Some(name)
+        }
+        _ => None,
+    }
+}
+
 /// Resolve primitive type associated constants (e.g. i64.MAX, i32.MIN).
 fn primitive_type_constant(type_name: &str, field: &str) -> Option<TypedOperand> {
     let (val, ty) = match (type_name, field) {
@@ -2636,6 +2653,14 @@ impl<'a> MirLowerer<'a> {
                     self.builder.switch_to_block(ok_block);
                     Ok((MirOperand::Constant(MirConst::Bool(true)), MirType::Bool))
                 } else {
+                    // Check for `is` pattern: assert x is Some
+                    let is_msg = if message.is_none() {
+                        extract_assert_is_pattern(condition)
+                            .map(|pat| format!("assertion failed: expected {}", pat))
+                    } else {
+                        None
+                    };
+
                     // Generic path: lower condition, pass optional message
                     let (cond_op, _) = self.lower_expr(condition)?;
                     let ok_block = self.builder.create_block();
@@ -2652,6 +2677,8 @@ impl<'a> MirLowerer<'a> {
                     if let Some(msg) = message {
                         let (msg_op, _) = self.lower_expr(msg)?;
                         args.push(msg_op);
+                    } else if let Some(is_msg) = is_msg {
+                        args.push(MirOperand::Constant(MirConst::String(is_msg)));
                     }
                     self.builder.push_stmt(MirStmt::dummy(MirStmtKind::Call {
                         dst: None,

--- a/compiler/crates/rask-mir/src/lower/expr.rs
+++ b/compiler/crates/rask-mir/src/lower/expr.rs
@@ -35,9 +35,7 @@ fn extract_assert_comparison(condition: &Expr) -> Option<(&Expr, &Expr, &'static
                 "ge" => ">=",
                 _ => return None,
             };
-            let is_string = matches!(&object.kind, ExprKind::String(_))
-                || matches!(&object.kind, ExprKind::Ident(_));
-            // Conservative: assume i64 unless obviously a string literal
+            // Conservative: assume i64 unless one side is obviously a string literal
             let is_string = matches!(&object.kind, ExprKind::String(_))
                 || matches!(&args[0].expr.kind, ExprKind::String(_));
             Some((object.as_ref(), &args[0].expr, op_str, is_string))

--- a/compiler/crates/rask-spec-test/src/extract.rs
+++ b/compiler/crates/rask-spec-test/src/extract.rs
@@ -24,8 +24,10 @@ pub enum Expectation {
     ParseFail,
     /// Don't test this block
     Skip,
-    /// Run and verify output matches expected
+    /// Run and verify output matches expected (interpreter + native)
     Run(String),
+    /// Run through interpreter only — escape hatch for unimplemented codegen
+    RunInterpOnly(String),
 }
 
 /// A single test case extracted from a spec file.
@@ -106,8 +108,14 @@ fn parse_annotation_multi(lines: &[&str], start: usize) -> Option<(Expectation, 
         // Must start with "test:"
         let test_spec = content.strip_prefix("test:")?.trim();
 
-        // Check for run with inline expected output: "run | expected"
-        if test_spec.starts_with("run") {
+        // Check for run variants with inline expected output: "run | expected"
+        if test_spec.starts_with("run-interp") {
+            let rest = test_spec.strip_prefix("run-interp").unwrap().trim();
+            if let Some(expected) = rest.strip_prefix("|") {
+                let expected = process_escapes(expected.trim());
+                return Some((Expectation::RunInterpOnly(expected), 1));
+            }
+        } else if test_spec.starts_with("run") {
             let rest = test_spec.strip_prefix("run").unwrap().trim();
             if let Some(expected) = rest.strip_prefix("|") {
                 let expected = process_escapes(expected.trim());
@@ -134,9 +142,11 @@ fn parse_annotation_multi(lines: &[&str], start: usize) -> Option<(Expectation, 
     }
 
     let test_spec = first_line_content.strip_prefix("test:")?.trim();
-    if test_spec != "run" {
-        return None;
-    }
+    let interp_only = match test_spec {
+        "run" => false,
+        "run-interp" => true,
+        _ => return None,
+    };
 
     // Collect expected output until -->
     let mut expected_lines = Vec::new();
@@ -145,7 +155,8 @@ fn parse_annotation_multi(lines: &[&str], start: usize) -> Option<(Expectation, 
         let line = lines[i];
         if line.trim() == "-->" {
             let expected = expected_lines.join("\n");
-            return Some((Expectation::Run(expected), i - start + 1));
+            let exp = if interp_only { Expectation::RunInterpOnly(expected) } else { Expectation::Run(expected) };
+            return Some((exp, i - start + 1));
         }
         if line.trim().ends_with("-->") {
             // Last line with content before -->
@@ -154,7 +165,8 @@ fn parse_annotation_multi(lines: &[&str], start: usize) -> Option<(Expectation, 
                 expected_lines.push(content);
             }
             let expected = expected_lines.join("\n");
-            return Some((Expectation::Run(expected), i - start + 1));
+            let exp = if interp_only { Expectation::RunInterpOnly(expected) } else { Expectation::Run(expected) };
+            return Some((exp, i - start + 1));
         }
         expected_lines.push(line);
         i += 1;

--- a/compiler/crates/rask-spec-test/src/extract.rs
+++ b/compiler/crates/rask-spec-test/src/extract.rs
@@ -186,6 +186,17 @@ fn is_rask_code_fence(line: &str) -> bool {
     trimmed.starts_with("```rask") || trimmed.starts_with("``` rask")
 }
 
+/// Check if a `.rk` file contains `test` blocks (Rask's built-in test system).
+///
+/// Returns true if the file has `test "..."` blocks, making it eligible for
+/// differential testing via `rask test <file>`.
+pub fn has_rk_tests(source: &str) -> bool {
+    source.lines().any(|line| {
+        let trimmed = line.trim();
+        trimmed.starts_with("test \"") || trimmed.starts_with("test '")
+    })
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/compiler/crates/rask-spec-test/src/lib.rs
+++ b/compiler/crates/rask-spec-test/src/lib.rs
@@ -15,7 +15,8 @@
 //! - `<!-- test: parse -->` - Must parse (skip type checking)
 //! - `<!-- test: parse-fail -->` - Must fail to parse
 //! - `<!-- test: skip -->` - Don't test this block
-//! - `<!-- test: run\n...\n-->` - Run and verify output matches
+//! - `<!-- test: run | expected -->` - Run via interpreter + native, verify output
+//! - `<!-- test: run-interp | expected -->` - Run via interpreter only (codegen escape hatch)
 //! - (no annotation) - Skipped by default
 
 pub mod deps;
@@ -24,4 +25,4 @@ pub mod runner;
 
 pub use deps::{check_staleness, extract_deps, SpecDeps, StalenessWarning};
 pub use extract::{extract_tests, Expectation, SpecTest};
-pub use runner::{run_test, TestResult, TestSummary};
+pub use runner::{run_test, run_test_with_config, NativeResult, RunConfig, TestResult, TestSummary};

--- a/compiler/crates/rask-spec-test/src/lib.rs
+++ b/compiler/crates/rask-spec-test/src/lib.rs
@@ -24,5 +24,5 @@ pub mod extract;
 pub mod runner;
 
 pub use deps::{check_staleness, extract_deps, SpecDeps, StalenessWarning};
-pub use extract::{extract_tests, Expectation, SpecTest};
-pub use runner::{run_test, run_test_with_config, NativeResult, RunConfig, TestResult, TestSummary};
+pub use extract::{extract_tests, has_rk_tests, Expectation, SpecTest};
+pub use runner::{run_test, run_test_with_config, run_rk_test_file, NativeResult, RkTestResult, RunConfig, TestResult, TestSummary};

--- a/compiler/crates/rask-spec-test/src/runner.rs
+++ b/compiler/crates/rask-spec-test/src/runner.rs
@@ -495,6 +495,143 @@ fn run_native(code: &str, expected: &str, rask_binary: &std::path::Path) -> Nati
     }
 }
 
+/// Run a `.rk` file's test blocks through the interpreter.
+///
+/// Returns (passed, total, failures) where failures is a list of test names.
+fn run_rk_tests_interp(source: &str) -> (usize, usize, Vec<String>) {
+    // Lex
+    let lex_result = rask_lexer::Lexer::new(source).tokenize();
+    if !lex_result.is_ok() {
+        return (0, 1, vec![format!("lex failed: {:?}", lex_result.errors)]);
+    }
+
+    // Parse
+    let mut parse_result = rask_parser::Parser::new(lex_result.tokens).parse();
+    if !parse_result.is_ok() {
+        return (0, 1, vec![format!("parse failed: {:?}", parse_result.errors)]);
+    }
+
+    // Desugar
+    rask_desugar::desugar(&mut parse_result.decls);
+
+    let mut interp = rask_interp::Interpreter::new();
+    let results = interp.run_tests(&parse_result.decls, None);
+
+    let total = results.len();
+    let mut passed = 0;
+    let mut failures = Vec::new();
+    for r in &results {
+        if r.passed {
+            passed += 1;
+        } else {
+            let err_msg = r.errors.first().map(|e| e.as_str()).unwrap_or("failed");
+            failures.push(format!("{}: {}", r.name, err_msg));
+        }
+    }
+    (passed, total, failures)
+}
+
+/// Run a `.rk` file's test blocks natively via `rask test <file>`.
+///
+/// Returns (passed, total, failures).
+fn run_rk_tests_native(path: &std::path::Path, rask_binary: &std::path::Path) -> (usize, usize, Vec<String>) {
+    let result = std::process::Command::new(rask_binary)
+        .arg("test")
+        .arg(path)
+        .output();
+
+    match result {
+        Ok(output) => {
+            let stdout = String::from_utf8_lossy(&output.stdout);
+            let stderr = String::from_utf8_lossy(&output.stderr);
+
+            // Parse test results from output
+            // Native test output format: "  ✓ test name" or "  ✗ test name"
+            let mut passed = 0;
+            let mut total = 0;
+            let mut failures = Vec::new();
+
+            for line in stderr.lines().chain(stdout.lines()) {
+                let trimmed = line.trim();
+                if trimmed.contains("✓") && trimmed.contains("test ") {
+                    total += 1;
+                    passed += 1;
+                } else if trimmed.contains("✗") && trimmed.contains("test ") {
+                    total += 1;
+                    failures.push(trimmed.to_string());
+                }
+            }
+
+            // If we couldn't parse output, check exit code
+            if total == 0 {
+                if output.status.success() {
+                    // Probably compiled and tests passed but we couldn't parse
+                    (1, 1, vec![])
+                } else {
+                    let err_preview: String = stderr.lines()
+                        .filter(|l| !l.contains("warning:"))
+                        .take(3)
+                        .collect::<Vec<_>>()
+                        .join("; ");
+                    (0, 1, vec![format!("native test failed (exit {}): {}", output.status.code().unwrap_or(-1), err_preview)])
+                }
+            } else {
+                (passed, total, failures)
+            }
+        }
+        Err(e) => (0, 1, vec![format!("failed to run rask binary: {}", e)]),
+    }
+}
+
+/// Result of running a `.rk` test file through both backends.
+#[derive(Debug)]
+pub struct RkTestResult {
+    /// Path to the .rk file
+    pub path: std::path::PathBuf,
+    /// Interpreter: (passed, total)
+    pub interp_passed: usize,
+    pub interp_total: usize,
+    pub interp_failures: Vec<String>,
+    /// Native: (passed, total) — None if binary unavailable
+    pub native_passed: Option<usize>,
+    pub native_total: Option<usize>,
+    pub native_failures: Vec<String>,
+}
+
+impl RkTestResult {
+    pub fn interp_ok(&self) -> bool {
+        self.interp_passed == self.interp_total && self.interp_total > 0
+    }
+    pub fn native_ok(&self) -> bool {
+        match (self.native_passed, self.native_total) {
+            (Some(p), Some(t)) => p == t && t > 0,
+            _ => true, // Not run
+        }
+    }
+}
+
+/// Run a `.rk` file through both interpreter and native test runners.
+pub fn run_rk_test_file(path: &std::path::Path, source: &str, config: &RunConfig) -> RkTestResult {
+    let (ip, it, ifails) = run_rk_tests_interp(source);
+
+    let (np, nt, nfails) = if let Some(binary) = &config.rask_binary {
+        let (p, t, f) = run_rk_tests_native(path, binary);
+        (Some(p), Some(t), f)
+    } else {
+        (None, None, vec![])
+    };
+
+    RkTestResult {
+        path: path.to_path_buf(),
+        interp_passed: ip,
+        interp_total: it,
+        interp_failures: ifails,
+        native_passed: np,
+        native_total: nt,
+        native_failures: nfails,
+    }
+}
+
 /// Summary statistics for a test run.
 #[derive(Debug, Default)]
 pub struct TestSummary {

--- a/compiler/crates/rask-spec-test/src/runner.rs
+++ b/compiler/crates/rask-spec-test/src/runner.rs
@@ -1,21 +1,53 @@
 // SPDX-License-Identifier: (MIT OR Apache-2.0)
-//! Run extracted spec tests through the compiler.
+//! Run extracted spec tests through the compiler and (optionally) native codegen.
+//!
+//! When a `rask_binary` path is provided, `Run` tests execute through both the
+//! tree-walk interpreter and native compilation, comparing outputs. This
+//! differential testing surfaces codegen/MIR bugs: if the interpreter produces
+//! correct output but the native binary doesn't, the bug is in the backend.
 
 use crate::extract::{Expectation, SpecTest};
+use std::path::PathBuf;
 
 /// Result of running a single spec test.
 #[derive(Debug)]
 pub struct TestResult {
     /// The test that was run
     pub test: SpecTest,
-    /// Whether the test passed
+    /// Whether the interpreter test passed
+    pub passed: bool,
+    /// Description of what happened (interpreter)
+    pub message: String,
+    /// Native compilation result (only for Run tests when binary is available)
+    pub native_result: Option<NativeResult>,
+}
+
+/// Result of native (compiled) execution.
+#[derive(Debug)]
+pub struct NativeResult {
+    /// Whether native output matched expected
     pub passed: bool,
     /// Description of what happened
     pub message: String,
+    /// The actual stdout from native execution (for diffing)
+    pub actual_output: Option<String>,
+}
+
+/// Configuration for the test runner.
+#[derive(Debug, Clone, Default)]
+pub struct RunConfig {
+    /// Path to the `rask` binary for native compilation tests.
+    /// When None, native tests are skipped.
+    pub rask_binary: Option<PathBuf>,
 }
 
 /// Run a single spec test and return the result.
 pub fn run_test(test: SpecTest) -> TestResult {
+    run_test_with_config(test, &RunConfig::default())
+}
+
+/// Run a single spec test with configuration.
+pub fn run_test_with_config(test: SpecTest, config: &RunConfig) -> TestResult {
     match test.expectation.clone() {
         Expectation::Compile => run_compile_test(test),
         Expectation::CompileFail => run_compile_fail_test(test),
@@ -25,8 +57,10 @@ pub fn run_test(test: SpecTest) -> TestResult {
             test,
             passed: true,
             message: "skipped".to_string(),
+            native_result: None,
         },
-        Expectation::Run(expected) => run_run_test(test, &expected),
+        Expectation::Run(expected) => run_run_test(test, &expected, config),
+        Expectation::RunInterpOnly(expected) => run_run_test_interp_only(test, &expected),
     }
 }
 
@@ -39,6 +73,7 @@ fn run_compile_test(test: SpecTest) -> TestResult {
             test,
             passed: false,
             message: format!("lex failed: {:?}", lex_result.errors),
+            native_result: None,
         };
     }
 
@@ -49,6 +84,7 @@ fn run_compile_test(test: SpecTest) -> TestResult {
             test,
             passed: false,
             message: format!("parse failed: {:?}", parse_result.errors),
+            native_result: None,
         };
     }
 
@@ -63,6 +99,7 @@ fn run_compile_test(test: SpecTest) -> TestResult {
                 test,
                 passed: false,
                 message: format!("resolve failed: {:?}", errors),
+                native_result: None,
             };
         }
     };
@@ -75,6 +112,7 @@ fn run_compile_test(test: SpecTest) -> TestResult {
                 test,
                 passed: false,
                 message: format!("type check failed: {:?}", errors),
+                native_result: None,
             };
         }
     };
@@ -86,6 +124,7 @@ fn run_compile_test(test: SpecTest) -> TestResult {
             test,
             passed: false,
             message: format!("ownership check failed: {:?}", ownership_result.errors),
+            native_result: None,
         };
     }
 
@@ -93,6 +132,7 @@ fn run_compile_test(test: SpecTest) -> TestResult {
         test,
         passed: true,
         message: "compiled".to_string(),
+        native_result: None,
     }
 }
 
@@ -105,6 +145,7 @@ fn run_compile_fail_test(test: SpecTest) -> TestResult {
             test,
             passed: true,
             message: "failed at lex (expected)".to_string(),
+            native_result: None,
         };
     }
 
@@ -115,6 +156,7 @@ fn run_compile_fail_test(test: SpecTest) -> TestResult {
             test,
             passed: true,
             message: "failed at parse (expected)".to_string(),
+            native_result: None,
         };
     }
 
@@ -129,6 +171,7 @@ fn run_compile_fail_test(test: SpecTest) -> TestResult {
                 test,
                 passed: true,
                 message: "failed at resolve (expected)".to_string(),
+                native_result: None,
             };
         }
     };
@@ -141,6 +184,7 @@ fn run_compile_fail_test(test: SpecTest) -> TestResult {
                 test,
                 passed: true,
                 message: "failed at typecheck (expected)".to_string(),
+                native_result: None,
             };
         }
     };
@@ -152,6 +196,7 @@ fn run_compile_fail_test(test: SpecTest) -> TestResult {
             test,
             passed: true,
             message: "failed at ownership check (expected)".to_string(),
+            native_result: None,
         };
     }
 
@@ -160,6 +205,7 @@ fn run_compile_fail_test(test: SpecTest) -> TestResult {
         test,
         passed: false,
         message: "expected compile failure, but compiled successfully".to_string(),
+        native_result: None,
     }
 }
 
@@ -172,6 +218,7 @@ fn run_parse_test(test: SpecTest) -> TestResult {
             test,
             passed: false,
             message: format!("lex failed: {:?}", lex_result.errors),
+            native_result: None,
         };
     }
 
@@ -182,6 +229,7 @@ fn run_parse_test(test: SpecTest) -> TestResult {
             test,
             passed: false,
             message: format!("parse failed: {:?}", parse_result.errors),
+            native_result: None,
         };
     }
 
@@ -189,6 +237,7 @@ fn run_parse_test(test: SpecTest) -> TestResult {
         test,
         passed: true,
         message: "parsed".to_string(),
+        native_result: None,
     }
 }
 
@@ -201,6 +250,7 @@ fn run_parse_fail_test(test: SpecTest) -> TestResult {
             test,
             passed: true,
             message: "failed at lex (expected)".to_string(),
+            native_result: None,
         };
     }
 
@@ -211,6 +261,7 @@ fn run_parse_fail_test(test: SpecTest) -> TestResult {
             test,
             passed: true,
             message: "failed at parse (expected)".to_string(),
+            native_result: None,
         };
     }
 
@@ -218,6 +269,7 @@ fn run_parse_fail_test(test: SpecTest) -> TestResult {
         test,
         passed: false,
         message: "expected parse failure, but parsed successfully".to_string(),
+        native_result: None,
     }
 }
 
@@ -300,29 +352,47 @@ fn wrap_in_main(code: &str) -> String {
     }
 }
 
-/// Test that code runs and produces expected output.
-fn run_run_test(test: SpecTest, expected: &str) -> TestResult {
-    // Wrap in main if needed
-    let code = wrap_in_main(&test.code);
+/// Run a test through interpreter only (escape hatch for unimplemented codegen).
+fn run_run_test_interp_only(test: SpecTest, expected: &str) -> TestResult {
+    let (passed, message) = run_interpreter(&test.code, expected);
+    TestResult {
+        test,
+        passed,
+        message,
+        native_result: None,
+    }
+}
+
+/// Run a test through both interpreter and native compilation.
+fn run_run_test(test: SpecTest, expected: &str, config: &RunConfig) -> TestResult {
+    let (interp_passed, interp_message) = run_interpreter(&test.code, expected);
+
+    let native_result = config.rask_binary.as_ref().map(|binary| {
+        run_native(&test.code, expected, binary)
+    });
+
+    TestResult {
+        test,
+        passed: interp_passed,
+        message: interp_message,
+        native_result,
+    }
+}
+
+/// Run code through the tree-walk interpreter and compare output.
+fn run_interpreter(code: &str, expected: &str) -> (bool, String) {
+    let code = wrap_in_main(code);
 
     // Lex
     let lex_result = rask_lexer::Lexer::new(&code).tokenize();
     if !lex_result.is_ok() {
-        return TestResult {
-            test,
-            passed: false,
-            message: format!("lex failed: {:?}", lex_result.errors),
-        };
+        return (false, format!("lex failed: {:?}", lex_result.errors));
     }
 
     // Parse
     let mut parse_result = rask_parser::Parser::new(lex_result.tokens).parse();
     if !parse_result.is_ok() {
-        return TestResult {
-            test,
-            passed: false,
-            message: format!("parse failed: {:?}", parse_result.errors),
-        };
+        return (false, format!("parse failed: {:?}", parse_result.errors));
     }
 
     // Desugar
@@ -338,26 +408,89 @@ fn run_run_test(test: SpecTest, expected: &str) -> TestResult {
             let expected_trimmed = expected.trim_end();
 
             if actual_trimmed == expected_trimmed {
-                TestResult {
-                    test,
-                    passed: true,
-                    message: "output matched".to_string(),
-                }
+                (true, "output matched".to_string())
             } else {
-                TestResult {
-                    test,
+                (false, format!(
+                    "output mismatch:\n  expected: {:?}\n  actual:   {:?}",
+                    expected_trimmed, actual_trimmed
+                ))
+            }
+        }
+        Err(e) => (false, format!("runtime error: {}", e)),
+    }
+}
+
+/// Run code through native compilation and compare output.
+///
+/// Writes code to a temp file, invokes `rask run <file>` (which defaults to
+/// native compilation), captures stdout.
+fn run_native(code: &str, expected: &str, rask_binary: &std::path::Path) -> NativeResult {
+    let code = wrap_in_main(code);
+
+    // Write to temp file
+    let tmp_dir = std::env::temp_dir();
+    let id = std::process::id();
+    let ts = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| d.as_nanos())
+        .unwrap_or(0);
+    let tmp_file = tmp_dir.join(format!("rask_spec_{}_{}.rk", id, ts));
+
+    if let Err(e) = std::fs::write(&tmp_file, &code) {
+        return NativeResult {
+            passed: false,
+            message: format!("failed to write temp file: {}", e),
+            actual_output: None,
+        };
+    }
+
+    // Run native compilation (rask run defaults to native)
+    let result = std::process::Command::new(rask_binary)
+        .arg("run")
+        .arg(&tmp_file)
+        .output();
+
+    // Clean up temp file
+    let _ = std::fs::remove_file(&tmp_file);
+
+    match result {
+        Ok(output) => {
+            let stdout = String::from_utf8_lossy(&output.stdout).to_string();
+            let stderr = String::from_utf8_lossy(&output.stderr).to_string();
+            let actual_trimmed = stdout.trim_end();
+            let expected_trimmed = expected.trim_end();
+
+            if !output.status.success() {
+                NativeResult {
                     passed: false,
                     message: format!(
-                        "output mismatch:\n  expected: {:?}\n  actual:   {:?}",
-                        expected_trimmed, actual_trimmed
+                        "native exited with {}: {}",
+                        output.status.code().unwrap_or(-1),
+                        stderr.lines().take(3).collect::<Vec<_>>().join("; "),
                     ),
+                    actual_output: Some(stdout),
+                }
+            } else if actual_trimmed == expected_trimmed {
+                NativeResult {
+                    passed: true,
+                    message: "native matched".to_string(),
+                    actual_output: Some(stdout),
+                }
+            } else {
+                NativeResult {
+                    passed: false,
+                    message: format!(
+                        "native output mismatch:\n  expected: {:?}\n  actual:   {:?}",
+                        expected_trimmed, actual_trimmed,
+                    ),
+                    actual_output: Some(stdout),
                 }
             }
         }
-        Err(e) => TestResult {
-            test,
+        Err(e) => NativeResult {
             passed: false,
-            message: format!("runtime error: {}", e),
+            message: format!("failed to run rask binary: {}", e),
+            actual_output: None,
         },
     }
 }
@@ -369,6 +502,12 @@ pub struct TestSummary {
     pub passed: usize,
     pub failed: usize,
     pub files: usize,
+    /// Native tests attempted
+    pub native_total: usize,
+    /// Native tests passed
+    pub native_passed: usize,
+    /// Native tests failed
+    pub native_failed: usize,
 }
 
 impl TestSummary {
@@ -378,6 +517,14 @@ impl TestSummary {
             self.passed += 1;
         } else {
             self.failed += 1;
+        }
+        if let Some(native) = &result.native_result {
+            self.native_total += 1;
+            if native.passed {
+                self.native_passed += 1;
+            } else {
+                self.native_failed += 1;
+            }
         }
     }
 }

--- a/compiler/runtime/rask_runtime.h
+++ b/compiler/runtime/rask_runtime.h
@@ -443,6 +443,15 @@ void rask_panic_unwrap(void);
 void rask_panic_unwrap_at(const char *file, int32_t line, int32_t col);
 void rask_assert_fail(void);
 void rask_assert_fail_at(const char *file, int32_t line, int32_t col);
+void rask_assert_fail_msg(const char *msg);
+void rask_assert_fail_msg_at(const char *msg, const char *file,
+                             int32_t line, int32_t col);
+void rask_assert_fail_cmp_i64(int64_t left, int64_t right,
+                              const char *op, const char *file,
+                              int32_t line, int32_t col);
+void rask_assert_fail_cmp_str(const char *left, const char *right,
+                              const char *op, const char *file,
+                              int32_t line, int32_t col);
 
 // Install/remove panic handler for the current thread.
 // Used internally by rask_spawn — not part of the public API.

--- a/compiler/runtime/runtime.c
+++ b/compiler/runtime/runtime.c
@@ -85,6 +85,37 @@ void rask_assert_fail_at(const char *file, int32_t line, int32_t col) {
     rask_panic_at(file, line, col, "assertion failed");
 }
 
+void rask_assert_fail_msg(const char *msg) {
+    rask_panic(msg ? msg : "assertion failed");
+}
+
+void rask_assert_fail_msg_at(const char *msg, const char *file,
+                             int32_t line, int32_t col) {
+    rask_panic_at(file, line, col, msg ? msg : "assertion failed");
+}
+
+void rask_assert_fail_cmp_i64(int64_t left, int64_t right,
+                              const char *op, const char *file,
+                              int32_t line, int32_t col) {
+    char buf[RASK_PANIC_MSG_MAX];
+    snprintf(buf, sizeof(buf),
+             "assertion failed: %lld %s %lld (left: %lld, right: %lld)",
+             (long long)left, op ? op : "?",
+             (long long)right, (long long)left, (long long)right);
+    rask_panic_at(file, line, col, buf);
+}
+
+void rask_assert_fail_cmp_str(const char *left, const char *right,
+                              const char *op, const char *file,
+                              int32_t line, int32_t col) {
+    char buf[RASK_PANIC_MSG_MAX];
+    snprintf(buf, sizeof(buf),
+             "assertion failed: \"%s\" %s \"%s\"",
+             left ? left : "(null)", op ? op : "?",
+             right ? right : "(null)");
+    rask_panic_at(file, line, col, buf);
+}
+
 // ─── I/O primitives ──────────────────────────────────────────────
 // Thin wrappers around POSIX syscalls. Return values match POSIX
 // conventions: bytes transferred on success, -1 on error.

--- a/specs/compiler/test-infrastructure.md
+++ b/specs/compiler/test-infrastructure.md
@@ -114,16 +114,16 @@ Annotations:
 
 Example from spec:
 
-````markdown
-<!-- test: run | 120 -->
-```rask
-func factorial(n: u32) -> u32 {
-    if n <= 1 { return 1 }
-    return n * factorial(n - 1)
-}
-println("{}", factorial(5))
 ```
-````
+  < !-- test: run | 120 -- >
+  ```rask
+  func factorial(n: u32) -> u32 {
+      if n <= 1 { return 1 }
+      return n * factorial(n - 1)
+  }
+  println("{}", factorial(5))
+  ```
+```
 
 Output shows differential results:
 

--- a/specs/compiler/test-infrastructure.md
+++ b/specs/compiler/test-infrastructure.md
@@ -97,29 +97,54 @@ fn parse_function_declaration() {
 
 Target: 90%+ coverage of each compiler phase.
 
-## L3: Spec Tests (Literate)
+## L3: Spec Tests (Literate + Differential)
 
-Tests embedded in spec markdown files using annotations. Already implemented in `rask-spec-test`.
+Tests embedded in spec markdown files using annotations. Implemented in `rask-spec-test`.
+
+**Differential testing:** `run` tests execute through both the tree-walk interpreter and native compilation (mono → MIR → Cranelift → binary). Output from both paths is compared against the expected value. Any divergence between interpreter and codegen is a backend bug. The interpreter acts as the oracle — it's simpler and closer to correct for basic operations.
 
 Annotations:
 - `<!-- test: parse -->` — Must parse successfully
 - `<!-- test: parse-fail -->` — Must fail to parse
 - `<!-- test: compile -->` — Must type-check
 - `<!-- test: compile-fail -->` — Must fail type-check
-- `<!-- test: run -->` — Must execute (interpreter only for now)
+- `<!-- test: run | expected -->` — Run via interpreter + native, verify output matches
+- `<!-- test: run-interp | expected -->` — Interpreter only (escape hatch for unimplemented codegen)
 - `<!-- test: skip -->` — Don't test
 
 Example from spec:
 
 ````markdown
-<!-- test: parse -->
+<!-- test: run | 120 -->
 ```rask
 func factorial(n: u32) -> u32 {
     if n <= 1 { return 1 }
     return n * factorial(n - 1)
 }
+println("{}", factorial(5))
 ```
 ````
+
+Output shows differential results:
+
+```
+specs/types/enums.md
+  ✓ line 558: Run("0\n1\n2") - output matched  native:ok
+```
+
+When native diverges from interpreter:
+
+```
+  ✓ line 42: Run("42") - output matched  native:FAIL
+       native: native output mismatch: expected "42", actual ""
+```
+
+Summary includes native stats:
+
+```
+97 files, 137 tests, 135 passed, 2 failed
+6/6 native passed
+```
 
 | Rule | Description |
 |------|-------------|
@@ -127,8 +152,10 @@ func factorial(n: u32) -> u32 {
 | **S2: Single responsibility** | Each block tests one concept |
 | **S3: Run on spec edit** | Auto-run via hook when specs change |
 | **S4: Staleness warnings** | Warn if spec dependencies changed |
+| **S5: Differential by default** | `run` tests exercise both interpreter and codegen |
+| **S6: Escape hatch** | `run-interp` for features codegen doesn't support yet |
 
-Command: `rask verify-specs specs/` (already implemented)
+Command: `rask test-specs specs/`
 
 ## L4: Integration Tests
 

--- a/tests/suite/t01_arithmetic.rk
+++ b/tests/suite/t01_arithmetic.rk
@@ -1,0 +1,67 @@
+// SPDX-License-Identifier: (MIT OR Apache-2.0)
+// Basic arithmetic and integer operations.
+
+test "addition" {
+    assert 2 + 3 == 5
+    assert 0 + 0 == 0
+    assert -1 + 1 == 0
+    assert 100 + 200 == 300
+}
+
+test "subtraction" {
+    assert 10 - 3 == 7
+    assert 0 - 5 == -5
+    assert 5 - 5 == 0
+}
+
+test "multiplication" {
+    assert 6 * 7 == 42
+    assert 0 * 100 == 0
+    assert -3 * 4 == -12
+    assert -2 * -3 == 6
+}
+
+test "division" {
+    assert 10 / 2 == 5
+    assert 10 / 3 == 3
+    assert 100 / 10 == 10
+    assert -10 / 3 == -3
+}
+
+test "modulo" {
+    assert 10 % 3 == 1
+    assert 10 % 5 == 0
+    assert 7 % 2 == 1
+}
+
+test "operator precedence" {
+    assert 1 + 2 * 3 == 7
+    assert (1 + 2) * 3 == 9
+    assert 10 - 2 * 3 == 4
+    assert 10 / 2 + 3 == 8
+}
+
+test "comparison operators" {
+    assert 5 > 3
+    assert 3 < 5
+    assert 5 >= 5
+    assert 5 <= 5
+    assert 5 == 5
+    assert 5 != 3
+    assert !(5 < 3)
+    assert !(3 > 5)
+}
+
+func factorial(n: i32) -> i32 {
+    if n <= 1 { return 1 }
+    return n * factorial(n - 1)
+}
+
+test "recursion" {
+    assert factorial(0) == 1
+    assert factorial(1) == 1
+    assert factorial(5) == 120
+    assert factorial(10) == 3628800
+}
+
+func main() {}

--- a/tests/suite/t02_strings.rk
+++ b/tests/suite/t02_strings.rk
@@ -1,0 +1,65 @@
+// SPDX-License-Identifier: (MIT OR Apache-2.0)
+// String operations, concatenation, and copy semantics.
+
+test "string equality" {
+    assert "hello" == "hello"
+    assert "hello" != "world"
+    assert "" == ""
+}
+
+test "string concatenation" {
+    const a = "hello"
+    const b = " world"
+    const result = "{a}{b}"
+    assert result == "hello world"
+}
+
+test "string length" {
+    assert "hello".len() == 5
+    assert "".len() == 0
+    assert "abc".len() == 3
+}
+
+test "string copy semantics" {
+    const original = "hello"
+    const copy1 = original
+    const copy2 = original
+    assert original == "hello"
+    assert copy1 == "hello"
+    assert copy2 == "hello"
+}
+
+test "string interpolation" {
+    const name = "world"
+    assert "hello, {name}" == "hello, world"
+
+    const x = 42
+    assert "{x}" == "42"
+
+    const a = 10
+    const b = 20
+    assert "{a} + {b}" == "10 + 20"
+}
+
+test "string trim" {
+    assert "  hello  ".trim() == "hello"
+}
+
+test "string contains" {
+    assert "hello world".contains("world")
+    assert "hello world".contains("hello")
+    assert !("hello".contains("xyz"))
+}
+
+func take_string(s: string) -> string {
+    return s
+}
+
+test "string passed to function stays valid" {
+    const s = "hello"
+    const result = take_string(s)
+    assert s == "hello"
+    assert result == "hello"
+}
+
+func main() {}

--- a/tests/suite/t03_structs.rk
+++ b/tests/suite/t03_structs.rk
@@ -1,0 +1,94 @@
+// SPDX-License-Identifier: (MIT OR Apache-2.0)
+// Struct construction, field access, methods, and string fields.
+
+struct Point {
+    x: i32
+    y: i32
+}
+
+extend Point {
+    func new(x: i32, y: i32) -> Point {
+        return Point { x: x, y: y }
+    }
+
+    func manhattan(self) -> i32 {
+        return self.x + self.y
+    }
+
+    func add(self, other: Point) -> Point {
+        return Point { x: self.x + other.x, y: self.y + other.y }
+    }
+}
+
+struct Named {
+    name: string
+    value: i32
+}
+
+extend Named {
+    func describe(self) -> string {
+        return "{self.name}={self.value}"
+    }
+}
+
+struct Nested {
+    inner: Point
+    label: string
+}
+
+test "struct construction and field access" {
+    const p = Point { x: 10, y: 20 }
+    assert p.x == 10
+    assert p.y == 20
+}
+
+test "struct method" {
+    const p = Point.new(3, 4)
+    assert p.manhattan() == 7
+}
+
+test "struct method returning struct" {
+    const a = Point.new(1, 2)
+    const b = Point.new(3, 4)
+    const c = a.add(b)
+    assert c.x == 4
+    assert c.y == 6
+}
+
+test "struct with string field" {
+    const n = Named { name: "foo", value: 42 }
+    assert n.name == "foo"
+    assert n.value == 42
+}
+
+test "struct method using string field" {
+    const n = Named { name: "x", value: 10 }
+    assert n.describe() == "x=10"
+}
+
+test "multiple structs with string fields" {
+    const a = Named { name: "alice", value: 1 }
+    const b = Named { name: "bob", value: 2 }
+    assert a.name == "alice"
+    assert b.name == "bob"
+    assert a.name != b.name
+}
+
+test "nested struct" {
+    const n = Nested {
+        inner: Point { x: 5, y: 10 },
+        label: "test",
+    }
+    assert n.inner.x == 5
+    assert n.inner.y == 10
+    assert n.label == "test"
+}
+
+test "struct update syntax" {
+    const p = Point { x: 1, y: 2 }
+    const q = Point { x: 10, ..p }
+    assert q.x == 10
+    assert q.y == 2
+}
+
+func main() {}

--- a/tests/suite/t04_enums.rk
+++ b/tests/suite/t04_enums.rk
@@ -1,0 +1,81 @@
+// SPDX-License-Identifier: (MIT OR Apache-2.0)
+// Enum variants, pattern matching, and payloads.
+
+enum Color {
+    Red
+    Green
+    Blue
+}
+
+enum Shape {
+    Circle(i32)
+    Rectangle(i32, i32)
+    Empty
+}
+
+enum Value {
+    Text(string)
+    Number(i32)
+    Nothing
+}
+
+func area(s: Shape) -> i32 {
+    match s {
+        Shape.Circle(r) => return r * r
+        Shape.Rectangle(w, h) => return w * h
+        Shape.Empty => return 0
+    }
+}
+
+test "simple enum match" {
+    const c = Color.Red
+    let name = ""
+    match c {
+        Color.Red => name = "red"
+        Color.Green => name = "green"
+        Color.Blue => name = "blue"
+    }
+    assert name == "red"
+}
+
+test "enum with payload" {
+    assert area(Shape.Circle(5)) == 25
+    assert area(Shape.Rectangle(3, 4)) == 12
+    assert area(Shape.Empty) == 0
+}
+
+test "enum payload extraction" {
+    const v = Shape.Circle(10)
+    match v {
+        Shape.Circle(r) => assert r == 10
+        _ => assert false, "expected Circle"
+    }
+}
+
+test "enum with string payload" {
+    const v = Value.Text("hello")
+    match v {
+        Value.Text(s) => assert s == "hello"
+        _ => assert false, "expected Text"
+    }
+}
+
+test "enum with number payload" {
+    const v = Value.Number(42)
+    match v {
+        Value.Number(n) => assert n == 42
+        _ => assert false, "expected Number"
+    }
+}
+
+test "enum wildcard match" {
+    const c = Color.Blue
+    let matched_wildcard = false
+    match c {
+        Color.Red => assert false, "wrong"
+        _ => matched_wildcard = true
+    }
+    assert matched_wildcard
+}
+
+func main() {}

--- a/tests/suite/t05_control_flow.rk
+++ b/tests/suite/t05_control_flow.rk
@@ -1,0 +1,100 @@
+// SPDX-License-Identifier: (MIT OR Apache-2.0)
+// if/else, loops, break, continue, early return.
+
+func classify(n: i32) -> string {
+    if n > 0 {
+        return "positive"
+    } else if n == 0 {
+        return "zero"
+    } else {
+        return "negative"
+    }
+}
+
+func abs(n: i32) -> i32 {
+    if n < 0 { return -n }
+    return n
+}
+
+func sum_range(start: i32, end: i32) -> i32 {
+    let total = 0
+    for i in start..end {
+        total += i
+    }
+    return total
+}
+
+test "if-else" {
+    assert classify(5) == "positive"
+    assert classify(0) == "zero"
+    assert classify(-3) == "negative"
+}
+
+test "nested if" {
+    const x = 42
+    let result = ""
+    if x > 0 {
+        if x > 100 {
+            result = "big"
+        } else {
+            result = "small positive"
+        }
+    } else {
+        result = "non-positive"
+    }
+    assert result == "small positive"
+}
+
+test "for range loop" {
+    assert sum_range(0, 5) == 10
+    assert sum_range(1, 4) == 6
+    assert sum_range(0, 0) == 0
+    assert sum_range(0, 1) == 0
+}
+
+test "while loop" {
+    let n = 0
+    let sum = 0
+    while n < 10 {
+        sum += n
+        n += 1
+    }
+    assert sum == 45
+    assert n == 10
+}
+
+test "break in while" {
+    let i = 0
+    while true {
+        if i == 5 { break }
+        i += 1
+    }
+    assert i == 5
+}
+
+test "continue in for" {
+    let sum = 0
+    for i in 0..10 {
+        if i % 2 == 0 { continue }
+        sum += i
+    }
+    // sum of odds 1+3+5+7+9 = 25
+    assert sum == 25
+}
+
+test "early return" {
+    assert abs(5) == 5
+    assert abs(-5) == 5
+    assert abs(0) == 0
+}
+
+test "multiple return paths" {
+    let x = 10
+    if x > 5 {
+        assert true
+    } else {
+        assert false, "should not reach"
+    }
+}
+
+func main() {}

--- a/tests/suite/t06_closures.rk
+++ b/tests/suite/t06_closures.rk
@@ -1,0 +1,39 @@
+// SPDX-License-Identifier: (MIT OR Apache-2.0)
+// Closures, captures, and higher-order functions.
+
+func apply(f: |i32| -> i32, x: i32) -> i32 {
+    return f(x)
+}
+
+func apply_twice(f: |i32| -> i32, x: i32) -> i32 {
+    return f(f(x))
+}
+
+test "basic closure" {
+    const double = |x: i32| -> i32 { return x * 2 }
+    assert double(5) == 10
+    assert double(0) == 0
+    assert double(-3) == -6
+}
+
+test "closure capture" {
+    const offset = 10
+    const add_offset = |x: i32| -> i32 { return x + offset }
+    assert add_offset(5) == 15
+    assert add_offset(0) == 10
+}
+
+test "closure passed to function" {
+    const inc = |x: i32| -> i32 { return x + 1 }
+    assert apply(inc, 5) == 6
+    assert apply_twice(inc, 5) == 7
+}
+
+test "closure with multiple captures" {
+    const a = 3
+    const b = 7
+    const sum = |_: i32| -> i32 { return a + b }
+    assert sum(0) == 10
+}
+
+func main() {}

--- a/tests/suite/t07_option.rk
+++ b/tests/suite/t07_option.rk
@@ -1,0 +1,70 @@
+// SPDX-License-Identifier: (MIT OR Apache-2.0)
+// Optional types, Some/None, pattern matching.
+
+func find(items: Vec<i32>, target: i32) -> i32? {
+    for i in 0..items.len() {
+        if items[i] == target {
+            return Some(items[i])
+        }
+    }
+    return None
+}
+
+func safe_div(a: i32, b: i32) -> i32? {
+    if b == 0 { return None }
+    return Some(a / b)
+}
+
+test "Some construction" {
+    const x = Some(42)
+    assert x is Some
+}
+
+test "None construction" {
+    const x: i32? = None
+    assert x is None
+}
+
+test "unwrap Some" {
+    const x = Some(42)
+    assert x.unwrap() == 42
+}
+
+test "is Some with binding" {
+    const x = Some(10)
+    if x is Some(val) {
+        assert val == 10
+    } else {
+        assert false, "expected Some"
+    }
+}
+
+test "is None" {
+    const x: i32? = None
+    assert x is None
+    if x is Some {
+        assert false, "expected None"
+    }
+}
+
+test "optional from function" {
+    assert safe_div(10, 2) is Some
+    assert safe_div(10, 2).unwrap() == 5
+    assert safe_div(10, 0) is None
+}
+
+test "optional with Vec" {
+    const v = Vec.new()
+    v.push(10)
+    v.push(20)
+    v.push(30)
+
+    const found = find(v, 20)
+    assert found is Some
+    assert found.unwrap() == 20
+
+    const not_found = find(v, 99)
+    assert not_found is None
+}
+
+func main() {}

--- a/tests/suite/t08_result.rk
+++ b/tests/suite/t08_result.rk
@@ -1,0 +1,64 @@
+// SPDX-License-Identifier: (MIT OR Apache-2.0)
+// Result type, try propagation, error handling.
+
+func divide(a: i32, b: i32) -> i32 or string {
+    if b == 0 {
+        return Err("division by zero")
+    }
+    return Ok(a / b)
+}
+
+func double_divide(a: i32, b: i32) -> i32 or string {
+    const result = try divide(a, b)
+    return Ok(result * 2)
+}
+
+func chained(a: i32, b: i32, c: i32) -> i32 or string {
+    const x = try divide(a, b)
+    const y = try divide(x, c)
+    return Ok(y)
+}
+
+test "Ok result" {
+    const r = divide(10, 2)
+    assert r is Ok
+    assert r.unwrap() == 5
+}
+
+test "Err result" {
+    const r = divide(10, 0)
+    assert r is Err
+}
+
+test "match on result" {
+    const r = divide(10, 2)
+    match r {
+        Ok(v) => assert v == 5
+        Err(_) => assert false, "expected Ok"
+    }
+}
+
+test "try propagation success" {
+    const r = double_divide(10, 2)
+    assert r is Ok
+    assert r.unwrap() == 10
+}
+
+test "try propagation failure" {
+    const r = double_divide(10, 0)
+    assert r is Err
+}
+
+test "chained try" {
+    const r1 = chained(100, 2, 5)
+    assert r1 is Ok
+    assert r1.unwrap() == 10
+
+    const r2 = chained(100, 0, 5)
+    assert r2 is Err
+
+    const r3 = chained(100, 2, 0)
+    assert r3 is Err
+}
+
+func main() {}

--- a/tests/suite/t09_vec.rk
+++ b/tests/suite/t09_vec.rk
@@ -1,0 +1,82 @@
+// SPDX-License-Identifier: (MIT OR Apache-2.0)
+// Vec operations: push, pop, index, length, iteration.
+
+test "vec push and len" {
+    const v = Vec.new()
+    assert v.len() == 0
+    v.push(1)
+    assert v.len() == 1
+    v.push(2)
+    v.push(3)
+    assert v.len() == 3
+}
+
+test "vec index access" {
+    const v = Vec.new()
+    v.push(10)
+    v.push(20)
+    v.push(30)
+    assert v[0] == 10
+    assert v[1] == 20
+    assert v[2] == 30
+}
+
+test "vec index assign" {
+    const v = Vec.new()
+    v.push(1)
+    v.push(2)
+    v[0] = 99
+    assert v[0] == 99
+    assert v[1] == 2
+}
+
+test "vec pop" {
+    const v = Vec.new()
+    v.push(10)
+    v.push(20)
+    v.pop()
+    assert v.len() == 1
+    assert v[0] == 10
+}
+
+test "vec sum via loop" {
+    const v = Vec.new()
+    v.push(1)
+    v.push(2)
+    v.push(3)
+    v.push(4)
+    v.push(5)
+    let sum = 0
+    for i in 0..v.len() {
+        sum += v[i]
+    }
+    assert sum == 15
+}
+
+test "vec of strings" {
+    const v = Vec.new()
+    v.push("hello")
+    v.push("world")
+    assert v.len() == 2
+    assert v[0] == "hello"
+    assert v[1] == "world"
+}
+
+test "vec string read twice" {
+    const v = Vec.new()
+    v.push("test")
+    const a = v[0]
+    const b = v[0]
+    assert a == "test"
+    assert b == "test"
+}
+
+test "vec get returns option" {
+    const v = Vec.new()
+    v.push(42)
+    assert v.get(0) is Some
+    assert v.get(0).unwrap() == 42
+    assert v.get(99) is None
+}
+
+func main() {}

--- a/tests/suite/t10_generics.rk
+++ b/tests/suite/t10_generics.rk
@@ -1,0 +1,68 @@
+// SPDX-License-Identifier: (MIT OR Apache-2.0)
+// Generic structs and functions.
+
+struct Box<T> {
+    value: T
+}
+
+extend Box {
+    func get(self) -> T {
+        return self.value
+    }
+}
+
+struct Pair<A, B> {
+    first: A
+    second: B
+}
+
+extend Pair {
+    func swap(self) -> Pair<B, A> {
+        return Pair { first: self.second, second: self.first }
+    }
+}
+
+func identity<T>(x: T) -> T {
+    return x
+}
+
+func max(a: i32, b: i32) -> i32 {
+    if a > b { return a }
+    return b
+}
+
+test "generic struct with int" {
+    const b = Box { value: 42 }
+    assert b.get() == 42
+}
+
+test "generic struct with string" {
+    const b = Box { value: "hello" }
+    assert b.get() == "hello"
+}
+
+test "two type params" {
+    const p = Pair { first: 1, second: "two" }
+    assert p.first == 1
+    assert p.second == "two"
+}
+
+test "generic swap" {
+    const p = Pair { first: 1, second: "two" }
+    const s = p.swap()
+    assert s.first == "two"
+    assert s.second == 1
+}
+
+test "generic function" {
+    assert identity(42) == 42
+    assert identity("hello") == "hello"
+}
+
+test "non-generic function" {
+    assert max(3, 5) == 5
+    assert max(10, 2) == 10
+    assert max(7, 7) == 7
+}
+
+func main() {}

--- a/tests/suite/t11_traits.rk
+++ b/tests/suite/t11_traits.rk
@@ -1,0 +1,52 @@
+// SPDX-License-Identifier: (MIT OR Apache-2.0)
+// Traits, trait objects, and dispatch.
+
+trait Describable {
+    func describe(self) -> string
+}
+
+struct Dog {
+    name: string
+}
+
+struct Cat {
+    name: string
+}
+
+extend Dog with Describable {
+    func describe(self) -> string {
+        return "Dog: {self.name}"
+    }
+}
+
+extend Cat with Describable {
+    func describe(self) -> string {
+        return "Cat: {self.name}"
+    }
+}
+
+func print_description(item: any Describable) -> string {
+    return item.describe()
+}
+
+test "trait method on concrete type" {
+    const d = Dog { name: "Rex" }
+    assert d.describe() == "Dog: Rex"
+}
+
+test "trait method on different type" {
+    const c = Cat { name: "Whiskers" }
+    assert c.describe() == "Cat: Whiskers"
+}
+
+test "trait object dispatch" {
+    const d = Dog { name: "Buddy" }
+    assert print_description(d) == "Dog: Buddy"
+}
+
+test "trait object dispatch different type" {
+    const c = Cat { name: "Luna" }
+    assert print_description(c) == "Cat: Luna"
+}
+
+func main() {}

--- a/tests/suite/t12_boolean_logic.rk
+++ b/tests/suite/t12_boolean_logic.rk
@@ -1,0 +1,39 @@
+// SPDX-License-Identifier: (MIT OR Apache-2.0)
+// Boolean operators, short-circuit evaluation.
+
+test "and" {
+    assert (true && true) == true
+    assert (true && false) == false
+    assert (false && true) == false
+    assert (false && false) == false
+}
+
+test "or" {
+    assert (true || true) == true
+    assert (true || false) == true
+    assert (false || true) == true
+    assert (false || false) == false
+}
+
+test "not" {
+    assert !false == true
+    assert !true == false
+    assert !!true == true
+}
+
+test "combined" {
+    assert (true && true) || false
+    assert !(false && true)
+    assert (5 > 3) && (10 < 20)
+    assert (5 > 3) || (10 > 20)
+}
+
+test "comparison chains" {
+    const x = 5
+    assert x > 0 && x < 10
+    assert !(x > 0 && x < 3)
+    assert x == 5 || x == 6
+    assert !(x == 3 || x == 4)
+}
+
+func main() {}

--- a/tests/suite/t13_map.rk
+++ b/tests/suite/t13_map.rk
@@ -1,0 +1,51 @@
+// SPDX-License-Identifier: (MIT OR Apache-2.0)
+// Map operations: insert, get, index, contains.
+
+test "map insert and get" {
+    const m = Map.new()
+    m.insert("key", 42)
+    assert m["key"] == 42
+}
+
+test "map multiple keys" {
+    const m = Map.new()
+    m.insert("a", 1)
+    m.insert("b", 2)
+    m.insert("c", 3)
+    assert m["a"] == 1
+    assert m["b"] == 2
+    assert m["c"] == 3
+}
+
+test "map overwrite" {
+    const m = Map.new()
+    m.insert("key", 10)
+    m.insert("key", 20)
+    assert m["key"] == 20
+}
+
+test "map len" {
+    const m = Map.new()
+    assert m.len() == 0
+    m.insert("a", 1)
+    assert m.len() == 1
+    m.insert("b", 2)
+    assert m.len() == 2
+}
+
+test "map contains" {
+    const m = Map.new()
+    m.insert("exists", 1)
+    assert m.contains("exists")
+    assert !m.contains("missing")
+}
+
+test "map string values" {
+    const m = Map.new()
+    m.insert("greeting", "hello")
+    m.insert("name", "world")
+    assert m["greeting"] == "hello"
+    assert m["name"] == "world"
+}
+
+func main() {}


### PR DESCRIPTION
## Summary

- Differential testing: `rask test-specs` now runs `run` tests through both interpreter and native codegen, comparing outputs. Any divergence surfaces codegen/MIR bugs immediately.
- `.rk` test suite: 13 test files with 84 `test` block assertions covering arithmetic, strings, structs, enums, control flow, closures, options, results, vec, generics, traits, booleans, maps. All pass interpreter; 9/13 fail native — surfacing real codegen gaps.
- Smart assert messages in both backends: `assert 3 == 5` now prints `assertion failed: 3 == 5 (left: 3, right: 5)` instead of just `assertion failed`. Works for `==`, `!=`, `<`, `>`, `<=`, `>=`, `is` patterns, and custom messages.
- `@test` functions now work in native codegen (was interpreter-only).
- Correct file:line:col in native assert failure messages.

## What changed

**`rask-spec-test` crate:**
- `extract.rs` — Added `RunInterpOnly` expectation, `run-interp` annotation escape hatch, `.rk` file test discovery via `has_rk_tests()`
- `runner.rs` — Native execution path (shells out to `rask run`), `.rk` test file runner (interp `run_tests()` + native `rask test`), `NativeResult`/`RkTestResult` types
- `lib.rs` — Updated exports and docs

**`rask-cli`:**
- `commands/specs.rs` — Differential display (inline `native:ok`/`native:FAIL`), `.rk` file discovery and differential results, native summary stats
- `commands/run.rs` — Fixed JSON parser for escaped quotes in test result messages
- `commands/compile.rs` — `@test` functions included in native test extraction, line map passed to codegen for test builds

**`rask-interp`:**
- `interp/eval_expr.rs` — `build_comparison_message()` re-evaluates comparison operands on failure path to show actual values. Handles desugared method calls (`a.eq(b)`), `!=` (`!a.eq(b)`), and `is` patterns.

**`rask-mir`:**
- `lower/expr.rs` — Assert lowering detects comparison patterns and emits `assert_fail_cmp_i64`/`assert_fail_cmp_str` with operand values. `is` pattern asserts emit `"assertion failed: expected {Pattern}"` message.

**`rask-codegen`:**
- `module.rs` — Declared `assert_fail_msg_at`, `assert_fail_cmp_i64`, `assert_fail_cmp_str` runtime functions. Line map passed to builder.
- `builder.rs` — Assert fail codegen passes message args, comparison operands, and operator strings to typed C runtime functions. `lower_operand_as_cstr()` for raw C string pointers. Per-statement line:col tracking from line map. Bool widening fix for comparison asserts.

**C runtime:**
- `runtime.c` — `rask_assert_fail_msg()`, `rask_assert_fail_msg_at()`, `rask_assert_fail_cmp_i64()`, `rask_assert_fail_cmp_str()`
- `rask_runtime.h` — Matching declarations

**Test suite (`tests/suite/`):**
- 13 `.rk` files: t01–t13 covering core language features

**Spec:**
- `specs/compiler/test-infrastructure.md` — Documented differential testing (S5, S6 rules)

## Test plan

- [x] `cargo test -p rask-spec-test` — 10/10 unit tests pass
- [x] `rask test-specs specs/` — 134/136 pass (2 pre-existing), 6/6 native pass
- [x] `rask test-specs tests/suite/` — 84/84 interp pass, 4/13 native pass (9 native failures are pre-existing codegen bugs, now tracked)
- [x] `rask test /tmp/test_all_assert.rk` — all 6 assert patterns show correct messages with file:line:col
- [x] Zero new warnings in changed crates

https://claude.ai/code/session_01S2T7mmRwvncCweoM7GMNHe