### PR TITLE
Enforce @unique move-only types (U1-U4) and for-mutate safety (LP14/LP16)

### DIFF
--- a/SPEC_AUDIT.md
+++ b/SPEC_AUDIT.md
@@ -149,9 +149,9 @@ The `trait Iterator<Item>` isn't registered in stdlib for user code to write gen
 
 Desugar now only auto-delegates for single-field variants whose type name ends with "Error" (ER25). Variants with fields but no `@message` and no auto-delegatable payload trigger an ER26 coverage error. Pipeline reports desugar errors before proceeding.
 
-### 22. ~~Step range validation (SP3)~~ PARTIALLY FIXED
+### 22. ~~Step range validation (SP1–SP3)~~ FIXED
 
-SP3 (zero step) now produces a compile error when `.step(0)` is called on a range with a literal zero argument. SP1/SP2 (direction mismatch) still produce empty ranges at runtime rather than compile-time warnings.
+SP3 (zero step) produces a compile error. SP1/SP2 (direction mismatch) now produce compile-time warnings when start, end, and step are all integer literals — e.g., `(10..0).step(2)` warns that the positive step on a descending range will produce zero iterations. Handles desugared negative literals (`-1` → `(1).neg()`).
 
 ### 23. ~~Comptime safety limits (CT27–CT35)~~ FIXED
 

--- a/SPEC_AUDIT.md
+++ b/SPEC_AUDIT.md
@@ -68,12 +68,12 @@ Full pipeline: lexer → parser → AST → type checker → ownership checker �
 
 ## Major Gaps (partially implemented, key behaviors missing)
 
-### 8. `for mutate` iteration — parsed but not enforced (LP11–LP16)
+### 8. `for mutate` iteration — partially enforced (LP11–LP16)
 
-Parser accepts `for mutate item in vec { ... }`. Type checker doesn't validate:
-- No structural mutation check inside body (LP14 — `vec.push()` during `for mutate` not rejected)
-- No enforcement that `item` can't be passed to `take` parameters (LP16)
-- MIR doesn't generate different access patterns for mutable vs immutable iteration
+Parser accepts `for mutate item in vec { ... }`. Ownership checker now enforces:
+- ~~No structural mutation check inside body (LP14 — `vec.push()` during `for mutate` not rejected)~~ FIXED — push/pop/insert/remove/clear/drain rejected on iterated collection
+- ~~No enforcement that `item` can't be passed to `take` parameters (LP16)~~ FIXED — `own item` to take params rejected with clear error
+- MIR doesn't generate different access patterns for mutable vs immutable iteration (LP11–LP13 in-place mutation codegen still pending)
 
 ### 9. Pool API — missing several spec-required features
 
@@ -105,9 +105,9 @@ Spec's own Phase A requirements (runtime-strategy.md) not met:
 
 Spec requires two borrows on different fields of the same struct to not conflict (F2). Borrow checker has `root_ident_name()` extraction but field-level granularity tracking isn't clearly implemented. Closures capturing individual fields (F4) not verified.
 
-### 12. `@unique` move-only types — enforcement unclear (U1–U4)
+### 12. ~~`@unique` move-only types — enforcement unclear (U1–U4)~~ FIXED
 
-`@unique` forces move semantics even for ≤16-byte types. Transitive propagation (U4: struct containing unique field is automatically unique) has no visible enforcement.
+`is_unique` flag on TypeDef::Struct, parsed from `@unique` attribute. Ownership checker's `is_copy()` returns false for unique types. `MoveReason::Unique` wired through diagnostics. U4 transitive propagation via fixed-point iteration in `propagate_uniqueness()` — structs containing unique fields are automatically marked unique.
 
 ### 13. Scope-limited closures — escape not detected (SL1–SL2)
 
@@ -251,7 +251,7 @@ For balance — these areas are solid:
 2. **Error origin tracking** — fundamental to error handling ergonomics
 3. **`comptime for` + reflection** — blocks encoding/serialization patterns
 4. **Pool weak handles + `try_insert`** — needed for real graph/entity patterns
-5. **`for mutate` enforcement** — correctness hole
+5. ~~**`for mutate` enforcement** — correctness hole~~ LP14/LP16 DONE (MIR codegen pending)
 6. **Concurrency Phase A surface** — spec commits to this for Phase A
 7. **`@binary` structs** — blocks a whole use case category
 8. **`Cell<T>`** — ergonomic gap for closure patterns

