### PR TITLE
Fix SP3 zero-step error, ER25/ER26 message coverage, CT35 comptime limits

### DIFF
--- a/SPEC_AUDIT.md
+++ b/SPEC_AUDIT.md
@@ -145,17 +145,17 @@ Both type checker and interpreter reject `.variants()` on enums with payload fie
 
 The `trait Iterator<Item>` isn't registered in stdlib for user code to write generic bounds like `T: Iterator<Item>`. Custom iterators can't be constrained.
 
-### 21. Error auto-delegation for `@message` wrapper variants (ER25)
+### 21. ~~Error auto-delegation for `@message` wrapper variants (ER25)~~ FIXED
 
-Variants with a single Error payload and no `@message` should auto-delegate to `inner.message()`. Desugar doesn't implement this.
+Desugar now only auto-delegates for single-field variants whose type name ends with "Error" (ER25). Variants with fields but no `@message` and no auto-delegatable payload trigger an ER26 coverage error. Pipeline reports desugar errors before proceeding.
 
-### 22. Step range validation (SP1–SP3)
+### 22. ~~Step range validation (SP3)~~ PARTIALLY FIXED
 
-No compile-time or runtime check for zero step (`step(0)`) or wrong-direction step (`(0..10).step(-1)`).
+SP3 (zero step) now produces a compile error when `.step(0)` is called on a range with a literal zero argument. SP1/SP2 (direction mismatch) still produce empty ranges at runtime rather than compile-time warnings.
 
-### 23. Comptime safety limits (CT27–CT35)
+### 23. ~~Comptime safety limits (CT27–CT35)~~ FIXED
 
-Backwards branch quota and recursion depth limits not enforced during compile-time evaluation.
+Default backwards branch quota set to 1,000 (CT35, was incorrectly 10,000). Call depth tracking added with 256-frame limit (CT29) — stack overflow detected separately from branch quota with clear error. `@comptime_quota(N)` attribute override not yet implemented.
 
 ### 24. Context clause auto-resolution — opaque (CC1–CC10)
 

