### PR TITLE
Refactor stdlib: formatting, string builders, and code style

### DIFF
--- a/stdlib/encoding.rk
+++ b/stdlib/encoding.rk
@@ -1,0 +1,35 @@
+// SPDX-License-Identifier: (MIT OR Apache-2.0)
+
+// Encoding: marker traits for format-agnostic serialization.
+//
+// Encode and Decode are marker traits with no methods (E11). They signal
+// that a type's structure is serialization-compatible. Format libraries
+// (JSON, TOML, MessagePack) use comptime for + reflect to serialize any
+// compatible struct with zero user ceremony.
+//
+// Auto-derive (E12): the compiler derives Encode for any struct where all
+// public fields have Encode types, unless @no_encode. Same for Decode.
+// Public fields only (E13). Enums auto-derive when all variant payloads
+// are compatible (E17).
+//
+// Base types (E14): bool, i8–i64, u8–u64, f32, f64, string.
+// Collection types (E15): Vec<T: Encode>, Map<string, T: Encode>, T?.
+//
+// Field annotations:
+//   @rename("name")      — override serialized key name (E18)
+//   @skip                — exclude from serialization (E19)
+//   @default(expr)       — comptime fallback for missing fields on decode (E20)
+//   @no_encode           — opt out of auto-derive for Encode (E16)
+//   @no_decode           — opt out of auto-derive for Decode (E16)
+
+// ─── Marker Traits ──────────────────────────────────────────────
+
+/// Type is serialization-compatible. Auto-derived for structs with all
+/// public fields Encode, unless @no_encode.
+public trait Encode {
+}
+
+/// Type can be deserialized. Auto-derived for structs with all public
+/// fields Decode, unless @no_decode.
+public trait Decode {
+}

--- a/stdlib/fmt.rk
+++ b/stdlib/fmt.rk
@@ -1,0 +1,34 @@
+// SPDX-License-Identifier: (MIT OR Apache-2.0)
+
+// String formatting: Displayable and Debug traits, format() function.
+//
+// format(template, args...) is compiler-known (CM1) — it accepts variadic
+// arguments through compiler support, not a general variadic mechanism.
+// The compiler parses the template at compile time (CM2), type-checks each
+// argument against its placeholder (CM3), and generates specialized
+// string-building code per call site (CM5).
+
+// ─── Displayable ────────────────────────────────────────────────
+
+/// User-facing string representation. Structs must opt in via
+/// `extend Type with Displayable`. Primitives implement it by default (D2).
+///
+/// format("{}", x) calls to_string() — compile error if not implemented (D4).
+///
+/// Error bridge (D5): types with message(self) -> string auto-satisfy
+/// Displayable — to_string() delegates to message(). No boilerplate for
+/// error types in format("{}", err).
+public trait Displayable {
+    func to_string(self) -> string
+}
+
+// ─── Debug ──────────────────────────────────────────────────────
+
+/// Developer-facing representation. Auto-derived for all types (G2).
+/// Override via `extend Type with Debug` (G3).
+///
+/// format("{:?}", x) calls debug_string() (G4).
+/// Auto-derived output shows struct fields and enum variants.
+public trait Debug {
+    func debug_string(self) -> string
+}

--- a/stdlib/json.rk
+++ b/stdlib/json.rk
@@ -31,34 +31,43 @@ extend JsonValue {
     }
 
     public func as_bool(self) -> bool? {
-        if self is Bool(b) { return Some(b) }
+        if self is Bool(b) {
+            return Some(b)
+        }
         return None
     }
 
     public func as_number(self) -> f64? {
-        if self is Number(n) { return Some(n) }
+        if self is Number(n) {
+            return Some(n)
+        }
         return None
     }
 
     public func as_string(self) -> string? {
-        if self is String(s) { return Some(s) }
+        if self is String(s) {
+            return Some(s)
+        }
         return None
     }
 
     public func as_array(self) -> Vec<JsonValue>? {
-        if self is Array(a) { return Some(a) }
+        if self is Array(a) {
+            return Some(a)
+        }
         return None
     }
 
     public func as_object(self) -> Map<string, JsonValue>? {
-        if self is Object(m) { return Some(m) }
+        if self is Object(m) {
+            return Some(m)
+        }
         return None
     }
 }
 
 // ─── Parser internals ────────────────────────────────────────────
 
-// Parser state: input string + current byte position.
 struct JsonParser {
     input: string
     pos: usize
@@ -74,32 +83,32 @@ extend JsonParser {
         }
     }
 
-    // Peek at the current byte without advancing.
     func peek(self) -> u8 {
-        if self.pos >= self.len { return 0 }
+        if self.pos >= self.len {
+            return 0
+        }
         return self.input.byte_at(self.pos)
     }
 
-    // Advance one byte and return it.
     func advance(mutate self) -> u8 {
-        if self.pos >= self.len { return 0 }
+        if self.pos >= self.len {
+            return 0
+        }
         const b = self.input.byte_at(self.pos)
-        self.pos += 1
+        self.pos = self.pos + 1
         return b
     }
 
-    // Skip past ASCII whitespace (space, tab, newline, carriage return).
     func skip_ws(mutate self) {
         while self.pos < self.len {
             const b = self.input.byte_at(self.pos)
             if b != 32 && b != 9 && b != 10 && b != 13 {
                 return
             }
-            self.pos += 1
+            self.pos = self.pos + 1
         }
     }
 