--- a/compiler/crates/rask-diagnostics/src/convert.rs
+++ b/compiler/crates/rask-diagnostics/src/convert.rs
@@ -944,6 +944,30 @@ impl ToDiagnostic for rask_ownership::OwnershipError {
                 .with_fix(format!("replace `discard {}` with `{}.close()`", name, name))
                 .with_why("resource types must be consumed properly — `discard` would silently leak the resource")
             }
+
+            ForMutateStructuralMutation { collection, operation, loop_span } => {
+                Diagnostic::error(format!(
+                    "cannot {} `{}` during `for mutate` — invalidates iteration",
+                    operation, collection
+                ))
+                .with_code("E0813")
+                .with_primary(self.span, format!("{} not allowed during mutable iteration", operation))
+                .with_secondary(*loop_span, format!("`{}` is being iterated here", collection))
+                .with_help("collect changes and apply them after the loop")
+                .with_why("structural mutations (insert, remove, push, clear) invalidate the iterator — elements may shift or be reallocated")
+            }
+
+            ForMutateTakeItem { item, collection, loop_span } => {
+                Diagnostic::error(format!(
+                    "cannot pass `{}` to `take` parameter — borrowed from `{}`",
+                    item, collection
+                ))
+                .with_code("E0814")
+                .with_primary(self.span, "would move element out of collection")
+                .with_secondary(*loop_span, format!("`{}` is borrowed from `{}` during iteration", item, collection))
+                .with_help(format!("clone `{}` before passing, or restructure to avoid taking ownership", item))
+                .with_why("for-mutate borrows elements in place — taking ownership would leave a hole in the collection")
+            }
         }
     }
 }

--- a/compiler/crates/rask-diagnostics/src/convert.rs
+++ b/compiler/crates/rask-diagnostics/src/convert.rs
@@ -604,6 +604,19 @@ impl ToDiagnostic for rask_types::TypeError {
                     .with_why("a zero step would loop forever without making progress [ctrl.ranges/SP3]")
             }
 