--- a/compiler/crates/rask-cli/src/commands/pipeline.rs
+++ b/compiler/crates/rask-cli/src/commands/pipeline.rs
@@ -105,8 +105,21 @@ fn run_frontend_single(path: &str, format: Format) -> FrontendResult {
     let cfg = rask_comptime::CfgConfig::from_host("debug", vec![]);
     rask_comptime::eliminate_comptime_if(&mut parse_result.decls, &cfg);
 
-    rask_desugar::desugar(&mut parse_result.decls);
+    let desugar_errors = rask_desugar::desugar_with_diagnostics(&mut parse_result.decls);
     rask_desugar::desugar_default_args(&mut parse_result.decls);
+
+    if !desugar_errors.is_empty() {
+        let diags: Vec<Diagnostic> = desugar_errors.iter().map(|e| {
+            Diagnostic::error(e.message.clone())
+                .with_code("E0338")
+                .with_primary(e.span, "variant needs @message(\"...\") annotation")
+        }).collect();
+        show_diagnostics(&diags, &source, path, "desugar", format);
+        if format == Format::Human {
+            eprintln!("\n{}", output::banner_fail("Desugar", desugar_errors.len()));
+        }
+        process::exit(1);
+    }
 
     let resolved = match rask_resolve::resolve_with_cfg(&parse_result.decls, cfg.to_cfg_values()) {
         Ok(r) => r,
@@ -197,8 +210,22 @@ fn run_frontend_package(pkg_ctx: &mut PackageContext, path: &str, format: Format
     let cfg = rask_comptime::CfgConfig::from_host("debug", vec![]);
     rask_comptime::eliminate_comptime_if(&mut pkg_ctx.all_decls, &cfg);
 
-    rask_desugar::desugar(&mut pkg_ctx.all_decls);
+    let desugar_errors = rask_desugar::desugar_with_diagnostics(&mut pkg_ctx.all_decls);
     rask_desugar::desugar_default_args(&mut pkg_ctx.all_decls);
+
+    if !desugar_errors.is_empty() {
+        let diags: Vec<Diagnostic> = desugar_errors.iter().map(|e| {
+            Diagnostic::error(e.message.clone())
+                .with_code("E0338")
+                .with_primary(e.span, "variant needs @message(\"...\") annotation")
+        }).collect();
+        show_multifile_diagnostics(&diags, &source_files, format);
+        if format == Format::Human {
+            eprintln!("\n{}", output::banner_fail("Desugar", desugar_errors.len()));
+        }
+        process::exit(1);
+    }
+
     let resolved = match rask_resolve::resolve_package_with_cfg(
         &pkg_ctx.all_decls,
         &pkg_ctx.registry,

--- a/compiler/crates/rask-comptime/src/lib.rs
+++ b/compiler/crates/rask-comptime/src/lib.rs
@@ -579,6 +579,9 @@ pub enum ComptimeError {
 
     #[error("not supported at comptime: {0}")]
     NotSupported(String),
+
+    #[error("comptime stack overflow (depth {0}); reduce recursion or increase limit")]
+    StackOverflow(usize),
 }
 
 /// Result type for comptime operations.
@@ -602,8 +605,12 @@ pub struct ComptimeEnv {
     functions: HashMap<String, FnDecl>,
     /// Backwards branch counter (loops + recursion).
     branch_count: usize,
-    /// Maximum allowed backwards branches.
+    /// Maximum allowed backwards branches (CT35: default 1,000).
     branch_quota: usize,
+    /// Current call stack depth (CT29).
+    call_depth: usize,
+    /// Maximum allowed call depth (CT29).
+    max_call_depth: usize,
 }
 
 impl ComptimeEnv {
@@ -612,7 +619,9 @@ impl ComptimeEnv {
             scopes: vec![HashMap::new()],
             functions: HashMap::new(),
             branch_count: 0,
-            branch_quota: 10_000, // Default
+            branch_quota: 1_000, // CT35: default 1,000
+            call_depth: 0,
+            max_call_depth: 256, // CT29: stack depth limit
         }
     }
 
@@ -622,6 +631,8 @@ impl ComptimeEnv {
             functions: HashMap::new(),
             branch_count: 0,
             branch_quota: quota,
+            call_depth: 0,
+            max_call_depth: 256,
         }
     }
 
@@ -678,6 +689,20 @@ impl ComptimeEnv {
         } else {
             Ok(())
         }
+    }
+
+    /// CT29: track call depth to prevent stack overflow.
+    fn push_call(&mut self) -> ComptimeResult<()> {
+        self.call_depth += 1;
+        if self.call_depth > self.max_call_depth {
+            Err(ComptimeError::StackOverflow(self.max_call_depth))
+        } else {
+            Ok(())
+        }
+    }
+
+    fn pop_call(&mut self) {
+        self.call_depth = self.call_depth.saturating_sub(1);
     }
 }
 
@@ -1443,6 +1468,7 @@ impl ComptimeInterpreter {
             });
         }
 
+        self.env.push_call()?; // CT29: stack depth check
         self.env.push_scope();
 
         // Bind parameters
@@ -1451,10 +1477,11 @@ impl ComptimeInterpreter {
         }
 
         // Execute body
-        let result = self.eval_block(&func.body)?;
+        let result = self.eval_block(&func.body);
         self.env.pop_scope();
+        self.env.pop_call();
 
-        Ok(result.value())
+        Ok(result?.value())
     }
 
     fn call_closure(
@@ -1471,6 +1498,8 @@ impl ComptimeInterpreter {
             });
         }
 
+        self.env.push_call()?; // CT29: stack depth check
+
         // Swap in the captured environment, preserving current env
         let saved_scopes = std::mem::replace(&mut self.env.scopes, captures.to_vec());
 
@@ -1484,6 +1513,7 @@ impl ComptimeInterpreter {
 
         // Restore original environment
         self.env.scopes = saved_scopes;
+        self.env.pop_call();
 
         Ok(result?.value())
     }