-    // Expect a specific byte, returning error if not found.
     func expect(mutate self, expected: u8) -> () or JsonError {
         self.skip_ws()
         if self.pos >= self.len {
@@ -112,7 +121,6 @@ extend JsonParser {
         return Ok(())
     }
 
-    // Parse a complete JSON value.
     func parse_value(mutate self) -> JsonValue or JsonError {
         self.skip_ws()
         if self.pos >= self.len {
@@ -121,81 +129,77 @@ extend JsonParser {
 
         const b = self.peek()
 
-        // Object
-        if b == 123 { return self.parse_object() }
-        // Array
-        if b == 91 { return self.parse_array() }
-        // String
-        if b == 34 { return self.parse_string_value() }
-        // true
-        if b == 116 { return self.parse_true() }
-        // false
-        if b == 102 { return self.parse_false() }
-        // null
-        if b == 110 { return self.parse_null() }
-        // Number: digit or minus sign
-        if b == 45 || (b >= 48 && b <= 57) {
+        if b == 123 {
+            return self.parse_object()
+        }
+        if b == 91 {
+            return self.parse_array()
+        }
+        if b == 34 {
+            return self.parse_string_value()
+        }
+        if b == 116 {
+            return self.parse_true()
+        }
+        if b == 102 {
+            return self.parse_false()
+        }
+        if b == 110 {
+            return self.parse_null()
+        }
+        if b == 45 || b >= 48 && b <= 57 {
             return self.parse_number()
         }
 
         return Err(JsonError.ParseError("unexpected character at position {self.pos}"))
     }
 
-    // Parse a JSON object: { "key": value, ... }
     func parse_object(mutate self) -> JsonValue or JsonError {
-        self.pos += 1  // skip '{'
+        self.pos = self.pos + 1
         self.skip_ws()
 
         let map = Map<string, JsonValue>.new()
 
-        // Empty object
         if self.peek() == 125 {
-            self.pos += 1
+            self.pos = self.pos + 1
             return Ok(JsonValue.Object(map))
         }
 
         loop {
             self.skip_ws()
-
-            // Parse key (must be a string)
             if self.peek() != 34 {
                 return Err(JsonError.ParseError("expected string key in object"))
             }
             const key = try self.parse_raw_string()
-
-            // Expect colon
             self.skip_ws()
             if self.advance() != 58 {
                 return Err(JsonError.ParseError("expected ':' after object key"))
             }
-
-            // Parse value
             const value = try self.parse_value()
-
             // Last value wins for duplicate keys (J5)
             map.insert(key, value)
 
             self.skip_ws()
             const next = self.advance()
-            // comma — continue
-            if next == 44 { continue }
-            // closing brace — done
-            if next == 125 { return Ok(JsonValue.Object(map)) }
+            if next == 44 {
+                continue
+            }
+            if next == 125 {
+                return Ok(JsonValue.Object(map))
+            }
 
             return Err(JsonError.ParseError("expected ',' or '}' in object"))
         }
     }
 
-    // Parse a JSON array: [ value, ... ]
     func parse_array(mutate self) -> JsonValue or JsonError {
-        self.pos += 1  // skip '['
+        self.pos = self.pos + 1
         self.skip_ws()
 
         let arr = Vec<JsonValue>.new()
 
-        // Empty array
         if self.peek() == 93 {
-            self.pos += 1
+            self.pos = self.pos + 1
             return Ok(JsonValue.Array(arr))
         }
 
@@ -205,63 +209,64 @@ extend JsonParser {
 
             self.skip_ws()
             const next = self.advance()
-            // comma — continue
-            if next == 44 { continue }
-            // closing bracket — done
-            if next == 93 { return Ok(JsonValue.Array(arr)) }
+            if next == 44 {
+                continue
+            }
+            if next == 93 {
+                return Ok(JsonValue.Array(arr))
+            }
 
             return Err(JsonError.ParseError("expected ',' or ']' in array"))
         }
     }
 
-    // Parse a JSON string, returning the raw string content.
     func parse_raw_string(mutate self) -> string or JsonError {
         if self.advance() != 34 {
             return Err(JsonError.ParseError("expected '\"'"))
         }
 
-        let result = string.new()
+        let b = string_builder.new()
 
         while self.pos < self.len {
-            const b = self.advance()
-
-            // End of string
-            if b == 34 {
-                return Ok(result)
+            const byte = self.advance()
+            if byte == 34 {
+                return Ok(b.build())
             }
-
-            // Escape sequence
-            if b == 92 {
+            if byte == 92 {
                 if self.pos >= self.len {
                     return Err(JsonError.ParseError("unterminated escape sequence"))
                 }
                 const esc = self.advance()
-                if esc == 34 { result.push('"') }
-                else if esc == 92 { result.push('\\') }
-                else if esc == 47 { result.push('/') }
-                else if esc == 110 { result.push('\n') }
-                else if esc == 114 { result.push('\r') }
-                else if esc == 116 { result.push('\t') }
-                else if esc == 98 { result.push(8 as char) }
-                else if esc == 102 { result.push(12 as char) }
-                else if esc == 117 {
-                    // \uXXXX unicode escape — parse 4 hex digits
+                if esc == 34 {
+                    b.append_char('"')
+                } else if esc == 92 {
+                    b.append_char('\\')
+                } else if esc == 47 {
+                    b.append_char('/')
+                } else if esc == 110 {
+                    b.append_char('\n')
+                } else if esc == 114 {
+                    b.append_char('\r')
+                } else if esc == 116 {
+                    b.append_char('\t')
+                } else if esc == 98 {
+                    b.append_char(8 as char)
+                } else if esc == 102 {
+                    b.append_char(12 as char)
+                } else if esc == 117 {
                     const cp = try self.parse_unicode_escape()
-                    result.push(cp)
+                    b.append_char(cp)
                 } else {
                     return Err(JsonError.ParseError("invalid escape character"))
                 }
                 continue
             }
-
-            // Regular byte
-            result.push(b as char)
+            b.append_char(byte as char)
         }
 
         return Err(JsonError.ParseError("unterminated string"))
     }
 
-    // Parse 4 hex digits after \u, return the codepoint as a char.
     func parse_unicode_escape(mutate self) -> char or JsonError {
         if self.pos + 4 > self.len {
             return Err(JsonError.ParseError("incomplete unicode escape"))
@@ -275,70 +280,65 @@ extend JsonParser {
                 return Err(JsonError.ParseError("invalid hex digit in unicode escape"))
             }
             cp = cp * 16 + digit as u32
-            i += 1
+            i = i + 1
         }
         return Ok(cp as char)
     }
 
-    // Parse a JSON string as a JsonValue.
     func parse_string_value(mutate self) -> JsonValue or JsonError {
         const s = try self.parse_raw_string()
         return Ok(JsonValue.String(s))
     }
 
-    // Parse "true".
     func parse_true(mutate self) -> JsonValue or JsonError {
         if self.pos + 4 > self.len {
             return Err(JsonError.ParseError("unexpected end of input"))
         }
         if self.input[self.pos..self.pos + 4] == "true" {
-            self.pos += 4
+            self.pos = self.pos + 4
             return Ok(JsonValue.Bool(true))
         }
         return Err(JsonError.ParseError("invalid token"))
     }
 
-    // Parse "false".
     func parse_false(mutate self) -> JsonValue or JsonError {
         if self.pos + 5 > self.len {
             return Err(JsonError.ParseError("unexpected end of input"))
         }
         if self.input[self.pos..self.pos + 5] == "false" {
-            self.pos += 5
+            self.pos = self.pos + 5
             return Ok(JsonValue.Bool(false))
         }
         return Err(JsonError.ParseError("invalid token"))
     }
 
-    // Parse "null".
     func parse_null(mutate self) -> JsonValue or JsonError {
         if self.pos + 4 > self.len {
             return Err(JsonError.ParseError("unexpected end of input"))
         }
         if self.input[self.pos..self.pos + 4] == "null" {
-            self.pos += 4
+            self.pos = self.pos + 4
             return Ok(JsonValue.Null)
         }
         return Err(JsonError.ParseError("invalid token"))
     }
 
-    // Parse a JSON number (integer or float).
     func parse_number(mutate self) -> JsonValue or JsonError {
         const start = self.pos
 
-        // Optional minus
-        if self.peek() == 45 { self.pos += 1 }
+        if self.peek() == 45 {
+            self.pos = self.pos + 1
+        }
 
-        // Integer part
         if self.pos >= self.len {
             return Err(JsonError.ParseError("unexpected end in number"))
         }
+        // Leading zero — only valid as "0" or "0.xxx"
         if self.peek() == 48 {
-            // Leading zero — only valid as "0" or "0.xxx"
-            self.pos += 1
+            self.pos = self.pos + 1
         } else if self.peek() >= 49 && self.peek() <= 57 {
             while self.pos < self.len && self.peek() >= 48 && self.peek() <= 57 {
-                self.pos += 1
+                self.pos = self.pos + 1
             }
         } else {
             return Err(JsonError.ParseError("invalid number"))
@@ -346,26 +346,26 @@ extend JsonParser {
 
         // Fractional part
         if self.pos < self.len && self.peek() == 46 {
-            self.pos += 1
+            self.pos = self.pos + 1
             if self.pos >= self.len || self.peek() < 48 || self.peek() > 57 {
                 return Err(JsonError.ParseError("expected digit after decimal point"))
             }
             while self.pos < self.len && self.peek() >= 48 && self.peek() <= 57 {
-                self.pos += 1
+                self.pos = self.pos + 1
             }
         }
 
         // Exponent part
         if self.pos < self.len && (self.peek() == 101 || self.peek() == 69) {
-            self.pos += 1
+            self.pos = self.pos + 1
             if self.pos < self.len && (self.peek() == 43 || self.peek() == 45) {
-                self.pos += 1
+                self.pos = self.pos + 1
             }
             if self.pos >= self.len || self.peek() < 48 || self.peek() > 57 {
                 return Err(JsonError.ParseError("expected digit in exponent"))
             }
             while self.pos < self.len && self.peek() >= 48 && self.peek() <= 57 {
-                self.pos += 1
+                self.pos = self.pos + 1
             }
         }
 
@@ -375,30 +375,32 @@ extend JsonParser {
     }
 }
 
-// Convert a hex ASCII byte to its numeric value, or -1 if invalid.
 func hex_digit(b: u8) -> i32 {
-    if b >= 48 && b <= 57 { return (b - 48) as i32 }
-    if b >= 65 && b <= 70 { return (b - 55) as i32 }
-    if b >= 97 && b <= 102 { return (b - 87) as i32 }
+    if b >= 48 && b <= 57 {
+        return b - 48 as i32
+    }
+    if b >= 65 && b <= 70 {
+        return b - 55 as i32
+    }
+    if b >= 97 && b <= 102 {
+        return b - 87 as i32
+    }
     return -1
 }
 
 // ─── Public API: parsing ─────────────────────────────────────────
 
-struct json { }
+struct json {  }
 
 extend json {
     /// Parse a JSON string into a JsonValue tree. RFC 8259 compliant.
     public func parse(input: string) -> JsonValue or JsonError {
         let parser = JsonParser.new(input)
         const value = try parser.parse_value()
-
-        // Verify no trailing content (except whitespace)
         parser.skip_ws()
         if parser.pos < parser.len {
             return Err(JsonError.ParseError("trailing content after JSON value"))
         }
-
         return Ok(value)
     }
 
@@ -409,108 +411,119 @@ extend json {
 
     /// Serialize a JsonValue to a pretty-printed JSON string.
     public func stringify_pretty(value: JsonValue) -> string {
-        let result = string.new()
-        stringify_pretty_inner(value, mutate result, 0)
-        return result
+        let b = string_builder.new()
+        stringify_pretty_inner(value, mutate b, 0)
+        return b.build()
     }
 
     /// Encode a value as a JSON string.
     /// Compiler-expanded at MIR level for structs via comptime for + reflect.
-    public func encode(value: T) -> string { }
+    public func encode<T: Encode>(value: T) -> string {}
 
     /// Decode a JSON string into a typed value.
     /// Compiler-expanded at MIR level for structs via comptime for + reflect.
-    public func decode(str: string) -> T or JsonError { }
+    public func decode<T: Decode>(str: string) -> T or JsonError {}
 
     /// Convert a typed value to a JsonValue tree.
-    public func to_value(value: T) -> JsonValue { }
+    public func to_value<T: Encode>(value: T) -> JsonValue {}
 
     /// Convert a JsonValue tree to a typed value.
-    public func from_value(value: JsonValue) -> T or JsonError { }
+    public func from_value<T: Decode>(value: JsonValue) -> T or JsonError {}
 }
 
 // ─── Stringify internals ─────────────────────────────────────────
 
 func stringify_value(value: JsonValue) -> string {
     match value {
-        JsonValue.Null => return "null",
+        JsonValue.Null => return "null"
         JsonValue.Bool(b) => {
-            if b { return "true" }
+            if b {
+                return "true"
+            }
             return "false"
         }
-        JsonValue.Number(n) => return format_number(n),
-        JsonValue.String(s) => return escape_string(s),
-        JsonValue.Array(arr) => return stringify_array(arr),
-        JsonValue.Object(map) => return stringify_object(map),
+        JsonValue.Number(n) => return format_number(n)
+        JsonValue.String(s) => return escape_string(s)
+        JsonValue.Array(arr) => return stringify_array(arr)
+        JsonValue.Object(map) => return stringify_object(map)
     }
 }
 
 func stringify_array(arr: Vec<JsonValue>) -> string {
-    let result = string.new()
-    result.push_str("[")
+    let b = string_builder.new()
+    b.append("[")
     let first = true
     for item in arr {
-        if !first { result.push_str(",") }
-        result.push_str(stringify_value(item))
+        if !first {
+            b.append(",")
+        }
+        b.append(stringify_value(item))
         first = false
     }
-    result.push_str("]")
-    return result
+    b.append("]")
+    return b.build()
 }
 
 func stringify_object(map: Map<string, JsonValue>) -> string {
-    let result = string.new()
-    result.push_str("{")
+    let b = string_builder.new()
+    b.append("{")
     let first = true
     for (key, value) in map {
-        if !first { result.push_str(",") }
-        result.push_str(escape_string(key))
-        result.push_str(":")
-        result.push_str(stringify_value(value))
+        if !first {
+            b.append(",")
+        }
+        b.append(escape_string(key))
+        b.append(":")
+        b.append(stringify_value(value))
         first = false
     }
-    result.push_str("}")
-    return result
+    b.append("}")
+    return b.build()
 }
 
-// Escape a string for JSON output: wrap in quotes, escape special chars.
 func escape_string(s: string) -> string {
-    let result = string.new()
-    result.push('"')
+    let b = string_builder.new()
+    b.append_char('"')
     let i: usize = 0
     while i < s.len() {
-        const b = s.byte_at(i)
-        if b == 34 { result.push_str("\\\"") }
-        else if b == 92 { result.push_str("\\\\") }
-        else if b == 10 { result.push_str("\\n") }
-        else if b == 13 { result.push_str("\\r") }
-        else if b == 9 { result.push_str("\\t") }
-        else if b == 8 { result.push_str("\\b") }
-        else if b == 12 { result.push_str("\\f") }
-        else if b < 32 {
-            // Control characters: \u00XX
-            result.push_str("\\u00")
-            result.push(hex_char(b / 16))
-            result.push(hex_char(b % 16))
+        const byte = s.byte_at(i)
+        if byte == 34 {
+            b.append("\\\"")
+        } else if byte == 92 {
+            b.append("\\\\")
+        } else if byte == 10 {
+            b.append("\\n")
+        } else if byte == 13 {
+            b.append("\\r")
+        } else if byte == 9 {
+            b.append("\\t")
+        } else if byte == 8 {
+            b.append("\\b")
+        } else if byte == 12 {
+            b.append("\\f")
+        } else if byte < 32 {
+            b.append("\\u00")
+            b.append_char(hex_char(byte / 16))
+            b.append_char(hex_char(byte % 16))
         } else {
-            result.push(b as char)
+            b.append_char(byte as char)
         }
-        i += 1
+        i = i + 1
     }
-    result.push('"')
-    return result
+    b.append_char('"')
+    return b.build()
 }
 
 func hex_char(n: u8) -> char {
-    if n < 10 { return (48 + n) as char }
-    return (87 + n) as char
+    if n < 10 {
+        return 48 + n as char
+    }
+    return 87 + n as char
 }
 
-// Format a number for JSON output.
-// Integers (no fractional part) render without decimal point.
 func format_number(n: f64) -> string {
     const i = n as i64
-    if (i as f64) == n && n >= -9007199254740992.0 && n <= 9007199254740992.0 {
+    if i as f64 == n && n >= -9007199254740992.0 && n <= 9007199254740992.0 {
         return "{i}"
     }
     return "{n}"
@@ -518,58 +531,63 @@ func format_number(n: f64) -> string {
 
 // ─── Pretty-print internals ─────────────────────────────────────
 
-func stringify_pretty_inner(value: JsonValue, mutate out: string, indent: usize) {
+func stringify_pretty_inner(value: JsonValue, mutate out: string_builder, indent: usize) {
     match value {
-        JsonValue.Null => out.push_str("null"),
-        JsonValue.Bool(b) => {
-            if b { out.push_str("true") }
-            else { out.push_str("false") }
+        JsonValue.Null => out.append("null")
+        JsonValue.Bool(b) => if b {
+            out.append("true")
+        } else {
+            out.append("false")
         }
-        JsonValue.Number(n) => out.push_str(format_number(n)),
-        JsonValue.String(s) => out.push_str(escape_string(s)),
+        JsonValue.Number(n) => out.append(format_number(n))
+        JsonValue.String(s) => out.append(escape_string(s))
         JsonValue.Array(arr) => {
             if arr.is_empty() {
-                out.push_str("[]")
+                out.append("[]")
                 return
             }
-            out.push_str("[\n")
+            out.append("[\n")
             let first = true
             for item in arr {
-                if !first { out.push_str(",\n") }
+                if !first {
+                    out.append(",\n")
+                }
                 write_indent(mutate out, indent + 1)
                 stringify_pretty_inner(item, mutate out, indent + 1)
                 first = false
             }
-            out.push('\n')
+            out.append_char('\n')
             write_indent(mutate out, indent)
-            out.push(']')
+            out.append_char(']')
         }
         JsonValue.Object(map) => {
             if map.is_empty() {
-                out.push_str("{}")
+                out.append("{}")
                 return
             }
-            out.push_str("{\n")
+            out.append("{\n")
             let first = true
             for (key, val) in map {
-                if !first { out.push_str(",\n") }
+                if !first {
+                    out.append(",\n")
+                }
                 write_indent(mutate out, indent + 1)
-                out.push_str(escape_string(key))
-                out.push_str(": ")
+                out.append(escape_string(key))
+                out.append(": ")
                 stringify_pretty_inner(val, mutate out, indent + 1)
                 first = false
             }
-            out.push('\n')
+            out.append_char('\n')
             write_indent(mutate out, indent)
-            out.push('}')
+            out.append_char('}')
         }
     }
 }
 
-func write_indent(mutate out: string, level: usize) {
+func write_indent(mutate out: string_builder, level: usize) {
     let i: usize = 0
     while i < level {
-        out.push_str("  ")
-        i += 1
+        out.append("  ")
+        i = i + 1
     }
 }

--- a/stdlib/reflect.rk
+++ b/stdlib/reflect.rk
@@ -1,0 +1,82 @@
+// SPDX-License-Identifier: (MIT OR Apache-2.0)
+
+// Compile-time type introspection. All functions resolve at compile time
+// with zero runtime cost (R1). Used by encoding libraries via comptime for
+// + field access.
+
+// ─── Info Types ─────────────────────────────────────────────────
+
+/// Metadata for a single struct field. Returned by reflect.fields<T>().
+public struct FieldInfo {
+    public name: string
+    public type_name: string
+    public offset: usize
+    public size: usize
+    public is_public: bool
+    public serial_name: string
+    public is_skipped: bool
+    public has_default: bool
+}
+
+/// Metadata for a method on a type. Returned by reflect.methods<T>().
+public struct MethodInfo {
+    public name: string
+    public is_public: bool
+    public param_count: usize
+    public return_type_name: string
+}
+
+/// Metadata for an enum variant. Returned by reflect.variants<T>().
+public struct VariantInfo {
+    public name: string
+    public has_fields: bool
+    public field_count: usize
+    public fields: Vec<FieldInfo>
+    public serial_name: string
+}
+
+// ─── Reflect Namespace ──────────────────────────────────────────
+
+struct reflect {  }
+
+extend reflect {
+    public func size_of<T>() -> usize {}
+
+    public func align_of<T>() -> usize {}
+
+    public func name_of<T>() -> string {}
+
+    public func is_copy<T>() -> bool {}
+
+    public func is_resource<T>() -> bool {}
+
+    public func is_struct<T>() -> bool {}
+
+    public func is_enum<T>() -> bool {}
+
+    public func is_optional<T>() -> bool {}
+
+    public func is_vec<T>() -> bool {}
+
+    public func is_map<T>() -> bool {}
+
+    public func is_integer<T>() -> bool {}
+
+    public func is_float<T>() -> bool {}
+
+    public func is_flat<T>() -> bool {}
+
+    public func fields<T>() -> Vec<FieldInfo> {}
+
+    public func has_field<T>(name: string) -> bool {}
+
+    public func methods<T>() -> Vec<MethodInfo> {}
+
+    public func has_method<T>(name: string) -> bool {}
+
+    public func implements<T, Trait>() -> bool {}
+
+    public func traits<T>() -> Vec<string> {}
+
+    public func variants<T>() -> Vec<VariantInfo> {}
+}

--- a/stdlib/string.rk
+++ b/stdlib/string.rk
@@ -1,41 +1,75 @@
 // SPDX-License-Identifier: (MIT OR Apache-2.0)
 
+// String types: immutable string, string_builder for construction,
+// string_view for stored indices, StringPool/StringSlice for handle-based
+// access, cstring for C interop.
+
+// ─── string ─────────────────────────────────────────────────────
+//
+// Immutable, refcounted, UTF-8, Copy (S1). 16 bytes — tagged union with
+// small string optimization for <=15 bytes (S8). No mutation methods (S7).
+
 extend string {
     /// Create a new empty string.
     public func new() -> string { }
 
-    /// Create a string with pre-allocated capacity.
-    public func with_capacity(n: usize) -> string { }
+    /// From validated UTF-8 bytes. Returns error on invalid UTF-8 (S4).
+    public func from_utf8(bytes: Vec<u8>) -> string or utf8_error { }
 
-    /// Length in bytes.
+    /// From UTF-8 bytes without validation. Unsafe — caller guarantees valid UTF-8.
+    public unsafe func from_utf8_unchecked(bytes: Vec<u8>) -> string { }
+
+    /// Single-character string.
+    public func from_char(c: char) -> string { }
+
+    /// String repeated n times.
+    public func repeat(s: string, n: usize) -> string { }
+
+    /// Concatenate two strings. Allocates.
+    public func concat(a: string, b: string) -> string { }
+
+    // ── Length and properties ────────────────────────────────
+
+    /// Byte length. O(1).
     public func len(self) -> usize { }
 
-    /// True if the string is empty.
+    /// Number of Unicode scalars. O(n).
+    public func char_count(self) -> usize { }
+
+    /// True if the string is empty. O(1).
     public func is_empty(self) -> bool { }
 
-    /// Byte value at the given position. Returns 0 if out of bounds.
-    public func byte_at(self, pos: usize) -> u8 { }
+    /// True if all bytes are ASCII. O(n) first call, cached.
+    public func is_ascii(self) -> bool { }
+
+    // ── Character and byte access ───────────────────────────
+
+    /// Byte at byte index. Returns None if out of bounds.
+    public func byte_at(self, idx: usize) -> u8? { }
+
+    /// Unicode scalar at char index (not byte index). Returns None if out of bounds.
+    public func char_at(self, idx: usize) -> char? { }
+
+    // ── Searching ───────────────────────────────────────────
+
+    /// Byte index of first occurrence. None if not found.
+    public func find(self, pat: string) -> usize? { }
+
+    /// Byte index of last occurrence. None if not found.
+    public func rfind(self, pat: string) -> usize? { }
 
     /// True if the string contains the substring.
-    public func contains(self, s: string) -> bool { }
+    public func contains(self, pat: string) -> bool { }
 
     /// True if the string starts with the given prefix.
-    public func starts_with(self, s: string) -> bool { }
+    public func starts_with(self, pat: string) -> bool { }
 
     /// True if the string ends with the given suffix.
-    public func ends_with(self, s: string) -> bool { }
+    public func ends_with(self, pat: string) -> bool { }
 
-    /// Find the first occurrence of a substring. Returns byte offset.
-    public func find(self, s: string) -> Option<usize> { }
-
-    /// Find the last occurrence of a substring. Returns byte offset.
-    public func rfind(self, s: string) -> Option<usize> { }
-
-    /// Convert to uppercase.
-    public func to_uppercase(self) -> string { }
-
-    /// Convert to lowercase.
-    public func to_lowercase(self) -> string { }
+    // ── Trimming ────────────────────────────────────────────
+    // Spec: these return expression-scoped slices (zero-copy).
+    // Current interpreter returns owned strings (see implementation notes).
 
     /// Remove leading and trailing whitespace.
     public func trim(self) -> string { }
@@ -49,55 +83,194 @@ extend string {
     /// Byte indices of trimmed content: (start, end).
     public func trim_bounds(self) -> (usize, usize) { }
 
-    /// Append a character.
-    public func push(mutate self, c: char) { }
+    // ── Case conversion ─────────────────────────────────────
 
-    /// Append a string.
-    public func push_str(mutate self, s: string) { }
+    /// Convert to uppercase. Allocates.
+    public func to_uppercase(self) -> string { }
 
-    /// Remove all content.
-    public func clear(mutate self) { }
+    /// Convert to lowercase. Allocates.
+    public func to_lowercase(self) -> string { }
 
-    /// Split by separator.
-    public func split(self, sep: string) -> Iterator<string> { }
+    // ── Substring extraction ────────────────────────────────
 
-    /// Split into lines.
-    public func lines(self) -> Iterator<string> { }
+    /// Extract chars from start (inclusive) to end (exclusive). Allocates.
+    public func substring(self, start: usize, end: usize) -> string { }
 
-    /// Iterate over characters.
+    // ── Iteration ───────────────────────────────────────────
+    // Iterators borrow for expression scope only. Cannot be stored.
+
+    /// Iterate over Unicode scalars.
     public func chars(self) -> Iterator<char> { }
+
+    /// Iterate over raw bytes.
+    public func bytes(self) -> Iterator<u8> { }
 
     /// Iterate over (byte_index, char) pairs.
     public func char_indices(self) -> Iterator<(usize, char)> { }
 
-    /// Iterate over bytes.
-    public func bytes(self) -> Iterator<u8> { }
+    /// Split by separator.
+    public func split(self, sep: string) -> Iterator<string> { }
 
-    /// Replace all occurrences of `from` with `to`.
+    /// Split on Unicode whitespace, skip empty.
+    public func split_whitespace(self) -> Iterator<string> { }
+
+    /// Split into lines.
+    public func lines(self) -> Iterator<string> { }
+
+    // ── Manipulation ────────────────────────────────────────
+
+    /// Replace all occurrences. Allocates.
     public func replace(self, from: string, to: string) -> string { }
 
-    /// Replace the first n occurrences of `from` with `to`.
+    /// Replace first n occurrences. Allocates.
     public func replacen(self, from: string, to: string, n: usize) -> string { }
 
-    /// Parse into a typed value.
-    public func parse(self) -> T or ParseError { }
+    /// Reverse by Unicode scalars. Allocates.
+    public func reverse(self) -> string { }
 
-    /// Iterate over characters (same as chars).
-    public func iter(self) -> Iterator<char> { }
+    /// Repeat this string n times. Allocates.
+    public func repeat(self, n: usize) -> string { }
 
-    // ── C interop ────────────────────────────────────────────
+    // ── Join ────────────────────────────────────────────────
 
-    /// Null-terminated pointer for C APIs. Zero-cost (strings are always null-terminated).
-    /// Pointer is valid as long as the string is alive.
+    // join() lives on Vec<string>: names.join(", ")
+
+    // ── Parsing ─────────────────────────────────────────────
+
+    /// Parse to integer. Trims whitespace.
+    public func parse_int(self) -> i64 or string { }
+
+    /// Parse to floating point. Trims whitespace.
+    public func parse_float(self) -> f64 or string { }
+
+    /// Parse to typed value.
+    public func parse<T>(self) -> T or ParseError { }
+
+    // ── Equality / Comparison ───────────────────────────────
+    // == is O(1) or O(n): SSO byte comparison, heap pointer+length fast path.
+    // < is O(n) lexicographic. hash() is O(n), not cached.
+
+    /// Hash the string contents.
+    public func hash(self) -> u64 { }
+
+    // ── C interop ───────────────────────────────────────────
+
+    /// Null-terminated pointer for C APIs. Valid while string is alive.
     public unsafe func as_c_str(self) -> *u8 { }
 
-    /// Raw data pointer + .len() for pointer+length C APIs.
+    /// Raw data pointer. Use with .len() for pointer+length C APIs.
     public unsafe func as_ptr(self) -> *u8 { }
 
     /// Copy from a null-terminated C string. Caller must ensure ptr is valid.
     public unsafe func from_c(ptr: *u8) -> string { }
 
-    /// Build a string from a raw pointer and byte length. No UTF-8 validation.
-    /// Caller must ensure ptr is valid for len bytes.
+    /// Build from raw pointer and byte length. No UTF-8 validation.
     public unsafe func from_raw(ptr: *u8, len: usize) -> string { }
+}
+
+// ─── string_builder ─────────────────────────────────────────────
+//
+// Growable mutable buffer. Sole owner — mutation is always O(1) amortized.
+// Move on assignment (not Copy).
+
+public struct string_builder { }
+
+extend string_builder {
+    /// Create an empty builder.
+    public func new() -> string_builder { }
+
+    /// Create a builder with pre-allocated capacity.
+    public func with_capacity(n: usize) -> string_builder { }
+
+    /// Append a string or expression-scoped slice.
+    public func append(mutate self, s: string) { }
+
+    /// Append a single character.
+    public func append_char(mutate self, c: char) { }
+
+    /// Consume the builder, return the built string.
+    public func build(take self) -> string { }
+
+    /// Return built string and reset to empty. Zero-copy buffer handoff.
+    public func build_and_reset(mutate self) -> string { }
+
+    /// Clear contents, keep capacity.
+    public func clear(mutate self) { }
+
+    /// Current byte length.
+    public func len(self) -> usize { }
+}
+
+// ─── string_view ────────────────────────────────────────────────
+//
+// Plain indices into a string — the span type for parsers, tokenizers,
+// and diagnostics. No validation — user ensures source string validity.
+// 16 bytes, Copy.
+
+public struct string_view {
+    public start: usize
+    public end: usize
+}
+
+extend string_view {
+    /// Create a view from start and end byte indices.
+    public func new(start: usize, end: usize) -> string_view {
+        return string_view { start: start, end: end }
+    }
+
+    /// Byte length of the view.
+    public func len(self) -> usize {
+        return self.end - self.start
+    }
+
+    /// Copy to owned string. Panics if out of bounds.
+    public func to_string(self, source: string) -> string { }
+}
+
+// ─── StringPool / StringSlice ───────────────────────────────────
+//
+// Validated stored references using handles. Follows Pool<T> pattern.
+// StringSlice is handle + indices — Copy (4 words).
+
+public struct StringSlice { }
+
+public struct StringPool { }
+
+extend StringPool {
+    /// Create an empty pool.
+    public func new() -> StringPool { }
+
+    /// Add a string, get a handle.
+    public func insert(mutate self, s: string) -> Handle<string> or InsertError { }
+
+    /// Create a validated slice from a handle and byte indices.
+    public func slice(self, h: Handle<string>, start: usize, end: usize) -> StringSlice or Error { }
+
+    /// Safe access — returns None on invalid handle/slice.
+    public func get(self, slice: StringSlice) -> string? { }
+
+    /// Remove string by handle, returning ownership.
+    public func remove(mutate self, h: Handle<string>) -> string? { }
+}
+
+// ─── cstring ────────────────────────────────────────────────────
+//
+// Owned null-terminated string for C FFI. Move on assignment (not Copy).
+
+public struct cstring { }
+
+extend cstring {
+    /// Raw pointer. Unsafe context only.
+    public unsafe func as_ptr(self) -> *u8 { }
+
+    /// Take ownership from a C pointer. Unsafe — caller must ensure validity.
+    public unsafe func from_ptr(ptr: *u8) -> cstring { }
+
+    /// Convert to Rask string. Fails if not valid UTF-8.
+    public func to_string(self) -> string or utf8_error { }
+}
+
+extend string {
+    /// Convert to null-terminated cstring. Fails if string contains \0.
+    public func to_cstring(self) -> cstring or null_byte_error { }
 }


### PR DESCRIPTION
## Summary

This PR refactors the Rask standard library to improve code consistency, introduce string builders for efficient string construction, and add comprehensive documentation for string types and encoding infrastructure.

## Key Changes

### Code Style & Formatting
- **Consistent brace placement**: Converted single-line if statements and match arms to multi-line format throughout `json.rk` for improved readability
- **Operator spacing**: Changed `+=` and `-=` to explicit `x = x + 1` style for consistency
- **Comment removal**: Removed inline comments from parser methods (e.g., "Peek at the current byte", "Parse a JSON object") to reduce noise; logic is self-documenting
- **Match expression cleanup**: Updated match arms to use consistent formatting with `=>` on same line

### String Builder Migration
- **Replaced `string` with `string_builder`** in JSON stringify operations:
  - `parse_raw_string()`: Changed from `string.new()` to `string_builder.new()` with `append_char()` calls
  - `stringify_array()`, `stringify_object()`, `escape_string()`: Migrated to builder pattern with `append()` and `append_char()`
  - `stringify_pretty_inner()`, `write_indent()`: Updated to accept `string_builder` parameter
  - All builders now call `.build()` to finalize the string
- **Variable naming**: Renamed string accumulator variables from `result` to `b` (builder) for clarity

### String Library Documentation & API Expansion (`string.rk`)
- **Comprehensive header documentation**: Added detailed comments explaining string types (immutable, refcounted, UTF-8, Copy with SSO)
- **Organized API sections**: Grouped methods by category (Length, Character access, Searching, Trimming, Case conversion, Iteration, Manipulation, Parsing, C interop)
- **New/enhanced methods**:
  - `from_utf8()`, `from_utf8_unchecked()`, `from_char()`, `repeat()`, `concat()`
  - `char_count()`, `is_ascii()`, `char_at()` (returns `char?` instead of `char`)
  - `byte_at()` now returns `u8?` instead of `u8`
  - `find()`, `rfind()` now return `usize?` instead of `Option<usize>`
  - `parse_int()`, `parse_float()` for numeric parsing
  - `hash()` for string hashing
  - `split_whitespace()`, `reverse()` for additional string operations
- **New `string_builder` struct**: Growable mutable buffer with `new()`, `with_capacity()`, `append()`, `append_char()`, `build()`, `build_and_reset()`, `clear()`, `len()`
- **New `string_view` struct**: Plain indices for spans in parsers/tokenizers with `new()`, `len()`, `to_string()`
- **New `StringPool`/`StringSlice`**: Handle-based validated string references
- **New `cstring` struct**: Owned null-terminated strings for C FFI with `as_ptr()`, `from_ptr()`, `to_string()`

### New Standard Library Modules
- **`reflect.rk`** (added): Compile-time type introspection with zero runtime cost
  - `FieldInfo`, `MethodInfo`, `VariantInfo` structs for metadata
  - `reflect` namespace with functions: `size_of<T>()`, `align_of<T>()`, `name_of<T>()`, `is_copy<T>()`, `is_struct<T>()`, `fields<T>()`, `methods<T>()`, `variants<T>()`, etc.
  
- **`encoding.rk`** (added): Marker traits for format-agnostic serialization
  - `Encode` and `Decode` traits (auto-derived for compatible structs)
  - Field annotations: `@rename()`, `@skip`, `@default()`, `@no_encode`, `@no_decode`
  - Support for base types, collections,

https://claude.ai/code/session_01VChhAJt19RExfJ3kdxqA4p