### PR TITLE
Add Presence spec and Owner identity properties to Allgard

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -166,7 +166,7 @@ Start with [CORE_DESIGN.md](specs/CORE_DESIGN.md). For specs: [specs/README.md](
 | Code generation | MIR-based pipeline, Cranelift backend, runtime library | [codegen.md](specs/compiler/codegen.md) |
 | Raido | Deterministic scripting VM — 32.32 fixed-point, serializable state, content-addressed bytecode. Independent project, also serves as verification engine for Allgard's verifiable transforms | [raido/](projects/raido/) |
 | Leden | Capability-based networking protocol — sessions, capabilities, object references, gossip discovery | [leden/](projects/leden/) |
-| Allgard | Federation model — primitives, conservation laws, domain sovereignty, bilateral trust | [allgard/](projects/allgard/) |
+| Allgard | Federation model — primitives, conservation laws, domain sovereignty, bilateral trust, owner presence | [allgard/](projects/allgard/) |
 | GDL | Gard Description Language — content schema for describing gards over Leden. Regions, entities, affordances, appearance, style system | [gdl/](projects/gdl/) |
 | Midgard | Virtual world example — uses Raido, Allgard, Leden, GDL together | [midgard/](projects/midgard/) |
 

--- a/projects/allgard/PRESENCE.md
+++ b/projects/allgard/PRESENCE.md
@@ -249,4 +249,7 @@ Without this, a Grant scoped `[0x42, 0x07]` on Domain A means nothing to Domain 
 ## Open Questions
 
 - **Presence privacy across trust levels.** Should a `presence` Grant reveal which specific Domains the Owner is on, or just "online/offline"? Full domain list is useful for routing but reveals movement patterns. Maybe two Grant scopes: `observe_liveness` (online/offline only) and `observe_presence` (full domain set). Keeping it simple for now — one scope, full presence. Can split later if privacy concerns are real.
-- **Home domain migration.** An Owner can change their home domain. What happens to existing presence subscriptions? The old home should redirect observers to the new home. This is a protocol concern that needs specifying — probably in TRANSFER.md, since it's a special case of identity transfer.
+
+## Resolved
+
+**Home domain migration.** Specified in [PRIMITIVES.md](PRIMITIVES.md#home-domain-migration). During cooperative migration, the old home sends `HomeMigrated(new_home)` to all presence observers — clients reconnect to the new home automatically. Name resolution redirects (`OwnerMigrated`) handle cached addresses. During uncooperative migration, the Owner notifies contacts directly through existing sessions. Presence subscriptions at the old home eventually fail; contacts that have the Owner's cryptographic identity can re-subscribe at the new home.

--- a/projects/allgard/PRESENCE.md
+++ b/projects/allgard/PRESENCE.md
@@ -48,9 +48,21 @@ Presence and profile are observable state. Other Owners can subscribe to changes
 1. Owner A grants Owner B a `presence` Grant (see [Standard Grants](#standard-grants) below).
 2. Owner B subscribes to Owner A's presence via Leden observation at Owner A's home domain.
 3. When Owner A's presence changes (connects to a new domain, disconnects from one), Owner B receives an update.
-4. Owner B can also observe Owner A's [profile Object](PRIMITIVES.md#profile) at the same home domain — avatar, bio, and any other profile fields update automatically.
 
 The home domain is the canonical observation point. It knows the Owner's session state because it manages leases and tracks where the Owner's objects are. Observing presence at the home domain gives a complete view. Observing at a visited domain only tells you about that specific domain.
+
+### Presence vs Profile Observation
+
+Presence and the [profile Object](PRIMITIVES.md#profile) are **separate observations**. A `presence` or `contact` Grant authorizes both, but they're independent Leden observation subscriptions:
+
+| Observation | What changes | Frequency | Subscribe to |
+|---|---|---|---|
+| Presence | Domain set (connect/disconnect) | Minutes to hours | Owner's presence state at home domain |
+| Profile | Avatar, bio, display name, extensions | Rarely (days, weeks) | Owner's profile Object at home domain |
+
+Separating them matters for bandwidth. An Owner tracking 200 contacts doesn't need profile updates every time someone connects to a new domain. Conversely, a domain rendering a player's profile card doesn't need real-time domain-set changes. Clients subscribe to what they need.
+
+Both use standard Leden observation semantics — snapshot on subscribe, delta updates, sequence numbers, backpressure. Profile observation uses Leden's [filtered observation](../leden/observation.md#filtered-observation) if the client only cares about specific fields (e.g., avatar only).
 
 ### Capability Gating
 
@@ -72,6 +84,19 @@ The observer receives which domains were added to or removed from the Owner's ac
 ## Reachability
 
 Knowing where an Owner is located enables contacting them. Reachability is the practical consequence of presence.
+
+### Name Resolution
+
+An Owner's global address is `name@home_domain` (see [PRIMITIVES.md](PRIMITIVES.md#name)). To resolve a name to a contactable identity:
+
+1. **Resolve the domain.** Look up `home_domain` via Leden gossip/discovery. This gives you a transport address — same as DNS resolving a hostname to an IP.
+2. **Contact the greeter.** Hit the home domain's greeter. The greeter is the public entry point for every domain (see [Bootstrapping](README.md#bootstrapping)).
+3. **Resolve the name.** Send a `ResolveName(name)` request. The home domain returns the Owner's public identity (`id`) — or `NameNotFound` if no such Owner exists.
+4. **Contact the Owner.** Use the resolved identity for Grant exchange, presence subscription, or messaging.
+
+Name resolution is a public operation — it doesn't require a Grant. Knowing someone's name and resolving it to an identity is like looking up a phone number in a directory. The identity alone grants nothing — you still need a `presence` or `contact` Grant to observe or message them.
+
+**Caching.** Name-to-identity mappings are stable (Owners don't change their cryptographic identity). Clients and domains can cache the mapping indefinitely. If an Owner re-keys (key compromise, migration), the old mapping returns `IdentityChanged(new_id)` — the cache invalidates and the caller learns the new identity.
 
 ### Routing Through Home Domain
 
@@ -126,7 +151,27 @@ Presence observation plus direct messaging. The grantee can observe the grantor'
 | `target` | The grantor's Owner identity |
 | `revocable` | Yes (always) |
 
-The `message` scope means the grantee can submit messages to the grantor's home domain for delivery. The home domain enforces rate limits (Law 5 applies to messages like any other operation).
+#### Messaging
+
+The `message` scope authorizes the grantee to send messages to the grantor. A message is a Leden method call on the Owner's identity at the home domain:
+
+```
+SendMessage(to: owner_id, content: bytes, content_type: string)
+```
+
+| Field | Description |
+|-------|-------------|
+| `to` | Recipient Owner identity |
+| `content` | Opaque bytes. Interpretation determined by `content_type`. |
+| `content_type` | MIME-style type tag: `text/plain`, `application/gdl+msgpack`, etc. |
+
+**Delivery semantics: at-most-once.** The home domain delivers the message to the recipient if reachable. No guaranteed delivery, no persistent queue obligation. If the recipient is offline, the home domain's queuing policy applies (see [Unreachable Owners](#unreachable-owners)). The sender receives `Delivered`, `Queued`, or `Unreachable`.
+
+**Size limit: 64KB per message.** Messages are for communication, not file transfer. Large payloads use Leden content store references inside the message body.
+
+**Rate limiting.** Law 5 applies. The home domain enforces message rate limits per sender. Default: 10 messages/second per sender-recipient pair. This prevents spam while allowing real-time conversation.
+
+**Content types are conventions.** `text/plain` is universal — every client can render it. Richer types (`application/gdl+msgpack` for structured game data, domain-specific types) degrade to "message received, type not supported" on clients that don't recognize them. Same principle as email MIME types.
 
 ### `block`
 
@@ -162,7 +207,7 @@ Without this, a Grant scoped `[0x42, 0x07]` on Domain A means nothing to Domain 
 ## What This Doesn't Cover
 
 - **Spatial location within a domain.** Presence says "Owner is on Domain X." It doesn't say "Owner is at coordinates (3,4) in region Y." Spatial protocols build on top of presence.
-- **Profile content schema.** The Owner's [profile Object](PRIMITIVES.md#profile) is defined as a mechanism in Allgard. The content schema (which fields, what they mean) is defined in [GDL](../gdl/) — content description is GDL's job.
+- **Profile content schema.** The Owner's [profile Object](PRIMITIVES.md#profile) is defined as a mechanism in Allgard. The content schema (which fields, what they mean) is defined in [GDL](../gdl/GDL.md#owner-profile-schema).
 - **Voice or media channels.** Real-time media between Owners is an application feature using Leden transport. Presence tells you who's reachable; media setup is a separate capability negotiation.
 - **Notification preferences.** Whether an Owner wants to be disturbed, what channels they prefer — local policy stored at the home domain, not a federation concern.
 

--- a/projects/allgard/PRESENCE.md
+++ b/projects/allgard/PRESENCE.md
@@ -1,0 +1,181 @@
+<!-- id: allgard.presence -->
+<!-- status: proposed -->
+<!-- summary: Owner presence — location, observability, reachability, standard relationship grants -->
+
+# Presence
+
+Where Owners are, and how to reach them.
+
+The [Conservation Laws](CONSERVATION.md) govern how Objects behave. This spec governs how Owners are located, observed, and contacted across domains. Presence is the observable consequence of Owners operating in a distributed federation — if entities exist across domains, their location is state, and state should be formalized.
+
+## Why This Is Physics
+
+The Conservation Laws define invariants: supply is conserved, ownership is singular, exchange balances. These are the physics of *things*.
+
+Presence is the physics of *entities*. An Owner has a location — the Domain(s) where it currently operates. That location is observable, changes over time, and affects what interactions are possible. A domain that hosts an Owner's leased objects needs to know the Owner is still there. A trading partner needs to know the Owner is reachable. An automated system needs to know its counterpart is online.
+
+This isn't a social feature. It's the same kind of fact as "this Object is on Domain X" — which is already an Object property in [PRIMITIVES.md](PRIMITIVES.md). Presence extends that to Owners.
+
+## Owner Location
+
+An Owner's **presence** is the set of Domains where the Owner currently has active authenticated sessions.
+
+Presence is derived from Leden session state. When an Owner opens an authenticated session with a Domain, that Domain is in the Owner's presence set. When the session closes, it's removed. No separate presence state to maintain — it falls out of existing session management.
+
+### Properties
+
+| Property | Description |
+|----------|------------|
+| `home_domain` | The Owner's authoritative domain (already defined in [PRIMITIVES.md](PRIMITIVES.md#home-domain)) |
+| `active_domains` | Set of Domains where the Owner has current authenticated sessions |
+
+### Not Singular
+
+Objects are on exactly one Domain (Law 2). Owners are not. An Owner visiting Domain B while maintaining a session with home Domain A is present on both. An automated Owner might have sessions with dozens of Domains simultaneously. There's no conservation of presence — it's not a scarce resource, it's observable state.
+
+I considered making presence singular ("an Owner is on one Domain at a time") and rejected it. The leased transfer model already has the Owner connected to both home and visited domain. Forcing singularity would either break that model or require pretending one of the sessions isn't real.
+
+### Offline
+
+An Owner with no active sessions has an empty presence set. This is valid state — not every Owner is always online. The home domain may still hold the Owner's objects and accept inbound Transforms on their behalf, but the Owner isn't actively operating.
+
+## Observability
+
+Presence is observable state. Other Owners can subscribe to presence changes via [Leden observation](../leden/observation.md), gated by a Grant.
+
+### How It Works
+
+1. Owner A grants Owner B a `presence` Grant (see [Standard Grants](#standard-grants) below).
+2. Owner B subscribes to Owner A's presence via Leden observation at Owner A's home domain.
+3. When Owner A's presence changes (connects to a new domain, disconnects from one), Owner B receives an update.
+
+The home domain is the canonical observation point. It knows the Owner's session state because it manages leases and tracks where the Owner's objects are. Observing presence at the home domain gives a complete view. Observing at a visited domain only tells you about that specific domain.
+
+### Capability Gating
+
+Presence is not observable by default. You need a Grant. This is different from Object observation, where holding a reference implies observation permission. The reason: Objects are things; Owners are entities. Knowing where an entity is located is a stronger capability than knowing what a thing contains.
+
+A Domain's greeter does NOT grant presence observation on its hosted Owners. A stranger connecting to a domain can see what the domain hosts (catalog observation), but not which specific Owners are currently active. That would make every greeter a tracking service.
+
+### What Updates Contain
+
+A presence update is a set change:
+
+```
+PresenceUpdate(owner_id, added: [domain_b], removed: [])
+PresenceUpdate(owner_id, added: [], removed: [domain_b])
+```
+
+The observer receives which domains were added to or removed from the Owner's active set. Snapshot-on-subscribe provides the initial full set. Delta updates follow. Sequence numbers and backpressure follow Leden observation conventions.
+
+## Reachability
+
+Knowing where an Owner is located enables contacting them. Reachability is the practical consequence of presence.
+
+### Routing Through Home Domain
+
+The home domain is the canonical contact point for an Owner. To reach Owner A:
+
+1. Contact Owner A's home domain (the home domain identity is part of the Owner's public identity, or discoverable via gossip).
+2. If Owner A is on the home domain: the home domain delivers the message directly.
+3. If Owner A is visiting Domain B: the home domain knows this (it manages the lease) and can either forward or provide Domain B's endpoint so the caller can contact directly.
+
+This is the same routing model as email (MX records point to the authoritative server) without the centralization (any Owner can change their home domain).
+
+### Direct Contact
+
+If the caller already knows which domain the Owner is on (from a presence subscription or prior interaction), they can contact that domain directly. No routing through home. The visited domain validates the caller's Grant and delivers the message.
+
+Direct contact is an optimization, not a requirement. Home routing always works as a fallback.
+
+### Unreachable Owners
+
+If an Owner is offline (empty presence set), messages can be:
+
+1. **Queued at the home domain.** The home domain holds messages until the Owner connects. Domain policy determines queue duration and size limits.
+2. **Rejected.** The caller receives "Owner unreachable." No queuing obligation.
+
+The home domain's choice. Some domains queue indefinitely. Some reject after 24 hours. Some don't queue at all. This is domain policy, not protocol.
+
+## Standard Grants
+
+The [Grant](PRIMITIVES.md#grant) primitive is general — any scope, any target, any expiry. Standard Grants are named conventions for common relationship patterns. They don't add new capabilities — they're pre-defined scope configurations that domains recognize consistently across the federation.
+
+Without these, every domain invents its own "friend" Grant with different semantics, and cross-domain relationships don't interoperate.
+
+### `presence`
+
+Unidirectional presence visibility. The grantee can observe which Domains the grantor is currently active on.
+
+| Property | Value |
+|----------|-------|
+| `scope` | `observe_presence` |
+| `target` | The grantor's Owner identity |
+| `revocable` | Yes (always) |
+
+This is the minimal social relationship. "You can see where I am." No messaging, no interaction beyond observation.
+
+### `contact`
+
+Presence observation plus direct messaging. The grantee can observe the grantor's presence AND send messages to the grantor, routed through the home domain or directly.
+
+| Property | Value |
+|----------|-------|
+| `scope` | `observe_presence` + `message` |
+| `target` | The grantor's Owner identity |
+| `revocable` | Yes (always) |
+
+The `message` scope means the grantee can submit messages to the grantor's home domain for delivery. The home domain enforces rate limits (Law 5 applies to messages like any other operation).
+
+### `block`
+
+Revocation of all inbound Grants from a specific Owner, plus an advisory suppression signal.
+
+Blocking is not a Grant — it's a **revocation pattern**:
+
+1. Revoke every Grant where the blocked Owner is the grantee.
+2. Instruct the home domain to reject future Grant offers from the blocked Owner.
+3. Optionally, signal to visited domains: "reject interactions from this Owner on my behalf." This is advisory — visited domains decide whether to honor it.
+
+Step 3 is advisory because sovereignty means a domain decides its own interaction policy. A visited domain may choose to honor blocks from visiting Owners, or not. The home domain always honors them (it's authoritative for the Owner's policy).
+
+### `group`
+
+Multi-party mutual `contact` Grants with a designated administrator.
+
+A group is not a primitive. It's a pattern composed from Grants:
+
+1. An administrator Owner creates a group identity (an Object of type `group`).
+2. The administrator issues `contact` Grants to each member, scoped to the group.
+3. Members receive mutual `contact` Grants — they can observe presence and message each other.
+4. The administrator can add/remove members by issuing/revoking Grants.
+
+Groups compose from existing primitives (Object + Grant). The "standard" part is the type tag (`group`) and the expected Grant structure, so any domain recognizing the `group` type can display membership, route group messages, and honor administrator actions.
+
+### Cross-Domain Consistency
+
+Standard Grants carry their type tag (`presence`, `contact`, `group`) so receiving domains know the convention. A `contact` Grant issued on Domain A is recognized on Domain B with the same semantics — Domain B knows what `observe_presence` + `message` means because the convention is standardized.
+
+Without this, a Grant scoped `[0x42, 0x07]` on Domain A means nothing to Domain B. Named conventions give Grants portable semantics.
+
+## What This Doesn't Cover
+
+- **Spatial location within a domain.** Presence says "Owner is on Domain X." It doesn't say "Owner is at coordinates (3,4) in region Y." Spatial protocols build on top of presence.
+- **Owner profiles or identity metadata.** What an Owner looks like, their display name, their preferences — application-level concerns, not federation physics. GDL or application-specific schemas handle this.
+- **Voice or media channels.** Real-time media between Owners is an application feature using Leden transport. Presence tells you who's reachable; media setup is a separate capability negotiation.
+- **Notification preferences.** Whether an Owner wants to be disturbed, what channels they prefer — local policy stored at the home domain, not a federation concern.
+
+## Relationship to Existing Specs
+
+| Spec | Relationship |
+|------|-------------|
+| [PRIMITIVES.md](PRIMITIVES.md) | Extends the Owner primitive with presence state. Uses the Grant primitive for standard conventions. |
+| [CONSERVATION.md](CONSERVATION.md) | No changes. Presence is not a conservation law. Law 5 (bounded rates) applies to presence updates and messaging like any other operation. |
+| [TRANSFER.md](TRANSFER.md) | Leased transfer already implies Owner presence on visited domains. Presence formalizes what was implicit. |
+| [TRUST.md](TRUST.md) | Presence enables richer trust signals — Owners that are consistently reachable build reputation faster than ghosts. |
+| [Leden observation](../leden/observation.md) | Presence updates are delivered via Leden observation. All existing observation semantics (backpressure, reconnection, filtered observation) apply. |
+
+## Open Questions
+
+- **Presence privacy across trust levels.** Should a `presence` Grant reveal which specific Domains the Owner is on, or just "online/offline"? Full domain list is useful for routing but reveals movement patterns. Maybe two Grant scopes: `observe_liveness` (online/offline only) and `observe_presence` (full domain set). Keeping it simple for now — one scope, full presence. Can split later if privacy concerns are real.
+- **Home domain migration.** An Owner can change their home domain. What happens to existing presence subscriptions? The old home should redirect observers to the new home. This is a protocol concern that needs specifying — probably in TRANSFER.md, since it's a special case of identity transfer.

--- a/projects/allgard/PRESENCE.md
+++ b/projects/allgard/PRESENCE.md
@@ -223,11 +223,108 @@ A group is not a primitive. It's a pattern composed from Grants:
 
 Groups compose from existing primitives (Object + Grant). The "standard" part is the type tag (`group`) and the expected Grant structure, so any domain recognizing the `group` type can display membership, route group messages, and honor administrator actions.
 
+#### Group Object
+
+The group Object lives on the administrator's home domain (or any domain the administrator chooses to host it). It's observable — members subscribe to it for membership changes.
+
+| Property | Description |
+|---|---|
+| `type` | `group` |
+| `name` | Group display name |
+| `admin` | Owner identity of the administrator |
+| `members` | Set of Owner identities |
+| `roles` | Optional. Map of Owner → role string (`admin`, `moderator`, `member`) |
+
+The group Object is the source of truth for membership. When the administrator adds a member, the Object updates, observers see the delta, and the new member receives their Grants. When a member is removed, their Grants are revoked and the Object updates.
+
+#### Group Messaging
+
+A message to a group is a message to the group Object's hosting domain:
+
+```
+SendMessage(to: group_object_ref, content: bytes, content_type: string)
+```
+
+The hosting domain is responsible for fan-out — delivering the message to all current members. Fan-out uses each member's home domain for routing (same as individual messaging). The sender sends one message; the hosting domain multiplies it.
+
+| Concern | How it works |
+|---|---|
+| Delivery | At-most-once per member, same as individual messages |
+| Rate limiting | Law 5 applies per sender per group |
+| Ordering | Messages carry sequence numbers on the group Object. Members see the same order. |
+| Offline members | Member's home domain queuing policy applies, same as individual messages |
+| Large groups | Hosting domain's fan-out capacity is the bottleneck. Domain policy can cap group size. |
+
+**Cross-domain groups.** Members can be on different home domains. The group Object's hosting domain routes to each member's home domain. This is the same pattern as any cross-domain interaction — bilateral sessions, capability-gated delivery. A group with members across 10 domains means the hosting domain maintains sessions with 10 home domains for fan-out.
+
+#### Group Presence
+
+A group's presence is the aggregated presence of its members. The group Object can be observed for member presence:
+
+- Observe the group Object → receive membership changes + per-member online/offline status
+- The hosting domain aggregates presence from members' home domains
+- Individual member domain sets are NOT exposed through group observation (only the member's home domain knows that). Group presence shows: member X is online/offline. Where they are is gated by individual `presence` Grants between members.
+
 ### Cross-Domain Consistency
 
 Standard Grants carry their type tag (`presence`, `contact`, `group`) so receiving domains know the convention. A `contact` Grant issued on Domain A is recognized on Domain B with the same semantics — Domain B knows what `observe_presence` + `message` means because the convention is standardized.
 
 Without this, a Grant scoped `[0x42, 0x07]` on Domain A means nothing to Domain B. Named conventions give Grants portable semantics.
+
+## Message Encryption
+
+Messages route through home domains. Home domains can read them unless they're encrypted. The protocol requires that message encryption is available, but does not mandate a specific cryptographic scheme.
+
+### Requirements
+
+1. **End-to-end encryption must be possible.** The protocol must support messages that the home domain cannot read. This is a structural requirement — the message `content` field is opaque bytes, and the protocol never requires the home domain to inspect content for routing or delivery.
+
+2. **The specific scheme is not specified.** Cryptographic standards evolve. Mandating a specific protocol (Signal, MLS, etc.) in a federation spec creates a migration problem when better schemes emerge. Instead, the protocol provides the mechanism; implementations choose the cryptography.
+
+3. **Key exchange uses existing primitives.** Owners have cryptographic identities ([key hierarchy](PRIMITIVES.md#key-hierarchy)). Key exchange for E2E encryption uses these identities — the Owner's device keys are the foundation for establishing encrypted channels. The specific key exchange protocol (X3DH, post-quantum KEM, etc.) is negotiated between clients.
+
+### How It Works
+
+The `contact` Grant establishes that two Owners can communicate. The encrypted channel setup happens at first message (or on Grant acceptance):
+
+1. Both Owners' device keys are public (published at their home domains as part of their identity).
+2. The sending client derives a shared secret using the recipient's public device key and its own private device key.
+3. Messages are encrypted client-side before submission to the home domain.
+4. The home domain routes the encrypted blob — it sees `to`, `content_type`, and opaque `content`. It cannot decrypt.
+5. The receiving client decrypts using the shared secret.
+
+**Content type signals encryption.** An encrypted message uses a content type like `application/encrypted+X` where X identifies the scheme. Clients that support the scheme decrypt and render. Clients that don't show "encrypted message, unsupported scheme." The home domain doesn't need to know the scheme — it routes the opaque blob.
+
+**Group encryption.** For group messages, the hosting domain fans out encrypted blobs. Each member receives the same ciphertext. Group encryption schemes (MLS, Sender Keys, etc.) handle the multi-party key management. The protocol's role is the same: route opaque bytes, let clients handle cryptography.
+
+### What the Protocol Guarantees
+
+- Message content is opaque bytes at every routing layer. No protocol operation requires content inspection.
+- Home domains and relays can be honest-but-curious — they route correctly but learn nothing from content.
+- Metadata (sender, recipient, timestamp, size) is visible to routing domains. Metadata privacy is a harder problem and out of scope — it requires onion routing or mixnets, which are transport-layer concerns (Leden), not federation-layer concerns (Allgard).
+
+### What the Protocol Does Not Guarantee
+
+- That a specific encryption scheme is secure. That's the scheme's job.
+- Metadata privacy. The home domain knows who talks to whom and when.
+- Forward secrecy, post-compromise security, deniability. These are properties of specific schemes, not the routing protocol.
+
+## Presence Privacy
+
+A `presence` Grant reveals which Domains the Owner is currently active on. This is useful for routing (contact them directly on Domain B instead of routing through home) but reveals movement patterns (Owner was on Domain X at 3am, moved to Domain Y at 9am).
+
+Two scopes, chosen by the grantor when issuing the Grant:
+
+| Scope | What the observer sees | Use case |
+|---|---|---|
+| `observe_liveness` | Online or offline. Nothing more. | Casual contacts — "is my friend online?" |
+| `observe_presence` | Full domain set (which Domains, when) | Close contacts — "where is my friend so I can join them?" |
+
+The grantor chooses per-grantee. Close friends get `observe_presence`. Acquaintances get `observe_liveness`. The choice is part of the Grant's scope field — same mechanism, different scope strings.
+
+**Default: `observe_liveness`.** When the spec says "a `presence` Grant" without qualification, it means `observe_liveness`. Full presence requires explicit `observe_presence` scope. This is the privacy-safe default — you have to opt in to revealing your location across domains.
+
+The `contact` Grant includes `observe_liveness` by default (not `observe_presence`). An Owner who wants a contact to see their full domain set upgrades the Grant scope explicitly.
 
 ## What This Doesn't Cover
 
@@ -235,6 +332,7 @@ Without this, a Grant scoped `[0x42, 0x07]` on Domain A means nothing to Domain 
 - **Profile content schema.** The Owner's [profile Object](PRIMITIVES.md#profile) is defined as a mechanism in Allgard. The content schema (which fields, what they mean) is defined in [GDL](../gdl/GDL.md#owner-profile-schema).
 - **Voice or media channels.** Real-time media between Owners is an application feature using Leden transport. Presence tells you who's reachable; media setup is a separate capability negotiation.
 - **Notification preferences.** Whether an Owner wants to be disturbed, what channels they prefer — local policy stored at the home domain, not a federation concern.
+- **Metadata privacy.** Who talks to whom and when is visible to routing domains. Hiding this requires onion routing or mixnets at the transport layer (Leden), not the federation layer.
 
 ## Relationship to Existing Specs
 
@@ -246,10 +344,8 @@ Without this, a Grant scoped `[0x42, 0x07]` on Domain A means nothing to Domain 
 | [TRUST.md](TRUST.md) | Presence enables richer trust signals — Owners that are consistently reachable build reputation faster than ghosts. |
 | [Leden observation](../leden/observation.md) | Presence updates are delivered via Leden observation. All existing observation semantics (backpressure, reconnection, filtered observation) apply. |
 
-## Open Questions
-
-- **Presence privacy across trust levels.** Should a `presence` Grant reveal which specific Domains the Owner is on, or just "online/offline"? Full domain list is useful for routing but reveals movement patterns. Maybe two Grant scopes: `observe_liveness` (online/offline only) and `observe_presence` (full domain set). Keeping it simple for now — one scope, full presence. Can split later if privacy concerns are real.
-
 ## Resolved
+
+**Presence privacy.** Two scopes: `observe_liveness` (online/offline only, the default) and `observe_presence` (full domain set). See [Presence Privacy](#presence-privacy). The grantor chooses per-grantee. Default is the privacy-safe option.
 
 **Home domain migration.** Specified in [PRIMITIVES.md](PRIMITIVES.md#home-domain-migration). During cooperative migration, the old home sends `HomeMigrated(new_home)` to all presence observers — clients reconnect to the new home automatically. Name resolution redirects (`OwnerMigrated`) handle cached addresses. During uncooperative migration, the Owner notifies contacts directly through existing sessions. Presence subscriptions at the old home eventually fail; contacts that have the Owner's cryptographic identity can re-subscribe at the new home.

--- a/projects/allgard/PRESENCE.md
+++ b/projects/allgard/PRESENCE.md
@@ -41,13 +41,14 @@ An Owner with no active sessions has an empty presence set. This is valid state 
 
 ## Observability
 
-Presence is observable state. Other Owners can subscribe to presence changes via [Leden observation](../leden/observation.md), gated by a Grant.
+Presence and profile are observable state. Other Owners can subscribe to changes via [Leden observation](../leden/observation.md), gated by a Grant.
 
 ### How It Works
 
 1. Owner A grants Owner B a `presence` Grant (see [Standard Grants](#standard-grants) below).
 2. Owner B subscribes to Owner A's presence via Leden observation at Owner A's home domain.
 3. When Owner A's presence changes (connects to a new domain, disconnects from one), Owner B receives an update.
+4. Owner B can also observe Owner A's [profile Object](PRIMITIVES.md#profile) at the same home domain — avatar, bio, and any other profile fields update automatically.
 
 The home domain is the canonical observation point. It knows the Owner's session state because it manages leases and tracks where the Owner's objects are. Observing presence at the home domain gives a complete view. Observing at a visited domain only tells you about that specific domain.
 
@@ -161,7 +162,7 @@ Without this, a Grant scoped `[0x42, 0x07]` on Domain A means nothing to Domain 
 ## What This Doesn't Cover
 
 - **Spatial location within a domain.** Presence says "Owner is on Domain X." It doesn't say "Owner is at coordinates (3,4) in region Y." Spatial protocols build on top of presence.
-- **Owner profiles or identity metadata.** What an Owner looks like, their display name, their preferences — application-level concerns, not federation physics. GDL or application-specific schemas handle this.
+- **Profile content schema.** The Owner's [profile Object](PRIMITIVES.md#profile) is defined as a mechanism in Allgard. The content schema (which fields, what they mean) is defined in [GDL](../gdl/) — content description is GDL's job.
 - **Voice or media channels.** Real-time media between Owners is an application feature using Leden transport. Presence tells you who's reachable; media setup is a separate capability negotiation.
 - **Notification preferences.** Whether an Owner wants to be disturbed, what channels they prefer — local policy stored at the home domain, not a federation concern.
 

--- a/projects/allgard/PRESENCE.md
+++ b/projects/allgard/PRESENCE.md
@@ -41,9 +41,40 @@ An Owner with no active sessions has an empty presence set. This is valid state 
 
 ## Observability
 
-Presence and profile are observable state. Other Owners can subscribe to changes via [Leden observation](../leden/observation.md), gated by a Grant.
+Presence operates at two tiers. The distinction matters: local presence is physics (you see who's in the room), cross-domain presence is a relationship (you choose who can track you).
 
-### How It Works
+### Tier 1: Local Presence (Same Domain)
+
+When you're on a Domain, you can see who else is there. No Grant needed.
+
+This falls out of existing mechanics. A Domain sends you its region state via [GDL](../gdl/GDL.md) — entities in the region, their names, their properties. Some entities are Owners (kind `agent`). Seeing them is just observing the region. The Domain already decides what entities you see (viewport filtering, fog of war, stealth mechanics). Local presence is part of that — not a separate system.
+
+**The Domain controls local visibility, not the Owner.** If the Domain shows you who's in the tavern, that's the Domain's policy. An Owner can't opt out of being visible to co-located Owners — that would be like demanding invisibility in someone else's house. What the Owner controls is which Domains they visit. What the Domain controls is what visitors see.
+
+| Domain policy | What visitors see | Use case |
+|---|---|---|
+| Full identity | Name, kind, profile ref | Social spaces, taverns, marketplaces |
+| Masked identity | "A hooded traveler" | Anonymity-supporting domains |
+| Selective visibility | Some Owners hidden | Stealth mechanics, admin-invisible mode |
+| No visitor list | Only entities you directly interact with | Privacy-focused domains |
+
+This is sovereignty. The protocol doesn't prescribe which policy a Domain uses. It requires that co-located Owners are representable as GDL entities — the Domain decides which Owners become visible entities and how much identity information to expose.
+
+**What local presence reveals:**
+
+At minimum, the Owner's GDL entity representation — whatever the Domain chooses to expose. At maximum, the entity carries a reference to the Owner's identity, letting the observer resolve name, kind, and profile. The Domain decides where on this spectrum each Owner lands.
+
+**What local presence does NOT reveal:**
+
+Which *other* Domains the Owner is connected to. Local presence tells you "this Owner is here." It doesn't tell you "this Owner is also on Domain C and Domain D." That's cross-domain presence — Tier 2.
+
+### Tier 2: Cross-Domain Presence (Granted)
+
+Seeing where an Owner is when you're NOT in the same place. This requires a `presence` or `contact` Grant.
+
+Cross-domain presence is the relationship layer. It answers: "where is my friend right now?" This is the tracking-capable tier — knowing someone's location across the federation — which is why it requires explicit authorization.
+
+#### How It Works
 
 1. Owner A grants Owner B a `presence` Grant (see [Standard Grants](#standard-grants) below).
 2. Owner B subscribes to Owner A's presence via Leden observation at Owner A's home domain.
@@ -63,12 +94,6 @@ Presence and the [profile Object](PRIMITIVES.md#profile) are **separate observat
 Separating them matters for bandwidth. An Owner tracking 200 contacts doesn't need profile updates every time someone connects to a new domain. Conversely, a domain rendering a player's profile card doesn't need real-time domain-set changes. Clients subscribe to what they need.
 
 Both use standard Leden observation semantics — snapshot on subscribe, delta updates, sequence numbers, backpressure. Profile observation uses Leden's [filtered observation](../leden/observation.md#filtered-observation) if the client only cares about specific fields (e.g., avatar only).
-
-### Capability Gating
-
-Presence is not observable by default. You need a Grant. This is different from Object observation, where holding a reference implies observation permission. The reason: Objects are things; Owners are entities. Knowing where an entity is located is a stronger capability than knowing what a thing contains.
-
-A Domain's greeter does NOT grant presence observation on its hosted Owners. A stranger connecting to a domain can see what the domain hosts (catalog observation), but not which specific Owners are currently active. That would make every greeter a tracking service.
 
 ### What Updates Contain
 

--- a/projects/allgard/PRIMITIVES.md
+++ b/projects/allgard/PRIMITIVES.md
@@ -93,15 +93,9 @@ An Owner's profile is an Object — a regular Object with type tag `owner_profil
 
 #### Well-Known Fields
 
-The profile Object's content is a typed map. [GDL](../gdl/) defines the standard schema for well-known fields — the fields that most domains recognize. This is the same pattern as HTTP headers: a small set of well-known names with defined semantics, plus arbitrary extensions.
+The profile Object's content is a typed map. [GDL](../gdl/GDL.md#owner-profile-schema) defines the standard schema — well-known fields like `display_name`, `avatar`, `bio`, `links`, `pronouns`, and `locale`. This is the same pattern as HTTP headers: a small set of well-known names with defined semantics, plus arbitrary extensions via namespaced keys.
 
-| Field | Type | Description |
-|-------|------|-------------|
-| `display_name` | string | Preferred display name. Optional — `name` from the Owner primitive is the canonical fallback. |
-| `avatar` | content ref | Content-addressed reference to an image. Fetched via Leden content store. |
-| `bio` | string | Short self-description. Max 500 characters. |
-
-These are defined in GDL because GDL's job is content description — what things look like and how to present them. The profile schema is a GDL concern, not an Allgard concern. Allgard defines the mechanism (profile is an Object, observable, at home domain). GDL defines the content (what fields exist, what they mean).
+The split is deliberate: Allgard defines the mechanism (profile is an Object, observable, at home domain). GDL defines the content (what fields exist, what they mean). Content description is GDL's job.
 
 #### Graceful Degradation
 

--- a/projects/allgard/PRIMITIVES.md
+++ b/projects/allgard/PRIMITIVES.md
@@ -46,6 +46,66 @@ Owners are cryptographic identities. The specific scheme (ed25519 keys, DIDs, et
 
 An Owner is *not* a person. A person may control multiple Owners. An automated system can be an Owner. The federation doesn't care about the entity behind the key.
 
+### Key Hierarchy
+
+An Owner's identity is a **master key**. The master key is the root of authority — it can do everything: sign Transforms, issue Grants, revoke Grants, migrate home domains, recover from wallet.
+
+The master key should NOT live on a daily-use device. It's too powerful. A compromised master key is total identity loss. The master key lives in cold storage — hardware security key, paper backup, airgapped device. You use it for setup, recovery, and emergencies. Not for logging in.
+
+Daily operations use **device keys**. Each device (phone, laptop, work machine) gets its own keypair. The master key signs a Device Grant to each device key — a scoped delegation of the Owner's authority.
+
+```
+Master key (cold storage)
+    |
+    ├── Device Grant → phone key
+    │     scope: sign_transforms, maintain_sessions, issue_grants(limited)
+    │     expiry: 90 days (auto-renewable while master key confirms)
+    │
+    ├── Device Grant → laptop key
+    │     scope: sign_transforms, maintain_sessions, issue_grants(limited)
+    │     expiry: 90 days
+    │
+    ├── Device Grant → work key
+    │     scope: read_only, maintain_sessions
+    │     expiry: 30 days
+    │
+    └── Relay Grant → relay service
+          scope: forward, queue, presence, name_resolution, lease_renewal
+          expiry: none (revoke-only)
+```
+
+Device Grants are standard [Grants](#grant) — same primitive, same attenuation rules, same revocation. A device key can do everything its Grant allows, nothing more. Different devices can have different scopes:
+
+| Device | Typical scope | Why |
+|---|---|---|
+| Phone (primary) | Full daily operations — sign, session, limited Grant issuance | Your main device, most trusted |
+| Laptop | Full daily operations | Same trust level as phone |
+| Work machine | Read-only, sessions, no signing | Untrusted hardware, limited exposure |
+| Shared/public terminal | Session only, expiry in hours | Minimal trust, auto-expires |
+
+#### Device Key Revocation
+
+Lost phone? Stolen laptop? Revoke the device key from any other device that holds sufficient authority:
+
+1. From another device with `revoke_device` scope — immediate, no master key needed.
+2. From the relay — if the relay holds a `revoke_device` Grant (recommended).
+3. From the master key — always works, the nuclear option.
+
+Device key revocation uses the same propagation mechanism as [Key Compromise](#key-compromise-propagation), but scoped to one device key. The home domain (or relay) broadcasts the revocation to all domains where that device key has active sessions. Sessions from the revoked key are terminated. Transforms signed by the revoked key after the revocation timestamp are rejected.
+
+**This is not a full key compromise.** The master key is safe. Other device keys are safe. Only the revoked device's sessions are affected. The Owner continues operating from other devices without interruption.
+
+#### Why Not Just One Key?
+
+The current spec says "Owners are cryptographic identities" — implying one key. That works for automated systems (one process, one key). It doesn't work for humans who use multiple devices.
+
+Without device keys, the options are:
+- **Copy the master key to every device.** One compromised device = total identity loss. Terrible.
+- **Use one device only.** That device goes offline, you're locked out. Also terrible.
+- **Create separate Owner identities per device.** Your inventory, Grants, and reputation fragment across identities. Defeats the purpose.
+
+Device keys solve all three. The master key stays safe. Any device can act. One device compromise is bounded. The Owner is one identity across all devices.
+
 ### Properties
 
 | Property | Description |
@@ -174,6 +234,72 @@ This is a Grant from the player to the backup domain — scoped to mirror and re
 
 Without a backup, home domain failure is permanent loss. That's the honest tradeoff. But with a backup, it's a recoverable event — same as a disk failure with a RAID mirror.
 
+### Deployment Models
+
+The protocol doesn't prescribe where a home domain runs. Three models, each with different sovereignty/convenience tradeoffs.
+
+#### Hosted
+
+Someone else runs your home domain. A gard operator, a hosting provider, a community server. You hold your device keys. They hold your Objects and run your Domain logic. Every Transform still requires YOUR device key's signature — the host can't forge operations.
+
+| Advantage | Disadvantage |
+|---|---|
+| Always-on, no ops | They have leverage — can refuse migration, change terms |
+| Low barrier | Your Objects are on their hardware |
+| Professional infrastructure | You depend on their availability |
+
+This is the default for most users. The wallet ensures you can leave. The migration protocol ensures you can leave smoothly (cooperative) or roughly (uncooperative). The host is a convenience layer, not a trust anchor.
+
+**The host is not a custodian.** The protocol should structurally discourage custodial hosting (where the host holds the Owner's keys). TRUST.md already says: "domain operators who hold player keys are undermining the ownership model." Device keys make non-custodial hosting natural — the host runs the Domain, the Owner's devices hold the signing keys. A host that demands your master key is a red flag.
+
+#### Self-Hosted
+
+You run your home domain on your own hardware — home server, VPS, dedicated machine. Full sovereignty.
+
+| Advantage | Disadvantage |
+|---|---|
+| Full control | You need ops skills |
+| No external dependency | You need uptime (or a relay) |
+| Your Objects on your hardware | You need a public address or relay |
+
+Viable for technical users, organizations, and automated systems. A Raspberry Pi or NAS running the Allgard runtime is enough for a personal home domain. A VPS is the simplest path for public reachability.
+
+#### Edge + Relay
+
+Your home domain runs on your device (phone, laptop, home server). A relay service handles reachability.
+
+```
+Your devices ──── relay service ──── the federation
+ (authority)      (reachability)
+```
+
+The relay is a thin service with a scoped [Grant](#grant):
+
+| Relay capability | What it does | What it can't do |
+|---|---|---|
+| Forward messages | Routes inbound messages to your active device | Read message content (encrypted end-to-end) |
+| Queue when offline | Holds messages until a device comes online | Sign Transforms or issue Grants |
+| Presence aggregation | Reports which devices are online, serves presence to observers | Modify presence state |
+| Name resolution | Responds to `ResolveName` requests | Change your name or identity |
+| Lease renewal | Renews leases on your behalf (scoped Grant) | Transfer or modify your Objects |
+| Profile cache | Serves cached profile to observers | Modify your profile |
+
+The relay is replaceable. It holds no authority beyond its Grant, no Objects, no master key. Switching relays is revoking one Grant and issuing another — not a home domain migration.
+
+**The relay IS the backup home, thin edition.** The existing backup home concept ranges from "full mirror" (holds all Objects, can promote to primary) to "thin relay" (forwarding + queuing only, Objects stay on devices). Both use the same Grant-based delegation. The difference is scope — a full backup can recover from total device loss, a thin relay can only bridge offline periods.
+
+**Recommended setup:** relay service for reachability + a full backup at a different provider for disaster recovery. The relay handles daily operations (forwarding, presence, lease renewal). The backup handles catastrophes (all devices lost, relay down).
+
+**When your phone is offline and you log in on your laptop:**
+
+1. Laptop has its own device key (from [Key Hierarchy](#key-hierarchy)).
+2. Laptop contacts the relay (stable network address).
+3. Relay validates the laptop's device key against the Owner's published Device Grants.
+4. Laptop can act as the Owner — sign Transforms, maintain sessions, access Objects.
+5. Phone comes back later, syncs state with the relay. Both devices active simultaneously.
+
+No single device is the home domain. The Owner's identity is the master key. Any device with a valid Device Grant can act. The relay aggregates and forwards. If the relay goes down, devices that know each other's addresses can communicate directly — the relay is a convenience, not a dependency.
+
 ### Home Domain Migration
 
 An Owner can change their home domain. This is the voluntary version of home domain failure — same mechanics, controlled circumstances.
@@ -285,11 +411,17 @@ The wallet's historical Proof chains from A remain valid — they're append-only
 
 ### Key Compromise Propagation
 
-When an Owner's key is compromised, the home domain must propagate revocation to every domain where the Owner has active sessions, outstanding Grants, or leased objects. This is the hardest revocation case — it's time-critical and cross-domain.
+With the [key hierarchy](#key-hierarchy), compromise has two severities:
+
+**Device key compromised** (phone stolen, laptop hacked). Bounded damage. Revoke the device key from any other device or the relay. Sessions from that device terminate. Transforms signed after revocation are rejected. Other devices continue unaffected. This is a routine security event, not an emergency.
+
+**Master key compromised** (cold storage breached). Total emergency. The attacker can issue new device keys, migrate the home domain, sign anything. This is the case described below — full propagation, all sessions terminated, identity recovery required.
+
+When an Owner's master key is compromised, the home domain must propagate revocation to every domain where the Owner has active sessions, outstanding Grants, or leased objects. This is the hardest revocation case — it's time-critical and cross-domain.
 
 **Revocation flow:**
 
-1. **Owner or home domain detects compromise.** The Owner reports a compromised key (out-of-band — new key signed by backup key, admin action, etc.), or the home domain detects anomalous behavior (impossible concurrent sessions, operations from conflicting locations).
+1. **Owner or home domain detects compromise.** The Owner reports a compromised key (out-of-band — new key signed by backup key, admin action, etc.), or the home domain detects anomalous behavior (impossible concurrent sessions, operations from conflicting locations, Device Grants issued that the Owner didn't authorize).
 
 2. **Home domain issues `KeyRevocation(owner_id, compromised_key, evidence, new_key)`** to all domains it has bilateral relationships with. This is a broadcast, not targeted — the home domain may not know every domain the Owner visited (Grants can chain through intermediaries). The message includes:
    - The Owner identity being revoked

--- a/projects/allgard/PRIMITIVES.md
+++ b/projects/allgard/PRIMITIVES.md
@@ -52,6 +52,12 @@ Every Owner has a home domain — the domain that is authoritative for their ide
 
 The home domain is where your stuff lives by default.
 
+### Presence
+
+An Owner's presence is the set of Domains where the Owner currently has active sessions. Presence is observable state — other Owners with appropriate Grants can subscribe to presence changes. The home domain is the canonical observation point.
+
+See [PRESENCE.md](PRESENCE.md) for the full spec: observability, reachability, and standard relationship Grant conventions.
+
 ### Leased Transfer
 
 When a player visits another domain, objects don't transfer permanently — they transfer on a **lease**. The lease is a time-limited escrow built from existing primitives (Transform + Grant + expiry):

--- a/projects/allgard/PRIMITIVES.md
+++ b/projects/allgard/PRIMITIVES.md
@@ -174,6 +174,115 @@ This is a Grant from the player to the backup domain — scoped to mirror and re
 
 Without a backup, home domain failure is permanent loss. That's the honest tradeoff. But with a backup, it's a recoverable event — same as a disk failure with a RAID mirror.
 
+### Home Domain Migration
+
+An Owner can change their home domain. This is the voluntary version of home domain failure — same mechanics, controlled circumstances.
+
+Migration matters because home domains aren't forever. A domain might shut down (planned), change terms, degrade in quality, or the Owner might just want to move. Without a migration protocol, the Owner's only option is wallet recovery to a new domain — which works but loses all active sessions, leases, presence subscriptions, and message routing. Migration preserves continuity.
+
+#### The Problem
+
+Everything points at the home domain:
+- Name resolution: `erik@northgard` resolves at `northgard`
+- Presence subscriptions: observers watch `northgard` for Owner state
+- Profile observation: profile Object lives on `northgard`
+- Message routing: contacts send messages through `northgard`
+- Inventory: Objects live on `northgard`
+- Leases: `northgard` manages outstanding leases for visited domains
+- Backup home: mirrors `northgard`
+
+Changing home domain means redirecting all of this. The Owner's cryptographic identity stays the same — only the domain changes.
+
+#### Cooperative Migration
+
+The happy path. Old home (Domain A) and new home (Domain B) both cooperate.
+
+```
+Owner              Old Home (A)         New Home (B)
+  |                     |                      |
+  | 1. MigrationIntent  |                      |
+  |────────────────────>|                      |
+  |                     |                      |
+  | 1. MigrationIntent  |                      |
+  |───────────────────────────────────────────>|
+  |                     |                      |
+  |                     | 2. InventoryTransfer |
+  |                     |─────────────────────>|
+  |                     |  (batch, per object) |
+  |                     |                      |
+  |                     | 3. MigrationCommit   |
+  |                     |─────────────────────>|
+  |                     |                      |
+  |                     | 4. Redirect active   |
+  |                     | state → Redirecting  |
+  |                     |                      |
+```
+
+**Phase 1: Intent.** Owner submits a signed `MigrationIntent(from: A, to: B)` to both domains. Both validate the Owner's signature. Domain B checks that it's willing to host this Owner (policy — rate limits, content rules, capacity). Domain A transitions the Owner to "migrating" state — no new leases, no new outbound transfers.
+
+**Phase 2: Inventory transfer.** Domain A transfers all Owner's Objects to Domain B using the existing [cross-domain transfer protocol](TRANSFER.md). This is a batch operation — potentially hundreds of Objects. Each transfer follows the standard escrow→commit→complete flow. The profile Object transfers as part of this batch.
+
+Outstanding leases complicate this. Objects currently leased to visited domains don't transfer through A — they'll return to A on lease expiry, then forward to B. Or A can revoke the leases early, forcing objects home, then transfer to B. The Owner chooses:
+
+| Lease strategy | Behavior | Disruption |
+|---|---|---|
+| **Revoke and transfer** | Revoke all leases, wait for objects to return, transfer to B | Immediate disruption — Owner is kicked from visited domains briefly |
+| **Forward on return** | Let leases expire naturally, forward objects to B as they return | No disruption — but migration isn't complete until the last lease returns |
+| **Re-lease from B** | Transfer unleased objects to B, then B issues new leases to the same visited domains | Minimal disruption — visited domains swap their lease source |
+
+I'd default to "re-lease from B" for the smoothest experience, with "revoke and transfer" as the fallback when speed matters.
+
+**Phase 3: Commit.** Once all Objects are transferred (or forwarded/re-leased), Domain A persists a `MigrationProof(owner_id, new_home: B)` — analogous to a Departure Proof. This is irrevocable. Domain A is no longer the home domain.
+
+**Phase 4: Redirect.** Domain A enters "redirecting" state for this Owner:
+
+- `ResolveName("erik")` → `OwnerMigrated(new_home: B)`. Like an HTTP 301.
+- Presence observers receive `HomeMigrated(new_home: B)`. Clients reconnect to B automatically.
+- Inbound messages receive `OwnerMigrated(new_home: B)`. Senders update their routing.
+- The Owner's name is reserved on A during the redirect period — nobody else can claim `erik@northgard`.
+
+**Redirect duration.** Domain A keeps the redirect for a minimum of 90 days (configurable per bilateral agreement). After that, the Owner's name on A is released. This gives contacts, cached name resolutions, and slow-updating systems time to discover the new home.
+
+The 90-day minimum is a protocol recommendation, not a law. A domain shutting down might redirect for 30 days. A domain with a good relationship might redirect indefinitely. The Owner should assume redirects are temporary and notify contacts directly.
+
+#### Uncooperative Migration
+
+Domain A refuses to cooperate — won't transfer Objects, won't redirect, won't release the name. This is the hostile case.
+
+The Owner still migrates. The tools already exist:
+
+1. **Wallet recovery.** The Owner's wallet contains Proof chains for all Objects. Present the wallet to Domain B. Domain B verifies mechanically and accepts via [witnessed recovery](#witnessed-recovery). Objects are now on B.
+
+2. **Direct notification.** The Owner has sessions with other domains (visited domains, contacts' home domains). The Owner announces the migration directly — "my new home is B." No redirect from A needed.
+
+3. **Gossip.** Trading partners of A learn through bilateral interaction that the Owner is now operating from B. The MigrationProof (if A eventually produces one) or the wallet's Proof chains serve as evidence.
+
+**What the Owner loses in uncooperative migration:**
+- Name on A. `erik@northgard` is gone. The Owner becomes `erik@newdomain`. Contacts using the old address get no redirect.
+- Active leases. Objects on visited domains have leases from A. A won't revoke or forward them. They return to A on lease timeout. The Owner recovers them via wallet once they return to A's inventory — or waits for lease expiry and uses witnessed recovery.
+- Smooth transition. There's a gap where some contacts still route through A and others route through B. This resolves as contacts learn the new address.
+
+This is the same cost as home domain failure without a backup. Uncooperative migration is effectively voluntary homelessness with wallet recovery. It works, but it's not smooth.
+
+#### Name Continuity
+
+`erik@northgard` becomes `erik@eastgard`. The identity (cryptographic key) is the same. The address changes. This is like changing email providers — everyone who had the old address needs the new one.
+
+**The redirect handles the transition.** During the redirect period, the old address forwards to the new one. After the redirect expires, the old address stops working.
+
+**Why not keep the old name permanently?** Because that makes Domain A a permanent dependency. The Owner left A — maybe because A is shutting down, maybe because A is hostile. Permanent redirects mean A has permanent leverage. The clean break is: redirects are temporary, contacts update, the old name is released.
+
+**Backup home as migration accelerator.** If the Owner has a backup home domain that's already mirroring, migration to the backup is nearly instant — it already has the inventory. The backup promotes itself to primary, the old primary becomes the redirect. This is the smoothest migration path and another reason to have a backup.
+
+#### What the Wallet Stores After Migration
+
+The wallet adds:
+- `MigrationProof(from: A, to: B)` — evidence of the migration
+- Updated `home_domain: B`
+- Fresh Proof chains from B for transferred Objects
+
+The wallet's historical Proof chains from A remain valid — they're append-only. The migration is a new entry in the Owner's history, not an edit.
+
 ### Key Compromise Propagation
 
 When an Owner's key is compromised, the home domain must propagate revocation to every domain where the Owner has active sessions, outstanding Grants, or leased objects. This is the hardest revocation case — it's time-critical and cross-domain.

--- a/projects/allgard/PRIMITIVES.md
+++ b/projects/allgard/PRIMITIVES.md
@@ -46,6 +46,83 @@ Owners are cryptographic identities. The specific scheme (ed25519 keys, DIDs, et
 
 An Owner is *not* a person. A person may control multiple Owners. An automated system can be an Owner. The federation doesn't care about the entity behind the key.
 
+### Properties
+
+| Property | Description |
+|----------|------------|
+| `id` | Cryptographic identity (public key or derived identifier) |
+| `name` | Human-readable identifier, unique within the home domain. Globally addressed as `name@home_domain`. |
+| `kind` | Advisory type tag: `individual`, `system`, `group`, `service`. Not enforced — domains can use it for policy (rate limits, trust defaults, display). |
+| `home_domain` | The Domain authoritative for this Owner's identity |
+| `profile` | Optional. Object reference to the Owner's profile Object (see [Profile](#profile)). |
+
+### Name
+
+Every Owner has a name — a human-readable identifier, unique within its home domain. The global form is `name@home_domain`, like email addresses. Globally unique by construction, no registry needed.
+
+Names are how Owners refer to each other across the federation. Without standardized naming, every cross-gard interaction would use raw cryptographic IDs. That's fine for machines. It's unusable for anything involving humans.
+
+The home domain is authoritative for name uniqueness within its namespace. Name resolution goes through the home domain, same as email MX resolution.
+
+**Names are not secrets.** An Owner's name is public — it's how you're addressed. Knowing someone's name doesn't grant any capability. You still need a Grant to observe their presence or contact them.
+
+### Kind
+
+Advisory type tag. The federation doesn't enforce it — an Owner claiming `individual` might be a bot. But kind serves two purposes:
+
+1. **Policy defaults.** A domain might apply different rate limits to `system` Owners (higher throughput, lower interactivity) vs `individual` Owners. A `service` Owner connecting at 3am to execute 1000 transfers looks normal. An `individual` doing that looks suspicious.
+
+2. **Interaction expectations.** A `group` Owner (guild, organization) has members and delegation. A `service` Owner (automated trading, monitoring) is expected to be always-on. These expectations aren't enforced — they inform how domains and other Owners interact.
+
+| Kind | Typical use |
+|------|------------|
+| `individual` | A person. May be offline. Has social relationships. |
+| `system` | Automated process. Expected to be always-on. High throughput, low interactivity. |
+| `group` | Multi-member entity (guild, organization). Has an administrator. Delegates via Grants. |
+| `service` | Provides functionality to other Owners (marketplace, exchange, hosting). Publicly reachable. |
+
+Kind is self-declared and immutable once set. Changing kind requires a new Owner identity. I considered making it mutable but rejected it — a `system` that becomes an `individual` mid-session breaks every policy assumption. If you need a different kind, create a new Owner.
+
+### Profile
+
+An Owner's profile is an Object — a regular Object with type tag `owner_profile`, owned by the Owner, published at the home domain. The profile carries identity metadata beyond the fundamental properties (name, kind).
+
+**Why an Object, not more primitive properties?** Because the boundary between "fundamental" and "application-specific" depends on context. Name and kind are universal — every federated system needs them. Avatar, bio, display name — almost universal, but not quite. Game class, sensor type — domain-specific. Putting everything in the primitive forces every system to carry fields it doesn't use. An Object with a typed schema lets each context carry what it needs.
+
+**The profile Object is observable.** Other Owners with a `presence` or `contact` Grant (see [PRESENCE.md](PRESENCE.md#standard-grants)) can observe the profile via Leden observation at the home domain. No transfer needed — read it from the authoritative source, cache locally. Content-addressed, so cache invalidation is free (content changes = new hash = refetch).
+
+#### Well-Known Fields
+
+The profile Object's content is a typed map. [GDL](../gdl/) defines the standard schema for well-known fields — the fields that most domains recognize. This is the same pattern as HTTP headers: a small set of well-known names with defined semantics, plus arbitrary extensions.
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `display_name` | string | Preferred display name. Optional — `name` from the Owner primitive is the canonical fallback. |
+| `avatar` | content ref | Content-addressed reference to an image. Fetched via Leden content store. |
+| `bio` | string | Short self-description. Max 500 characters. |
+
+These are defined in GDL because GDL's job is content description — what things look like and how to present them. The profile schema is a GDL concern, not an Allgard concern. Allgard defines the mechanism (profile is an Object, observable, at home domain). GDL defines the content (what fields exist, what they mean).
+
+#### Graceful Degradation
+
+Domains render what they recognize, ignore what they don't. GDL's first design principle — "ignore what you don't understand" — applies directly to profiles.
+
+| What the domain recognizes | What it shows |
+|---|---|
+| Full GDL profile schema + domain extensions | Rich profile — avatar, bio, custom fields |
+| Standard GDL profile fields only | Avatar, bio, display name |
+| No profile support | `name` and `kind` from the Owner primitive |
+
+Every step is functional. A supply chain system that doesn't render avatars still has `name` and `kind`. A game domain that adds `class` and `level` fields can render rich character profiles. Neither breaks when encountering the other's profiles — unknown fields are silently ignored.
+
+#### Domain-Specific Extensions
+
+Domains add custom fields to the profile Object. A game domain might add `class`, `level`, `guild`. A supply chain domain might add `facility_type`, `capacity`. These fields travel with the profile Object and are available to any domain that recognizes them.
+
+Custom fields use a namespaced key convention to avoid collisions: `domain_name.field_name`. A game domain `northgard` adding a class field uses `northgard.class`. Domains never need to coordinate field names — the namespace prevents collisions by construction.
+
+Namespaced fields that a domain doesn't recognize are preserved but not rendered. If a player from `northgard` visits `eastgard`, and `eastgard` doesn't know about `northgard.class`, the field survives in the profile Object — it's just not displayed. When the player returns to `northgard`, the field is still there.
+
 ### Home Domain
 
 Every Owner has a home domain — the domain that is authoritative for their identity and primary inventory. An Owner can operate in other domains, but their home domain is the root of trust for their identity.

--- a/projects/allgard/PRIMITIVES.md
+++ b/projects/allgard/PRIMITIVES.md
@@ -50,16 +50,22 @@ An Owner is *not* a person. A person may control multiple Owners. An automated s
 
 An Owner's identity is a **master key**. The master key is the root of authority — it can do everything: sign Transforms, issue Grants, revoke Grants, migrate home domains, recover from wallet.
 
-The master key should NOT live on a daily-use device. It's too powerful. A compromised master key is total identity loss. The master key lives in cold storage — hardware security key, paper backup, airgapped device. You use it for setup, recovery, and emergencies. Not for logging in.
+The master key doesn't live on any device in the clear. It's password-encrypted and stored on the home domain (and backup home, and optionally synced to enrolled devices). The encrypted blob is useless without the password. Redundancy is free — store it everywhere.
+
+```
+encrypted(master_key, password) → stored on home domain, backup, devices
+```
+
+"Log in on a new device" is: contact home domain, authenticate with password, home domain decrypts the master key server-side (or sends the encrypted blob for client-side decryption), issue a Device Grant to the new device's keypair. This is the login flow everyone already understands.
 
 Daily operations use **device keys**. Each device (phone, laptop, work machine) gets its own keypair. The master key signs a Device Grant to each device key — a scoped delegation of the Owner's authority.
 
 ```
-Master key (cold storage)
+Master key (password-encrypted, on home domain)
     |
     ├── Device Grant → phone key
     │     scope: sign_transforms, maintain_sessions, issue_grants(limited)
-    │     expiry: 90 days (auto-renewable while master key confirms)
+    │     expiry: 90 days (auto-renewable)
     │
     ├── Device Grant → laptop key
     │     scope: sign_transforms, maintain_sessions, issue_grants(limited)
@@ -82,6 +88,40 @@ Device Grants are standard [Grants](#grant) — same primitive, same attenuation
 | Laptop | Full daily operations | Same trust level as phone |
 | Work machine | Read-only, sessions, no signing | Untrusted hardware, limited exposure |
 | Shared/public terminal | Session only, expiry in hours | Minimal trust, auto-expires |
+
+#### Password Security
+
+The encrypted master key blob is protected by a key derived from the password using Argon2 (memory-hard KDF). This makes brute-force expensive — seconds per attempt, not microseconds. The runtime enforces minimum password strength at identity creation.
+
+The home domain never sees the master key in the clear if client-side decryption is used. The home domain stores the encrypted blob and serves it to authenticated devices. The device decrypts locally. This means a compromised home domain gets the encrypted blob but not the password — and a strong password holds up against offline brute-force.
+
+For convenience, the home domain can offer server-side decryption (password sent over the authenticated Leden session, decryption happens on the server, device key issued). This is less sovereign but simpler — same trust model as any password-authenticated web service. The Owner chooses.
+
+#### Recovery
+
+Forgot password, lost all devices — how do you get back in?
+
+**Social recovery.** At identity creation, the Owner designates M-of-N trusted Owners as recovery contacts. The home domain stores encrypted recovery shards (one per contact). To recover: M contacts confirm your identity (through their own authenticated sessions), the home domain releases enough shards to reconstruct access, the Owner sets a new password.
+
+From the user's perspective: "I forgot my password. My three friends confirmed it's me. I set a new password." That's it.
+
+Social recovery is opt-in but the runtime should strongly encourage it during identity creation — same as "add a recovery email" in every account setup flow.
+
+**Home domain recovery.** The home domain operator can offer out-of-band identity verification (email, phone, government ID — domain policy). Less sovereign, more familiar. This is the standard "forgot password" flow. The domain operator has the power to reset access, which means the domain operator is a trust dependency for recovery.
+
+**Both.** Social recovery handles the "domain operator is hostile/gone" case. Home domain recovery handles the "I have no friends online right now" case. They complement each other.
+
+| Scenario | Recovery path |
+|---|---|
+| Forgot password, have a device | Device key still works. Change password from enrolled device. |
+| Forgot password, no devices | Social recovery (M-of-N contacts) or home domain recovery |
+| Lost all devices, know password | Log in from new device with password |
+| Lost all devices, forgot password | Social recovery → new password → new device |
+| Home domain down, have a device | Device key still works via backup home |
+| Home domain down, no devices, know password | Encrypted blob from backup home + password |
+| Everything gone (no devices, no password, home down) | Social recovery via backup home, or wallet recovery if you have a wallet backup |
+
+The bottom row is the real disaster scenario. Without social recovery contacts or a wallet backup, it's permanent loss. That's the honest tradeoff — but every row above it has a recovery path that doesn't require security expertise.
 
 #### Device Key Revocation
 
@@ -415,7 +455,7 @@ With the [key hierarchy](#key-hierarchy), compromise has two severities:
 
 **Device key compromised** (phone stolen, laptop hacked). Bounded damage. Revoke the device key from any other device or the relay. Sessions from that device terminate. Transforms signed after revocation are rejected. Other devices continue unaffected. This is a routine security event, not an emergency.
 
-**Master key compromised** (cold storage breached). Total emergency. The attacker can issue new device keys, migrate the home domain, sign anything. This is the case described below — full propagation, all sessions terminated, identity recovery required.
+**Master key compromised** (attacker obtained encrypted blob + password, or home domain with server-side decryption was breached). Total emergency. The attacker can issue new device keys, migrate the home domain, sign anything. This is the case described below — full propagation, all sessions terminated, identity recovery required. Note: master key compromise requires both the encrypted blob AND the password — stealing one without the other is insufficient.
 
 When an Owner's master key is compromised, the home domain must propagate revocation to every domain where the Owner has active sessions, outstanding Grants, or leased objects. This is the hardest revocation case — it's time-critical and cross-domain.
 

--- a/projects/allgard/README.md
+++ b/projects/allgard/README.md
@@ -20,7 +20,7 @@ The name is Old Norse: *all* + *garðr*. All the gards, together.
 ## What Allgard Is Not
 
 - Not a protocol. Leden is the protocol. Allgard is the model that gives protocol messages meaning.
-- Not a registry. Discovery is Leden's gossip layer. Allgard doesn't know who's online.
+- Not a registry. Discovery is Leden's gossip layer. Owner [presence](PRESENCE.md) is observable state — each Domain knows which Owners have active sessions — but there is no central directory.
 - Not a blockchain. No global ledger, no consensus mechanism. Trust is bilateral and capability-based.
 
 ## The Stack
@@ -80,6 +80,7 @@ No step requires permission from a central authority. See [Bootstrapping](#boots
 | [CONSERVATION.md](CONSERVATION.md) | The seven conservation laws every domain must enforce |
 | [TRANSFER.md](TRANSFER.md) | Cross-domain transfer protocol: escrow, timeouts, partition recovery, Law 2 proof |
 | [TRUST.md](TRUST.md) | Adversarial trust model: introductions, reputation, Sybil resistance |
+| [PRESENCE.md](PRESENCE.md) | Owner presence: location, observability, reachability, standard relationship grants |
 
 ## Bootstrapping
 

--- a/projects/gdl/GDL.md
+++ b/projects/gdl/GDL.md
@@ -1038,6 +1038,30 @@ Resolved
 
 Regions are not entities. A region is a container. Entities are contents. Regions have metadata (name, description, spatial model, properties, theme). Entities have affordances and appearance. Mixing them creates ambiguity about what "observing an entity" means vs. "observing a region." Clean separation.
 
+Owner profile schema. [Allgard](../allgard/PRIMITIVES.md#profile) defines the mechanism: every Owner can publish a profile Object at their home domain. GDL defines the content — what fields exist and what they mean. The profile Object's content is a typed map with well-known fields and domain-specific extensions.
+
+**Well-known fields:**
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `display_name` | string | No | Preferred display name. Fallback: `name` from the Owner primitive. Max 64 characters. |
+| `avatar` | content ref | No | Content-addressed reference to an image (PNG or WebP, max 512×512, max 256KB). Fetched via Leden content store. |
+| `bio` | string | No | Short self-description. Max 500 characters. |
+| `links` | list of `{label, url}` | No | External references — website, social, documentation. Max 10 entries. |
+| `pronouns` | string | No | For `individual` kind Owners. Free-form: "he/him", "they/them", etc. |
+| `locale` | string | No | BCP 47 language tag. Hint for communication preferences, not a rendering directive. |
+
+**Domain-specific extensions** use namespaced keys: `domain_name.field_name`. A game domain `northgard` adds `northgard.class: "warrior"`. A supply chain domain `logistics` adds `logistics.facility_type: "warehouse"`. Namespaces prevent collisions by construction.
+
+**Rendering rules:**
+- Unknown fields: skip (GDL principle #1)
+- Missing optional fields: omit from display, don't show blank placeholders
+- `avatar` not present: client uses a generated icon from the Owner's `name` and `kind`
+- `display_name` not present: use `name` from the Owner primitive
+- Domain-specific fields: render if the client has a handler for the namespace, skip otherwise
+
+This follows the same pattern as entity properties — typed key-value pairs with conventions for common patterns and graceful degradation for unknown fields.
+
 Vocabulary is convention, not protocol. Entity kinds, affordance categories, property names, event types — these are initial conventions that communities extend. The protocol defines mechanisms (entities have a `kind` string, affordances have a `category` string). The specific terms (`agent`, `navigate`, `health`) are conventions that emerge from use. Like HTTP content types — `text/html` is not in the HTTP spec. GDL's `creature` kind should not be in the GDL spec either. I kept a small core set for bootstrapping, but they're conventions, not protocol.
 
 Existing scene formats for 3D, not a custom hint format. I considered building a vocabulary of shapes, skeletons, PBR surface hints, and animation layers as a GDL-native "hint" system for 3D clients. I got far enough to see the problem: any GDL-native scene vocabulary would always be a subset of what existing 3D formats already standardize, maintained by a smaller team, with less tooling support. GDL shouldn't compete with scene format developers on geometry, materials, and animation. GDL's job is the game layer (interaction, observation, theming). Scene formats handle the content layer (geometry, materials, animation, lighting). Sharp boundary. GDL defines the abstract structure a scene asset must have (model + animations + parts + attachment points) and names glTF `.glb` as the mandatory baseline, but the fidelity mechanism allows future formats without spec changes.


### PR DESCRIPTION
## Summary

This PR introduces the Presence specification for Allgard, formalizing how Owners are located, observed, and contacted across federated domains. It also extends the Owner primitive with identity properties (name, kind, profile, home domain) and home domain migration mechanics.

## Key Changes

**New Specification:**
- Added `PRESENCE.md` — comprehensive spec covering:
  - Owner location as observable state (set of active domains)
  - Two-tier observability model (local presence on same domain, cross-domain presence via Grants)
  - Reachability and name resolution (`name@home_domain` addressing)
  - Standard Grant conventions: `presence`, `contact`, `block`, and `group`
  - Messaging semantics (at-most-once delivery, 64KB limit, rate limiting)

**Extended Owner Primitive (PRIMITIVES.md):**
- Added Owner properties: `id`, `name`, `kind`, `home_domain`, `profile`
- Defined `name` as human-readable identifier, globally addressed as `name@home_domain`
- Defined `kind` as advisory type tag (`individual`, `system`, `group`, `service`) for policy defaults
- Added `profile` as an Object mechanism for identity metadata (avatar, bio, display name, etc.)
- Specified presence as observable state with home domain as canonical observation point

**Home Domain Migration (PRIMITIVES.md):**
- Cooperative migration protocol: intent → inventory transfer → commit → redirect
- Uncooperative migration via wallet recovery
- Lease handling strategies (revoke, forward, re-lease)
- 90-day minimum redirect period with name reservation
- Migration proof and wallet updates

**GDL Profile Schema (GDL.md):**
- Well-known profile fields: `display_name`, `avatar`, `bio`, `links`, `pronouns`, `locale`
- Domain-specific extensions via namespaced keys (`domain_name.field_name`)
- Graceful degradation rules for unknown fields and missing optional fields

## Notable Implementation Details

- **Presence is not singular:** Owners can have active sessions on multiple domains simultaneously, unlike Objects which are on exactly one domain
- **Two-tier observability:** Local presence (same domain, no Grant needed) vs. cross-domain presence (requires Grant)
- **Standard Grants as conventions:** Named Grant configurations (`presence`, `contact`) provide portable semantics across domains without adding new primitives
- **Name resolution as public operation:** Resolving `name@home_domain` to identity requires no Grant; Grants control what you can do with that identity
- **Profile as Object:** Separates mechanism (Allgard) from content schema (GDL), allowing graceful degradation and domain-specific extensions
- **Migration preserves identity:** Cryptographic identity stays the same; only home domain changes, with temporary redirects for transition period

https://claude.ai/code/session_01BWHkaLNKHqqSZE7LTQ8XGE