+            StepDirectionMismatch { range_span, step_span, range_direction, step_direction } => {
+                Diagnostic::warning("step direction mismatch — range will be empty".to_string())
+                    .with_code("W0302")
+                    .with_primary(*step_span, format!("{} step on {} range", step_direction, range_direction))
+                    .with_secondary(*range_span, format!("range is {}", range_direction))
+                    .with_help(format!(
+                        "use a {} step for a {} range, or swap start and end",
+                        if *step_direction == "positive" { "negative" } else { "positive" },
+                        range_direction
+                    ))
+                    .with_why("a positive step on a descending range (or negative step on ascending range) produces zero iterations [ctrl.ranges/SP1-SP2]")
+            }
+
             MessageCoverageMissing { variant, enum_name, span } => {
                 Diagnostic::error(format!(
                     "@message variant `{}` on `{}` has no message template and cannot auto-delegate",

--- a/compiler/crates/rask-ownership/src/error.rs
+++ b/compiler/crates/rask-ownership/src/error.rs
@@ -121,6 +121,22 @@ pub enum OwnershipErrorKind {
         binding_span: Span,
     },
 
+    /// LP14: structural mutation during `for mutate`
+    #[error("cannot {operation} `{collection}` during `for mutate` — invalidates iteration")]
+    ForMutateStructuralMutation {
+        collection: String,
+        operation: String,
+        loop_span: Span,
+    },
+
+    /// LP16: passing `for mutate` item to `take` parameter
+    #[error("cannot pass `{item}` to `take` parameter — item is borrowed from collection")]
+    ForMutateTakeItem {
+        item: String,
+        collection: String,
+        loop_span: Span,
+    },
+
     /// D1: use after discard
     #[error("use of discarded value `{name}`")]
     UseAfterDiscard {

--- a/compiler/crates/rask-ownership/src/lib.rs
+++ b/compiler/crates/rask-ownership/src/lib.rs
@@ -46,6 +46,17 @@ struct WithBindingInfo {
     span: Span,
 }
 
+/// LP14/LP16: Tracks the collection being iterated in a `for mutate` loop.
+#[derive(Debug, Clone)]
+struct ForMutateInfo {
+    /// Collection variable name (e.g. "items" from `for mutate item in items`)
+    collection_name: String,
+    /// Binding variable names (e.g. ["item"])
+    binding_names: Vec<String>,
+    /// Span for error messages
+    span: Span,
+}
+
 /// Ownership and borrow checker.
 pub struct OwnershipChecker<'a> {
     /// The typed program from type checking.
@@ -71,6 +82,8 @@ pub struct OwnershipChecker<'a> {
     frozen_contexts: HashSet<String>,
     /// Active `with` block bindings for W2 checking.
     active_with_bindings: Vec<WithBindingInfo>,
+    /// LP14/LP16: Active `for mutate` loops for structural mutation checking.
+    active_for_mutates: Vec<ForMutateInfo>,
     /// Parameter type strings: param name → type annotation (e.g. "Pool<Entity>").
     param_type_strings: HashMap<String, String>,
     /// Errors accumulated during analysis.
@@ -91,6 +104,7 @@ impl<'a> OwnershipChecker<'a> {
             in_ensure: false,
             frozen_contexts: HashSet::new(),
             active_with_bindings: Vec::new(),
+            active_for_mutates: Vec::new(),
             param_type_strings: HashMap::new(),
             errors: Vec::new(),
         }
@@ -332,8 +346,9 @@ impl<'a> OwnershipChecker<'a> {
                 self.register_pattern_bindings(pattern);
                 self.check_block(body);
             }
-            StmtKind::For { label: _, binding, iter, body, .. } => {
+            StmtKind::For { label: _, binding, mutate, iter, body, .. } => {
                 self.check_expr(iter);
+                let binding_names: Vec<String> = binding.names().iter().map(|s| s.to_string()).collect();
                 match binding {
                     ForBinding::Single(name) => {
                         self.bindings.insert(name.clone(), BindingState::Owned);
@@ -344,7 +359,21 @@ impl<'a> OwnershipChecker<'a> {
                         }
                     }
                 }
+                // LP14/LP16: track for-mutate context
+                if *mutate {
+                    let collection_name = Self::extract_iter_collection(iter);
+                    if let Some(coll) = collection_name {
+                        self.active_for_mutates.push(ForMutateInfo {
+                            collection_name: coll,
+                            binding_names: binding_names.clone(),
+                            span: stmt.span,
+                        });
+                    }
+                }
                 self.check_block(body);
+                if *mutate {
+                    self.active_for_mutates.pop();
+                }
             }
             StmtKind::Loop { label: _, body } => {
                 self.check_block(body);
@@ -435,7 +464,18 @@ impl<'a> OwnershipChecker<'a> {
                 for arg in args {
                     self.check_expr(&arg.expr);
                     if arg.mode == ArgMode::Own {
+                        // LP16: reject passing for-mutate binding to take parameter
                         if let ExprKind::Ident(name) = &arg.expr.kind {
+                            if let Some(fm) = self.active_for_mutates.iter().find(|fm| fm.binding_names.contains(name)) {
+                                self.errors.push(OwnershipError {
+                                    kind: OwnershipErrorKind::ForMutateTakeItem {
+                                        item: name.clone(),
+                                        collection: fm.collection_name.clone(),
+                                        loop_span: fm.span,
+                                    },
+                                    span: arg.expr.span,
+                                });
+                            }
                             self.bindings.insert(name.clone(), BindingState::Moved { at: arg.expr.span });
                         }
                     }
@@ -446,7 +486,18 @@ impl<'a> OwnershipChecker<'a> {
                 for arg in args {
                     self.check_expr(&arg.expr);
                     if arg.mode == ArgMode::Own {
+                        // LP16: reject passing for-mutate binding to take parameter
                         if let ExprKind::Ident(name) = &arg.expr.kind {
+                            if let Some(fm) = self.active_for_mutates.iter().find(|fm| fm.binding_names.contains(name)) {
+                                self.errors.push(OwnershipError {
+                                    kind: OwnershipErrorKind::ForMutateTakeItem {
+                                        item: name.clone(),
+                                        collection: fm.collection_name.clone(),
+                                        loop_span: fm.span,
+                                    },
+                                    span: arg.expr.span,
+                                });
+                            }
                             self.bindings.insert(name.clone(), BindingState::Moved { at: arg.expr.span });
                         }
                     }
@@ -510,6 +561,24 @@ impl<'a> OwnershipChecker<'a> {
                                         span: expr.span,
                                     });
                                 }
+                                break;
+                            }
+                        }
+                    }
+                }
+                // LP14: Check structural mutations on collection during `for mutate`
+                if matches!(method.as_str(), "insert" | "remove" | "clear" | "push" | "pop" | "drain") {
+                    if let ExprKind::Ident(coll_name) = &object.kind {
+                        for fm in &self.active_for_mutates {
+                            if fm.collection_name == *coll_name {
+                                self.errors.push(OwnershipError {
+                                    kind: OwnershipErrorKind::ForMutateStructuralMutation {
+                                        collection: coll_name.clone(),
+                                        operation: method.clone(),
+                                        loop_span: fm.span,
+                                    },
+                                    span: expr.span,
+                                });
                                 break;
                             }
                         }
@@ -982,6 +1051,22 @@ impl<'a> OwnershipChecker<'a> {
         }
     }
 
+    /// LP14: Extract the collection name from a for-loop iterator expression.
+    /// `items` → Some("items"), `items.iter()` → Some("items")
+    fn extract_iter_collection(iter: &Expr) -> Option<String> {
+        match &iter.kind {
+            ExprKind::Ident(name) => Some(name.clone()),
+            ExprKind::MethodCall { object, .. } => {
+                if let ExprKind::Ident(name) = &object.kind {
+                    Some(name.clone())
+                } else {
+                    None
+                }
+            }
+            _ => None,
+        }
+    }
+
 
     fn create_borrow_with_projection(
         &mut self,
@@ -1109,7 +1194,9 @@ impl<'a> OwnershipChecker<'a> {
             Type::Named(type_id) => {
                 if let Some(def) = self.program.types.get(*type_id) {
                     match def {
-                        rask_types::TypeDef::Struct { fields, .. } => {
+                        rask_types::TypeDef::Struct { fields, is_unique, .. } => {
+                            // U1: @unique disables implicit copy regardless of size
+                            if *is_unique { return false; }
                             fields.iter().all(|(_, t)| self.is_copy(t))
                                 && self.type_size(ty) <= 16
                         }
@@ -1220,7 +1307,11 @@ impl<'a> OwnershipChecker<'a> {
             Type::Named(type_id) => {
                 if let Some(def) = self.program.types.get(*type_id) {
                     match def {
-                        rask_types::TypeDef::Struct { fields, .. } => {
+                        rask_types::TypeDef::Struct { fields, is_unique, .. } => {
+                            // U1: @unique types report as Unique, not size/heap
+                            if *is_unique {
+                                return MoveReason::Unique { type_name };
+                            }
                             let all_fields_copy = fields.iter().all(|(_, t)| self.is_copy(t));
                             if all_fields_copy {
                                 MoveReason::SizeExceedsThreshold { type_name, size: self.type_size(ty) }

--- a/compiler/crates/rask-types/src/checker/check_expr.rs
+++ b/compiler/crates/rask-types/src/checker/check_expr.rs
@@ -1388,6 +1388,7 @@ impl TypeChecker {
         let arg_types: Vec<_> = args.iter().map(|a| self.infer_expr(&a.expr)).collect();
 
         // SP3: zero step on range is a compile error
+        // SP1/SP2: step direction mismatch is a warning
         if method == "step" {
             let is_range = matches!(
                 &self.ctx.apply(&obj_ty),
@@ -1401,6 +1402,9 @@ impl TypeChecker {
                     );
                     if is_zero {
                         self.errors.push(TypeError::ZeroStep { span: first_arg.expr.span });
+                    } else {
+                        // SP1/SP2: check direction mismatch when literals are available
+                        self.check_step_direction(object, first_arg);
                     }
                 }
             }
@@ -1425,6 +1429,71 @@ impl TypeChecker {
         });
 
         ret_ty
+    }
+
+    /// SP1/SP2: Check for step direction mismatch on range literals.
+    /// Only fires when start, end, and step are all integer literals.
+    fn check_step_direction(&mut self, range_expr: &rask_ast::expr::Expr, step_arg: &rask_ast::expr::CallArg) {
+        use rask_ast::expr::ExprKind;
+
+        // Extract step value from literal
+        let step_val: Option<i64> = match &step_arg.expr.kind {
+            ExprKind::Int(v, _) => Some(*v),
+            // After desugar, `-1` becomes `(1).neg()`
+            ExprKind::MethodCall { object, method: neg_method, args: neg_args, .. }
+                if neg_method == "neg" && neg_args.is_empty() =>
+            {
+                if let ExprKind::Int(v, _) = &object.kind {
+                    Some(-v)
+                } else {
+                    None
+                }
+            }
+            _ => None,
+        };
+
+        let step_val = match step_val {
+            Some(v) => v,
+            None => return, // non-literal step, can't check at compile time
+        };
+
+        // Extract start/end from Range expression
+        let (start_val, end_val, range_span) = match &range_expr.kind {
+            ExprKind::Range { start, end, .. } => {
+                let s = start.as_ref().and_then(|e| {
+                    if let ExprKind::Int(v, _) = &e.kind { Some(*v) } else { None }
+                });
+                let e = end.as_ref().and_then(|e| {
+                    if let ExprKind::Int(v, _) = &e.kind { Some(*v) } else { None }
+                });
+                (s, e, range_expr.span)
+            }
+            _ => return,
+        };
+
+        let (start, end) = match (start_val, end_val) {
+            (Some(s), Some(e)) => (s, e),
+            _ => return, // non-literal bounds, can't check
+        };
+
+        // SP1: positive step requires start < end (ascending)
+        // SP2: negative step requires start > end (descending)
+        let mismatch = if step_val > 0 && start >= end {
+            Some(("descending", "positive"))
+        } else if step_val < 0 && start <= end {
+            Some(("ascending", "negative"))
+        } else {
+            None
+        };
+
+        if let Some((range_dir, step_dir)) = mismatch {
+            self.errors.push(TypeError::StepDirectionMismatch {
+                range_span,
+                step_span: step_arg.expr.span,
+                range_direction: range_dir.to_string(),
+                step_direction: step_dir.to_string(),
+            });
+        }
     }
 
     /// Resolve methods on raw pointer types (*T).

--- a/compiler/crates/rask-types/src/checker/declarations.rs
+++ b/compiler/crates/rask-types/src/checker/declarations.rs
@@ -46,6 +46,7 @@ impl TypeChecker {
                 self.register_impl_methods(i);
             }
         }
+        self.propagate_uniqueness();
         self.auto_derive_traits();
 
         // GC1/GC2: Pre-register type vars for functions with inferred params/returns
@@ -159,12 +160,14 @@ impl TypeChecker {
 
         let type_params: Vec<String> = s.type_params.iter().map(|p| p.name.clone()).collect();
         let is_resource = s.attrs.iter().any(|a| a == "resource");
+        let is_unique = s.attrs.iter().any(|a| a == "unique");
         self.types.register_type(TypeDef::Struct {
             name: s.name.clone(),
             type_params,
             fields,
             methods,
             is_resource,
+            is_unique,
             private_fields,
         });
     }
@@ -287,6 +290,41 @@ impl TypeChecker {
             self_param,
             params,
             ret,
+        }
+    }
+
+    // ------------------------------------------------------------------------
+    // U4: Transitive uniqueness — struct containing @unique field is itself unique.
+    // Fixed-point iteration: propagate until no changes.
+    // ------------------------------------------------------------------------
+
+    fn propagate_uniqueness(&mut self) {
+        use crate::types::TypeId;
+
+        loop {
+            let mut changed = false;
+            let type_count = self.types.types.len();
+            for idx in 0..type_count {
+                let id = TypeId(idx as u32);
+                let def = self.types.get(id).unwrap().clone();
+                if let TypeDef::Struct { fields, is_unique, .. } = &def {
+                    if *is_unique { continue; }
+                    let has_unique_field = fields.iter().any(|(_, ty)| {
+                        match ty {
+                            Type::Named(field_id) => self.types.is_unique_type_by_id(*field_id),
+                            Type::Generic { base, .. } => self.types.is_unique_type_by_id(*base),
+                            _ => false,
+                        }
+                    });
+                    if has_unique_field {
+                        if let Some(TypeDef::Struct { is_unique, .. }) = self.types.get_mut(id) {
+                            *is_unique = true;
+                            changed = true;
+                        }
+                    }
+                }
+            }
+            if !changed { break; }
         }
     }
 

--- a/compiler/crates/rask-types/src/checker/errors.rs
+++ b/compiler/crates/rask-types/src/checker/errors.rs
@@ -228,6 +228,17 @@ pub enum TypeError {
         span: Span,
     },
 
+    /// SP1/SP2: step direction doesn't match range direction (warning)
+    #[error("step direction mismatch — range will be empty")]
+    StepDirectionMismatch {
+        range_span: Span,
+        step_span: Span,
+        /// "ascending" or "descending"
+        range_direction: String,
+        /// "positive" or "negative"
+        step_direction: String,
+    },
+
     /// ER26: @message variant missing coverage
     #[error("@message variant `{variant}` has no message template and cannot auto-delegate")]
     MessageCoverageMissing {

--- a/compiler/crates/rask-types/src/checker/type_defs.rs
+++ b/compiler/crates/rask-types/src/checker/type_defs.rs
@@ -19,6 +19,8 @@ pub enum TypeDef {
         fields: Vec<(String, Type)>,
         methods: Vec<MethodSig>,
         is_resource: bool,
+        /// U1–U4: marked @unique — no implicit copy even if small enough
+        is_unique: bool,
         /// V5: fields marked `private` — accessible only inside extend blocks
         private_fields: Vec<String>,
     },

--- a/compiler/crates/rask-types/src/checker/type_table.rs
+++ b/compiler/crates/rask-types/src/checker/type_table.rs
@@ -217,6 +217,14 @@ impl TypeTable {
         false
     }
 
+    /// Check if a TypeId refers to a `@unique` struct.
+    pub fn is_unique_type_by_id(&self, id: TypeId) -> bool {
+        if let Some(TypeDef::Struct { is_unique, .. }) = self.types.get(id.0 as usize) {
+            return *is_unique;
+        }
+        false
+    }
+
     /// Get TypeId for the builtin Option<T> enum.
     pub fn get_option_type_id(&self) -> Option<TypeId> {
         self.option_type_id

--- a/tests/compile_errors/for_mutate_errors.rk
+++ b/tests/compile_errors/for_mutate_errors.rk
@@ -1,0 +1,33 @@
+// LP14: structural mutation during `for mutate`
+// ERROR: cannot push during mutable iteration
+
+func test_structural_mutation() {
+    let items = Vec.new<string>()
+    items.push("hello")
+
+    for mutate item in items {
+        item = "updated"
+        items.push("extra")    // ERROR LP14: structural mutation
+    }
+}
+
+// LP16: passing for-mutate item to take parameter
+// ERROR: cannot take item out of collection
+
+func consume(take s: string) {
+    println(s)
+}
+
+func test_take_item() {
+    let items = Vec.new<string>()
+    items.push("hello")
+
+    for mutate item in items {
+        consume(own item)      // ERROR LP16: take from borrowed element
+    }
+}
+
+func main() {
+    test_structural_mutation()
+    test_take_item()
+}

--- a/tests/compile_errors/ownership_errors.rk
+++ b/tests/compile_errors/ownership_errors.rk
@@ -48,9 +48,19 @@ func test_double_move() {
 struct Token { id: i32 }
 
 func test_unique_no_copy() {
-    const t = Token { id: 1 }
-    const t2 = t         // moves, not copies (despite being small)
+    let t = Token { id: 1 }
+    let t2 = t           // moves, not copies (despite being small)
     println("{t.id}")    // ERROR: t was moved
+}
+
+// --- @unique transitive propagation (U4) ---
+// ERROR: struct containing @unique field is itself unique
+struct Wrapper { tok: Token, label: string }
+
+func test_unique_transitive() {
+    let w = Wrapper { tok: Token { id: 1 }, label: "test" }
+    let w2 = w           // moves (Wrapper contains @unique Token)
+    println("{w.label}")  // ERROR: w was moved
 }
 
 // --- discard on @resource (D3) ---


### PR DESCRIPTION
@unique: Added is_unique flag to TypeDef::Struct, parsed from @unique attribute.
Ownership checker returns false from is_copy() for unique types, with proper
MoveReason::Unique diagnostics. Transitive propagation (U4) via fixed-point
iteration marks structs containing unique fields as unique.

for-mutate: Ownership checker now tracks iterated collections and rejects
structural mutations (push/pop/insert/remove/clear/drain) on them (LP14).
Also rejects passing for-mutate bindings to take parameters (LP16).

https://claude.ai/code/session_01DdcinC8qPbfmhBGESPBkry