### PR TITLE
Implement @binary, Cell<T>, comptime for, and for-mutate Pool/Map

### DIFF
--- a/compiler/crates/rask-ast/src/expr.rs
+++ b/compiler/crates/rask-ast/src/expr.rs
@@ -57,6 +57,11 @@ pub enum ExprKind {
         object: Box<Expr>,
         field: String,
     },
+    /// Dynamic field access: value.(expr) — comptime field name
+    DynamicField {
+        object: Box<Expr>,
+        field_expr: Box<Expr>,
+    },
     /// Optional chaining field access (a?.b)
     OptionalField {
         object: Box<Expr>,

--- a/compiler/crates/rask-codegen/src/dispatch.rs
+++ b/compiler/crates/rask-codegen/src/dispatch.rs
@@ -412,6 +412,12 @@ pub fn stdlib_entries() -> Vec<StdlibEntry> {
             params: &[types::I64, types::I64, types::I64], ret_ty: Some(types::I64), can_panic: false,
             arg_adapt: ArgAdapt::WrapArg1And2, ret_adapt: RetAdapt::None,
         },
+        // LP13: for mutate writeback — insert/replace value by key (same as Map_insert)
+        StdlibEntry {
+            mir_name: "Map_set", c_name: "rask_map_insert",
+            params: &[types::I64, types::I64, types::I64], ret_ty: Some(types::I64), can_panic: false,
+            arg_adapt: ArgAdapt::WrapArg1And2, ret_adapt: RetAdapt::None,
+        },
         StdlibEntry {
             mir_name: "Map_contains_key", c_name: "rask_map_contains",
             params: &[types::I64, types::I64], ret_ty: Some(types::I64), can_panic: false,
@@ -457,6 +463,12 @@ pub fn stdlib_entries() -> Vec<StdlibEntry> {
         StdlibEntry::simple("Pool_is_empty", "rask_pool_is_empty", &[types::I64], Some(types::I64), false),
         StdlibEntry::simple("Pool_cursor", "rask_pool_handles_packed", &[types::I64], Some(types::I64), false),
         StdlibEntry::simple("Pool_contains", "rask_pool_is_valid_packed", &[types::I64, types::I64], Some(types::I64), false),
+        // LP13: for mutate writeback — write value to existing pool slot
+        StdlibEntry {
+            mir_name: "Pool_set", c_name: "rask_pool_set_packed",
+            params: &[types::I64, types::I64, types::I64], ret_ty: None, can_panic: false,
+            arg_adapt: ArgAdapt::WrapArg2, ret_adapt: RetAdapt::None,
+        },
         StdlibEntry {
             mir_name: "Pool_insert", c_name: "rask_pool_insert_packed_sized",
             params: &[types::I64, types::I64, types::I64], ret_ty: Some(types::I64), can_panic: false,

--- a/compiler/crates/rask-desugar/src/defaults.rs
+++ b/compiler/crates/rask-desugar/src/defaults.rs
@@ -51,6 +51,9 @@ pub fn is_valid_default_expr(expr: &Expr) -> bool {
             matches!(&object.kind, ExprKind::Ident(_))
         }
 
+        // Dynamic field — not valid as a default
+        ExprKind::DynamicField { .. } => false,
+
         // Array of valid defaults: [1, 2, 3]
         ExprKind::Array(elems) => elems.iter().all(is_valid_default_expr),
 
@@ -406,6 +409,10 @@ impl DefaultDesugarer {
             ExprKind::Unary { operand, .. } => self.desugar_expr(operand),
             ExprKind::Field { object, .. } | ExprKind::OptionalField { object, .. } => {
                 self.desugar_expr(object);
+            }
+            ExprKind::DynamicField { object, field_expr } => {
+                self.desugar_expr(object);
+                self.desugar_expr(field_expr);
             }
             ExprKind::Index { object, index } => {
                 self.desugar_expr(object);

--- a/compiler/crates/rask-desugar/src/lib.rs
+++ b/compiler/crates/rask-desugar/src/lib.rs
@@ -354,6 +354,10 @@ impl Desugarer {
             ExprKind::Field { object, .. } | ExprKind::OptionalField { object, .. } => {
                 self.desugar_expr(object);
             }
+            ExprKind::DynamicField { object, field_expr } => {
+                self.desugar_expr(object);
+                self.desugar_expr(field_expr);
+            }
             ExprKind::Index { object, index } => {
                 self.desugar_expr(object);
                 self.desugar_expr(index);

--- a/compiler/crates/rask-effects/src/infer.rs
+++ b/compiler/crates/rask-effects/src/infer.rs
@@ -284,6 +284,10 @@ fn classify_expr(expr: &Expr, effects: &mut Effects, callees: &mut HashSet<Strin
         ExprKind::Field { object, .. } | ExprKind::OptionalField { object, .. } => {
             classify_expr(object, effects, callees);
         }
+        ExprKind::DynamicField { object, field_expr } => {
+            classify_expr(object, effects, callees);
+            classify_expr(field_expr, effects, callees);
+        }
         ExprKind::Index { object, index } => {
             classify_expr(object, effects, callees);
             classify_expr(index, effects, callees);

--- a/compiler/crates/rask-effects/src/warnings.rs
+++ b/compiler/crates/rask-effects/src/warnings.rs
@@ -192,6 +192,10 @@ impl<'a> WarnContext<'a> {
             ExprKind::Field { object, .. } | ExprKind::OptionalField { object, .. } => {
                 self.check_expr(object, warnings);
             }
+            ExprKind::DynamicField { object, field_expr } => {
+                self.check_expr(object, warnings);
+                self.check_expr(field_expr, warnings);
+            }
             ExprKind::Index { object, index } => {
                 self.check_expr(object, warnings);
                 self.check_expr(index, warnings);

--- a/compiler/crates/rask-fmt/src/printer.rs
+++ b/compiler/crates/rask-fmt/src/printer.rs
@@ -1411,6 +1411,12 @@ impl<'a> Printer<'a> {
                 self.emit("?.");
                 self.emit(field);
             }
+            ExprKind::DynamicField { object, field_expr } => {
+                self.format_expr(object);
+                self.emit(".(");
+                self.format_expr(field_expr);
+                self.emit(")");
+            }
             ExprKind::Index { object, index } => {
                 self.format_expr(object);
                 self.emit("[");

--- a/compiler/crates/rask-hidden-params/src/lib.rs
+++ b/compiler/crates/rask-hidden-params/src/lib.rs
@@ -468,6 +468,10 @@ impl HiddenParamPass {
             ExprKind::Field { object, .. } | ExprKind::OptionalField { object, .. } => {
                 self.rewrite_expr(object);
             }
+            ExprKind::DynamicField { object, field_expr } => {
+                self.rewrite_expr(object);
+                self.rewrite_expr(field_expr);
+            }
             ExprKind::Index { object, index } => {
                 self.rewrite_expr(object);
                 self.rewrite_expr(index);
@@ -754,6 +758,10 @@ fn collect_callees_from_expr(expr: &Expr, callees: &mut HashSet<String>) {
         ExprKind::Unary { operand, .. } => collect_callees_from_expr(operand, callees),
         ExprKind::Field { object, .. } | ExprKind::OptionalField { object, .. } => {
             collect_callees_from_expr(object, callees);
+        }
+        ExprKind::DynamicField { object, field_expr } => {
+            collect_callees_from_expr(object, callees);
+            collect_callees_from_expr(field_expr, callees);
         }
         ExprKind::Index { object, index } => {
             collect_callees_from_expr(object, callees);

--- a/compiler/crates/rask-interp/src/builtins/collections.rs
+++ b/compiler/crates/rask-interp/src/builtins/collections.rs
@@ -729,6 +729,66 @@ impl Interpreter {
                 new_pool.type_param = pool.type_param.clone();
                 Ok(Value::Pool(Arc::new(Mutex::new(new_pool))))
             }
+            "try_insert" => {
+                // Pools don't have capacity limits yet, so try_insert always succeeds
+                let item = args.into_iter().next().unwrap_or(Value::Unit);
+                let mut pool = p.lock().unwrap();
+                let pool_id = pool.pool_id;
+                let (index, generation) = pool.insert(item);
+                Ok(Value::Enum {
+                    name: "Option".to_string(),
+                    variant: "Some".to_string(),
+                    fields: vec![Value::Handle { pool_id, index, generation }],
+                    variant_index: 0, origin: None,
+                })
+            }
+            "drain" => {
+                let mut pool = p.lock().unwrap();
+                let mut items = Vec::new();
+                for (gen, slot) in pool.slots.iter_mut() {
+                    if let Some(value) = slot.take() {
+                        items.push(value);
+                        *gen = gen.saturating_add(1);
+                    }
+                }
+                pool.free_list = (0..pool.slots.len() as u32).collect();
+                pool.len = 0;
+                Ok(Value::Vec(Arc::new(Mutex::new(items))))
+            }
+            "entries" => {
+                let pool = p.lock().unwrap();
+                let pool_id = pool.pool_id;
+                let pairs: Vec<Value> = pool.slots.iter().enumerate()
+                    .filter_map(|(i, (gen, slot))| {
+                        slot.as_ref().map(|val| {
+                            // Pair as a 2-element Vec (tuple representation)
+                            Value::Vec(Arc::new(Mutex::new(vec![
+                                Value::Handle { pool_id, index: i as u32, generation: *gen },
+                                val.clone(),
+                            ])))
+                        })
+                    })
+                    .collect();
+                Ok(Value::Vec(Arc::new(Mutex::new(pairs))))
+            }
+            "get_unchecked" => {
+                if let Some(Value::Handle { pool_id, index, generation }) = args.first() {
+                    let pool = p.lock().unwrap();
+                    match pool.validate(*pool_id, *index, *generation) {
+                        Ok(idx) => {
+                            let val = pool.slots[idx].1.as_ref().unwrap().clone();
+                            Ok(val)
+                        }
+                        Err(msg) => Err(RuntimeError::Panic(format!(
+                            "get_unchecked: invalid handle — {}", msg
+                        ))),
+                    }
+                } else {
+                    Err(RuntimeError::TypeError(
+                        "pool.get_unchecked() expects a Handle".to_string(),
+                    ))
+                }
+            }
             "take_all" => {
                 let mut pool = p.lock().unwrap();
                 let mut items = Vec::new();
@@ -1206,6 +1266,14 @@ impl Interpreter {
                     got: 0,
                 })?;
                 Ok(Value::Shared(Arc::new(RwLock::new(value))))
+            }
+            // CE1: Cell.new(value) — heap-allocate a single mutable value
+            (TypeConstructorKind::Cell, "new") => {
+                let value = args.into_iter().next().ok_or(RuntimeError::ArityMismatch {
+                    expected: 1,
+                    got: 0,
+                })?;
+                Ok(Value::Cell(Arc::new(Mutex::new(value))))
             }
             (TypeConstructorKind::Mutex, "new") => {
                 let value = args.into_iter().next().ok_or(RuntimeError::ArityMismatch {

--- a/compiler/crates/rask-interp/src/interp/binary.rs
+++ b/compiler/crates/rask-interp/src/interp/binary.rs
@@ -1,0 +1,459 @@
+// SPDX-License-Identifier: (MIT OR Apache-2.0)
+//! @binary struct parse/build implementation for the interpreter.
+
+use std::sync::{Arc, Mutex};
+use indexmap::IndexMap;
+
+use crate::value::{StructData, Value};
+use super::{Interpreter, RuntimeError, RuntimeDiagnostic};
+use rask_ast::Span;
+
+/// Endianness for multi-byte fields.
+#[derive(Debug, Clone, Copy)]
+pub enum Endian {
+    Big,
+    Little,
+}
+
+/// A field in a @binary struct.
+#[derive(Debug, Clone)]
+pub struct BinaryFieldMeta {
+    pub name: String,
+    pub bits: u32,
+    pub endian: Option<Endian>,
+    pub bit_offset: u32,
+    pub is_byte_array: bool,
+    pub byte_array_len: usize,
+    /// "u8", "u16", "u32", "u64", "i8", "i16", "i32", "i64", "f32", "f64"
+    pub runtime_type: String,
+}
+
+/// Metadata for a @binary struct.
+#[derive(Debug, Clone)]
+pub struct BinaryStructMeta {
+    pub name: String,
+    pub fields: Vec<BinaryFieldMeta>,
+    pub total_bits: u32,
+    pub size_bytes: u32,
+}
+
+impl BinaryStructMeta {
+    /// Parse @binary struct fields from AST declarations.
+    pub fn from_decl(name: &str, fields: &[rask_ast::decl::Field]) -> Option<Self> {
+        let mut binary_fields = Vec::new();
+        let mut bit_offset: u32 = 0;
+
+        for field in fields {
+            let spec = parse_field_spec(&field.ty)?;
+            binary_fields.push(BinaryFieldMeta {
+                name: field.name.clone(),
+                bits: spec.0,
+                endian: spec.1,
+                bit_offset,
+                is_byte_array: spec.3,
+                byte_array_len: spec.4,
+                runtime_type: spec.2,
+            });
+            bit_offset += spec.0;
+        }
+
+        let size_bytes = (bit_offset + 7) / 8;
+        Some(BinaryStructMeta {
+            name: name.to_string(),
+            fields: binary_fields,
+            total_bits: bit_offset,
+            size_bytes,
+        })
+    }
+}
+
+/// Parse a binary field type specifier: returns (bits, endian, runtime_type_name, is_byte_array, byte_array_len)
+fn parse_field_spec(ty: &str) -> Option<(u32, Option<Endian>, String, bool, usize)> {
+    let s = ty.trim();
+
+    // [N]u8 — fixed byte array
+    if s.starts_with('[') {
+        let bracket_end = s.find(']')?;
+        let count: usize = s[1..bracket_end].parse().ok()?;
+        let elem = &s[bracket_end + 1..];
+        if elem != "u8" { return None; }
+        return Some((count as u32 * 8, None, "byte_array".into(), true, count));
+    }
+
+    // Bare number
+    if let Ok(n) = s.parse::<u32>() {
+        if n == 0 || n > 64 { return None; }
+        let rt = match n {
+            1..=8 => "u8",
+            9..=16 => "u16",
+            17..=32 => "u32",
+            33..=64 => "u64",
+            _ => unreachable!(),
+        };
+        return Some((n, None, rt.into(), false, 0));
+    }
+
+    // Endian types
+    let (base, endian) = if let Some(base) = s.strip_suffix("be") {
+        (base, Some(Endian::Big))
+    } else if let Some(base) = s.strip_suffix("le") {
+        (base, Some(Endian::Little))
+    } else {
+        match s {
+            "u8" => return Some((8, None, "u8".into(), false, 0)),
+            "i8" => return Some((8, None, "i8".into(), false, 0)),
+            _ => return None,
+        }
+    };
+
+    let (bits, rt) = match base {
+        "u16" => (16, "u16"),
+        "i16" => (16, "i16"),
+        "u32" => (32, "u32"),
+        "i32" => (32, "i32"),
+        "u64" => (64, "u64"),
+        "i64" => (64, "i64"),
+        "f32" => (32, "f32"),
+        "f64" => (64, "f64"),
+        _ => return None,
+    };
+
+    Some((bits, endian, rt.into(), false, 0))
+}
+
+impl Interpreter {
+    /// Detect and dispatch @binary static method calls (e.g. IpHeader.parse(data)).
+    pub(crate) fn try_binary_static_method(
+        &mut self,
+        type_name: &str,
+        method: &str,
+        args: Vec<Value>,
+        span: Span,
+    ) -> Option<Result<Value, RuntimeDiagnostic>> {
+        let meta = self.binary_structs.get(type_name)?.clone();
+        match method {
+            "parse" => Some(self.binary_parse(&meta, args, span)),
+            _ => None,
+        }
+    }
+
+    /// Detect and dispatch @binary instance method calls (e.g. header.build()).
+    pub(crate) fn try_binary_instance_method(
+        &mut self,
+        receiver: &Value,
+        type_name: &str,
+        method: &str,
+        args: Vec<Value>,
+        span: Span,
+    ) -> Option<Result<Value, RuntimeDiagnostic>> {
+        let meta = self.binary_structs.get(type_name)?.clone();
+        match method {
+            "build" => Some(self.binary_build(&meta, receiver, span)),
+            "build_into" => {
+                if args.len() != 1 {
+                    return Some(Err(RuntimeDiagnostic::new(
+                        RuntimeError::TypeError("build_into expects 1 argument".into()),
+                        span,
+                    )));
+                }
+                Some(self.binary_build_into(&meta, receiver, args.into_iter().next().unwrap(), span))
+            }
+            _ => None,
+        }
+    }
+
+    /// G1: parse(data: []u8) -> (T, []u8) or ParseError
+    fn binary_parse(
+        &mut self,
+        meta: &BinaryStructMeta,
+        args: Vec<Value>,
+        span: Span,
+    ) -> Result<Value, RuntimeDiagnostic> {
+        if args.len() != 1 {
+            return Err(RuntimeDiagnostic::new(
+                RuntimeError::TypeError("parse expects 1 argument".into()),
+                span,
+            ));
+        }
+
+        let data = match &args[0] {
+            Value::Vec(v) => {
+                let guard = v.lock().unwrap();
+                guard.iter().map(|v| match v {
+                    Value::Int(n) => *n as u8,
+                    _ => 0,
+                }).collect::<Vec<u8>>()
+            }
+            _ => {
+                return Err(RuntimeDiagnostic::new(
+                    RuntimeError::TypeError("parse expects []u8 argument".into()),
+                    span,
+                ));
+            }
+        };
+
+        let needed = meta.size_bytes as usize;
+        if data.len() < needed {
+            // Return Err(ParseError)
+            return Ok(Value::Enum {
+                name: "Result".into(),
+                variant: "Err".into(),
+                fields: vec![Value::String(Arc::new(Mutex::new(format!(
+                    "not enough data: need {} bytes, got {}",
+                    needed,
+                    data.len()
+                ))))],
+                variant_index: 1,
+                origin: None,
+            });
+        }
+
+        let mut fields = IndexMap::new();
+        for field in &meta.fields {
+            let value = read_binary_field(&data, field);
+            fields.insert(field.name.clone(), value);
+        }
+
+        let struct_val = Value::Struct(Arc::new(Mutex::new(StructData {
+            name: meta.name.clone(),
+            fields,
+            resource_id: None,
+        })));
+
+        // Remaining data as slice
+        let remaining: Vec<Value> = data[needed..]
+            .iter()
+            .map(|&b| Value::Int(b as i64))
+            .collect();
+        let remaining_val = Value::Vec(Arc::new(Mutex::new(remaining)));
+
+        // Return Ok((struct, remaining))
+        Ok(Value::Enum {
+            name: "Result".into(),
+            variant: "Ok".into(),
+            fields: vec![Value::Vec(Arc::new(Mutex::new(vec![struct_val, remaining_val])))],
+            variant_index: 0,
+            origin: None,
+        })
+    }
+
+    /// G2: build(self) -> Vec<u8>
+    fn binary_build(
+        &mut self,
+        meta: &BinaryStructMeta,
+        receiver: &Value,
+        span: Span,
+    ) -> Result<Value, RuntimeDiagnostic> {
+        let guard = match receiver {
+            Value::Struct(s) => s.lock().unwrap(),
+            _ => {
+                return Err(RuntimeDiagnostic::new(
+                    RuntimeError::TypeError("build requires a struct receiver".into()),
+                    span,
+                ));
+            }
+        };
+
+        let mut buf = vec![0u8; meta.size_bytes as usize];
+        for field_meta in &meta.fields {
+            let val = guard.fields.get(&field_meta.name).cloned().unwrap_or(Value::Int(0));
+            write_binary_field(&mut buf, field_meta, &val);
+        }
+
+        let result: Vec<Value> = buf.iter().map(|&b| Value::Int(b as i64)).collect();
+        Ok(Value::Vec(Arc::new(Mutex::new(result))))
+    }
+
+    /// G3: build_into(self, buffer: []u8) -> usize or BuildError
+    fn binary_build_into(
+        &mut self,
+        meta: &BinaryStructMeta,
+        receiver: &Value,
+        buffer: Value,
+        span: Span,
+    ) -> Result<Value, RuntimeDiagnostic> {
+        let guard = match receiver {
+            Value::Struct(s) => s.lock().unwrap(),
+            _ => {
+                return Err(RuntimeDiagnostic::new(
+                    RuntimeError::TypeError("build_into requires a struct receiver".into()),
+                    span,
+                ));
+            }
+        };
+
+        let needed = meta.size_bytes as usize;
+
+        // Build into a local buffer first
+        let mut buf = vec![0u8; needed];
+        for field_meta in &meta.fields {
+            let val = guard.fields.get(&field_meta.name).cloned().unwrap_or(Value::Int(0));
+            write_binary_field(&mut buf, field_meta, &val);
+        }
+        drop(guard);
+
+        // Write to the target buffer
+        match buffer {
+            Value::Vec(v) => {
+                let mut guard = v.lock().unwrap();
+                if guard.len() < needed {
+                    return Ok(Value::Enum {
+                        name: "Result".into(),
+                        variant: "Err".into(),
+                        fields: vec![Value::String(Arc::new(Mutex::new(format!(
+                            "buffer too small: need {} bytes, got {}",
+                            needed,
+                            guard.len()
+                        ))))],
+                        variant_index: 1,
+                        origin: None,
+                    });
+                }
+                for (i, &b) in buf.iter().enumerate() {
+                    guard[i] = Value::Int(b as i64);
+                }
+            }
+            _ => {
+                return Err(RuntimeDiagnostic::new(
+                    RuntimeError::TypeError("build_into expects []u8 buffer".into()),
+                    span,
+                ));
+            }
+        }
+
+        Ok(Value::Enum {
+            name: "Result".into(),
+            variant: "Ok".into(),
+            fields: vec![Value::Int(needed as i64)],
+            variant_index: 0,
+            origin: None,
+        })
+    }
+}
+
+/// Read a binary field value from a byte buffer at the given bit offset.
+fn read_binary_field(data: &[u8], field: &BinaryFieldMeta) -> Value {
+    if field.is_byte_array {
+        let byte_start = (field.bit_offset / 8) as usize;
+        let values: Vec<Value> = data[byte_start..byte_start + field.byte_array_len]
+            .iter()
+            .map(|&b| Value::Int(b as i64))
+            .collect();
+        return Value::Vec(Arc::new(Mutex::new(values)));
+    }
+
+    let raw = read_bits(data, field.bit_offset, field.bits);
+
+    match field.runtime_type.as_str() {
+        "u8" | "u16" | "u32" | "u64" => Value::Int(raw as i64),
+        "i8" => Value::Int(raw as u8 as i8 as i64),
+        "i16" => {
+            let v = match field.endian {
+                Some(Endian::Little) => i16::from_le_bytes((raw as u16).to_le_bytes()),
+                _ => raw as u16 as i16,
+            };
+            Value::Int(v as i64)
+        }
+        "i32" => {
+            let v = match field.endian {
+                Some(Endian::Little) => i32::from_le_bytes((raw as u32).to_le_bytes()),
+                _ => raw as u32 as i32,
+            };
+            Value::Int(v as i64)
+        }
+        "i64" => {
+            let v = match field.endian {
+                Some(Endian::Little) => i64::from_le_bytes(raw.to_le_bytes()),
+                _ => raw as i64,
+            };
+            Value::Int(v)
+        }
+        "f32" => {
+            let bits = raw as u32;
+            Value::Float(f32::from_bits(bits) as f64)
+        }
+        "f64" => {
+            Value::Float(f64::from_bits(raw))
+        }
+        _ => Value::Int(raw as i64),
+    }
+}
+
+/// Write a binary field value into a byte buffer at the given bit offset.
+fn write_binary_field(buf: &mut [u8], field: &BinaryFieldMeta, value: &Value) {
+    if field.is_byte_array {
+        let byte_start = (field.bit_offset / 8) as usize;
+        if let Value::Vec(v) = value {
+            let guard = v.lock().unwrap();
+            for (i, val) in guard.iter().enumerate().take(field.byte_array_len) {
+                if let Value::Int(n) = val {
+                    buf[byte_start + i] = *n as u8;
+                }
+            }
+        }
+        return;
+    }
+
+    let raw: u64 = match value {
+        Value::Int(n) => *n as u64,
+        Value::Float(f) => {
+            if field.bits == 32 {
+                (*f as f32).to_bits() as u64
+            } else {
+                f.to_bits()
+            }
+        }
+        _ => 0,
+    };
+
+    // Apply endianness for multi-byte fields
+    let raw = match (field.endian, field.bits) {
+        (Some(Endian::Little), 16) => {
+            let bytes = (raw as u16).to_le_bytes();
+            u16::from_be_bytes(bytes) as u64
+        }
+        (Some(Endian::Little), 32) => {
+            let bytes = (raw as u32).to_le_bytes();
+            u32::from_be_bytes(bytes) as u64
+        }
+        (Some(Endian::Little), 64) => {
+            let bytes = raw.to_le_bytes();
+            u64::from_be_bytes(bytes)
+        }
+        _ => raw, // Big endian or sub-byte: use as-is (MSB-first is natural)
+    };
+
+    write_bits(buf, field.bit_offset, field.bits, raw);
+}
+
+/// Read `count` bits starting at `bit_offset` from a byte buffer (MSB-first, B3).
+fn read_bits(data: &[u8], bit_offset: u32, count: u32) -> u64 {
+    let mut result: u64 = 0;
+    for i in 0..count {
+        let abs_bit = bit_offset + i;
+        let byte_idx = (abs_bit / 8) as usize;
+        let bit_idx = 7 - (abs_bit % 8); // MSB-first
+        if byte_idx < data.len() && (data[byte_idx] >> bit_idx) & 1 == 1 {
+            result |= 1u64 << (count - 1 - i);
+        }
+    }
+
+    result
+}
+
+/// Write `count` bits starting at `bit_offset` into a byte buffer (MSB-first, B3).
+fn write_bits(buf: &mut [u8], bit_offset: u32, count: u32, value: u64) {
+    for i in 0..count {
+        let abs_bit = bit_offset + i;
+        let byte_idx = (abs_bit / 8) as usize;
+        let bit_idx = 7 - (abs_bit % 8); // MSB-first
+        if byte_idx < buf.len() {
+            let bit_val = (value >> (count - 1 - i)) & 1;
+            if bit_val == 1 {
+                buf[byte_idx] |= 1 << bit_idx;
+            } else {
+                buf[byte_idx] &= !(1 << bit_idx);
+            }
+        }
+    }
+}

--- a/compiler/crates/rask-interp/src/interp/dispatch.rs
+++ b/compiler/crates/rask-interp/src/interp/dispatch.rs
@@ -266,6 +266,20 @@ impl Interpreter {
                     "f32x8 has no method '{}'", method
                 ))),
             },
+            // @binary struct instance methods (build, build_into)
+            Value::Struct(ref s) => {
+                let name = s.lock().unwrap().name.clone();
+                if self.binary_structs.contains_key(&name)
+                    && matches!(method, "build" | "build_into")
+                {
+                    let span = rask_ast::Span::new(0, 0);
+                    if let Some(result) = self.try_binary_instance_method(&receiver, &name, method, args, span) {
+                        return result.map_err(|d| d.error);
+                    }
+                    unreachable!();
+                }
+                self.call_builtin_method(receiver, method, args)
+            }
             _ => self.call_builtin_method(receiver, method, args),
         }
     }

--- a/compiler/crates/rask-interp/src/interp/dispatch.rs
+++ b/compiler/crates/rask-interp/src/interp/dispatch.rs
@@ -280,6 +280,38 @@ impl Interpreter {
                 }
                 self.call_builtin_method(receiver, method, args)
             }
+            // CE6: Cell<T> instance methods
+            Value::Cell(ref c) => match method {
+                "get" => {
+                    let guard = c.lock().unwrap();
+                    Ok(guard.clone())
+                }
+                "set" => {
+                    if args.len() != 1 {
+                        return Err(RuntimeError::TypeError("Cell.set expects 1 argument".into()));
+                    }
+                    let mut guard = c.lock().unwrap();
+                    *guard = args.into_iter().next().unwrap();
+                    Ok(Value::Unit)
+                }
+                "replace" => {
+                    if args.len() != 1 {
+                        return Err(RuntimeError::TypeError("Cell.replace expects 1 argument".into()));
+                    }
+                    let mut guard = c.lock().unwrap();
+                    let old = std::mem::replace(&mut *guard, args.into_iter().next().unwrap());
+                    Ok(old)
+                }
+                "into_inner" => {
+                    // Consume the cell — return inner value
+                    let guard = c.lock().unwrap();
+                    Ok(guard.clone())
+                }
+                _ => Err(RuntimeError::NoSuchMethod {
+                    ty: "Cell".to_string(),
+                    method: method.to_string(),
+                }),
+            },
             _ => self.call_builtin_method(receiver, method, args),
         }
     }

--- a/compiler/crates/rask-interp/src/interp/eval_expr.rs
+++ b/compiler/crates/rask-interp/src/interp/eval_expr.rs
@@ -353,6 +353,17 @@ impl Interpreter {
                         }
                     }
 
+                    // @binary static methods (e.g. IpHeader.parse(data))
+                    if self.binary_structs.contains_key(name) {
+                        let arg_vals: Vec<Value> = args
+                            .iter()
+                            .map(|a| self.eval_expr(&a.expr))
+                            .collect::<Result<_, _>>()?;
+                        if let Some(result) = self.try_binary_static_method(name, method, arg_vals, expr.span) {
+                            return result;
+                        }
+                    }
+
                     if let Some(type_methods) = self.methods.get(name).cloned() {
                         if let Some(method_fn) = type_methods.get(method) {
                             // Skip empty-body stubs (e.g. fs.write_bytes) —
@@ -381,7 +392,7 @@ impl Interpreter {
                     .map(|a| self.eval_expr(&a.expr))
                     .collect::<Result<_, _>>()?;
 
-                // Inject type_args for generic methods (e.g. json.decode<T>)
+                // Inject type_args for generic methods (e.g. json.decode<T>, reflect.fields<T>)
                 if let Some(ta) = type_args {
                     if let Some(first_type) = ta.first() {
                         if let Value::Module(ModuleKind::Json) = &receiver {
@@ -391,6 +402,12 @@ impl Interpreter {
                                     Value::String(Arc::new(Mutex::new(first_type.clone()))),
                                 );
                             }
+                        }
+                        if let Value::Module(ModuleKind::Reflect) = &receiver {
+                            arg_vals.insert(
+                                0,
+                                Value::String(Arc::new(Mutex::new(first_type.clone()))),
+                            );
                         }
                     }
                 }
@@ -765,6 +782,45 @@ impl Interpreter {
                             obj.type_name()
                         )),
                         expr.span
+                    )),
+                }
+            }
+
+            // CT49: Dynamic field access — value.(expr) resolves to field access by string
+            ExprKind::DynamicField { object, field_expr } => {
+                let field_name_val = self.eval_expr(field_expr)?;
+                let field_name = match &field_name_val {
+                    Value::String(s) => s.lock().unwrap().clone(),
+                    _ => {
+                        return Err(RuntimeDiagnostic::new(
+                            RuntimeError::TypeError(
+                                "dynamic field access requires a string expression".into(),
+                            ),
+                            expr.span,
+                        ));
+                    }
+                };
+                let obj = self.eval_expr(object)?;
+                match obj {
+                    Value::Struct(ref s) => {
+                        let guard = s.lock().unwrap();
+                        match guard.fields.get(&field_name) {
+                            Some(val) => Ok(val.clone()),
+                            None => Err(RuntimeDiagnostic::new(
+                                RuntimeError::TypeError(format!(
+                                    "struct '{}' has no field '{}'",
+                                    guard.name, field_name
+                                )),
+                                expr.span,
+                            )),
+                        }
+                    }
+                    _ => Err(RuntimeDiagnostic::new(
+                        RuntimeError::TypeError(format!(
+                            "cannot access dynamic field on {}",
+                            obj.type_name()
+                        )),
+                        expr.span,
                     )),
                 }
             }

--- a/compiler/crates/rask-interp/src/interp/eval_expr.rs
+++ b/compiler/crates/rask-interp/src/interp/eval_expr.rs
@@ -200,6 +200,10 @@ impl Interpreter {
                         kind: TypeConstructorKind::Pool,
                         type_param,
                     }),
+                    "Cell" => return Ok(Value::TypeConstructor {
+                        kind: TypeConstructorKind::Cell,
+                        type_param,
+                    }),
                     "Channel" => return Ok(Value::TypeConstructor {
                         kind: TypeConstructorKind::Channel,
                         type_param,
@@ -766,6 +770,14 @@ impl Interpreter {
                                         variant_index: vidx as u32,
                                     });
                                 }
+                            }
+                        }
+                        // G4: @binary SIZE and SIZE_BITS constants
+                        if let Some(meta) = self.binary_structs.get(&type_name) {
+                            match field.as_str() {
+                                "SIZE" => return Ok(Value::Int(meta.size_bytes as i64)),
+                                "SIZE_BITS" => return Ok(Value::Int(meta.total_bits as i64)),
+                                _ => {}
                             }
                         }
                         Err(RuntimeDiagnostic::new(
@@ -1541,6 +1553,8 @@ impl Interpreter {
                     Index { collection: Value, key: Value },
                     /// Mutex — exclusive lock
                     Mutex(Arc<Mutex<Value>>),
+                    /// Cell<T> — exclusive access (CE4/CE5)
+                    Cell(Arc<Mutex<Value>>),
                     /// Shared.read() — shared read lock
                     SharedRead(Arc<RwLock<Value>>),
                     /// Shared.write() — exclusive write lock
@@ -1582,10 +1596,11 @@ impl Interpreter {
                         let val = self.eval_expr(&binding.source)?;
                         match val {
                             Value::RaskMutex(m) => WithSource::Mutex(m),
+                            Value::Cell(c) => WithSource::Cell(c),
                             _ => {
                                 return Err(RuntimeDiagnostic::new(
                                     RuntimeError::TypeError(format!(
-                                        "with...as: expected Mutex, Shared, or collection index, got {}",
+                                        "with...as: expected Cell, Mutex, Shared, or collection index, got {}",
                                         val.type_name()
                                     )),
                                     expr.span,
@@ -1643,6 +1658,16 @@ impl Interpreter {
                             self.env.define(info.name.clone(), guard.clone());
                             mutex_guards.push((info.name.clone(), guard));
                         }
+                        WithSource::Cell(c) => {
+                            let guard = c.lock().map_err(|_| RuntimeDiagnostic::new(
+                                RuntimeError::Panic(
+                                    "Cell is exclusively borrowed — recursive access in with block".to_string(),
+                                ),
+                                expr.span,
+                            ))?;
+                            self.env.define(info.name.clone(), guard.clone());
+                            mutex_guards.push((info.name.clone(), guard));
+                        }
                         WithSource::SharedRead(s) => {
                             let guard = s.read().map_err(|e| RuntimeDiagnostic::new(
                                 RuntimeError::Panic(format!("Shared.read: poisoned: {}", e)),
@@ -1677,7 +1702,7 @@ impl Interpreter {
                                     self.write_back_index(collection, key, updated)
                                         .map_err(|e| RuntimeDiagnostic::new(e, expr.span))?;
                                 }
-                                WithSource::Mutex(_) | WithSource::SharedWrite(_) => {
+                                WithSource::Mutex(_) | WithSource::Cell(_) | WithSource::SharedWrite(_) => {
                                     // Writeback handled via guards below
                                 }
                                 WithSource::SharedRead(_) => {

--- a/compiler/crates/rask-interp/src/interp/exec_stmt.rs
+++ b/compiler/crates/rask-interp/src/interp/exec_stmt.rs
@@ -256,6 +256,187 @@ impl Interpreter {
                         }
                         Ok(Value::Unit)
                     }
+                    // LP13: for mutate on Map — write back values by key
+                    Value::Map(ref m) if *mutate => {
+                        let map_arc = std::sync::Arc::clone(m);
+                        let pairs: Vec<(Value, Value)> = map_arc.lock().unwrap().clone();
+                        for (key, val) in pairs {
+                            self.env.push_scope();
+                            // Bind as tuple (k, v) or single pair
+                            if let ForBinding::Tuple(names) = binding {
+                                if names.len() >= 2 {
+                                    self.env.define(names[0].clone(), key.clone());
+                                    self.env.define(names[1].clone(), val);
+                                }
+                            } else {
+                                let pair = Value::Vec(std::sync::Arc::new(std::sync::Mutex::new(vec![key.clone(), val])));
+                                self.define_for_binding(binding, pair);
+                            }
+                            match self.exec_stmts(body) {
+                                Ok(_) => {}
+                                Err(diag) if matches!(diag.error, RuntimeError::Break(_)) => {
+                                    // Write back before breaking
+                                    if let ForBinding::Tuple(names) = binding {
+                                        if names.len() >= 2 {
+                                            if let Some(v) = self.env.get(&names[1]).cloned() {
+                                                let mut guard = map_arc.lock().unwrap();
+                                                if let Some(pair) = guard.iter_mut().find(|(k, _)| Self::value_eq(k, &key)) {
+                                                    pair.1 = v;
+                                                }
+                                            }
+                                        }
+                                    }
+                                    self.env.pop_scope();
+                                    break;
+                                }
+                                Err(diag) if matches!(diag.error, RuntimeError::Continue) => {
+                                    if let ForBinding::Tuple(names) = binding {
+                                        if names.len() >= 2 {
+                                            if let Some(v) = self.env.get(&names[1]).cloned() {
+                                                let mut guard = map_arc.lock().unwrap();
+                                                if let Some(pair) = guard.iter_mut().find(|(k, _)| Self::value_eq(k, &key)) {
+                                                    pair.1 = v;
+                                                }
+                                            }
+                                        }
+                                    }
+                                    self.env.pop_scope();
+                                    continue;
+                                }
+                                Err(e) => {
+                                    self.env.pop_scope();
+                                    return Err(e);
+                                }
+                            }
+                            // Write back value
+                            if let ForBinding::Tuple(names) = binding {
+                                if names.len() >= 2 {
+                                    if let Some(v) = self.env.get(&names[1]).cloned() {
+                                        let mut guard = m.lock().unwrap();
+                                        if let Some(pair) = guard.iter_mut().find(|(k, _)| Self::value_eq(k, &key)) {
+                                            pair.1 = v;
+                                        }
+                                    }
+                                }
+                            }
+                            self.env.pop_scope();
+                        }
+                        Ok(Value::Unit)
+                    }
+                    // LP13: for mutate on Pool entries — write back values by handle
+                    Value::Pool(ref p) if *mutate => {
+                        let pool_arc = std::sync::Arc::clone(p);
+                        let pool = pool_arc.lock().unwrap();
+                        let pool_id = pool.pool_id;
+                        let entries: Vec<(Value, Value)> = pool
+                            .slots
+                            .iter()
+                            .enumerate()
+                            .filter_map(|(i, (gen, slot))| {
+                                slot.as_ref().map(|val| (
+                                    Value::Handle { pool_id, index: i as u32, generation: *gen },
+                                    val.clone(),
+                                ))
+                            })
+                            .collect();
+                        drop(pool);
+
+                        for (handle, val) in entries {
+                            self.env.push_scope();
+                            if let ForBinding::Tuple(names) = binding {
+                                if names.len() >= 2 {
+                                    self.env.define(names[0].clone(), handle.clone());
+                                    self.env.define(names[1].clone(), val);
+                                }
+                            } else {
+                                self.define_for_binding(binding, handle.clone());
+                            }
+                            match self.exec_stmts(body) {
+                                Ok(_) => {}
+                                Err(diag) if matches!(diag.error, RuntimeError::Break(_)) => {
+                                    if let ForBinding::Tuple(names) = binding {
+                                        if names.len() >= 2 {
+                                            if let (Some(v), Value::Handle { index, .. }) = (self.env.get(&names[1]).cloned(), &handle) {
+                                                let mut pool = pool_arc.lock().unwrap();
+                                                if let Some((_, slot)) = pool.slots.get_mut(*index as usize) {
+                                                    *slot = Some(v);
+                                                }
+                                            }
+                                        }
+                                    }
+                                    self.env.pop_scope();
+                                    break;
+                                }
+                                Err(diag) if matches!(diag.error, RuntimeError::Continue) => {
+                                    if let ForBinding::Tuple(names) = binding {
+                                        if names.len() >= 2 {
+                                            if let (Some(v), Value::Handle { index, .. }) = (self.env.get(&names[1]).cloned(), &handle) {
+                                                let mut pool = pool_arc.lock().unwrap();
+                                                if let Some((_, slot)) = pool.slots.get_mut(*index as usize) {
+                                                    *slot = Some(v);
+                                                }
+                                            }
+                                        }
+                                    }
+                                    self.env.pop_scope();
+                                    continue;
+                                }
+                                Err(e) => {
+                                    self.env.pop_scope();
+                                    return Err(e);
+                                }
+                            }
+                            // Write back
+                            if let ForBinding::Tuple(names) = binding {
+                                if names.len() >= 2 {
+                                    if let (Some(v), Value::Handle { index, .. }) = (self.env.get(&names[1]).cloned(), &handle) {
+                                        let mut pool = p.lock().unwrap();
+                                        if let Some((_, slot)) = pool.slots.get_mut(*index as usize) {
+                                            *slot = Some(v);
+                                        }
+                                    }
+                                }
+                            }
+                            self.env.pop_scope();
+                        }
+                        Ok(Value::Unit)
+                    }
+                    // Map iteration (non-mutating): yield (key, value) tuples
+                    Value::Map(m) => {
+                        let pairs: Vec<(Value, Value)> = m.lock().unwrap().clone();
+                        for (key, val) in pairs {
+                            self.env.push_scope();
+                            if let ForBinding::Tuple(names) = binding {
+                                if names.len() >= 2 {
+                                    self.env.define(names[0].clone(), key);
+                                    self.env.define(names[1].clone(), val);
+                                } else if names.len() == 1 {
+                                    let pair = Value::Vec(std::sync::Arc::new(std::sync::Mutex::new(vec![key, val])));
+                                    self.define_for_binding(binding, pair);
+                                }
+                            } else {
+                                let pair = Value::Vec(std::sync::Arc::new(std::sync::Mutex::new(vec![key, val])));
+                                self.define_for_binding(binding, pair);
+                            }
+                            match self.exec_stmts(body) {
+                                Ok(_) => {}
+                                Err(diag) if matches!(diag.error, RuntimeError::Break(_)) => {
+                                    self.env.pop_scope();
+                                    break;
+                                }
+                                Err(diag) if matches!(diag.error, RuntimeError::Continue) => {
+                                    self.env.pop_scope();
+                                    continue;
+                                }
+                                Err(e) => {
+                                    self.env.pop_scope();
+                                    return Err(e);
+                                }
+                            }
+                            self.env.pop_scope();
+                        }
+                        Ok(Value::Unit)
+                    }
                     Value::Vec(v) => {
                         let items: Vec<Value> = v.lock().unwrap().clone();
                         for item in items {

--- a/compiler/crates/rask-interp/src/interp/mod.rs
+++ b/compiler/crates/rask-interp/src/interp/mod.rs
@@ -30,6 +30,8 @@ use crate::env::Environment;
 use crate::resource::ResourceTracker;
 use crate::value::Value;
 
+pub(crate) mod binary;
+
 /// Declarations collected during registration.
 struct RegisteredProgram {
     entry_fn: Option<FnDecl>,
@@ -66,7 +68,7 @@ pub struct Interpreter {
     /// Function declarations by name.
     functions: HashMap<String, FnDecl>,
     /// Enum declarations by name.
-    enums: HashMap<String, EnumDecl>,
+    pub(crate) enums: HashMap<String, EnumDecl>,
     /// Struct declarations by name (for @resource checking).
     pub(crate) struct_decls: HashMap<String, StructDecl>,
     /// Monomorphized struct declarations (e.g., "Buffer<i32, 256>" -> concrete struct).
@@ -83,6 +85,8 @@ pub struct Interpreter {
     pub(crate) build_state: Option<crate::build_context::BuildState>,
     /// Source info for error origin tracking (ER15): file name + line map.
     pub(crate) source_info: Option<SourceInfo>,
+    /// B1–G4: binary struct metadata for @binary parse/build.
+    pub(crate) binary_structs: HashMap<String, binary::BinaryStructMeta>,
 }
 
 /// Source location info for computing error origins (ER15).
@@ -106,6 +110,7 @@ impl Interpreter {
             cli_args: vec![],
             build_state: None,
             source_info: None,
+            binary_structs: HashMap::new(),
         }
     }
 
@@ -120,6 +125,7 @@ impl Interpreter {
             resource_tracker: ResourceTracker::new(),
             output_buffer: None,
             cli_args: args,
+            binary_structs: HashMap::new(),
             build_state: None,
             source_info: None,
         }
@@ -140,6 +146,7 @@ impl Interpreter {
             cli_args: vec![],
             build_state: None,
             source_info: None,
+            binary_structs: HashMap::new(),
         };
         (interp, buffer)
     }

--- a/compiler/crates/rask-interp/src/interp/register.rs
+++ b/compiler/crates/rask-interp/src/interp/register.rs
@@ -112,6 +112,16 @@ impl Interpreter {
                 }
                 DeclKind::Import(import) => {
                     if let Some(module_name) = import.path.first() {
+                        // Handle std.reflect as a special two-component module
+                        if module_name == "std"
+                            && import.path.len() >= 2
+                            && import.path[1] == "reflect"
+                        {
+                            let alias = import.alias.clone().unwrap_or_else(|| "reflect".to_string());
+                            imports.push((alias, ModuleKind::Reflect));
+                            continue;
+                        }
+
                         let module_kind = match module_name.as_str() {
                             "fs" => Some(ModuleKind::Fs),
                             "io" => Some(ModuleKind::Io),
@@ -154,6 +164,12 @@ impl Interpreter {
                 }
                 DeclKind::Struct(s) => {
                     let base_name = strip_generics(&s.name).to_string();
+                    // Register @binary struct metadata
+                    if s.attrs.iter().any(|a| a == "binary") {
+                        if let Some(meta) = super::binary::BinaryStructMeta::from_decl(&s.name, &s.fields) {
+                            self.binary_structs.insert(base_name.clone(), meta);
+                        }
+                    }
                     self.struct_decls.insert(base_name.clone(), s.clone());
                     if !s.methods.is_empty() {
                         let type_methods = self.methods.entry(base_name).or_default();

--- a/compiler/crates/rask-interp/src/stdlib/async_mod.rs
+++ b/compiler/crates/rask-interp/src/stdlib/async_mod.rs
@@ -71,6 +71,39 @@ impl Interpreter {
                     ))),
                 }
             }
+            "join_all" => {
+                // join_all(handles) — wait for all task handles, return Vec of results
+                if args.is_empty() {
+                    return Ok(Value::Vec(Arc::new(Mutex::new(Vec::new()))));
+                }
+
+                // Accept either a Vec of handles or variadic handles
+                let handles: Vec<Value> = match &args[0] {
+                    Value::Vec(v) => v.lock().unwrap().clone(),
+                    _ => args,
+                };
+
+                let mut results = Vec::with_capacity(handles.len());
+                for handle in handles {
+                    match handle {
+                        Value::TaskHandle(h) => {
+                            let result = self.call_task_handle_method(&h, "join")?;
+                            results.push(result);
+                        }
+                        Value::ThreadHandle(h) => {
+                            let result = self.call_thread_handle_method(&h, "join")?;
+                            results.push(result);
+                        }
+                        _ => {
+                            return Err(RuntimeError::TypeError(format!(
+                                "join_all expects TaskHandle or ThreadHandle, got {}",
+                                handle.type_name()
+                            )));
+                        }
+                    }
+                }
+                Ok(Value::Vec(Arc::new(Mutex::new(results))))
+            }
             _ => Err(RuntimeError::NoSuchMethod {
                 ty: "async".to_string(),
                 method: method.to_string(),

--- a/compiler/crates/rask-interp/src/stdlib/mod.rs
+++ b/compiler/crates/rask-interp/src/stdlib/mod.rs
@@ -154,6 +154,7 @@ impl Interpreter {
     ) -> Result<Value, RuntimeError> {
         match type_name {
             "Instant" | "Duration" => self.call_time_type_method(type_name, method, args),
+            "Timer" => self.call_timer_type_method(method, args),
             "Path" => self.call_path_type_method(method, args),
             "f32x8" => self.call_simd_type_method(method, args),
             "Rng" => self.call_rng_type_method(method, args),
@@ -172,6 +173,18 @@ impl Interpreter {
                 } else {
                     Err(RuntimeError::TypeError(format!(
                         "ThreadPool has no method '{}'", method
+                    )))
+                }
+            }
+            // CE1: Cell.new(value) — heap-allocate a single value
+            "Cell" => {
+                if method == "new" && args.len() == 1 {
+                    Ok(Value::Cell(std::sync::Arc::new(std::sync::Mutex::new(
+                        args.into_iter().next().unwrap(),
+                    ))))
+                } else {
+                    Err(RuntimeError::TypeError(format!(
+                        "Cell has no static method '{}' (expected Cell.new(value))", method
                     )))
                 }
             }

--- a/compiler/crates/rask-interp/src/stdlib/mod.rs
+++ b/compiler/crates/rask-interp/src/stdlib/mod.rs
@@ -17,6 +17,7 @@ mod net;
 mod os;
 mod path;
 mod random;
+mod reflect;
 mod thread;
 mod time;
 #[cfg(not(target_arch = "wasm32"))]
@@ -69,6 +70,8 @@ impl Interpreter {
             ModuleKind::Http => Err(RuntimeError::Generic(
                 "http module not available in browser playground".to_string()
             )),
+
+            ModuleKind::Reflect => self.call_reflect_method(method, args),
 
             // Legacy aliases — forward to new modules
             ModuleKind::Env => self.call_env_method(method, args),

--- a/compiler/crates/rask-interp/src/stdlib/reflect.rs
+++ b/compiler/crates/rask-interp/src/stdlib/reflect.rs
@@ -1,0 +1,85 @@
+// SPDX-License-Identifier: (MIT OR Apache-2.0)
+//! std.reflect — compile-time type introspection (interpreter implementation).
+
+use std::sync::{Arc, Mutex};
+use indexmap::IndexMap;
+
+use crate::interp::{Interpreter, RuntimeError};
+use crate::value::{StructData, Value};
+
+impl Interpreter {
+    pub(crate) fn call_reflect_method(
+        &self,
+        method: &str,
+        args: Vec<Value>,
+    ) -> Result<Value, RuntimeError> {
+        // All reflect methods take a type name as first arg (injected from type_args)
+        let type_name = match args.first() {
+            Some(Value::String(s)) => s.lock().unwrap().clone(),
+            _ => {
+                return Err(RuntimeError::TypeError(
+                    "reflect methods require a type argument: reflect.fields<T>()".into(),
+                ));
+            }
+        };
+
+        match method {
+            "fields" => self.reflect_fields(&type_name),
+            "name_of" => Ok(Value::String(Arc::new(Mutex::new(type_name)))),
+            "is_struct" => Ok(Value::Bool(self.struct_decls.contains_key(&type_name))),
+            "is_enum" => Ok(Value::Bool(self.enums.contains_key(&type_name))),
+            "size_of" | "align_of" => Ok(Value::Int(0)), // Placeholder
+            "is_copy" | "is_resource" | "is_flat" => Ok(Value::Bool(false)), // Placeholder
+            "is_optional" | "is_vec" | "is_map" | "is_integer" | "is_float" => Ok(Value::Bool(false)),
+            _ => Err(RuntimeError::NoSuchMethod {
+                ty: "reflect".to_string(),
+                method: method.to_string(),
+            }),
+        }
+    }
+
+    /// reflect.fields<T>() → []FieldInfo
+    fn reflect_fields(&self, type_name: &str) -> Result<Value, RuntimeError> {
+        let decl = self.struct_decls.get(type_name).ok_or_else(|| {
+            RuntimeError::TypeError(format!(
+                "reflect.fields<{}>(): not a struct type",
+                type_name
+            ))
+        })?;
+
+        let field_infos: Vec<Value> = decl
+            .fields
+            .iter()
+            .map(|f| {
+                let mut fields = IndexMap::new();
+                fields.insert(
+                    "name".to_string(),
+                    Value::String(Arc::new(Mutex::new(f.name.clone()))),
+                );
+                fields.insert(
+                    "type_name".to_string(),
+                    Value::String(Arc::new(Mutex::new(f.ty.clone()))),
+                );
+                fields.insert("offset".to_string(), Value::Int(0));
+                fields.insert("size".to_string(), Value::Int(0));
+                fields.insert(
+                    "is_public".to_string(),
+                    Value::Bool(f.visibility.is_pub()),
+                );
+                fields.insert(
+                    "serial_name".to_string(),
+                    Value::String(Arc::new(Mutex::new(f.name.clone()))),
+                );
+                fields.insert("is_skipped".to_string(), Value::Bool(false));
+                fields.insert("has_default".to_string(), Value::Bool(false));
+                Value::Struct(Arc::new(Mutex::new(StructData {
+                    name: "FieldInfo".to_string(),
+                    fields,
+                    resource_id: None,
+                })))
+            })
+            .collect();
+
+        Ok(Value::Vec(Arc::new(Mutex::new(field_infos))))
+    }
+}

--- a/compiler/crates/rask-interp/src/stdlib/time.rs
+++ b/compiler/crates/rask-interp/src/stdlib/time.rs
@@ -5,6 +5,7 @@
 
 use crate::interp::{Interpreter, RuntimeError};
 use crate::value::Value;
+use std::sync::{Arc, Mutex, mpsc};
 
 impl Interpreter {
     // === RUNTIME: module-level functions (sleep) ===
@@ -273,6 +274,60 @@ impl Interpreter {
             _ => Err(RuntimeError::TypeError(format!(
                 "type {} has no method '{}'",
                 type_name, method
+            ))),
+        }
+    }
+
+    // === RUNTIME: Timer static methods (TM2–TM3) ===
+
+    /// Handle Timer static methods: after(duration), interval(duration).
+    pub(crate) fn call_timer_type_method(
+        &self,
+        method: &str,
+        args: Vec<Value>,
+    ) -> Result<Value, RuntimeError> {
+        match method {
+            "after" => {
+                // Timer.after(duration) -> Receiver<()>
+                // Spawn a thread that sleeps then sends Unit on a channel.
+                // The returned Receiver acts like a one-shot timer.
+                let duration_nanos = args.first()
+                    .ok_or_else(|| RuntimeError::ArityMismatch { expected: 1, got: 0 })?
+                    .as_duration()
+                    .map_err(|e| RuntimeError::TypeError(e))?;
+                let duration = std::time::Duration::from_nanos(duration_nanos);
+
+                let (tx, rx) = mpsc::sync_channel(1);
+                std::thread::spawn(move || {
+                    std::thread::sleep(duration);
+                    let _ = tx.send(Value::Unit);
+                });
+
+                Ok(Value::Receiver(Arc::new(Mutex::new(rx))))
+            }
+            "interval" => {
+                // Timer.interval(duration) -> Receiver<()>
+                // Spawn a thread that sends Unit repeatedly at fixed intervals.
+                let duration_nanos = args.first()
+                    .ok_or_else(|| RuntimeError::ArityMismatch { expected: 1, got: 0 })?
+                    .as_duration()
+                    .map_err(|e| RuntimeError::TypeError(e))?;
+                let duration = std::time::Duration::from_nanos(duration_nanos);
+
+                let (tx, rx) = mpsc::sync_channel(1);
+                std::thread::spawn(move || {
+                    loop {
+                        std::thread::sleep(duration);
+                        if tx.send(Value::Unit).is_err() {
+                            break; // Receiver dropped
+                        }
+                    }
+                });
+
+                Ok(Value::Receiver(Arc::new(Mutex::new(rx))))
+            }
+            _ => Err(RuntimeError::TypeError(format!(
+                "Timer has no method '{}'", method
             ))),
         }
     }

--- a/compiler/crates/rask-interp/src/value.rs
+++ b/compiler/crates/rask-interp/src/value.rs
@@ -164,7 +164,8 @@ pub enum ModuleKind {
     Net,    // net.tcp_listen, net.tcp_connect
     Async,  // async.spawn (green task spawner)
     Thread, // thread.Thread, thread.ThreadPool
-    Http,   // http.listen_and_serve, http.get, etc.
+    Http,    // http.listen_and_serve, http.get, etc.
+    Reflect, // std.reflect — compile-time type introspection
 }
 
 /// Inner state for a spawned thread/task handle.
@@ -809,6 +810,7 @@ impl fmt::Display for Value {
                 ModuleKind::Async => write!(f, "<module async>"),
                 ModuleKind::Thread => write!(f, "<module thread>"),
                 ModuleKind::Http => write!(f, "<module http>"),
+                ModuleKind::Reflect => write!(f, "<module reflect>"),
             },
             Value::Package(name) => write!(f, "<package {}>", name),
             Value::File(file) => {

--- a/compiler/crates/rask-interp/src/value.rs
+++ b/compiler/crates/rask-interp/src/value.rs
@@ -140,6 +140,7 @@ pub enum TypeConstructorKind {
     Map,
     String,
     Pool,
+    Cell,
     Channel,
     Shared,
     Mutex,
@@ -334,6 +335,8 @@ pub enum Value {
     Instant(std::time::Instant),
     /// Type value (for accessing static methods like Instant.now())
     Type(String),
+    /// Cell<T> (CE1–CE6: single heap-allocated mutable value)
+    Cell(Arc<Mutex<Value>>),
     /// Pool (sparse storage with generation counters)
     Pool(Arc<Mutex<PoolData>>),
     /// Handle (opaque reference into a pool)
@@ -566,6 +569,7 @@ impl Value {
             Value::Duration(_) => "Duration",
             Value::Instant(_) => "Instant",
             Value::Type(_) => "type",
+            Value::Cell(_) => "Cell",
             Value::Pool(_) => "Pool",
             Value::Handle { .. } => "Handle",
             Value::ThreadHandle(_) => "ThreadHandle",
@@ -629,6 +633,10 @@ impl Value {
                     variant_index: *variant_index,
                     origin: origin.clone(),
                 }
+            }
+            Value::Cell(c) => {
+                let inner = c.lock().unwrap().deep_clone();
+                Value::Cell(Arc::new(Mutex::new(inner)))
             }
             Value::Pool(p) => {
                 let pool = p.lock().unwrap();
@@ -775,6 +783,7 @@ impl fmt::Display for Value {
                     TypeConstructorKind::Map => "Map",
                     TypeConstructorKind::String => "string",
                     TypeConstructorKind::Pool => "Pool",
+                    TypeConstructorKind::Cell => "Cell",
                     TypeConstructorKind::Channel => "Channel",
                     TypeConstructorKind::Shared => "Shared",
                     TypeConstructorKind::Mutex => "Mutex",
@@ -836,6 +845,10 @@ impl fmt::Display for Value {
             }
             Value::Instant(_) => write!(f, "<Instant>"),
             Value::Type(name) => write!(f, "<type {}>", name),
+            Value::Cell(c) => {
+                let inner = c.lock().unwrap();
+                write!(f, "Cell({})", inner)
+            }
             Value::Pool(p) => {
                 let pool = p.lock().unwrap();
                 write!(f, "<Pool len={}>", pool.len)

--- a/compiler/crates/rask-lint/src/idiom.rs
+++ b/compiler/crates/rask-lint/src/idiom.rs
@@ -176,6 +176,10 @@ fn walk_expr_for_unwrap(expr: &Expr, source: &str, diags: &mut Vec<LintDiagnosti
         ExprKind::Field { object, .. } | ExprKind::OptionalField { object, .. } => {
             walk_expr_for_unwrap(object, source, diags);
         }
+        ExprKind::DynamicField { object, field_expr } => {
+            walk_expr_for_unwrap(object, source, diags);
+            walk_expr_for_unwrap(field_expr, source, diags);
+        }
         ExprKind::Index { object, index } => {
             walk_expr_for_unwrap(object, source, diags);
             walk_expr_for_unwrap(index, source, diags);

--- a/compiler/crates/rask-mir/src/lower/expr.rs
+++ b/compiler/crates/rask-mir/src/lower/expr.rs
@@ -1813,6 +1813,14 @@ impl<'a> MirLowerer<'a> {
                 Ok((MirOperand::Local(result_local), result_ty))
             }
 
+            // Dynamic field access: value.(expr) — should be resolved by comptime before MIR
+            ExprKind::DynamicField { object, field_expr } => {
+                let _ = (object, field_expr);
+                Err(LoweringError::InvalidConstruct(
+                    "dynamic field access (value.(expr)) must be resolved at comptime before MIR lowering".into()
+                ))
+            }
+
             // Index access
             ExprKind::Index { object, index } => {
                 // Range index → slice operation: vec[start..end] or string[start..end]

--- a/compiler/crates/rask-mir/src/lower/mod.rs
+++ b/compiler/crates/rask-mir/src/lower/mod.rs
@@ -1254,6 +1254,10 @@ impl<'a> MirLowerer<'a> {
             ExprKind::Field { object, .. } => {
                 self.walk_free_vars(object, bound, seen, free);
             }
+            ExprKind::DynamicField { object, field_expr } => {
+                self.walk_free_vars(object, bound, seen, free);
+                self.walk_free_vars(field_expr, bound, seen, free);
+            }
             ExprKind::Index { object, index } => {
                 self.walk_free_vars(object, bound, seen, free);
                 self.walk_free_vars(index, bound, seen, free);

--- a/compiler/crates/rask-mir/src/lower/stmt.rs
+++ b/compiler/crates/rask-mir/src/lower/stmt.rs
@@ -939,7 +939,7 @@ impl<'a> MirLowerer<'a> {
                             || matches!(ty, rask_types::Type::UnresolvedGeneric { name, .. } if name == "Pool")
                     });
                     if obj_is_pool {
-                        return self.lower_for_pool_entries(label, names, object, body);
+                        return self.lower_for_pool_entries(label, names, object, body, mutate);
                     }
                 }
             }
@@ -954,6 +954,17 @@ impl<'a> MirLowerer<'a> {
             ) || matches!(
                 ty,
                 rask_types::Type::UnresolvedGeneric { name, .. } if name == "Pool"
+            )
+        });
+
+        // LP13: Detect Map iteration for correct writeback target.
+        let is_map = self.ctx.lookup_raw_type(iter_expr.id).map_or(false, |ty| {
+            matches!(
+                ty,
+                rask_types::Type::UnresolvedNamed(n) if n == "Map"
+            ) || matches!(
+                ty,
+                rask_types::Type::UnresolvedGeneric { name, .. } if name == "Map"
             )
         });
 
@@ -1096,6 +1107,8 @@ impl<'a> MirLowerer<'a> {
 
         // Tuple destructuring: for (a, b) in collection { ... }
         // Extract fields from the loaded element into each binding.
+        // LP13: Track value local for Map writeback (key=field0, value=field1).
+        let mut map_value_local = None;
         if let ForBinding::Tuple(names) = binding {
             for (i, name) in names.iter().enumerate() {
                 if i == 0 { continue; }
@@ -1110,6 +1123,10 @@ impl<'a> MirLowerer<'a> {
                         field_size: None,
                     },
                 }));
+                // Track value local (field 1) for Map writeback
+                if i == 1 && is_map {
+                    map_value_local = Some(field_local);
+                }
             }
             // Re-extract field 0 into the first binding (was whole tuple)
             let first_field = self.builder.alloc_temp(MirType::I64);
@@ -1144,33 +1161,58 @@ impl<'a> MirLowerer<'a> {
         self.emit_loop_cleanup(ensure_depth);
         self.builder.terminate(MirTerminator::dummy(MirTerminatorKind::Goto { target: continue_target }));
 
-        // Writeback blocks for `for mutate`: Vec_set(collection, idx, binding_local)
+        // Writeback blocks for `for mutate`
+        // LP13: Vec uses Vec_set(vec, idx, elem), Map uses Map_set(map, key, value)
         if let Some(wb) = wb_block {
-            // Normal/continue writeback → inc
             self.builder.switch_to_block(wb);
-            self.builder.push_stmt(MirStmt::dummy(MirStmtKind::Call {
-                dst: None,
-                func: FunctionRef::internal("Vec_set".to_string()),
-                args: vec![
-                    MirOperand::Local(collection),
-                    MirOperand::Local(idx),
-                    MirOperand::Local(binding_local),
-                ],
-            }));
+            if let Some(val_local) = map_value_local {
+                // Map writeback: Map_set(collection, key, value)
+                self.builder.push_stmt(MirStmt::dummy(MirStmtKind::Call {
+                    dst: None,
+                    func: FunctionRef::internal("Map_set".to_string()),
+                    args: vec![
+                        MirOperand::Local(collection),
+                        MirOperand::Local(binding_local), // key (field 0)
+                        MirOperand::Local(val_local),     // value (field 1)
+                    ],
+                }));
+            } else {
+                // Vec writeback: Vec_set(collection, idx, elem)
+                self.builder.push_stmt(MirStmt::dummy(MirStmtKind::Call {
+                    dst: None,
+                    func: FunctionRef::internal("Vec_set".to_string()),
+                    args: vec![
+                        MirOperand::Local(collection),
+                        MirOperand::Local(idx),
+                        MirOperand::Local(binding_local),
+                    ],
+                }));
+            }
             self.builder.terminate(MirTerminator::dummy(MirTerminatorKind::Goto { target: inc_block }));
         }
         if let Some(break_wb) = break_wb_block {
-            // Break writeback → exit
             self.builder.switch_to_block(break_wb);
-            self.builder.push_stmt(MirStmt::dummy(MirStmtKind::Call {
-                dst: None,
-                func: FunctionRef::internal("Vec_set".to_string()),
-                args: vec![
-                    MirOperand::Local(collection),
-                    MirOperand::Local(idx),
-                    MirOperand::Local(binding_local),
-                ],
-            }));
+            if let Some(val_local) = map_value_local {
+                self.builder.push_stmt(MirStmt::dummy(MirStmtKind::Call {
+                    dst: None,
+                    func: FunctionRef::internal("Map_set".to_string()),
+                    args: vec![
+                        MirOperand::Local(collection),
+                        MirOperand::Local(binding_local),
+                        MirOperand::Local(val_local),
+                    ],
+                }));
+            } else {
+                self.builder.push_stmt(MirStmt::dummy(MirStmtKind::Call {
+                    dst: None,
+                    func: FunctionRef::internal("Vec_set".to_string()),
+                    args: vec![
+                        MirOperand::Local(collection),
+                        MirOperand::Local(idx),
+                        MirOperand::Local(binding_local),
+                    ],
+                }));
+            }
             self.builder.terminate(MirTerminator::dummy(MirTerminatorKind::Goto { target: exit_block }));
         }
 
@@ -1199,12 +1241,14 @@ impl<'a> MirLowerer<'a> {
 
     /// Pool entries iteration: `for (h, val) in pool.entries()`
     /// Desugars to snapshot handle iteration with Pool_get for each handle.
+    /// LP11-LP13: `for mutate` adds Pool_set writeback.
     fn lower_for_pool_entries(
         &mut self,
         label: Option<&str>,
         names: &[String],
         pool_expr: &Expr,
         body: &[Stmt],
+        mutate: bool,
     ) -> Result<(), LoweringError> {
         let (pool_op, _) = self.lower_expr(pool_expr)?;
         let pool_local = self.builder.alloc_temp(MirType::I64);
@@ -1241,6 +1285,17 @@ impl<'a> MirLowerer<'a> {
         let inc_block = self.builder.create_block();
         let exit_block = self.builder.create_block();
 
+        // LP11-LP13: for mutate writeback blocks for Pool_set
+        let (wb_block, break_wb_block) = if mutate && names.len() > 1 {
+            let wb = self.builder.create_block();
+            let break_wb = self.builder.create_block();
+            (Some(wb), Some(break_wb))
+        } else {
+            (None, None)
+        };
+        let continue_target = wb_block.unwrap_or(inc_block);
+        let break_target = break_wb_block.unwrap_or(exit_block);
+
         self.builder.terminate(MirTerminator::dummy(MirTerminatorKind::Goto { target: check_block }));
 
         // check: _i < _len
@@ -1274,7 +1329,7 @@ impl<'a> MirLowerer<'a> {
         }));
 
         // Bind value (second name) via Pool_get
-        if names.len() > 1 {
+        let val_local = if names.len() > 1 {
             let val_name = &names[1];
             let val_local = self.builder.alloc_local(val_name.clone(), MirType::I64);
             self.locals.insert(val_name.clone(), (val_local, MirType::I64));
@@ -1283,13 +1338,16 @@ impl<'a> MirLowerer<'a> {
                 func: FunctionRef::internal("Pool_get".to_string()),
                 args: vec![MirOperand::Local(pool_local), MirOperand::Local(handle_local)],
             }));
-        }
+            Some(val_local)
+        } else {
+            None
+        };
 
         let ensure_depth = self.ensure_stack.len();
         self.loop_stack.push(LoopContext {
             label: label.map(|s| s.to_string()),
-            continue_block: inc_block,
-            exit_block,
+            continue_block: continue_target,
+            exit_block: break_target,
             result_local: None,
             ensure_depth,
         });
@@ -1299,7 +1357,35 @@ impl<'a> MirLowerer<'a> {
         }
         // EN7: run loop-scoped ensures at iteration end
         self.emit_loop_cleanup(ensure_depth);
-        self.builder.terminate(MirTerminator::dummy(MirTerminatorKind::Goto { target: inc_block }));
+        self.builder.terminate(MirTerminator::dummy(MirTerminatorKind::Goto { target: continue_target }));
+
+        // LP13: Pool_set writeback blocks for `for mutate`
+        if let (Some(wb), Some(vl)) = (wb_block, val_local) {
+            self.builder.switch_to_block(wb);
+            self.builder.push_stmt(MirStmt::dummy(MirStmtKind::Call {
+                dst: None,
+                func: FunctionRef::internal("Pool_set".to_string()),
+                args: vec![
+                    MirOperand::Local(pool_local),
+                    MirOperand::Local(handle_local),
+                    MirOperand::Local(vl),
+                ],
+            }));
+            self.builder.terminate(MirTerminator::dummy(MirTerminatorKind::Goto { target: inc_block }));
+        }
+        if let (Some(break_wb), Some(vl)) = (break_wb_block, val_local) {
+            self.builder.switch_to_block(break_wb);
+            self.builder.push_stmt(MirStmt::dummy(MirStmtKind::Call {
+                dst: None,
+                func: FunctionRef::internal("Pool_set".to_string()),
+                args: vec![
+                    MirOperand::Local(pool_local),
+                    MirOperand::Local(handle_local),
+                    MirOperand::Local(vl),
+                ],
+            }));
+            self.builder.terminate(MirTerminator::dummy(MirTerminatorKind::Goto { target: exit_block }));
+        }
 
         // inc: _i = _i + 1
         self.builder.switch_to_block(inc_block);

--- a/compiler/crates/rask-mono/src/instantiate.rs
+++ b/compiler/crates/rask-mono/src/instantiate.rs
@@ -382,6 +382,10 @@ impl TypeSubstitutor {
                     object: Box::new(self.clone_expr(object)),
                     field: field.clone(),
                 },
+                ExprKind::DynamicField { object, field_expr } => ExprKind::DynamicField {
+                    object: Box::new(self.clone_expr(object)),
+                    field_expr: Box::new(self.clone_expr(field_expr)),
+                },
                 ExprKind::OptionalField { object, field } => ExprKind::OptionalField {
                     object: Box::new(self.clone_expr(object)),
                     field: field.clone(),

--- a/compiler/crates/rask-mono/src/reachability.rs
+++ b/compiler/crates/rask-mono/src/reachability.rs
@@ -409,6 +409,10 @@ impl<'a> Monomorphizer<'a> {
             ExprKind::Field { object, .. } | ExprKind::OptionalField { object, .. } => {
                 self.visit_expr(object);
             }
+            ExprKind::DynamicField { object, field_expr } => {
+                self.visit_expr(object);
+                self.visit_expr(field_expr);
+            }
             ExprKind::Index { object, index } => {
                 self.visit_expr(object);
                 self.visit_expr(index);

--- a/compiler/crates/rask-ownership/src/lib.rs
+++ b/compiler/crates/rask-ownership/src/lib.rs
@@ -703,6 +703,10 @@ impl<'a> OwnershipChecker<'a> {
             ExprKind::Field { object, field: _ } => {
                 self.check_expr(object);
             }
+            ExprKind::DynamicField { object, field_expr } => {
+                self.check_expr(object);
+                self.check_expr(field_expr);
+            }
             ExprKind::OptionalField { object, field: _ } => {
                 self.check_expr(object);
             }

--- a/compiler/crates/rask-parser/src/parser.rs
+++ b/compiler/crates/rask-parser/src/parser.rs
@@ -954,6 +954,17 @@ impl Parser {
                 return Ok(format!("[]{}", elem_ty));
             }
 
+            // [N]T — fixed-count type (used by @binary byte arrays)
+            if let TokenKind::Int(n, _) = self.current_kind().clone() {
+                if matches!(self.peek(1), TokenKind::RBracket) {
+                    let count = n;
+                    self.advance(); // consume N
+                    self.advance(); // consume ]
+                    let elem_ty = self.parse_base_type()?;
+                    return Ok(format!("[{}]{}", count, elem_ty));
+                }
+            }
+
             let elem_ty = self.parse_type_name()?;
             self.expect(&TokenKind::Semi)?;
             let size = match self.current_kind().clone() {
@@ -3238,6 +3249,19 @@ impl Parser {
 
             TokenKind::Dot => {
                 self.advance();
+
+                // Dynamic field access: value.(expr) — comptime field name
+                if self.check(&TokenKind::LParen) {
+                    self.advance();
+                    let field_expr = self.parse_expr()?;
+                    self.expect(&TokenKind::RParen)?;
+                    let end = self.tokens[self.pos - 1].span.end;
+                    return Ok(Expr {
+                        id: self.next_id(),
+                        kind: ExprKind::DynamicField { object: Box::new(lhs), field_expr: Box::new(field_expr) },
+                        span: Span::new(start, end),
+                    });
+                }
 
                 // Tuple field access: expr.0, expr.1, ...
                 if let TokenKind::Int(n, None) = self.current_kind().clone() {

--- a/compiler/crates/rask-resolve/src/resolver.rs
+++ b/compiler/crates/rask-resolve/src/resolver.rs
@@ -1644,6 +1644,10 @@ impl Resolver {
             ExprKind::OptionalField { object, .. } => {
                 self.resolve_expr(object);
             }
+            ExprKind::DynamicField { object, field_expr } => {
+                self.resolve_expr(object);
+                self.resolve_expr(field_expr);
+            }
             ExprKind::Index { object, index } => {
                 self.resolve_expr(object);
                 self.resolve_expr(index);

--- a/compiler/crates/rask-resolve/src/resolver.rs
+++ b/compiler/crates/rask-resolve/src/resolver.rs
@@ -94,6 +94,7 @@ impl Resolver {
             ("Error", BuiltinTypeKind::Error),
             ("Channel", BuiltinTypeKind::Channel),
             ("Pool", BuiltinTypeKind::Pool),
+            ("Cell", BuiltinTypeKind::Cell),
             ("Handle", BuiltinTypeKind::Handle),
             ("Atomic", BuiltinTypeKind::Atomic),
             ("AtomicBool", BuiltinTypeKind::Atomic),

--- a/compiler/crates/rask-resolve/src/symbol.rs
+++ b/compiler/crates/rask-resolve/src/symbol.rs
@@ -115,6 +115,8 @@ pub enum BuiltinTypeKind {
     Channel,
     /// Pool<T> - arena allocator for graph structures
     Pool,
+    /// Cell<T> - single heap-allocated mutable value (CE1-CE6)
+    Cell,
     /// Handle<T> - typed reference into a Pool<T>
     Handle,
     /// Atomic<T> - atomic operations

--- a/compiler/crates/rask-semantic-hash/src/hasher.rs
+++ b/compiler/crates/rask-semantic-hash/src/hasher.rs
@@ -578,6 +578,11 @@ impl Hasher {
                 self.hash_expr(object);
                 self.feed_str(field);
             }
+            ExprKind::DynamicField { object, field_expr } => {
+                self.feed_tag(96);
+                self.hash_expr(object);
+                self.hash_expr(field_expr);
+            }
             ExprKind::OptionalField { object, field } => {
                 self.feed_tag(52);
                 self.hash_expr(object);

--- a/compiler/crates/rask-types/src/checker/check_expr.rs
+++ b/compiler/crates/rask-types/src/checker/check_expr.rs
@@ -1638,6 +1638,14 @@ impl TypeChecker {
             if let Some(ty) = Self::primitive_type_constant(name, field) {
                 return ty;
             }
+            // G4: @binary struct SIZE/SIZE_BITS constants
+            if matches!(field, "SIZE" | "SIZE_BITS") {
+                if let Some(type_id) = self.types.get_type_id(name) {
+                    if self.types.is_binary_type_by_id(type_id) {
+                        return Type::U64;
+                    }
+                }
+            }
         }
 
         let obj_ty_raw = self.infer_expr(object);

--- a/compiler/crates/rask-types/src/checker/check_expr.rs
+++ b/compiler/crates/rask-types/src/checker/check_expr.rs
@@ -141,6 +141,14 @@ impl TypeChecker {
 
             ExprKind::Field { object, field } => self.check_field_access(object, field, expr.span),
 
+            ExprKind::DynamicField { object, field_expr } => {
+                // Infer both sub-expressions; actual comptime field resolution
+                // happens in the comptime pass — here we just type-check children.
+                let _obj_ty = self.infer_expr(object);
+                let _field_ty = self.infer_expr(field_expr);
+                Type::Error
+            }
+
             ExprKind::Index { object, index } => {
                 let raw_obj_ty = self.infer_expr(object);
                 let _idx_ty = self.infer_expr(index);

--- a/compiler/crates/rask-types/src/checker/declarations.rs
+++ b/compiler/crates/rask-types/src/checker/declarations.rs
@@ -3,13 +3,14 @@
 
 use rask_ast::decl::{Decl, DeclKind, EnumDecl, FnDecl, ImplDecl, StructDecl, TraitDecl, UnionDecl, TypeAliasDecl};
 use rask_resolve::SymbolKind;
-use super::type_defs::{TypeDef, MethodSig, SelfParam, ParamMode};
+use super::type_defs::{TypeDef, MethodSig, SelfParam, ParamMode, BinaryFieldSpec, BinaryStructInfo, Endian};
 use super::errors::TypeError;
 use super::inference::TypeConstraint;
 use super::parse_type::parse_type_string;
 use super::TypeChecker;
 
 use crate::types::Type;
+use rask_ast::Span;
 
 impl TypeChecker {
     // ------------------------------------------------------------------------
@@ -48,6 +49,7 @@ impl TypeChecker {
         }
         self.propagate_uniqueness();
         self.auto_derive_traits();
+        self.register_binary_methods();
 
         // GC1/GC2: Pre-register type vars for functions with inferred params/returns
         self.pre_register_inferred_fns(decls);
@@ -161,15 +163,40 @@ impl TypeChecker {
         let type_params: Vec<String> = s.type_params.iter().map(|p| p.name.clone()).collect();
         let is_resource = s.attrs.iter().any(|a| a == "resource");
         let is_unique = s.attrs.iter().any(|a| a == "unique");
-        self.types.register_type(TypeDef::Struct {
+        let is_binary = s.attrs.iter().any(|a| a == "binary");
+
+        // For @binary structs, convert binary field specifiers to runtime types
+        let (fields, binary_info) = if is_binary {
+            let result = parse_binary_struct_fields(&s.name, &s.fields);
+            match result {
+                Ok((typed_fields, info)) => {
+                    (typed_fields, Some(info))
+                }
+                Err(errors) => {
+                    for err in errors {
+                        self.errors.push(err);
+                    }
+                    (fields, None)
+                }
+            }
+        } else {
+            (fields, None)
+        };
+
+        let type_id = self.types.register_type(TypeDef::Struct {
             name: s.name.clone(),
             type_params,
             fields,
             methods,
             is_resource,
             is_unique,
+            is_binary,
             private_fields,
         });
+
+        if let Some(info) = binary_info {
+            self.types.register_binary_info(type_id, info);
+        }
     }
 
     pub(super) fn register_enum(&mut self, e: &EnumDecl) {
@@ -687,4 +714,204 @@ impl TypeChecker {
             _ => {}
         }
     }
+
+    /// G1–G4: Register parse/build/build_into methods and SIZE/SIZE_BITS for @binary structs.
+    fn register_binary_methods(&mut self) {
+        use crate::types::TypeId;
+
+        let type_count = self.types.types.len();
+        for idx in 0..type_count {
+            let id = TypeId(idx as u32);
+            if !self.types.is_binary_type_by_id(id) {
+                continue;
+            }
+
+            let struct_type = Type::Named(id);
+
+            // G1: parse(data: []u8) -> (T, []u8) or ParseError
+            let parse_result = Type::Result {
+                ok: Box::new(Type::Tuple(vec![
+                    struct_type.clone(),
+                    Type::Slice(Box::new(Type::U8)),
+                ])),
+                err: Box::new(Type::UnresolvedNamed("ParseError".to_string())),
+            };
+
+            // G2: build(self) -> Vec<u8>
+            let vec_u8 = Type::UnresolvedGeneric {
+                name: "Vec".to_string(),
+                args: vec![crate::types::GenericArg::Type(Box::new(Type::U8))],
+            };
+
+            // G3: build_into(self, buffer: []u8) -> usize or BuildError
+            let build_into_result = Type::Result {
+                ok: Box::new(Type::U64), // usize
+                err: Box::new(Type::UnresolvedNamed("BuildError".to_string())),
+            };
+
+            let mut methods = vec![
+                MethodSig {
+                    name: "parse".to_string(),
+                    self_param: SelfParam::None,
+                    params: vec![(Type::Slice(Box::new(Type::U8)), ParamMode::Default)],
+                    ret: parse_result,
+                },
+                MethodSig {
+                    name: "build".to_string(),
+                    self_param: SelfParam::Value,
+                    params: vec![],
+                    ret: vec_u8,
+                },
+                MethodSig {
+                    name: "build_into".to_string(),
+                    self_param: SelfParam::Value,
+                    params: vec![(Type::Slice(Box::new(Type::U8)), ParamMode::Mutate)],
+                    ret: build_into_result,
+                },
+            ];
+
+            if let Some(TypeDef::Struct { methods: existing, .. }) = self.types.get_mut(id) {
+                existing.append(&mut methods);
+            }
+        }
+    }
+}
+
+/// Parse a binary field type specifier and return (bits, endian, runtime_type).
+fn parse_binary_field_spec(ty_str: &str) -> Result<(u32, Option<Endian>, Type, bool, usize), String> {
+    let s = ty_str.trim();
+
+    // [N]u8 — fixed byte array
+    if s.starts_with('[') {
+        let bracket_end = s.find(']').ok_or_else(|| format!("invalid binary type: {}", s))?;
+        let count_str = &s[1..bracket_end];
+        let elem_str = &s[bracket_end + 1..];
+        if elem_str != "u8" {
+            return Err(format!("binary byte arrays only support u8, found [{}]{}", count_str, elem_str));
+        }
+        let count: usize = count_str.parse()
+            .map_err(|_| format!("invalid byte array count: {}", count_str))?;
+        let bits = (count as u32) * 8;
+        return Ok((bits, None, Type::Array { elem: Box::new(Type::U8), len: count }, true, count));
+    }
+
+    // Bare number — N bits
+    if let Ok(n) = s.parse::<u32>() {
+        if n == 0 || n > 64 {
+            return Err(format!("bit count must be >= 1 and <= 64, found {}", n));
+        }
+        let runtime_type = match n {
+            1..=8 => Type::U8,
+            9..=16 => Type::U16,
+            17..=32 => Type::U32,
+            33..=64 => Type::U64,
+            _ => unreachable!(),
+        };
+        return Ok((n, None, runtime_type, false, 0));
+    }
+
+    // Endian types: u16be, i32le, f64be, etc.
+    let (base, endian) = if let Some(base) = s.strip_suffix("be") {
+        (base, Endian::Big)
+    } else if let Some(base) = s.strip_suffix("le") {
+        (base, Endian::Little)
+    } else {
+        // Non-endian types: u8, i8
+        return match s {
+            "u8" => Ok((8, None, Type::U8, false, 0)),
+            "i8" => Ok((8, None, Type::I8, false, 0)),
+            _ => Err(format!("multi-byte field '{}' must specify endianness (be/le)", s)),
+        };
+    };
+
+    let (bits, runtime_type) = match base {
+        "u16" => (16, Type::U16),
+        "i16" => (16, Type::I16),
+        "u32" => (32, Type::U32),
+        "i32" => (32, Type::I32),
+        "u64" => (64, Type::U64),
+        "i64" => (64, Type::I64),
+        "f32" => (32, Type::F32),
+        "f64" => (64, Type::F64),
+        _ => return Err(format!("unknown binary type: {}", s)),
+    };
+
+    Ok((bits, Some(endian), runtime_type, false, 0))
+}
+
+/// B1–V4: Parse and validate all fields of a @binary struct.
+fn parse_binary_struct_fields(
+    struct_name: &str,
+    fields: &[rask_ast::decl::Field],
+) -> Result<(Vec<(String, Type)>, BinaryStructInfo), Vec<TypeError>> {
+    let mut errors = Vec::new();
+    let mut typed_fields = Vec::new();
+    let mut binary_fields = Vec::new();
+    let mut bit_offset: u32 = 0;
+
+    for field in fields {
+        match parse_binary_field_spec(&field.ty) {
+            Ok((bits, endian, runtime_type, is_byte_array, byte_array_len)) => {
+                // F3: multi-byte endian types must be byte-aligned
+                if endian.is_some() && bits > 8 && (bit_offset % 8) != 0 {
+                    errors.push(TypeError::GenericError(
+                        format!(
+                            "[type.binary/F3] endian type '{}' not byte-aligned: starts at bit {}, not a byte boundary",
+                            field.ty, bit_offset
+                        ),
+                        field.name_span,
+                    ));
+                }
+
+                // V1: bit count range
+                if !is_byte_array && (bits == 0 || bits > 64) {
+                    errors.push(TypeError::GenericError(
+                        format!("[type.binary/V1] invalid bit count: {} (must be 1-64)", bits),
+                        field.name_span,
+                    ));
+                }
+
+                typed_fields.push((field.name.clone(), runtime_type.clone()));
+                binary_fields.push(BinaryFieldSpec {
+                    name: field.name.clone(),
+                    bits,
+                    endian,
+                    runtime_type,
+                    bit_offset,
+                    is_byte_array,
+                    byte_array_len,
+                });
+                bit_offset += bits;
+            }
+            Err(msg) => {
+                errors.push(TypeError::GenericError(msg, field.name_span));
+                typed_fields.push((field.name.clone(), Type::Error));
+            }
+        }
+    }
+
+    // V3: total size limit (65535 bits = 8KB)
+    if bit_offset > 65535 {
+        errors.push(TypeError::GenericError(
+            format!(
+                "[type.binary/V3] total size {} bits exceeds 65535-bit limit (8KB)",
+                bit_offset
+            ),
+            Span::new(0, 0),
+        ));
+    }
+
+    if !errors.is_empty() {
+        return Err(errors);
+    }
+
+    let size_bytes = (bit_offset + 7) / 8;
+    let info = BinaryStructInfo {
+        name: struct_name.to_string(),
+        fields: binary_fields,
+        total_bits: bit_offset,
+        size_bytes,
+    };
+
+    Ok((typed_fields, info))
 }

--- a/compiler/crates/rask-types/src/checker/resolve.rs
+++ b/compiler/crates/rask-types/src/checker/resolve.rs
@@ -420,7 +420,7 @@ impl TypeChecker {
                 self.resolve_simd_method(name, &method, &args, &ret, span)
             }
             // Shared<T>, Sender<T>, Receiver<T>, Channel<T>
-            Type::UnresolvedGeneric { name, args: type_args } if matches!(name.as_str(), "Shared" | "Mutex" | "Sender" | "Receiver" | "Channel") => {
+            Type::UnresolvedGeneric { name, args: type_args } if matches!(name.as_str(), "Cell" | "Shared" | "Mutex" | "Sender" | "Receiver" | "Channel") => {
                 self.resolve_concurrency_generic_method(name, &type_args, &method, &args, &ret, span)
             }
             // Builtin runtime types: Instant, Duration, TcpListener, TcpConnection, Shared (bare)
@@ -966,6 +966,15 @@ impl TypeChecker {
                 };
                 self.unify(ret, &shared_ty, span)
             }
+            // Cell static constructor: Cell.new(value) -> Cell<T>
+            ("Cell", "new") if args.len() == 1 => {
+                let inner = args[0].clone();
+                let cell_ty = Type::UnresolvedGeneric {
+                    name: "Cell".to_string(),
+                    args: vec![GenericArg::Type(Box::new(inner))],
+                };
+                self.unify(ret, &cell_ty, span)
+            }
             // Mutex static constructor: Mutex.new(value) -> Mutex<T>
             ("Mutex", "new") if args.len() == 1 => {
                 let inner = args[0].clone();
@@ -1057,6 +1066,24 @@ impl TypeChecker {
                     args: type_args.to_vec(),
                 };
                 self.unify(ret, &shared_ty, span)
+            }
+            // Cell<T>.get() -> T (CE6: Copy types only, not enforced in type checker)
+            ("Cell", "get") if args.is_empty() => {
+                self.unify(ret, &inner_type, span)
+            }
+            // Cell<T>.set(value: T) -> ()
+            ("Cell", "set") if args.len() == 1 => {
+                let _ = self.unify(&args[0], &inner_type, span);
+                self.unify(ret, &Type::Unit, span)
+            }
+            // Cell<T>.replace(value: T) -> T
+            ("Cell", "replace") if args.len() == 1 => {
+                let _ = self.unify(&args[0], &inner_type, span);
+                self.unify(ret, &inner_type, span)
+            }
+            // Cell<T>.into_inner() -> T (consumes cell)
+            ("Cell", "into_inner") if args.is_empty() => {
+                self.unify(ret, &inner_type, span)
             }
             // Mutex<T>.lock() -> T  (inline access, E5/MX3)
             ("Mutex", "lock") if args.is_empty() => {

--- a/compiler/crates/rask-types/src/checker/type_defs.rs
+++ b/compiler/crates/rask-types/src/checker/type_defs.rs
@@ -21,6 +21,8 @@ pub enum TypeDef {
         is_resource: bool,
         /// U1–U4: marked @unique — no implicit copy even if small enough
         is_unique: bool,
+        /// B1–G4: @binary struct for wire-format parsing/building
+        is_binary: bool,
         /// V5: fields marked `private` — accessible only inside extend blocks
         private_fields: Vec<String>,
     },
@@ -80,6 +82,37 @@ pub struct ModuleMethodSig {
     pub name: String,
     pub params: Vec<Type>,
     pub ret: Type,
+}
+
+/// Endianness for multi-byte binary fields.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Endian {
+    Big,
+    Little,
+}
+
+/// A single field's binary layout specifier.
+#[derive(Debug, Clone)]
+pub struct BinaryFieldSpec {
+    pub name: String,
+    pub bits: u32,
+    pub endian: Option<Endian>,
+    pub runtime_type: Type,
+    /// Byte offset within the struct where this field's bits start
+    pub bit_offset: u32,
+    /// Whether this is a fixed byte array ([N]u8)
+    pub is_byte_array: bool,
+    pub byte_array_len: usize,
+}
+
+/// Metadata for a @binary struct.
+#[derive(Debug, Clone)]
+pub struct BinaryStructInfo {
+    pub name: String,
+    pub fields: Vec<BinaryFieldSpec>,
+    pub total_bits: u32,
+    /// SIZE in bytes (rounded up)
+    pub size_bytes: u32,
 }
 
 /// Result of type checking.

--- a/compiler/crates/rask-types/src/checker/type_table.rs
+++ b/compiler/crates/rask-types/src/checker/type_table.rs
@@ -4,7 +4,7 @@
 use std::collections::HashMap;
 
 use super::builtins::BuiltinModules;
-use super::type_defs::TypeDef;
+use super::type_defs::{BinaryStructInfo, TypeDef};
 use super::errors::TypeError;
 
 use crate::types::{GenericArg, Type, TypeId, TypeVarId};
@@ -26,6 +26,8 @@ pub struct TypeTable {
     pub(super) result_type_id: Option<TypeId>,
     /// Builtin modules registry.
     pub(super) builtin_modules: BuiltinModules,
+    /// B1–G4: binary struct metadata indexed by TypeId
+    pub binary_structs: HashMap<TypeId, BinaryStructInfo>,
 }
 
 impl TypeTable {
@@ -38,6 +40,7 @@ impl TypeTable {
             option_type_id: None,
             result_type_id: None,
             builtin_modules: BuiltinModules::new(),
+            binary_structs: HashMap::new(),
         };
         table.register_builtins();
         table
@@ -223,6 +226,24 @@ impl TypeTable {
             return *is_unique;
         }
         false
+    }
+
+    /// Check if a TypeId refers to a `@binary` struct.
+    pub fn is_binary_type_by_id(&self, id: TypeId) -> bool {
+        if let Some(TypeDef::Struct { is_binary, .. }) = self.types.get(id.0 as usize) {
+            return *is_binary;
+        }
+        false
+    }
+
+    /// Store binary struct metadata.
+    pub fn register_binary_info(&mut self, id: TypeId, info: BinaryStructInfo) {
+        self.binary_structs.insert(id, info);
+    }
+
+    /// Get binary struct metadata.
+    pub fn get_binary_info(&self, id: TypeId) -> Option<&BinaryStructInfo> {
+        self.binary_structs.get(&id)
     }
 
     /// Get TypeId for the builtin Option<T> enum.

--- a/compiler/runtime/pool.c
+++ b/compiler/runtime/pool.c
@@ -255,6 +255,14 @@ void *rask_pool_get_checked(const RaskPool *p, int64_t packed,
     return result;
 }
 
+// LP13: Write value back to an existing pool slot (for mutate writeback).
+void rask_pool_set_packed(RaskPool *p, int64_t packed, const void *value) {
+    RaskHandle h = handle_unpack(p, packed);
+    if (!pool_validate(p, h)) return;
+    void *dst = slot_data(slot_at(p, h.index));
+    memcpy(dst, value, (size_t)p->elem_size);
+}
+
 int64_t rask_pool_remove_packed(RaskPool *p, int64_t packed) {
     return rask_pool_remove(p, handle_unpack(p, packed), NULL);
 }


### PR DESCRIPTION
<![CDATA[## Summary

- **`@binary` structs (B1–G4):** Parser, type checker, interpreter — full parse/build/build_into with bit-level MSB-first packing, plus `T.SIZE`/`T.SIZE_BITS` comptime constants
- **`Cell<T>` (CE1–CE6):** Heap-allocated mutable container with `Cell.new()`, `.get()`, `.set()`, `.replace()`, `.into_inner()`, and `with...as` exclusive access
- **`comptime for` + field reflection (CT48–CT54):** `value.(expr)` dynamic field access syntax, `std.reflect` module with `reflect.fields<T>()` returning `[]FieldInfo`
- **`for mutate` Pool/Map MIR (LP11–LP13):** Pool writeback via `Pool_set`, Map writeback via `Map_set`, C runtime `rask_pool_set_packed()`, non-mutating Map iteration added
- **Pool API gaps:** `try_insert`, `drain`, `entries`, `get_unchecked`
- **Concurrency gaps:** `join_all`, `Timer.after`, `Timer.interval`

37 files changed, +1630 −36 lines. 214 spec tests pass, 0 failures.

## Test plan

- [x] `@binary` IP header round-trips through build→parse (20 bytes, all field types)
- [x] `@binary` SIZE/SIZE_BITS constants (`IpHeader.SIZE == 20`, `IpHeader.SIZE_BITS == 160`)
- [x] `Cell<T>` full lifecycle: new → get → set → with...as → replace → into_inner
- [x] `reflect.fields<T>()` returns correct field names/types, `value.(field.name)` accesses fields
- [x] `comptime for field in reflect.fields<Point>()` iterates and prints all fields
- [x] `for mutate` Vec writeback (existing, still works)
- [x] Non-mutating `for (k, v) in map` iteration (was missing, now works)
- [x] 214 spec tests pass

https://claude.ai/code/session_014XB6xgRFUwhhJXVoe7SMpJ]]>