### PR TITLE
Add beacon protocol spec and improve transform simulation

### DIFF
--- a/projects/allgard/BEACON_PROTOCOL.md
+++ b/projects/allgard/BEACON_PROTOCOL.md
@@ -1,0 +1,291 @@
+# Beacon Wire Protocol
+<!-- id: allgard.beacon-protocol --> <!-- status: proposed --> <!-- summary: How commit-reveal maps to Leden messages, tick timing, commitment locks, gossip propagation -->
+
+[BEACON.md](BEACON.md) defines what the beacon is. This spec defines how it works on the wire — the Leden messages, the timing, and the mechanical interactions with Allgard transforms.
+
+## Tick Timing
+
+**Tick interval: 30 seconds.** Long enough for gossip to propagate across the network. Short enough that crafting and combat don't stall.
+
+Each tick has three phases:
+
+```
+|-- commit (0-20s) --|-- reveal (20-27s) --|-- grace (27-30s) --|
+                     ^                      ^                    ^
+               commit closes          reveal closes         tick boundary
+```
+
+**Commit window: 20 seconds.** Contributors publish commitment hashes. Domains lock transform inputs. Long enough for gossip propagation across a healthy network.
+
+**Reveal window: 7 seconds.** Contributors reveal values. Short — reveal is cheap, no reason to wait. If you committed, reveal immediately.
+
+**Grace period: 3 seconds.** Final gossip propagation. Any domain that hasn't received all reveals catches up. The beacon value is computable as soon as all reveals are in — the grace period is for stragglers.
+
+At the tick boundary: the new beacon value is final. Locked transforms evaluate. The next tick's commit window opens immediately.
+
+### Why 30 Seconds
+
+Shorter ticks (5-10s) make combat responsive but stress gossip convergence — a commit might not reach all peers before the window closes. Longer ticks (2-5min) are fine for crafting but make multi-tick combat feel sluggish.
+
+30 seconds is a starting point. The founding cluster publishes this as a constant in the standard physics script. It can change (new script version, voluntary adoption). I expect combat zones might run faster local ticks for sub-tick resolution while the federation beacon stays at 30s.
+
+## Clock Synchronization
+
+No global clock. Domains use the beacon log itself as the clock.
+
+Each beacon log entry has a tick number. Domains count ticks from the beacon chain, not from wall clocks. When a domain receives a beacon entry for tick N, it knows tick N+1's commit window is open.
+
+**Bootstrap:** a domain joining the network fetches the beacon log from any peer (it's public, gossiped via Leden). The latest entry tells them the current tick. They sync to the network's tick cadence, not to any clock authority.
+
+**Drift tolerance:** commit timestamps are judged by the receiving domain's local view of the tick phase. A commitment that arrives during the reveal window (late) is rejected by that domain but might be accepted by others who received it earlier. This is fine — the commitment is valid if ANY peer logged it during the commit window. Bilateral partners who logged the timestamp are the witnesses.
+
+**Partition behavior:** a network partition produces two beacon chains that diverge at the partition point. Each partition produces beacon values from whoever reveals on their side. When the partition heals, domains reconcile by accepting the chain with more contributors (more reveals = stronger unpredictability guarantee). The founding cluster's presence on one side makes that side's chain authoritative in practice.
+
+## Leden Message Types
+
+Beacon messages use the application-defined range (0x80+):
+
+| Tag | Message | Direction |
+|-----|---------|-----------|
+| 0x80 | `BeaconCommit` | Contributor → gossip |
+| 0x81 | `BeaconReveal` | Contributor → gossip |
+| 0x82 | `BeaconEntry` | Any → gossip |
+| 0x83 | `BeaconLogRequest` | Any → any |
+| 0x84 | `BeaconLogResponse` | Any → any |
+| 0x85 | `TransformCommit` | Domain → bilateral partners |
+| 0x86 | `TransformResult` | Domain → bilateral partners |
+
+### BeaconCommit (0x80)
+
+A contributor announces their commitment for an upcoming tick.
+
+```
+{
+    type: 0x80,
+    tick: uint,              // which tick this commitment is for
+    contributor: endpoint_id, // who's committing
+    commitment: bytes[32],   // hash(reveal_value)
+    signature: bytes         // signs (tick, commitment)
+}
+```
+
+Gossiped via existing Leden sessions. Every peer that receives it forwards to their peers (standard gossip protocol, same as PeerUpdate). Deduplicated by (tick, contributor).
+
+### BeaconReveal (0x81)
+
+A contributor reveals their value after the commit window closes.
+
+```
+{
+    type: 0x81,
+    tick: uint,
+    contributor: endpoint_id,
+    reveal_value: bytes[32], // the actual random value
+    signature: bytes
+}
+```
+
+Any receiver verifies: `hash(reveal_value) == commitment` from the corresponding BeaconCommit. Invalid reveals are dropped.
+
+### BeaconEntry (0x82)
+
+The computed beacon value for a completed tick. Any domain can produce this once they have all reveals (or the reveal window closes).
+
+```
+{
+    type: 0x82,
+    tick: uint,
+    beacon_value: bytes[32],   // hash(reveal_1 || reveal_2 || ... || reveal_n)
+    contributors: [endpoint_id...],  // who revealed, in canonical order
+    reveals: [bytes[32]...],   // corresponding reveal values
+    prev_hash: bytes[32],      // hash of previous BeaconEntry
+    signature: bytes           // producer signs the entry
+}
+```
+
+Self-verifying: any receiver can recompute `beacon_value` from the reveals and check `prev_hash` against the prior entry. The producer's signature is convenience, not authority — the entry's correctness is independently verifiable.
+
+Contributors are sorted by endpoint_id (canonical order) so every domain computing the beacon value independently gets the same hash.
+
+### BeaconLogRequest (0x83) / BeaconLogResponse (0x84)
+
+For syncing. A domain that missed ticks requests a range:
+
+```
+// Request
+{
+    type: 0x83,
+    id: uint,
+    from_tick: uint,    // inclusive
+    to_tick: uint       // inclusive, max 100 entries per request
+}
+
+// Response
+{
+    type: 0x84,
+    id: uint,
+    entries: [BeaconEntry...]
+}
+```
+
+Used during bootstrap and partition recovery. The beacon log is public — any peer can serve it.
+
+### TransformCommit (0x85)
+
+A domain commits to transform parameters before the beacon tick. This is the application-level commitment — "I'm going to craft/fight/mine with these parameters on the next tick."
+
+```
+{
+    type: 0x85,
+    id: uint,
+    tick: uint,                // which beacon tick this transform evaluates against
+    domain: endpoint_id,       // who's committing
+    commitment_hash: bytes[32], // hash(transform_parameters)
+    locked_objects: [object_id...], // objects locked for this transform
+    signature: bytes
+}
+```
+
+Sent to bilateral partners (not gossiped to the whole network — transform details are domain business). Partners log the commitment with their local timestamp. This timestamp is the evidence that the commitment preceded the beacon.
+
+### TransformResult (0x86)
+
+After the beacon reveals, the domain evaluates and publishes the result.
+
+```
+{
+    type: 0x86,
+    id: uint,
+    tick: uint,
+    domain: endpoint_id,
+    beacon_value: bytes[32],    // the beacon value used
+    parameters: bytes,          // the full transform parameters (hash must match commitment)
+    result: bytes,              // the transform output
+    proof: bytes,               // Raido execution proof
+    signature: bytes
+}
+```
+
+Partners verify:
+1. `hash(parameters) == commitment_hash` from the TransformCommit
+2. `beacon_value` matches the beacon log for that tick
+3. The TransformCommit timestamp was before the beacon tick
+4. Re-execute the transform script with (parameters, beacon_value) and confirm the result matches
+
+All local. No federation interaction needed.
+
+## Commitment Locks
+
+When a domain sends a TransformCommit, the listed objects are **locked**. Locked objects cannot be transferred, mutated, or included in another transform until the lock resolves.
+
+### Lock Lifecycle
+
+```
+1. Domain sends TransformCommit listing objects → objects locked
+2. Beacon tick completes → beacon value available
+3. Domain evaluates transform → produces result
+4. Domain sends TransformResult → lock released, transforms applied
+5. OR: domain abandons (doesn't send result within 2 ticks) → lock released, no transform
+```
+
+### Lock Visibility
+
+Bilateral partners who receive the TransformCommit know which objects are locked. If the domain tries to transfer a locked object, the partner rejects it — the transfer proof would reference an object that's currently committed to a transform.
+
+### Lock Duration
+
+A lock lasts at most 2 tick intervals (60 seconds at the default rate). If the domain doesn't publish a TransformResult within 2 ticks after the committed tick, the lock expires and the objects are free. This prevents griefing — a domain can't lock objects forever by committing and never resolving.
+
+### Interaction With Combat
+
+Combat transforms follow the same pattern:
+
+1. Combatant commits orders (TransformCommit with fleet objects locked)
+2. Beacon reveals
+3. Domain computes combat round
+4. Domain publishes result (TransformResult with damage/destruction outcomes)
+5. Both sides verify independently
+
+The fleet objects are locked during the tick — they can't be transferred mid-combat. This is the mechanical "your ships are committed to this fight" enforcement. Retreat releases the lock over multiple ticks (per COMBAT.md retreat timing).
+
+## Gossip Propagation
+
+Beacon messages ride on existing Leden sessions — the same gossip infrastructure used for peer discovery. No special connections needed.
+
+### Propagation Model
+
+Same as PeerDigest/PeerRequest/PeerUpdate but for beacon data:
+
+1. A contributor sends BeaconCommit to all direct peers
+2. Each peer forwards to their peers (deduplicate by tick + contributor)
+3. Convergence in O(log N) rounds for N endpoints
+
+With 30-second ticks and sub-second gossip rounds, a 1000-domain network converges within the commit window. The 20-second commit window is conservative — most networks converge in under 5 seconds.
+
+### Bandwidth
+
+Per tick, per contributor: one BeaconCommit (~100 bytes) + one BeaconReveal (~100 bytes). With 10 contributors, that's ~2 KB per tick per peer, gossiped. Negligible compared to normal Leden session traffic.
+
+BeaconEntry is larger (~500 bytes with 10 contributors) but only produced once per tick and only needs to reach each domain once.
+
+## Byzantine Behavior
+
+### Non-Reveal
+
+A contributor who commits but doesn't reveal is simply excluded from the beacon value. Their commitment is ignored. The beacon is produced from whoever revealed.
+
+If a contributor repeatedly commits and doesn't reveal, peers stop forwarding their commits (local policy, not protocol enforcement). They're wasting bandwidth. The standard recommendation: after 3 consecutive non-reveals, stop relaying commits from that contributor for 10 ticks.
+
+### Invalid Reveal
+
+A reveal whose hash doesn't match the commitment is dropped. The contributor is treated as a non-revealer for that tick. Same bandwidth penalty applies.
+
+### Late Commit
+
+A commitment that arrives after the commit window is rejected by the receiving domain. Other domains that received it in time may accept it. This is fine — the commitment is valid if at least one bilateral partner timestamped it within the window. A domain trying to use a transform commitment that nobody witnessed as on-time won't find partners willing to verify its proofs.
+
+### Equivocation
+
+A contributor who sends two different commitments for the same tick (to different peers) is detectable: when the reveals propagate, the two different commitment hashes surface. Equivocation proof is published via gossip. The contributor's reputation takes the hit. Both commitments are excluded from the beacon value for that tick.
+
+### Withholding Bias
+
+A contributor who sees other reveals and decides not to reveal (to bias the beacon by exclusion) is possible. This is the known weakness of commit-reveal schemes. Mitigation: the contributor already committed. Not revealing means their commitment is wasted and they gain bandwidth penalties. The beacon value without their contribution is still unpredictable (one honest contributor is enough). The cost of withholding (wasted commitment, reputation) exceeds the benefit (marginal influence on the value) in practice.
+
+## Capability Model
+
+### Contributing
+
+Any domain can contribute to the beacon. No special capability required — just send BeaconCommit to your peers. Contributing is permissionless because adding contributors can only strengthen the beacon (one honest contributor is enough).
+
+### Consuming
+
+Reading the beacon log is permissionless. It's public data, gossiped to everyone. Any domain can fetch any historical beacon value.
+
+### Committing Transforms
+
+TransformCommit/TransformResult use standard Leden capabilities. A domain must have the appropriate capability for the objects it locks (ownership or delegated authority). Partners verify this against the object's capability chain.
+
+No new capability types are needed for the beacon itself. The beacon is infrastructure — like the clock. Everyone can read it. The capabilities govern what you DO with it (transforms on objects you have authority over).
+
+## Constants
+
+| Constant | Initial Value | What it controls |
+|----------|---------------|-----------------|
+| `tick_interval` | 30s | Total tick duration |
+| `commit_window` | 20s | Time for commitments |
+| `reveal_window` | 7s | Time for reveals |
+| `grace_period` | 3s | Final propagation |
+| `lock_timeout` | 2 ticks (60s) | Max commitment lock duration |
+| `non_reveal_penalty` | 3 consecutive | Commits ignored after N non-reveals |
+| `penalty_duration` | 10 ticks | How long the non-reveal penalty lasts |
+
+Published by the founding cluster in the standard physics script. Changeable via new script version, voluntary adoption.
+
+## Design Notes
+
+I picked 30-second ticks as the initial value because it's the smallest interval where gossip reliably converges across a global network with realistic latency. 10 seconds works for a founding cluster of 5-20 domains in the same region. 30 seconds works when the network spans continents.
+
+The commit-reveal scheme is deliberately simple. I considered threshold signatures (BLS, DRAND-style) which would eliminate the withholding attack entirely. I rejected them because they require a fixed committee, which requires election, which requires governance. Commit-reveal with one-honest-contributor is weaker cryptographically but requires zero governance. That fits Allgard's bilateral model. If the withholding attack becomes a real problem in practice, threshold signatures can be layered on top without changing the message format — just the beacon value computation.
+
+Transform commitments are bilateral (sent to trading partners), not gossiped globally, because transform details are domain business. The beacon itself is public. What you do with it is between you and your partners. This separation keeps the gossip bandwidth low and respects domain sovereignty.

--- a/projects/apeiron/COMBAT.md
+++ b/projects/apeiron/COMBAT.md
@@ -1,0 +1,158 @@
+# Combat Model
+<!-- id: apeiron.combat --> <!-- status: proposed --> <!-- summary: Authority model, execution model, and structural decisions for combat -->
+
+Combat in Apeiron is a federation problem before it's a game design problem. Who computes the fight? Who has authority over the outcome? What prevents cheating? These structural questions constrain what mechanics are even possible. This spec answers the structural questions and defers mechanics to playtesting.
+
+## Principles
+
+**Verifiable, not enforced.** Same as constraint physics. The standard combat script is deterministic Raido bytecode. Any party can re-execute and verify any combat outcome. Non-standard combat scripts are visible, not banned.
+
+**No authority required.** Combat resolution doesn't depend on either combatant's honesty. The outcome is deterministic from public inputs. Disputes are resolved by re-execution, not adjudication.
+
+**War is expensive.** Destroyed objects are gone (Allgard conservation). Damaged components need replacement (material cost). Combat is a consumption sink — the economy's most violent one. Nobody fights casually.
+
+**Counters emerge from physics.** No type chart. No damage multiplier table. The five constraint laws create natural tradeoffs between armor, speed, firepower, and range. Counter-strategies emerge from those tradeoffs. The founding cluster doesn't prescribe a meta — they publish the physics and let players discover it.
+
+## Execution Model
+
+### Hybrid: Orders + Scripts
+
+Two layers of control, one required and one optional:
+
+**Strategic orders** — what every combatant submits each tick. A structured data format: stance, target priority, formation, engagement range, power allocation, retreat conditions. No code required. This is the menu.
+
+**Execution scripts** — Raido bytecode that interprets strategic orders into per-ship tactical decisions within each tick's simulation. The standard execution script (published by the founding cluster) does what the orders say literally. Community scripts are tradeable Allgard objects — combat doctrine as intellectual property. Custom scripts give an edge to factions with combat programmers.
+
+A casual player selects orders from a menu and uses the standard script. A faction combat engineer writes a custom script that implements conditional logic the menu can't express. Both are valid combatants. The custom script player has an edge — like a better-tuned ship, not a different game.
+
+### Multi-Tick Engagement
+
+Combat spans multiple beacon ticks. Each tick:
+
+1. **Observe.** Both sides see the result of the previous tick — positions, visible damage, fleet composition changes.
+2. **Commit.** Both sides submit orders (hashed) before the beacon. Can't see the opponent's current orders.
+3. **Reveal.** Beacon tick produces the randomness seed.
+4. **Execute.** The combat script runs one round of simulation using (fleet states, orders, execution scripts, beacon value).
+5. **Verify.** Result is deterministic. Any party can re-run and check.
+6. **Repeat.** Until one side is destroyed, retreats, or both disengage.
+
+Between ticks, combatants observe what happened and adapt. This is where strategy evolves — you saw their formation, you counter it, they counter your counter. Campaigns develop dynamics across dozens of ticks. No single strategy dominates because opponents adapt.
+
+### Fleet Scale
+
+A fleet is a set of ships (Allgard objects). Strategic orders apply at fleet level. The execution script translates fleet orders to per-ship actions. A single ship is a fleet of one — same model, no special case.
+
+Fleet composition matters because constraint physics creates tradeoffs at fleet level: the slowest ship limits fleet speed, different ships prefer different engagement ranges, more ship types means more coordination overhead. A specialized fleet is focused but predictable. A mixed fleet is flexible but slower.
+
+## Authority Model
+
+### Who Computes
+
+**The domain always computes.** Combat happens within a domain's jurisdiction — a star system, a route domain, a station. The domain runs the standard combat script. That's what domains do: host objects, run transforms.
+
+**Anyone can verify.** The combat script is content-addressed Raido. The inputs are public: fleet states at engagement start, committed orders (revealed after beacon), beacon values, execution script hashes. Any party — combatant, observer, trading partner — can re-run the script and get the same result. Deterministic. No trust required.
+
+### PvP on Neutral Ground
+
+Two players fighting in a third party's star system or on a route domain. The domain has no stake in the outcome.
+
+The domain is the referee. It receives orders from both sides, runs the script after the beacon, publishes the result with full execution trace. Either player can verify. If the domain lies (favors one player), the other proves it by re-executing — the false result doesn't match the deterministic output from the public inputs.
+
+This is the clean case. Most PvP happens here — contested route domains, arena zones in star systems, border skirmishes.
+
+### Attacking a Domain
+
+The hard case. You're attacking the domain operator's own system. The referee IS the defendant.
+
+**Computation still works.** The inputs are public. The script is deterministic. The attacker re-runs the script locally and knows the real outcome. If the domain claims a different result, the attacker has cryptographic proof: "here are the committed orders, here's the beacon value, here's the script hash — re-run it yourself."
+
+**The real problem is custody.** The attacker's ships are hosted on the domain (they entered via consent-on-entry). Even if the attacker proves they won, the domain can refuse to apply damage transforms to its own ships. The domain physically controls the objects in its memory.
+
+Three enforcement mechanisms:
+
+**Reputation destruction.** A domain that provably cheats at combat is done as a trading partner. The proof is published via Leden gossip. Every bilateral partner can re-run the script and see the cheating. Economic isolation follows. For most domains, this deterrent is sufficient — the long-term cost of lost trade far exceeds the short-term gain of winning one fight.
+
+**Retreat escrow.** The departure domain (where the attacker jumped from) holds a retreat claim on the attacker's fleet objects. The claim is established during the consent-on-entry capability exchange. If the hostile domain refuses to honor a verified combat outcome, the attacker invokes the retreat — ships revert to the departure domain's custody. The hostile domain can block this, but the block is visible in Leden session logs. This limits what the cheating domain gains: they can't keep the attacker's ships AND maintain honest reputation.
+
+**Third-party verification.** Not enforced — voluntary. Mutual trading partners can re-run the combat script from the public inputs and see who's right. They adjust trust accordingly. This is the same mechanism Allgard uses for everything: verification propagates through self-interest, not authority.
+
+### Consent-on-Entry
+
+Entering a PvP-enabled domain means accepting a combat capability grant via Leden. The grant specifies:
+
+- **Combat script hash** — which standard combat script applies. Visible before entry. Non-standard is your choice to accept or avoid.
+- **Rules of engagement** — what triggers combat (always-on, flag-based, challenge-based). Domain policy.
+- **Retreat rights** — whether retreat is possible and under what conditions. A domain that doesn't allow retreat is visible — most players won't enter.
+- **Consequence scope** — what the combat script can do to your objects. Damage and destruction within the script's logic, not arbitrary modification.
+
+The grant is inspectable. A player can see exactly what they're consenting to before entering. "This route domain uses standard combat v2.1, allows retreat after 3 ticks, PvP is always-on." Informed consent.
+
+## Retreat and Disengagement
+
+If combat is always to the death, nobody fights. Retreat is essential.
+
+**Retreat takes time.** Committing a retreat order starts the disengagement — ships turn, accelerate away, still take fire for a number of ticks (domain parameter, visible in consent-on-entry). A fighting retreat is costly.
+
+**Damaged ships may not escape.** A ship with a failed engine can't match fleet speed during retreat. It's left behind — captured or destroyed. "What do you sacrifice?" is a real decision.
+
+**Pursuit costs fuel.** The attacker can pursue, but pursuit extends the engagement and burns fuel. Maybe not worth it for one crippled cruiser.
+
+**Mutual disengagement.** Both sides commit "cease fire." Bilateral agreement. Possible at any tick.
+
+**Retreat escrow protects the retreating party.** Once retreat is committed and the retreat timer expires, the departure domain's claim activates. Ships transfer back. The combat domain can't hold them.
+
+## Counter-Strategies From Physics
+
+No type chart. The five constraint laws create natural tradeoffs:
+
+**Heavy brawler.** Dense armor (high density, hardness materials), short-range high-damage weapons, slow. Law 1: armor mass. Law 2: big hull, structural cost. Devastating up close but takes ticks to close distance.
+
+**Long-range artillery.** Big weapons (high radiance, conductivity), light armor, moderate speed. Law 3: big weapons need big reactors. Fragile if reached. Kills brawlers before they arrive.
+
+**Evasive skirmisher.** Fast, light, hard to hit. Low mass = high thrust-to-weight. Minimal coupling costs (Law 5 — few systems). Can't tank hits. Dances around artillery at range. Gets caught and crushed by brawlers.
+
+These archetypes aren't prescribed — they emerge because the physics rewards specialization (Law 5 coupling costs punish generalists) while constraint interactions create natural weaknesses (heavy = slow, light = fragile, big guns = big reactor = big mass).
+
+Fleet composition adds another dimension: mixed fleets cover weaknesses but pay coordination costs. A fleet of brawlers is predictable. A fleet of brawlers screening for artillery is harder to counter but slower and more complex to command.
+
+## Deterministic Noise in Combat
+
+Equipment quality shapes combat outcomes without introducing randomness:
+
+```
+actual_damage = base_damage + noise(weapon.quality, weapon_id, shot_index)
+```
+
+High-quality weapons: tight scatter, predictable damage. Crude weapons: wide scatter, volatile. The noise seed is `(weapon_id, shot_index)` — deterministic, not rerollable. You can't retry for a better roll. The shot is the shot.
+
+The beacon seeds the engagement-level noise: initial positioning scatter, environmental conditions. You committed your orders before the beacon, so you can't optimize for specific conditions. Your strategy must be robust across different beacon values.
+
+Combined: equipment quality determines shot-to-shot consistency (per PHYSICS.md). The beacon determines engagement-level conditions. Strategy must handle both.
+
+## What This Spec Doesn't Cover
+
+**Specific orders.** What stances exist, what formations look like, what "engagement range" means in spatial terms. Game design. Founding cluster publishes the first standard combat script with a specific order vocabulary. It evolves through playtesting.
+
+**Damage formulas.** How weapon material properties map to base damage, how shields absorb, how stress accumulates. Game design within the constraint physics framework. The standard combat script encodes these. Content-addressed, versioned, voluntarily adopted.
+
+**Sub-tick resolution.** How many simulation steps happen within each beacon tick's combat round. Tuning parameter in the combat script. More steps = more tactical richness but more compute.
+
+**Spatial model.** 2D or 3D combat space. Range calculation, movement model, line-of-sight. Game design. The model here is agnostic — it works with any spatial model that's deterministic.
+
+**Information model.** How much each side sees of the opponent. Full state, sensor-limited, fog of war. Game design. Sensors as a real system (Law 3 power draw, Law 5 coupling) would add depth. Deferred.
+
+**Loot and capture.** What happens to destroyed ships' cargo, how capture works. Allgard transfer mechanics apply — destroyed objects are gone, captured objects transfer via standard bilateral escrow. The details are game design.
+
+**Multi-party combat.** More than two sides in the same engagement. The bilateral model extends but the commit-reveal flow gets more complex. Deferred until two-party combat is solid.
+
+## Interaction With Other Systems
+
+**Constraint physics.** Ships are component trees. Combat stresses components. Damaged components fail (Law 4). Replacement consumes materials. The five laws constrain what ships can exist and what tradeoffs they face — combat exploits those tradeoffs.
+
+**Beacon.** Commit-reveal per tick provides strategic blindness (can't react to opponent's current move) and engagement-level noise seeding (can't optimize for specific conditions).
+
+**Transformation physics.** Better materials = better weapons, shields, engines. Combat creates demand for the best materials. The material research game feeds the combat game.
+
+**Conservation laws.** Destroyed objects are permanently gone. Combat is a consumption sink. War has real economic cost — the most powerful deterrent against frivolous aggression.
+
+**Leden capabilities.** Combat consent, retreat rights, and order submission all flow through the capability model. Revocation of combat consent = leaving the PvP zone.

--- a/projects/apeiron/sim/transform_sim.py
+++ b/projects/apeiron/sim/transform_sim.py
@@ -100,8 +100,11 @@ class Galaxy:
         peaks = []
         for ei in range(num_elements):
             for ej in range(ei + 1, num_elements):
-                raw = _sf(f"{self.seed}:peaks:{ei}:{ej}", 200)
-                n_peaks = 3 + int(raw[0] * 3)  # 3-5 peaks per pair
+                raw = _sf(f"{self.seed}:peaks:{ei}:{ej}", 800)
+                # num_centers controls peak density: 10→1-2, 30→3-4, 100→10-16
+                base_n = max(1, self.num_centers // 10)
+                extra_n = max(1, self.num_centers // 15)
+                n_peaks = base_n + int(raw[0] * extra_n)
                 idx = 1
                 for pk in range(n_peaks):
                     # Stoichiometric ratio for this pair (where in the
@@ -117,7 +120,7 @@ class Galaxy:
                         heights.append(h)
                         idx += 1
                     # Width (how forgiving the stoichiometry is)
-                    width = 0.03 + raw[idx] * 0.15; idx += 1
+                    width = 0.06 + raw[idx] * 0.15; idx += 1
                     # Shape
                     shape_idx = int(raw[idx] * len(SHAPES)) % len(SHAPES); idx += 1
                     # Energy window: [lo, hi] — peak only active in this range
@@ -425,6 +428,27 @@ class Researcher:
                 if stall > 30:
                     self.current = self._smart_restart()
                     stall = 0
+            elif self.strategy == "phased":
+                # Phase 1: random exploration (first 40% of budget)
+                # Phase 2: hill-climb the best find (remaining 60%)
+                total = self.exp_count + self.budget
+                explore_end = int(total * 0.4)
+                if self.exp_count < explore_end:
+                    self._eval(self._rand())
+                elif self.exp_count == explore_end:
+                    # Transition: start exploiting from best discovery
+                    self.current = self.best_point
+                    pt = self._perturb(self.current)
+                    old = self.best_val
+                    _, v = self._eval(pt)
+                    if v >= old:
+                        self.current = pt
+                else:
+                    pt = self._perturb(self.current)
+                    old = self.best_val
+                    _, v = self._eval(pt)
+                    if v >= old:
+                        self.current = pt
         return self.history
 
 
@@ -453,7 +477,7 @@ def run_sim(galaxy_seed=42, ne=3, budget=500, nr=20, tp=1, nc=30,
             max_e=50, catalyst=None, precision=None):
     g = Galaxy(galaxy_seed, nc)
     data = {}
-    for s in ["random", "hillclimb", "smart"]:
+    for s in ["random", "hillclimb", "smart", "phased"]:
         runs = []
         for run in range(nr):
             random.seed(run * 1000 + hash(s))
@@ -501,6 +525,61 @@ def test_basic():
     data = run_sim()
     print_curves(data)
     print_metrics(data)
+
+
+def test_exploitation():
+    """Within-peak exploitation: once you've found a peak, does
+    hill-climbing within it beat random sampling?
+
+    Seeds a researcher at a known good point (found by random scan),
+    then compares hill-climbing exploitation vs continued random search
+    with the same remaining budget.
+    """
+    print("\n" + "=" * 70)
+    print("EXPLOITATION: Hill-climbing within a peak vs continued random")
+    print("=" * 70)
+    print("\n  Phase 1: 100 random experiments to find a peak.")
+    print("  Phase 2: 400 more experiments — hill-climb from peak vs random.\n")
+
+    g = Galaxy(42)
+    nr = 20
+
+    for ne in [2, 3, 4]:
+        random_finals = []
+        exploit_finals = []
+
+        for run in range(nr):
+            # Phase 1: identical random scan for both
+            random.seed(run * 1000)
+            scout = Researcher(g, ne, 100, "random")
+            scout.run()
+            peak_point = scout.best_point
+            peak_val = scout.best_val
+
+            # Phase 2a: continue random (ignore the peak)
+            random.seed(run * 2000)
+            r_rand = Researcher(g, ne, 400, "random")
+            r_rand.best_val = peak_val
+            r_rand.run()
+            random_finals.append(r_rand.best_val)
+
+            # Phase 2b: hill-climb from the peak
+            random.seed(run * 2000)
+            r_exploit = Researcher(g, ne, 400, "hillclimb")
+            r_exploit.current = peak_point
+            r_exploit.best_val = peak_val
+            r_exploit.best_point = peak_point
+            r_exploit.run()
+            exploit_finals.append(r_exploit.best_val)
+
+        rm = sum(random_finals) / nr
+        em = sum(exploit_finals) / nr
+        ratio = em / rm if rm > 0.01 else 0
+        print(f"  {ne} elements:  random={rm:.3f}  exploit={em:.3f}"
+              f"  ratio={ratio:.2f}")
+
+    print(f"\n  ratio > 1.0 = hill-climbing adds value within a peak")
+    print(f"  ratio < 1.0 = peaks too narrow for local search to help")
 
 
 def test_catalyst():
@@ -647,21 +726,22 @@ def test_seeds():
     print("\n" + "=" * 70)
     print("SEED VARIANCE: Different galaxies, different landscapes?")
     print("=" * 70)
-    print(f"{'Seed':>6} {'random':>10} {'smart':>10}")
-    print("-" * 30)
-    vals = {"random": [], "smart": []}
+    strats = ["random", "smart", "phased"]
+    print(f"{'Seed':>6}" + "".join(f"{s:>10}" for s in strats))
+    print("-" * (6 + 10 * len(strats)))
+    vals = {s: [] for s in strats}
     for seed in range(20):
         d = run_sim(galaxy_seed=seed, nr=10, budget=300)
-        for s in ["random", "smart"]:
+        for s in strats:
             f = sum(r.history[-1][1] for r in d[s]) / 10
             vals[s].append(f)
-        print(f"{seed:>6} {vals['random'][-1]:>10.3f} {vals['smart'][-1]:>10.3f}")
-    print("-" * 30)
+        print(f"{seed:>6}" + "".join(f"{vals[s][-1]:>10.3f}" for s in strats))
+    print("-" * (6 + 10 * len(strats)))
     for label, fn in [("mean", lambda v: sum(v)/len(v)),
                       ("std", lambda v: (sum((x-sum(v)/len(v))**2 for x in v)/len(v))**0.5),
                       ("min", min), ("max", max)]:
         print(f"{label:>6}", end="")
-        for s in ["random", "smart"]:
+        for s in strats:
             print(f"{fn(vals[s]):>10.3f}", end="")
         print()
 
@@ -1004,79 +1084,108 @@ def test_beacon_batches():
 
 
 def test_beacon_hillclimb():
-    """Hill-climbing across tick windows.
+    """Neighborhood knowledge transfer across beacon ticks.
 
-    The landscape shifts each tick (new beacon = new peak positions).
-    Can a researcher still make progress across ticks by knowing the
-    right neighborhood, even though the exact optimum moves?
+    The landscape shifts each tick. Three strategies compared on
+    the SAME beacon ticks, using the same total budget (300 experiments):
 
-    Compare: 1 experiment per tick (pure sequential hill-climbing across
-    shifting landscape) vs base landscape (no beacon, stable peaks).
+    - Random: N random experiments per tick, no learning
+    - Fixed: pre-optimized recipe from base landscape, submitted each tick
+    - Adaptive: N experiments per tick near current best, learns across ticks
+
+    The key question: does knowing the right neighborhood (from prior
+    ticks) help on the next tick, even though the exact peaks shifted?
     """
     print("\n" + "=" * 70)
-    print("BEACON HILL-CLIMBING: Can researchers climb across shifting ticks?")
+    print("BEACON KNOWLEDGE TRANSFER: Does neighborhood knowledge help?")
     print("=" * 70)
 
     g = Galaxy(42)
     nr = 20
-    budget = 300
+    total_budget = 300
 
-    # Without beacon: stable landscape, smart strategy
-    no_beacon = []
-    for run in range(nr):
-        random.seed(run * 1000)
-        r = Researcher(g, 3, budget, "smart")
-        r.run()
-        no_beacon.append(r.best_val)
+    # Fixed baseline: pre-optimize on base landscape
+    random.seed(42)
+    scout = Researcher(g, 3, 1000, "smart")
+    scout.run()
+    fixed_recipe = scout.best_point
 
-    # With beacon: landscape shifts each tick, 1 experiment per tick
-    with_beacon = []
-    for run in range(nr):
-        random.seed(run * 1000)
-        best_val = -float('inf')
-        best_point = None
-        current = None
-        stall = 0
+    for batch_size in [1, 5, 10, 25]:
+        n_ticks = total_budget // batch_size
 
-        for tick in range(budget):
-            beacon_val = hash(f"tick:{tick}:{run}")
+        fixed_scores = []
+        adaptive_scores = []
+        random_scores = []
 
-            if current is None:
-                raw = [random.random() for _ in range(3)]
-                t = sum(raw)
-                pt = ([r / t for r in raw], random.uniform(0, 50))
-            else:
-                f, e = current
-                nf = [max(0.001, fi + random.gauss(0, 0.03)) for fi in f]
-                t = sum(nf)
-                nf = [fi / t for fi in nf]
-                ne = max(0, min(50, e + random.gauss(0, 3.0)))
-                pt = (nf, ne)
+        for run in range(nr):
+            tick_fixed = []
+            tick_adaptive = []
+            tick_random = []
 
-            props = interact(pt[0], pt[1], g, beacon=beacon_val)
-            v = props[1]
+            current = None  # adaptive's current neighborhood
 
-            if v > best_val:
-                best_val = v
-                best_point = pt
-                current = pt
-                stall = 0
-            else:
-                stall += 1
+            for tick in range(n_ticks):
+                beacon_val = hash(f"tick:{tick}:{run}")
 
-            if stall > 30:
-                current = None
-                stall = 0
+                # Fixed: submit pre-optimized recipe
+                ff, fe = fixed_recipe
+                props_f = interact(ff, fe, g, beacon=beacon_val)
+                tick_fixed.append(props_f[1])
 
-        with_beacon.append(best_val)
+                # Random: N random experiments, take best
+                random.seed(run * 1000 + tick)
+                best_rand = -float('inf')
+                for _ in range(batch_size):
+                    raw = [random.random() for _ in range(3)]
+                    t = sum(raw)
+                    rf = [r / t for r in raw]
+                    re = random.uniform(0, 50)
+                    v = interact(rf, re, g, beacon=beacon_val)[1]
+                    best_rand = max(best_rand, v)
+                tick_random.append(best_rand)
 
-    mean_nb = sum(no_beacon) / nr
-    mean_wb = sum(with_beacon) / nr
-    ratio = mean_wb / mean_nb if mean_nb > 0.01 else 0
-    print(f"\n  No beacon (stable landscape): {mean_nb:.3f}")
-    print(f"  With beacon (shifting ticks):  {mean_wb:.3f}  (ratio: {ratio:.2f})")
-    print(f"\n  If ratio > 0.7: hill-climbing across ticks works")
-    print(f"  If ratio < 0.3: beacon shifts destroy all learned knowledge")
+                # Adaptive: N experiments near current best
+                random.seed(run * 2000 + tick)
+                best_adapt = -float('inf')
+                best_adapt_pt = None
+                for _ in range(batch_size):
+                    if current is None:
+                        raw = [random.random() for _ in range(3)]
+                        t = sum(raw)
+                        pt = ([r / t for r in raw], random.uniform(0, 50))
+                    else:
+                        f, e = current
+                        nf = [max(0.001, fi + random.gauss(0, 0.05))
+                              for fi in f]
+                        t = sum(nf)
+                        nf = [fi / t for fi in nf]
+                        ne = max(0, min(50, e + random.gauss(0, 5.0)))
+                        pt = (nf, ne)
+                    v = interact(pt[0], pt[1], g, beacon=beacon_val)[1]
+                    if v > best_adapt:
+                        best_adapt = v
+                        best_adapt_pt = pt
+                tick_adaptive.append(best_adapt)
+                current = best_adapt_pt
+
+            # Score: average over final half of ticks (after warmup)
+            half = max(1, n_ticks // 2)
+            fixed_scores.append(sum(tick_fixed[-half:]) / half)
+            adaptive_scores.append(sum(tick_adaptive[-half:]) / half)
+            random_scores.append(sum(tick_random[-half:]) / half)
+
+        mean_r = sum(random_scores) / nr
+        mean_f = sum(fixed_scores) / nr
+        mean_a = sum(adaptive_scores) / nr
+        print(f"\n  batch={batch_size:>2}, ticks={n_ticks:>3}:"
+              f"  random={mean_r:.3f}  fixed={mean_f:.3f}"
+              f"  adaptive={mean_a:.3f}"
+              f"  (adapt/fixed={mean_a/mean_f:.2f})" if mean_f > 0.01
+              else "")
+
+    print(f"\n  fixed = value of knowing the right neighborhood")
+    print(f"  adapt/fixed > 1 = active search adds value over memorized recipe")
+    print(f"  adapt/fixed < 1 = not enough per-tick budget to beat memorized")
 
 
 def test_beacon_bruteforce():
@@ -1187,7 +1296,8 @@ if __name__ == "__main__":
         return int(sys.argv[2]) if len(sys.argv) > 2 else 42
 
     tests = {
-        "basic": test_basic, "catalyst": test_catalyst, "energy": test_energy,
+        "basic": test_basic, "exploitation": test_exploitation,
+        "catalyst": test_catalyst, "energy": test_energy,
         "precision": test_precision, "sharing": test_sharing,
         "reverse": test_reverse, "seeds": test_seeds,
         "elements": test_elements, "density": test_density,


### PR DESCRIPTION
## Summary

This PR adds comprehensive protocol documentation for the beacon system and enhances the transform simulation with new search strategies and test cases.

## Key Changes

**New Documentation:**
- Added `BEACON_PROTOCOL.md` specifying the wire protocol for commit-reveal beacon consensus, including:
  - 30-second tick timing with commit (20s), reveal (7s), and grace (3s) phases
  - Leden message types (BeaconCommit, BeaconReveal, BeaconEntry, etc.)
  - Commitment lock lifecycle for transform execution
  - Byzantine behavior handling (non-reveal, invalid reveal, equivocation, withholding bias)
  - Gossip propagation model and bandwidth estimates
  - Capability model for contributing, consuming, and committing transforms

- Added `COMBAT.md` specifying the combat execution and authority model, including:
  - Hybrid orders + scripts execution model
  - Multi-tick engagement with commit-reveal for orders
  - Authority model for PvP on neutral ground vs attacking a domain
  - Consent-on-entry capability grants
  - Retreat mechanics and disengagement
  - Counter-strategies emerging from constraint physics

**Simulation Improvements:**
- Enhanced peak generation in `_get_peaks()` to scale peak density with `num_centers` parameter (base + extra peaks)
- Increased peak width from 0.03-0.18 to 0.06-0.21 for more forgiving stoichiometry
- Added "phased" search strategy: 40% random exploration followed by 60% hill-climbing exploitation
- Added `test_exploitation()` to measure hill-climbing value within peaks vs continued random search
- Refactored `test_beacon_hillclimb()` to test neighborhood knowledge transfer across beacon ticks with three strategies (random, fixed recipe, adaptive)
- Updated `test_seeds()` to include "phased" strategy in variance analysis
- Expanded test suite to measure whether learned neighborhoods help on subsequent ticks despite landscape shifts

## Implementation Details

The beacon protocol spec defines a permissionless commit-reveal scheme where any domain can contribute (one honest contributor is sufficient). The 30-second tick interval balances gossip convergence across global networks with responsiveness for combat/crafting. Transform commitments are bilateral (not gossiped) to preserve domain sovereignty while the beacon itself is public infrastructure.

The combat spec establishes that combat is deterministic and verifiable rather than enforced, with the domain computing outcomes but any party able to re-execute and verify. Reputation destruction and retreat escrow provide enforcement mechanisms without requiring a central authority.

The simulation enhancements focus on understanding how search strategies perform within and across shifting landscapes (beacon ticks), with the phased strategy and exploitation tests measuring whether local optimization adds value when the global landscape changes each tick.

https://claude.ai/code/session_017QHcAjTfCj6cyyBb9AFfBt