@@ -2002,6 +2032,6 @@ mod tests {
 
         // We'd need to construct AST nodes for proper testing
         // For now, just verify the interpreter can be created
-        assert_eq!(interp.env.branch_quota, 10_000);
+        assert_eq!(interp.env.branch_quota, 1_000); // CT35: default 1,000
     }
 }

--- a/compiler/crates/rask-desugar/src/lib.rs
+++ b/compiler/crates/rask-desugar/src/lib.rs
@@ -36,14 +36,31 @@ pub fn desugar_with_start_id(decls: &mut [Decl], start_id: u32) {
     }
 }
 
+/// ER26 coverage error from @message desugaring.
+#[derive(Debug, Clone)]
+pub struct DesugarError {
+    pub message: String,
+    pub span: Span,
+}
+
+/// Desugar all operators, returning any ER26 coverage errors.
+pub fn desugar_with_diagnostics(decls: &mut [Decl]) -> Vec<DesugarError> {
+    let mut desugarer = Desugarer::new(1_000_000);
+    for decl in decls {
+        desugarer.desugar_decl(decl);
+    }
+    desugarer.errors
+}
+
 /// The desugaring context.
 struct Desugarer {
     next_id: u32,
+    errors: Vec<DesugarError>,
 }
 
 impl Desugarer {
     fn new(start_id: u32) -> Self {
-        Self { next_id: start_id }
+        Self { next_id: start_id, errors: Vec::new() }
     }
 
     fn fresh_id(&mut self) -> NodeId {
@@ -111,7 +128,20 @@ impl Desugarer {
         let mut arms = Vec::new();
 
         for variant in &e.variants {
-            let template = self.extract_message_template(variant);
+            let template = match self.extract_message_template(variant) {
+                Some(t) => t,
+                None => {
+                    // ER26: missing coverage — record error, use variant name as fallback
+                    self.errors.push(DesugarError {
+                        message: format!(
+                            "@message variant `{}` on `{}` has no message template and cannot auto-delegate",
+                            variant.name, e.name
+                        ),
+                        span: sp,
+                    });
+                    MessageTemplate::Format(variant.name.clone())
+                }
+            };
 
             // Build pattern bindings for this variant
             let field_patterns: Vec<Pattern> = if variant.fields.is_empty() {
@@ -207,19 +237,27 @@ impl Desugarer {
     }
 
     /// Extract the message template for a variant.
-    fn extract_message_template(&self, variant: &rask_ast::decl::Variant) -> MessageTemplate {
+    ///
+    /// ER24: explicit @message("template") on the variant.
+    /// ER25: single-field variant with Error-typed payload auto-delegates to inner.message().
+    /// ER26: variants without coverage return None (caller must handle).
+    fn extract_message_template(&self, variant: &rask_ast::decl::Variant) -> Option<MessageTemplate> {
         // Check for @message("template") on the variant
         for attr in &variant.attrs {
             if let Some(tmpl) = extract_message_attr_template(attr) {
-                return MessageTemplate::Format(tmpl);
+                return Some(MessageTemplate::Format(tmpl));
             }
         }
-        // Auto-delegate: single payload field → delegate to inner.message()
-        if variant.fields.len() == 1 {
-            return MessageTemplate::Delegate(variant.fields[0].name.clone());
+        // No-payload variants use the variant name as a reasonable default
+        if variant.fields.is_empty() {
+            return Some(MessageTemplate::Format(variant.name.clone()));
         }
-        // Fallback: variant name as message
-        MessageTemplate::Format(variant.name.clone())
+        // ER25: auto-delegate for single-field variants with Error-typed payload
+        if variant.fields.len() == 1 && is_error_type_name(&variant.fields[0].ty) {
+            return Some(MessageTemplate::Delegate(variant.fields[0].name.clone()));
+        }
+        // ER26: missing coverage — caller should report error
+        None
     }
 
     fn desugar_trait(&mut self, t: &mut TraitDecl) {
@@ -619,6 +657,12 @@ enum MessageTemplate {
     Format(String),
     /// Delegate to inner value: `inner.message()`
     Delegate(String),
+}
+
+/// Heuristic: does this type name look like an error type?
+/// Matches names ending in "Error" (e.g., IoError, ManifestError).
+fn is_error_type_name(ty: &str) -> bool {
+    ty.ends_with("Error")
 }
 
 /// Extract the template from a `message("template")` attribute string.

--- a/compiler/crates/rask-diagnostics/src/convert.rs
+++ b/compiler/crates/rask-diagnostics/src/convert.rs
@@ -595,6 +595,25 @@ impl ToDiagnostic for rask_types::TypeError {
                     .with_help("remove the `discard` or restructure so the value isn't needed after this point")
                     .with_why("`discard` explicitly drops a value and invalidates its binding — using it afterwards is an error")
             }
+
+            ZeroStep { span } => {
+                Diagnostic::error("zero step".to_string())
+                    .with_code("E0337")
+                    .with_primary(*span, "step must be non-zero")
+                    .with_help("use a positive step for ascending ranges, or a negative step for descending ranges")
+                    .with_why("a zero step would loop forever without making progress [ctrl.ranges/SP3]")
+            }
+
+            MessageCoverageMissing { variant, enum_name, span } => {
+                Diagnostic::error(format!(
+                    "@message variant `{}` on `{}` has no message template and cannot auto-delegate",
+                    variant, enum_name
+                ))
+                    .with_code("E0338")
+                    .with_primary(*span, "variant needs @message(\"...\") annotation")
+                    .with_help("add @message(\"template\") to this variant, or change the payload to an error type")
+                    .with_why("every variant in a @message enum must have an explicit template or a single Error payload that auto-delegates [type.errors/ER26]")
+            }
         }
     }
 }

--- a/compiler/crates/rask-types/src/checker/check_expr.rs
+++ b/compiler/crates/rask-types/src/checker/check_expr.rs
@@ -1387,6 +1387,25 @@ impl TypeChecker {
         let obj_ty = self.resolve_named(&obj_ty_raw);
         let arg_types: Vec<_> = args.iter().map(|a| self.infer_expr(&a.expr)).collect();
 
+        // SP3: zero step on range is a compile error
+        if method == "step" {
+            let is_range = matches!(
+                &self.ctx.apply(&obj_ty),
+                Type::UnresolvedNamed(n) if n == "Range"
+            );
+            if is_range {
+                if let Some(first_arg) = args.first() {
+                    let is_zero = matches!(
+                        &first_arg.expr.kind,
+                        rask_ast::expr::ExprKind::Int(0, _)
+                    );
+                    if is_zero {
+                        self.errors.push(TypeError::ZeroStep { span: first_arg.expr.span });
+                    }
+                }
+            }
+        }
+
         // Raw pointer methods — resolve directly instead of through HasMethod constraints
         let resolved_obj = self.ctx.apply(&obj_ty);
         if let Type::RawPtr(ref inner) = resolved_obj {

--- a/compiler/crates/rask-types/src/checker/errors.rs
+++ b/compiler/crates/rask-types/src/checker/errors.rs
@@ -221,4 +221,18 @@ pub enum TypeError {
         discarded_at: Span,
         span: Span,
     },
+
+    /// SP3: zero step on range
+    #[error("zero step")]
+    ZeroStep {
+        span: Span,
+    },
+
+    /// ER26: @message variant missing coverage
+    #[error("@message variant `{variant}` has no message template and cannot auto-delegate")]
+    MessageCoverageMissing {
+        variant: String,
+        enum_name: String,
+        span: Span,
+    },
 }


### PR DESCRIPTION
- SP3: Type checker detects .step(0) on ranges and emits compile error
- ER25: Desugar only auto-delegates .message() for Error-typed payloads
- ER26: Desugar reports coverage error for variants without @message or
  auto-delegatable payload; pipeline wired to report desugar errors
- CT35: Default backwards branch quota changed from 10,000 to 1,000
- CT29: Added call depth tracking (256 frame limit) with StackOverflow error

https://claude.ai/code/session_013Q74AbuPuHdeMUJNtwsdD2