### PR TITLE
Fix empty-body stdlib stubs being inlined as no-ops

### DIFF
--- a/compiler/crates/rask-cli/src/commands/codegen.rs
+++ b/compiler/crates/rask-cli/src/commands/codegen.rs
@@ -514,6 +514,14 @@ pub fn cmd_mir(path: &str, format: Format) {
 
     let mut mir_errors = 0;
     for mono_fn in &mono.functions {
+        // Skip empty-body stdlib stubs (same filter as compile path).
+        if let rask_ast::decl::DeclKind::Fn(f) = &mono_fn.body.kind {
+            if f.body.is_empty()
+                && rask_stdlib::mir_metadata::lookup(&mono_fn.name).is_some()
+            {
+                continue;
+            }
+        }
         match rask_mir::lower::MirLowerer::lower_function_named(&mono_fn.body, &all_mono_decls, &mir_ctx, Some(&mono_fn.name)) {
             Ok(mir_fns) => {
                 if format == Format::Human {

--- a/compiler/crates/rask-cli/src/commands/compile.rs
+++ b/compiler/crates/rask-cli/src/commands/compile.rs
@@ -75,6 +75,17 @@ fn lower_to_mir(
         if skip_main && mono_fn.name == "main" {
             continue;
         }
+        // Skip empty-body stdlib stubs (e.g. fs_write_bytes). The real
+        // implementation lives in the C runtime dispatch table. Lowering
+        // them to MIR produces a no-op that the inliner substitutes for
+        // the call, silently dropping the actual operation.
+        if let rask_ast::decl::DeclKind::Fn(f) = &mono_fn.body.kind {
+            if f.body.is_empty()
+                && rask_stdlib::mir_metadata::lookup(&mono_fn.name).is_some()
+            {
+                continue;
+            }
+        }
         match rask_mir::lower::MirLowerer::lower_function_named(
             &mono_fn.body, all_mono_decls, mir_ctx, Some(&mono_fn.name)
         ) {

--- a/compiler/crates/rask-codegen/src/module.rs
+++ b/compiler/crates/rask-codegen/src/module.rs
@@ -506,6 +506,12 @@ impl CodeGenerator {
         self.enum_layouts = mono.enum_layouts.clone();
 
         for mir_fn in mir_functions {
+            // Skip empty-body stubs that shadow stdlib entries (e.g.
+            // fs.write_bytes has an empty .rk body but dispatches to
+            // rask_fs_write_bytes in the C runtime via the dispatch table).
+            if self.func_ids.contains_key(&mir_fn.name) && is_empty_stub(mir_fn) {
+                continue;
+            }
             let mut sig = self.module.make_signature();
 
             // Build parameter list
@@ -764,6 +770,12 @@ impl CodeGenerator {
 
     /// Generate code for a single MIR function.
     pub fn gen_function(&mut self, mir_fn: &MirFunction) -> CodegenResult<()> {
+        // Skip empty stubs — they were not declared as internal functions,
+        // so the stdlib dispatch table handles them at the call site.
+        if !self.internal_fns.contains(&mir_fn.name) {
+            return Ok(());
+        }
+
         // Pre-register source file string for runtime panic locations
         if let Some(ref src_file) = mir_fn.source_file {
             self.register_string(src_file)?;
@@ -871,6 +883,19 @@ impl CodeGenerator {
         Ok(())
     }
 
+}
+
+/// A MIR function is an empty stub if it has a single block with no
+/// statements and a bare return. These come from empty-body `.rk` stubs
+/// that exist only so the type checker sees a signature — the real
+/// implementation lives in the C runtime dispatch table.
+fn is_empty_stub(mir_fn: &MirFunction) -> bool {
+    if mir_fn.blocks.len() != 1 {
+        return false;
+    }
+    let block = &mir_fn.blocks[0];
+    block.statements.is_empty()
+        && matches!(&block.terminator.kind, rask_mir::MirTerminatorKind::Return { .. })
 }
 
 /// Collect all string constants referenced by a single MIR function.

--- a/compiler/crates/rask-interp/src/builtins/mod.rs
+++ b/compiler/crates/rask-interp/src/builtins/mod.rs
@@ -193,14 +193,14 @@ impl Interpreter {
                 let has_to_string = self.methods.get(tn)
                     .and_then(|m| m.get("to_string"))
                     .or_else(|| self.methods.get(base_name).and_then(|m| m.get("to_string")));
-                if let Some(method_fn) = has_to_string {
+                if let Some(method_fn) = has_to_string.filter(|f| !f.body.is_empty()) {
                     let method_fn = method_fn.clone();
                     return self.call_function(&method_fn, vec![receiver]).map_err(|diag| diag.error);
                 }
                 let has_message = self.methods.get(tn)
                     .and_then(|m| m.get("message"))
                     .or_else(|| self.methods.get(base_name).and_then(|m| m.get("message")));
-                if let Some(method_fn) = has_message {
+                if let Some(method_fn) = has_message.filter(|f| !f.body.is_empty()) {
                     let method_fn = method_fn.clone();
                     return self.call_function(&method_fn, vec![receiver]).map_err(|diag| diag.error);
                 }
@@ -230,7 +230,7 @@ impl Interpreter {
                 })
             });
 
-        if let Some(method_fn) = resolved_method {
+        if let Some(method_fn) = resolved_method.filter(|f| !f.body.is_empty()) {
             let consumes_self = method_fn.params.first()
                 .map(|p| p.name == "self" && p.is_take)
                 .unwrap_or(false);

--- a/compiler/crates/rask-interp/src/interp/eval_expr.rs
+++ b/compiler/crates/rask-interp/src/interp/eval_expr.rs
@@ -317,12 +317,16 @@ impl Interpreter {
 
                     if let Some(type_methods) = self.methods.get(name).cloned() {
                         if let Some(method_fn) = type_methods.get(method) {
+                            // Skip empty-body stubs (e.g. fs.write_bytes) —
+                            // they exist for native codegen and should fall
+                            // through to the built-in module dispatch.
+                            let has_body = !method_fn.body.is_empty();
                             let is_static = method_fn
                                 .params
                                 .first()
                                 .map(|p| p.name != "self")
                                 .unwrap_or(true);
-                            if is_static {
+                            if is_static && has_body {
                                 let arg_vals: Vec<Value> = args
                                     .iter()
                                     .map(|a| self.eval_expr(&a.expr))

--- a/compiler/crates/rask-interp/src/stdlib/mod.rs
+++ b/compiler/crates/rask-interp/src/stdlib/mod.rs
@@ -194,12 +194,13 @@ impl Interpreter {
                 // User-defined static methods from extend blocks
                 if let Some(type_methods) = self.methods.get(type_name).cloned() {
                     if let Some(method_fn) = type_methods.get(method) {
+                        let has_body = !method_fn.body.is_empty();
                         let is_static = method_fn
                             .params
                             .first()
                             .map(|p| p.name != "self")
                             .unwrap_or(true);
-                        if is_static {
+                        if is_static && has_body {
                             return self.call_function(&method_fn, args).map_err(|diag| diag.error);
                         }
                     }

--- a/compiler/crates/rask-stdlib/src/stubs.rs
+++ b/compiler/crates/rask-stdlib/src/stubs.rs
@@ -137,7 +137,7 @@ impl StubRegistry {
                 // Include all declarations: functions with bodies, extern blocks,
                 // and struct/enum definitions. The resolver processes these in
                 // stdlib_mode to avoid builtin-shadowing errors.
-                for decl in parse_result.decls {
+                for mut decl in parse_result.decls {
                     let dominated = match &decl.kind {
                         DeclKind::Fn(f) => !f.body.is_empty(),
                         DeclKind::Impl(i) => i.methods.iter().any(|m| !m.body.is_empty()),
@@ -147,6 +147,12 @@ impl StubRegistry {
                         _ => false,
                     };
                     if dominated {
+                        // Strip empty-body methods from Impl blocks so they
+                        // don't reach the monomorphizer or interpreter as
+                        // no-op stubs that shadow C runtime implementations.
+                        if let DeclKind::Impl(ref mut i) = decl.kind {
+                            i.methods.retain(|m| !m.body.is_empty());
+                        }
                         decls.push(decl);
                     }
                 }


### PR DESCRIPTION
## Summary

- Empty-body `.rk` stubs (e.g. `fs.write_bytes`) were being lowered to MIR as no-op functions, then the MIR inliner would substitute them for the actual call — silently dropping the operation. `fs.write_bytes()` would compile and "succeed" but never write any bytes.
- Fix skips empty-body stdlib stubs during MIR lowering so they never enter the inliner's candidate set. The C runtime dispatch table handles these calls correctly.
- Added defense-in-depth in codegen (don't shadow stdlib dispatch entries) and interpreter (fall through to module dispatch for empty-body methods).

## Root cause

The stdlib uses empty-body `.rk` declarations as type signatures for functions implemented in C (`rask_fs_write_bytes`, etc.). These get included via `compilable_decls()`, monomorphized as reachable, lowered to MIR as single-block return-void functions, and then inlined by the MIR optimizer — replacing the call with nothing.

## Test plan

- [x] `rask run` (native) with `fs.write_bytes()` now creates the file with correct contents
- [x] `rask run --interp` with `fs.write_bytes()` also works
- [x] `cargo test --release` passes (pre-existing `TaskHandle` drift test failure unrelated)
- [x] Empty-body `func main() {}` still compiles correctly

https://claude.ai/code/session_015tEHMvGb8wx5gJvEsGjxRS