### PR TITLE
Add C header import support with parser and translator

### DIFF
--- a/compiler/Cargo.lock
+++ b/compiler/Cargo.lock
@@ -1339,11 +1339,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "rask-c-parse"
+version = "0.1.0"
+
+[[package]]
 name = "rask-cli"
 version = "0.1.0"
 dependencies = [
  "colored",
  "rask-ast",
+ "rask-c-parse",
  "rask-codegen",
  "rask-comptime",
  "rask-describe",
@@ -1563,6 +1568,7 @@ dependencies = [
  "flate2",
  "rand",
  "rask-ast",
+ "rask-c-parse",
  "rask-lexer",
  "rask-parser",
  "reqwest",

--- a/compiler/Cargo.toml
+++ b/compiler/Cargo.toml
@@ -26,6 +26,7 @@ members = [
     "crates/rask-hidden-params",
     "crates/rask-semantic-hash",
     "crates/rask-effects",
+    "crates/rask-c-parse",
 ]
 
 [workspace.package]

--- a/compiler/crates/rask-c-parse/Cargo.toml
+++ b/compiler/crates/rask-c-parse/Cargo.toml
@@ -1,0 +1,7 @@
+[package]
+name = "rask-c-parse"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+
+[dependencies]

--- a/compiler/crates/rask-c-parse/src/lexer.rs
+++ b/compiler/crates/rask-c-parse/src/lexer.rs
@@ -1,0 +1,535 @@
+// SPDX-License-Identifier: (MIT OR Apache-2.0)
+
+//! C header lexer — tokenizes preprocessed C source.
+
+use crate::parser::ParseError;
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct CToken {
+    pub kind: CTokenKind,
+    pub line: usize,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub enum CTokenKind {
+    // Literals
+    Ident(String),
+    IntLit(i64),
+    UIntLit(u64),
+    FloatLit(f64),
+    StringLit(String),
+    CharLit(char),
+
+    // Keywords
+    Void,
+    Char,
+    Short,
+    Int,
+    Long,
+    Float,
+    Double,
+    Signed,
+    Unsigned,
+    Struct,
+    Union,
+    Enum,
+    Typedef,
+    Const,
+    Volatile,
+    Restrict,
+    Static,
+    Extern,
+    Inline,
+    Bool,       // _Bool / bool
+    Sizeof,
+    Alignof,    // _Alignof
+
+    // Punctuation
+    LParen,
+    RParen,
+    LBrace,
+    RBrace,
+    LBracket,
+    RBracket,
+    Semi,
+    Comma,
+    Star,
+    Ampersand,
+    Eq,
+    Plus,
+    Minus,
+    Slash,
+    Percent,
+    Dot,
+    Arrow,      // ->
+    Ellipsis,   // ...
+    Hash,       // #
+    DoubleHash, // ##
+    Pipe,       // |
+    Caret,      // ^
+    Tilde,      // ~
+    Bang,       // !
+    Lt,
+    Gt,
+    LtEq,      // <=
+    GtEq,      // >=
+    EqEq,      // ==
+    BangEq,    // !=
+    LShift,    // <<
+    RShift,    // >>
+    Question,
+    Colon,
+
+    // Preprocessor (kept as tokens for #define parsing)
+    PPDefine,
+    PPInclude,
+    PPIfdef,
+    PPIfndef,
+    PPIf,
+    PPElse,
+    PPElif,
+    PPEndif,
+    PPUndef,
+    PPPragma,
+    PPError,
+    PPLine,
+
+    Newline,
+    Eof,
+}
+
+pub struct CLexer<'a> {
+    source: &'a [u8],
+    pos: usize,
+    line: usize,
+}
+
+impl<'a> CLexer<'a> {
+    pub fn new(source: &'a str) -> Self {
+        Self {
+            source: source.as_bytes(),
+            pos: 0,
+            line: 1,
+        }
+    }
+
+    pub fn tokenize(&mut self) -> Result<Vec<CToken>, ParseError> {
+        let mut tokens = Vec::new();
+        loop {
+            let tok = self.next_token()?;
+            let is_eof = tok.kind == CTokenKind::Eof;
+            tokens.push(tok);
+            if is_eof {
+                break;
+            }
+        }
+        Ok(tokens)
+    }
+
+    fn peek(&self) -> u8 {
+        if self.pos < self.source.len() {
+            self.source[self.pos]
+        } else {
+            0
+        }
+    }
+
+    fn peek_at(&self, offset: usize) -> u8 {
+        let idx = self.pos + offset;
+        if idx < self.source.len() {
+            self.source[idx]
+        } else {
+            0
+        }
+    }
+
+    fn advance(&mut self) -> u8 {
+        let ch = self.peek();
+        if ch == b'\n' {
+            self.line += 1;
+        }
+        self.pos += 1;
+        ch
+    }
+
+    fn skip_whitespace_no_newline(&mut self) {
+        while self.pos < self.source.len() {
+            match self.peek() {
+                b' ' | b'\t' | b'\r' => { self.advance(); }
+                _ => break,
+            }
+        }
+    }
+
+    fn next_token(&mut self) -> Result<CToken, ParseError> {
+        // Skip whitespace (not newlines — they matter for preprocessor)
+        self.skip_whitespace_no_newline();
+
+        if self.pos >= self.source.len() {
+            return Ok(CToken { kind: CTokenKind::Eof, line: self.line });
+        }
+
+        let line = self.line;
+        let ch = self.peek();
+
+        // Newline
+        if ch == b'\n' {
+            self.advance();
+            return Ok(CToken { kind: CTokenKind::Newline, line });
+        }
+
+        // Line continuation
+        if ch == b'\\' && self.peek_at(1) == b'\n' {
+            self.advance(); // backslash
+            self.advance(); // newline
+            return self.next_token();
+        }
+
+        // Preprocessor directive
+        if ch == b'#' {
+            self.advance();
+            // ## ?
+            if self.peek() == b'#' {
+                self.advance();
+                return Ok(CToken { kind: CTokenKind::DoubleHash, line });
+            }
+            self.skip_whitespace_no_newline();
+            let directive = self.read_ident();
+            let kind = match directive.as_str() {
+                "define" => CTokenKind::PPDefine,
+                "include" => CTokenKind::PPInclude,
+                "ifdef" => CTokenKind::PPIfdef,
+                "ifndef" => CTokenKind::PPIfndef,
+                "if" => CTokenKind::PPIf,
+                "else" => CTokenKind::PPElse,
+                "elif" => CTokenKind::PPElif,
+                "endif" => CTokenKind::PPEndif,
+                "undef" => CTokenKind::PPUndef,
+                "pragma" => CTokenKind::PPPragma,
+                "error" => CTokenKind::PPError,
+                "line" => CTokenKind::PPLine,
+                _ => CTokenKind::Hash, // unknown directive, treat as hash
+            };
+            return Ok(CToken { kind, line });
+        }
+
+        // Numbers
+        if ch.is_ascii_digit() || (ch == b'.' && self.peek_at(1).is_ascii_digit()) {
+            return self.read_number(line);
+        }
+
+        // String literal
+        if ch == b'"' {
+            return self.read_string_lit(line);
+        }
+
+        // Char literal
+        if ch == b'\'' {
+            return self.read_char_lit(line);
+        }
+
+        // Identifiers and keywords
+        if ch.is_ascii_alphabetic() || ch == b'_' {
+            let ident = self.read_ident();
+            let kind = match ident.as_str() {
+                "void" => CTokenKind::Void,
+                "char" => CTokenKind::Char,
+                "short" => CTokenKind::Short,
+                "int" => CTokenKind::Int,
+                "long" => CTokenKind::Long,
+                "float" => CTokenKind::Float,
+                "double" => CTokenKind::Double,
+                "signed" => CTokenKind::Signed,
+                "unsigned" => CTokenKind::Unsigned,
+                "struct" => CTokenKind::Struct,
+                "union" => CTokenKind::Union,
+                "enum" => CTokenKind::Enum,
+                "typedef" => CTokenKind::Typedef,
+                "const" => CTokenKind::Const,
+                "volatile" => CTokenKind::Volatile,
+                "restrict" | "__restrict" | "__restrict__" => CTokenKind::Restrict,
+                "static" => CTokenKind::Static,
+                "extern" => CTokenKind::Extern,
+                "inline" | "__inline" | "__inline__" | "__forceinline" => CTokenKind::Inline,
+                "_Bool" | "bool" => CTokenKind::Bool,
+                "sizeof" => CTokenKind::Sizeof,
+                "_Alignof" | "alignof" => CTokenKind::Alignof,
+                // GCC/Clang attributes — skip
+                "__attribute__" => {
+                    self.skip_attribute();
+                    return self.next_token();
+                }
+                "__declspec" => {
+                    self.skip_attribute();
+                    return self.next_token();
+                }
+                "__extension__" => return self.next_token(),
+                "__asm__" | "__asm" | "asm" => {
+                    self.skip_attribute();
+                    return self.next_token();
+                }
+                _ => CTokenKind::Ident(ident),
+            };
+            return Ok(CToken { kind, line });
+        }
+
+        // Punctuation
+        self.advance();
+        let kind = match ch {
+            b'(' => CTokenKind::LParen,
+            b')' => CTokenKind::RParen,
+            b'{' => CTokenKind::LBrace,
+            b'}' => CTokenKind::RBrace,
+            b'[' => CTokenKind::LBracket,
+            b']' => CTokenKind::RBracket,
+            b';' => CTokenKind::Semi,
+            b',' => CTokenKind::Comma,
+            b'*' => CTokenKind::Star,
+            b'&' => CTokenKind::Ampersand,
+            b'+' => CTokenKind::Plus,
+            b'%' => CTokenKind::Percent,
+            b'^' => CTokenKind::Caret,
+            b'~' => CTokenKind::Tilde,
+            b'?' => CTokenKind::Question,
+            b':' => CTokenKind::Colon,
+            b'|' => CTokenKind::Pipe,
+            b'/' => CTokenKind::Slash,
+            b'.' => {
+                if self.peek() == b'.' && self.peek_at(1) == b'.' {
+                    self.advance();
+                    self.advance();
+                    CTokenKind::Ellipsis
+                } else {
+                    CTokenKind::Dot
+                }
+            }
+            b'-' => {
+                if self.peek() == b'>' {
+                    self.advance();
+                    CTokenKind::Arrow
+                } else {
+                    CTokenKind::Minus
+                }
+            }
+            b'=' => {
+                if self.peek() == b'=' {
+                    self.advance();
+                    CTokenKind::EqEq
+                } else {
+                    CTokenKind::Eq
+                }
+            }
+            b'!' => {
+                if self.peek() == b'=' {
+                    self.advance();
+                    CTokenKind::BangEq
+                } else {
+                    CTokenKind::Bang
+                }
+            }
+            b'<' => {
+                if self.peek() == b'=' {
+                    self.advance();
+                    CTokenKind::LtEq
+                } else if self.peek() == b'<' {
+                    self.advance();
+                    CTokenKind::LShift
+                } else {
+                    CTokenKind::Lt
+                }
+            }
+            b'>' => {
+                if self.peek() == b'=' {
+                    self.advance();
+                    CTokenKind::GtEq
+                } else if self.peek() == b'>' {
+                    self.advance();
+                    CTokenKind::RShift
+                } else {
+                    CTokenKind::Gt
+                }
+            }
+            _ => {
+                return Err(ParseError::new(
+                    format!("unexpected character: {:?}", ch as char),
+                    line,
+                ));
+            }
+        };
+        Ok(CToken { kind, line })
+    }
+
+    fn read_ident(&mut self) -> String {
+        let start = self.pos;
+        while self.pos < self.source.len()
+            && (self.source[self.pos].is_ascii_alphanumeric() || self.source[self.pos] == b'_')
+        {
+            self.pos += 1;
+        }
+        String::from_utf8_lossy(&self.source[start..self.pos]).into_owned()
+    }
+
+    fn read_number(&mut self, line: usize) -> Result<CToken, ParseError> {
+        let start = self.pos;
+
+        // Hex
+        if self.peek() == b'0' && (self.peek_at(1) == b'x' || self.peek_at(1) == b'X') {
+            self.advance();
+            self.advance();
+            let hex_start = self.pos;
+            while self.pos < self.source.len() && self.source[self.pos].is_ascii_hexdigit() {
+                self.pos += 1;
+            }
+            let hex = String::from_utf8_lossy(&self.source[hex_start..self.pos]);
+            let val = u64::from_str_radix(&hex, 16)
+                .map_err(|e| ParseError::new(format!("bad hex literal: {}", e), line))?;
+            self.skip_int_suffix();
+            return Ok(CToken { kind: CTokenKind::UIntLit(val), line });
+        }
+
+        // Octal check
+        let is_octal = self.peek() == b'0' && self.peek_at(1).is_ascii_digit();
+
+        // Read digits
+        while self.pos < self.source.len() && self.source[self.pos].is_ascii_digit() {
+            self.pos += 1;
+        }
+
+        // Float?
+        let is_float = self.peek() == b'.' || self.peek() == b'e' || self.peek() == b'E';
+        if is_float {
+            if self.peek() == b'.' {
+                self.pos += 1;
+                while self.pos < self.source.len() && self.source[self.pos].is_ascii_digit() {
+                    self.pos += 1;
+                }
+            }
+            if self.peek() == b'e' || self.peek() == b'E' {
+                self.pos += 1;
+                if self.peek() == b'+' || self.peek() == b'-' {
+                    self.pos += 1;
+                }
+                while self.pos < self.source.len() && self.source[self.pos].is_ascii_digit() {
+                    self.pos += 1;
+                }
+            }
+            // Skip float suffix (f, F, l, L)
+            if matches!(self.peek(), b'f' | b'F' | b'l' | b'L') {
+                self.pos += 1;
+            }
+            let text = String::from_utf8_lossy(&self.source[start..self.pos]);
+            // Strip suffix for parsing
+            let clean: String = text.chars().filter(|c| !matches!(c, 'f' | 'F' | 'l' | 'L')).collect();
+            let val: f64 = clean.parse()
+                .map_err(|e| ParseError::new(format!("bad float literal: {}", e), line))?;
+            return Ok(CToken { kind: CTokenKind::FloatLit(val), line });
+        }
+
+        let text = String::from_utf8_lossy(&self.source[start..self.pos]);
+        let val = if is_octal && text.len() > 1 {
+            i64::from_str_radix(&text[1..], 8)
+                .map_err(|e| ParseError::new(format!("bad octal literal: {}", e), line))?
+        } else {
+            text.parse::<i64>()
+                .map_err(|e| ParseError::new(format!("bad integer literal: {}", e), line))?
+        };
+
+        let is_unsigned = self.skip_int_suffix();
+        if is_unsigned {
+            Ok(CToken { kind: CTokenKind::UIntLit(val as u64), line })
+        } else {
+            Ok(CToken { kind: CTokenKind::IntLit(val), line })
+        }
+    }
+
+    /// Skip integer suffixes (u, U, l, L, ll, LL, etc). Returns true if unsigned.
+    fn skip_int_suffix(&mut self) -> bool {
+        let mut unsigned = false;
+        loop {
+            match self.peek() {
+                b'u' | b'U' => { unsigned = true; self.pos += 1; }
+                b'l' | b'L' => { self.pos += 1; }
+                _ => break,
+            }
+        }
+        unsigned
+    }
+
+    fn read_string_lit(&mut self, line: usize) -> Result<CToken, ParseError> {
+        self.advance(); // opening quote
+        let mut s = String::new();
+        loop {
+            if self.pos >= self.source.len() {
+                return Err(ParseError::new("unterminated string literal".into(), line));
+            }
+            let ch = self.advance();
+            match ch {
+                b'"' => break,
+                b'\\' => {
+                    let esc = self.advance();
+                    match esc {
+                        b'n' => s.push('\n'),
+                        b't' => s.push('\t'),
+                        b'r' => s.push('\r'),
+                        b'0' => s.push('\0'),
+                        b'\\' => s.push('\\'),
+                        b'"' => s.push('"'),
+                        b'\'' => s.push('\''),
+                        _ => {
+                            s.push('\\');
+                            s.push(esc as char);
+                        }
+                    }
+                }
+                _ => s.push(ch as char),
+            }
+        }
+        Ok(CToken { kind: CTokenKind::StringLit(s), line })
+    }
+
+    fn read_char_lit(&mut self, line: usize) -> Result<CToken, ParseError> {
+        self.advance(); // opening quote
+        let ch = if self.peek() == b'\\' {
+            self.advance();
+            match self.advance() {
+                b'n' => '\n',
+                b't' => '\t',
+                b'r' => '\r',
+                b'0' => '\0',
+                b'\\' => '\\',
+                b'\'' => '\'',
+                other => other as char,
+            }
+        } else {
+            self.advance() as char
+        };
+        if self.peek() == b'\'' {
+            self.advance();
+        }
+        Ok(CToken { kind: CTokenKind::CharLit(ch), line })
+    }
+
+    /// Skip `__attribute__((...))` or `__declspec(...)` or `asm(...)`.
+    fn skip_attribute(&mut self) {
+        self.skip_whitespace_no_newline();
+        if self.peek() != b'(' {
+            return;
+        }
+        let mut depth = 0u32;
+        loop {
+            if self.pos >= self.source.len() {
+                break;
+            }
+            match self.peek() {
+                b'(' => { depth += 1; self.advance(); }
+                b')' => {
+                    self.advance();
+                    depth -= 1;
+                    if depth == 0 { break; }
+                }
+                b'\n' => { self.advance(); }
+                _ => { self.advance(); }
+            }
+        }
+    }
+}

--- a/compiler/crates/rask-c-parse/src/lexer.rs
+++ b/compiler/crates/rask-c-parse/src/lexer.rs
@@ -8,6 +8,8 @@ use crate::parser::ParseError;
 pub struct CToken {
     pub kind: CTokenKind,
     pub line: usize,
+    /// True if whitespace preceded this token (used for #define disambiguation).
+    pub space_before: bool,
 }
 
 #[derive(Debug, Clone, PartialEq)]
@@ -162,11 +164,19 @@ impl<'a> CLexer<'a> {
     }
 
     fn next_token(&mut self) -> Result<CToken, ParseError> {
-        // Skip whitespace (not newlines — they matter for preprocessor)
+        // Skip whitespace and track whether there was any (for #define disambiguation).
+        let pos_before_ws = self.pos;
         self.skip_whitespace_no_newline();
+        let had_space = self.pos > pos_before_ws;
 
+        let mut tok = self.next_token_raw()?;
+        tok.space_before = had_space;
+        Ok(tok)
+    }
+
+    fn next_token_raw(&mut self) -> Result<CToken, ParseError> {
         if self.pos >= self.source.len() {
-            return Ok(CToken { kind: CTokenKind::Eof, line: self.line });
+            return Ok(CToken { kind: CTokenKind::Eof, line: self.line, space_before: false });
         }
 
         let line = self.line;
@@ -175,7 +185,7 @@ impl<'a> CLexer<'a> {
         // Newline
         if ch == b'\n' {
             self.advance();
-            return Ok(CToken { kind: CTokenKind::Newline, line });
+            return Ok(CToken { kind: CTokenKind::Newline, line, space_before: false });
         }
 
         // Line continuation
@@ -191,7 +201,7 @@ impl<'a> CLexer<'a> {
             // ## ?
             if self.peek() == b'#' {
                 self.advance();
-                return Ok(CToken { kind: CTokenKind::DoubleHash, line });
+                return Ok(CToken { kind: CTokenKind::DoubleHash, line, space_before: false });
             }
             self.skip_whitespace_no_newline();
             let directive = self.read_ident();
@@ -210,7 +220,7 @@ impl<'a> CLexer<'a> {
                 "line" => CTokenKind::PPLine,
                 _ => CTokenKind::Hash, // unknown directive, treat as hash
             };
-            return Ok(CToken { kind, line });
+            return Ok(CToken { kind, line, space_before: false });
         }
 
         // Numbers
@@ -254,8 +264,8 @@ impl<'a> CLexer<'a> {
                 "_Bool" | "bool" => CTokenKind::Bool,
                 "sizeof" => CTokenKind::Sizeof,
                 "_Alignof" | "alignof" => CTokenKind::Alignof,
-                // GCC/Clang attributes — skip
-                "__attribute__" => {
+                // GCC/Clang attributes and glibc macros — skip entirely
+                "__attribute__" | "__attribute" => {
                     self.skip_attribute();
                     return self.next_token();
                 }
@@ -268,9 +278,31 @@ impl<'a> CLexer<'a> {
                     self.skip_attribute();
                     return self.next_token();
                 }
+                // glibc function attributes — skip ident + optional parens
+                "__THROW" | "__THROWNL" | "__nonnull" | "__wur"
+                | "__attribute_pure__" | "__attribute_const__"
+                | "__attribute_malloc__" | "__attribute_format_strfmon__"
+                | "__attribute_warn_unused_result__"
+                | "__attr_access" | "__attr_access_none" | "__attr_dealloc"
+                | "__attr_dealloc_free" | "__fortified_attr_access"
+                | "__nonnull_attribute__" | "__returns_nonnull"
+                | "__glibc_fortify" | "__glibc_fortify_n"
+                | "__REDIRECT" | "__REDIRECT_NTH" | "__REDIRECT_NTHNL"
+                | "__COLD" | "__warnattr" | "__errordecl" => {
+                    self.skip_optional_parens();
+                    return self.next_token();
+                }
+                // glibc scope markers — skip
+                "__BEGIN_DECLS" | "__END_DECLS"
+                | "__BEGIN_NAMESPACE_STD" | "__END_NAMESPACE_STD"
+                | "__USING_NAMESPACE_STD"
+                | "__BEGIN_NAMESPACE_C99" | "__END_NAMESPACE_C99"
+                | "__USING_NAMESPACE_C99" => {
+                    return self.next_token();
+                }
                 _ => CTokenKind::Ident(ident),
             };
-            return Ok(CToken { kind, line });
+            return Ok(CToken { kind, line, space_before: false });
         }
 
         // Punctuation
@@ -356,7 +388,7 @@ impl<'a> CLexer<'a> {
                 ));
             }
         };
-        Ok(CToken { kind, line })
+        Ok(CToken { kind, line, space_before: false })
     }
 
     fn read_ident(&mut self) -> String {
@@ -384,7 +416,7 @@ impl<'a> CLexer<'a> {
             let val = u64::from_str_radix(&hex, 16)
                 .map_err(|e| ParseError::new(format!("bad hex literal: {}", e), line))?;
             self.skip_int_suffix();
-            return Ok(CToken { kind: CTokenKind::UIntLit(val), line });
+            return Ok(CToken { kind: CTokenKind::UIntLit(val), line, space_before: false });
         }
 
         // Octal check
@@ -422,7 +454,7 @@ impl<'a> CLexer<'a> {
             let clean: String = text.chars().filter(|c| !matches!(c, 'f' | 'F' | 'l' | 'L')).collect();
             let val: f64 = clean.parse()
                 .map_err(|e| ParseError::new(format!("bad float literal: {}", e), line))?;
-            return Ok(CToken { kind: CTokenKind::FloatLit(val), line });
+            return Ok(CToken { kind: CTokenKind::FloatLit(val), line, space_before: false });
         }
 
         let text = String::from_utf8_lossy(&self.source[start..self.pos]);
@@ -436,9 +468,9 @@ impl<'a> CLexer<'a> {
 
         let is_unsigned = self.skip_int_suffix();
         if is_unsigned {
-            Ok(CToken { kind: CTokenKind::UIntLit(val as u64), line })
+            Ok(CToken { kind: CTokenKind::UIntLit(val as u64), line, space_before: false })
         } else {
-            Ok(CToken { kind: CTokenKind::IntLit(val), line })
+            Ok(CToken { kind: CTokenKind::IntLit(val), line, space_before: false })
         }
     }
 
@@ -484,7 +516,7 @@ impl<'a> CLexer<'a> {
                 _ => s.push(ch as char),
             }
         }
-        Ok(CToken { kind: CTokenKind::StringLit(s), line })
+        Ok(CToken { kind: CTokenKind::StringLit(s), line, space_before: false })
     }
 
     fn read_char_lit(&mut self, line: usize) -> Result<CToken, ParseError> {
@@ -506,7 +538,7 @@ impl<'a> CLexer<'a> {
         if self.peek() == b'\'' {
             self.advance();
         }
-        Ok(CToken { kind: CTokenKind::CharLit(ch), line })
+        Ok(CToken { kind: CTokenKind::CharLit(ch), line, space_before: false })
     }
 
     /// Skip `__attribute__((...))` or `__declspec(...)` or `asm(...)`.
@@ -515,6 +547,19 @@ impl<'a> CLexer<'a> {
         if self.peek() != b'(' {
             return;
         }
+        self.skip_balanced_parens();
+    }
+
+    /// Skip optional parenthesized arguments (for glibc macros like `__nonnull ((1, 2))`).
+    fn skip_optional_parens(&mut self) {
+        self.skip_whitespace_no_newline();
+        if self.peek() == b'(' {
+            self.skip_balanced_parens();
+        }
+    }
+
+    /// Consume balanced parentheses starting at current `(`.
+    fn skip_balanced_parens(&mut self) {
         let mut depth = 0u32;
         loop {
             if self.pos >= self.source.len() {

--- a/compiler/crates/rask-c-parse/src/lib.rs
+++ b/compiler/crates/rask-c-parse/src/lib.rs
@@ -1,0 +1,232 @@
+// SPDX-License-Identifier: (MIT OR Apache-2.0)
+
+//! Minimal C header parser for `import c "header.h"`.
+//!
+//! Parses C declarations (functions, structs, unions, enums, typedefs, #define
+//! constants) into a C-level AST. No libclang dependency. Handles the subset
+//! of C that appears in well-behaved library headers.
+
+mod lexer;
+mod parser;
+pub mod translate;
+
+pub use lexer::{CLexer, CToken, CTokenKind};
+pub use parser::{CParser, ParseError};
+
+/// A parsed C declaration.
+#[derive(Debug, Clone, PartialEq)]
+pub enum CDecl {
+    Function(CFuncDecl),
+    Struct(CStructDecl),
+    Union(CStructDecl),
+    Enum(CEnumDecl),
+    Typedef(CTypedef),
+    /// `#define NAME value` — integer or string constant.
+    Define(CDefine),
+    /// Global variable declaration.
+    Variable(CVarDecl),
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct CFuncDecl {
+    pub name: String,
+    pub params: Vec<CParam>,
+    pub ret_ty: CType,
+    pub is_variadic: bool,
+    pub is_static: bool,
+    pub is_inline: bool,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct CParam {
+    pub name: Option<String>,
+    pub ty: CType,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct CStructDecl {
+    pub tag: Option<String>,
+    pub fields: Vec<CField>,
+    /// True if this is a forward declaration (no body).
+    pub is_forward: bool,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct CField {
+    pub name: String,
+    pub ty: CType,
+    pub bit_width: Option<u32>,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct CEnumDecl {
+    pub tag: Option<String>,
+    pub variants: Vec<CEnumVariant>,
+    pub is_forward: bool,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct CEnumVariant {
+    pub name: String,
+    pub value: Option<i64>,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct CTypedef {
+    pub name: String,
+    pub target: CType,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct CDefine {
+    pub name: String,
+    pub kind: CDefineKind,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub enum CDefineKind {
+    Integer(i64),
+    UnsignedInteger(u64),
+    Float(f64),
+    String(String),
+    /// Function-like macro — skipped per spec, but recorded for warnings.
+    FunctionMacro { params: Vec<String> },
+    /// Unparseable expression — skipped.
+    Unparseable,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct CVarDecl {
+    pub name: String,
+    pub ty: CType,
+    pub is_extern: bool,
+    pub is_const: bool,
+}
+
+/// C type representation.
+#[derive(Debug, Clone, PartialEq)]
+pub enum CType {
+    Void,
+    Char,
+    SignedChar,
+    UnsignedChar,
+    Short,
+    UnsignedShort,
+    Int,
+    UnsignedInt,
+    Long,
+    UnsignedLong,
+    LongLong,
+    UnsignedLongLong,
+    Float,
+    Double,
+    Bool,
+    /// `size_t`
+    SizeT,
+    /// `ssize_t` / `ptrdiff_t`
+    SSizeT,
+    /// `int8_t`, `uint32_t`, etc.
+    FixedInt { bits: u8, signed: bool },
+    /// `intptr_t` / `uintptr_t`
+    IntPtr { signed: bool },
+    /// Pointer to T.
+    Pointer(Box<CType>),
+    /// `const T` (qualifiers on inner type).
+    Const(Box<CType>),
+    /// Array `T[N]`.
+    Array(Box<CType>, Option<u64>),
+    /// Named type (struct tag, typedef name, etc.)
+    Named(String),
+    /// `struct tag` (before resolution to Named).
+    StructTag(String),
+    /// `union tag`.
+    UnionTag(String),
+    /// `enum tag`.
+    EnumTag(String),
+    /// Function pointer: `ret (*)(params...)`.
+    FuncPtr {
+        ret: Box<CType>,
+        params: Vec<CType>,
+        is_variadic: bool,
+    },
+}
+
+/// Warning emitted during parsing (non-fatal).
+#[derive(Debug, Clone)]
+pub struct CWarning {
+    pub message: String,
+    pub line: usize,
+}
+
+/// Result of parsing a C header.
+#[derive(Debug, Clone)]
+pub struct CParseResult {
+    pub decls: Vec<CDecl>,
+    pub warnings: Vec<CWarning>,
+}
+
+/// Parse a C header source string into declarations.
+pub fn parse_c_header(source: &str) -> Result<CParseResult, ParseError> {
+    let preprocessed = preprocess(source);
+    let tokens = CLexer::new(&preprocessed).tokenize()?;
+    let mut parser = CParser::new(tokens);
+    parser.parse()
+}
+
+#[cfg(test)]
+mod tests;
+
+/// Minimal preprocessor: strips comments, handles simple #define/#include/#ifdef.
+fn preprocess(source: &str) -> String {
+    let mut out = String::with_capacity(source.len());
+    let mut chars = source.chars().peekable();
+    let mut in_line_comment = false;
+    let mut in_block_comment = false;
+
+    while let Some(&ch) = chars.peek() {
+        if in_line_comment {
+            if ch == '\n' {
+                in_line_comment = false;
+                out.push('\n');
+            }
+            chars.next();
+            continue;
+        }
+        if in_block_comment {
+            if ch == '*' {
+                chars.next();
+                if chars.peek() == Some(&'/') {
+                    chars.next();
+                    in_block_comment = false;
+                    out.push(' ');
+                }
+            } else {
+                if ch == '\n' {
+                    out.push('\n');
+                }
+                chars.next();
+            }
+            continue;
+        }
+        if ch == '/' {
+            chars.next();
+            match chars.peek() {
+                Some(&'/') => {
+                    chars.next();
+                    in_line_comment = true;
+                }
+                Some(&'*') => {
+                    chars.next();
+                    in_block_comment = true;
+                }
+                _ => {
+                    out.push('/');
+                }
+            }
+            continue;
+        }
+        out.push(ch);
+        chars.next();
+    }
+    out
+}

--- a/compiler/crates/rask-c-parse/src/parser.rs
+++ b/compiler/crates/rask-c-parse/src/parser.rs
@@ -69,6 +69,10 @@ impl CParser {
                 | CTokenKind::PPLine => {
                     self.skip_to_newline();
                 }
+                // Stray closing brace (from extern "C" { ... })
+                CTokenKind::RBrace => {
+                    self.advance();
+                }
                 // Declarations
                 _ => {
                     match self.try_parse_declaration() {
@@ -76,7 +80,7 @@ impl CParser {
                         Ok(None) => {}
                         Err(e) => {
                             self.warnings.push(CWarning {
-                                message: format!("skipping declaration: {}", e.message),
+                                message: format!("skipping declaration: {} (at {:?})", e.message, self.peek()),
                                 line: e.line,
                             });
                             self.skip_to_semi_or_brace();
@@ -96,6 +100,15 @@ impl CParser {
 
     fn at_eof(&self) -> bool {
         self.pos >= self.tokens.len() || self.peek() == CTokenKind::Eof
+    }
+
+    fn peek_token(&self) -> &CToken {
+        static EOF_TOKEN: CToken = CToken { kind: CTokenKind::Eof, line: 0, space_before: false };
+        if self.pos < self.tokens.len() {
+            &self.tokens[self.pos]
+        } else {
+            &EOF_TOKEN
+        }
     }
 
     fn peek(&self) -> CTokenKind {
@@ -208,8 +221,8 @@ impl CParser {
         let name = self.expect_ident()?;
 
         // Function-like macro: #define FOO(a, b) ...
-        if self.peek() == CTokenKind::LParen {
-            // Check if paren is adjacent (no space) — true function-like macro
+        // Only if `(` immediately follows name (no space). `#define EOF (-1)` has a space.
+        if self.peek() == CTokenKind::LParen && !self.peek_token().space_before {
             let mut params = Vec::new();
             self.advance(); // (
             while self.peek() != CTokenKind::RParen && !self.at_eof()
@@ -351,12 +364,45 @@ impl CParser {
             match self.peek() {
                 CTokenKind::Typedef => { is_typedef = true; self.advance(); }
                 CTokenKind::Static => { is_static = true; self.advance(); }
-                CTokenKind::Extern => { is_extern = true; self.advance(); }
+                CTokenKind::Extern => {
+                    is_extern = true;
+                    self.advance();
+                    self.skip_newlines();
+                    // `extern "C"` or `extern "C++"` — handle ABI blocks
+                    if let CTokenKind::StringLit(ref abi) = self.peek() {
+                        let abi = abi.clone();
+                        if abi == "C++" {
+                            // Skip entire extern "C++" block or declaration
+                            self.advance();
+                            self.skip_newlines();
+                            if self.peek() == CTokenKind::LBrace {
+                                self.skip_brace_block();
+                            } else {
+                                self.skip_to_semi_or_brace();
+                            }
+                            return Ok(None);
+                        } else if abi == "C" {
+                            // extern "C" { ... } — just skip the "C" and braces,
+                            // parse contents normally
+                            self.advance();
+                            self.skip_newlines();
+                            if self.peek() == CTokenKind::LBrace {
+                                self.advance(); // skip {
+                                // Contents will be parsed as top-level declarations
+                                // by the main loop. Just skip the opening brace.
+                                return Ok(None);
+                            }
+                            // extern "C" func_decl — just continue parsing
+                        }
+                    }
+                }
                 CTokenKind::Inline => { is_inline = true; self.advance(); }
                 CTokenKind::Newline => { self.advance(); }
                 _ => break,
             }
         }
+
+        self.skip_newlines();
 
         // struct/union/enum with possible tag
         match self.peek() {
@@ -443,6 +489,7 @@ impl CParser {
 
     /// Parse type specifier: `int`, `unsigned long`, `const char`, `size_t`, etc.
     fn parse_type_specifier(&mut self) -> Result<CType, ParseError> {
+        self.skip_newlines();
         let mut is_const = false;
         let mut is_signed: Option<bool> = None;
         let mut base: Option<CType> = None;

--- a/compiler/crates/rask-c-parse/src/parser.rs
+++ b/compiler/crates/rask-c-parse/src/parser.rs
@@ -1,0 +1,1079 @@
+// SPDX-License-Identifier: (MIT OR Apache-2.0)
+
+//! C header parser — turns tokens into C declarations.
+
+use crate::lexer::{CToken, CTokenKind};
+use crate::*;
+
+#[derive(Debug, Clone)]
+pub struct ParseError {
+    pub message: String,
+    pub line: usize,
+}
+
+impl ParseError {
+    pub fn new(message: String, line: usize) -> Self {
+        Self { message, line }
+    }
+}
+
+impl std::fmt::Display for ParseError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "line {}: {}", self.line, self.message)
+    }
+}
+
+impl std::error::Error for ParseError {}
+
+pub struct CParser {
+    tokens: Vec<CToken>,
+    pos: usize,
+    warnings: Vec<CWarning>,
+}
+
+impl CParser {
+    pub fn new(tokens: Vec<CToken>) -> Self {
+        Self {
+            tokens,
+            pos: 0,
+            warnings: Vec::new(),
+        }
+    }
+
+    pub fn parse(&mut self) -> Result<CParseResult, ParseError> {
+        let mut decls = Vec::new();
+
+        loop {
+            self.skip_newlines();
+            if self.at_eof() {
+                break;
+            }
+
+            match self.peek() {
+                // Preprocessor directives
+                CTokenKind::PPDefine => {
+                    if let Some(d) = self.parse_define()? {
+                        decls.push(CDecl::Define(d));
+                    }
+                }
+                CTokenKind::PPInclude
+                | CTokenKind::PPIfdef
+                | CTokenKind::PPIfndef
+                | CTokenKind::PPIf
+                | CTokenKind::PPElse
+                | CTokenKind::PPElif
+                | CTokenKind::PPEndif
+                | CTokenKind::PPUndef
+                | CTokenKind::PPPragma
+                | CTokenKind::PPError
+                | CTokenKind::PPLine => {
+                    self.skip_to_newline();
+                }
+                // Declarations
+                _ => {
+                    match self.try_parse_declaration() {
+                        Ok(Some(mut new_decls)) => decls.append(&mut new_decls),
+                        Ok(None) => {}
+                        Err(e) => {
+                            self.warnings.push(CWarning {
+                                message: format!("skipping declaration: {}", e.message),
+                                line: e.line,
+                            });
+                            self.skip_to_semi_or_brace();
+                        }
+                    }
+                }
+            }
+        }
+
+        Ok(CParseResult {
+            decls,
+            warnings: self.warnings.clone(),
+        })
+    }
+
+    // ---- Token helpers ----
+
+    fn at_eof(&self) -> bool {
+        self.pos >= self.tokens.len() || self.peek() == CTokenKind::Eof
+    }
+
+    fn peek(&self) -> CTokenKind {
+        if self.pos < self.tokens.len() {
+            self.tokens[self.pos].kind.clone()
+        } else {
+            CTokenKind::Eof
+        }
+    }
+
+    fn line(&self) -> usize {
+        if self.pos < self.tokens.len() {
+            self.tokens[self.pos].line
+        } else {
+            0
+        }
+    }
+
+    fn advance(&mut self) -> CTokenKind {
+        let tok = self.peek();
+        if self.pos < self.tokens.len() {
+            self.pos += 1;
+        }
+        tok
+    }
+
+    fn expect(&mut self, kind: &CTokenKind) -> Result<(), ParseError> {
+        let got = self.peek();
+        if std::mem::discriminant(&got) == std::mem::discriminant(kind) {
+            self.advance();
+            Ok(())
+        } else {
+            Err(ParseError::new(
+                format!("expected {:?}, got {:?}", kind, got),
+                self.line(),
+            ))
+        }
+    }
+
+    fn expect_ident(&mut self) -> Result<String, ParseError> {
+        match self.advance() {
+            CTokenKind::Ident(s) => Ok(s),
+            other => Err(ParseError::new(
+                format!("expected identifier, got {:?}", other),
+                self.line(),
+            )),
+        }
+    }
+
+    fn match_token(&mut self, kind: &CTokenKind) -> bool {
+        if std::mem::discriminant(&self.peek()) == std::mem::discriminant(kind) {
+            self.advance();
+            true
+        } else {
+            false
+        }
+    }
+
+    fn skip_newlines(&mut self) {
+        while self.peek() == CTokenKind::Newline {
+            self.advance();
+        }
+    }
+
+    fn skip_to_newline(&mut self) {
+        while !self.at_eof() && self.peek() != CTokenKind::Newline {
+            self.advance();
+        }
+        if self.peek() == CTokenKind::Newline {
+            self.advance();
+        }
+    }
+
+    fn skip_to_semi_or_brace(&mut self) {
+        let mut brace_depth = 0u32;
+        loop {
+            if self.at_eof() {
+                break;
+            }
+            match self.peek() {
+                CTokenKind::LBrace => { brace_depth += 1; self.advance(); }
+                CTokenKind::RBrace => {
+                    if brace_depth == 0 {
+                        break;
+                    }
+                    brace_depth -= 1;
+                    self.advance();
+                    if brace_depth == 0 {
+                        // Consume trailing semicolon if present
+                        self.skip_newlines();
+                        self.match_token(&CTokenKind::Semi);
+                        break;
+                    }
+                }
+                CTokenKind::Semi if brace_depth == 0 => {
+                    self.advance();
+                    break;
+                }
+                _ => { self.advance(); }
+            }
+        }
+    }
+
+    // ---- Preprocessor ----
+
+    fn parse_define(&mut self) -> Result<Option<CDefine>, ParseError> {
+        self.advance(); // consume PPDefine
+        self.skip_whitespace_tokens();
+
+        let name = self.expect_ident()?;
+
+        // Function-like macro: #define FOO(a, b) ...
+        if self.peek() == CTokenKind::LParen {
+            // Check if paren is adjacent (no space) — true function-like macro
+            let mut params = Vec::new();
+            self.advance(); // (
+            while self.peek() != CTokenKind::RParen && !self.at_eof()
+                && self.peek() != CTokenKind::Newline
+            {
+                if let CTokenKind::Ident(p) = self.peek() {
+                    params.push(p);
+                    self.advance();
+                } else if self.peek() == CTokenKind::Ellipsis {
+                    params.push("...".to_string());
+                    self.advance();
+                } else {
+                    self.advance();
+                }
+                self.match_token(&CTokenKind::Comma);
+            }
+            self.match_token(&CTokenKind::RParen);
+            self.skip_to_newline();
+
+            self.warnings.push(CWarning {
+                message: format!("function-like macro `{}` skipped", name),
+                line: self.line(),
+            });
+            return Ok(Some(CDefine {
+                name,
+                kind: CDefineKind::FunctionMacro { params },
+            }));
+        }
+
+        // Object-like macro: try to parse value
+        self.skip_whitespace_tokens();
+
+        if self.peek() == CTokenKind::Newline || self.at_eof() {
+            // Empty define — skip
+            return Ok(None);
+        }
+
+        let kind = match self.peek() {
+            CTokenKind::IntLit(v) => {
+                self.advance();
+                self.skip_to_newline();
+                CDefineKind::Integer(v)
+            }
+            CTokenKind::UIntLit(v) => {
+                self.advance();
+                self.skip_to_newline();
+                CDefineKind::UnsignedInteger(v)
+            }
+            CTokenKind::FloatLit(v) => {
+                self.advance();
+                self.skip_to_newline();
+                CDefineKind::Float(v)
+            }
+            CTokenKind::StringLit(s) => {
+                self.advance();
+                self.skip_to_newline();
+                CDefineKind::String(s)
+            }
+            // Negative literal: - <number>
+            CTokenKind::Minus => {
+                self.advance();
+                match self.peek() {
+                    CTokenKind::IntLit(v) => {
+                        self.advance();
+                        self.skip_to_newline();
+                        CDefineKind::Integer(-v)
+                    }
+                    CTokenKind::FloatLit(v) => {
+                        self.advance();
+                        self.skip_to_newline();
+                        CDefineKind::Float(-v)
+                    }
+                    _ => {
+                        self.skip_to_newline();
+                        CDefineKind::Unparseable
+                    }
+                }
+            }
+            // Parenthesized constant: #define X (42)
+            CTokenKind::LParen => {
+                self.advance();
+                let inner = match self.peek() {
+                    CTokenKind::IntLit(v) => {
+                        self.advance();
+                        Some(CDefineKind::Integer(v))
+                    }
+                    CTokenKind::UIntLit(v) => {
+                        self.advance();
+                        Some(CDefineKind::UnsignedInteger(v))
+                    }
+                    CTokenKind::Minus => {
+                        self.advance();
+                        match self.peek() {
+                            CTokenKind::IntLit(v) => {
+                                self.advance();
+                                Some(CDefineKind::Integer(-v))
+                            }
+                            _ => None,
+                        }
+                    }
+                    _ => None,
+                };
+                if inner.is_some() && self.peek() == CTokenKind::RParen {
+                    self.advance();
+                    self.skip_to_newline();
+                    inner.unwrap()
+                } else {
+                    self.skip_to_newline();
+                    CDefineKind::Unparseable
+                }
+            }
+            _ => {
+                self.skip_to_newline();
+                CDefineKind::Unparseable
+            }
+        };
+
+        Ok(Some(CDefine { name, kind }))
+    }
+
+    fn skip_whitespace_tokens(&mut self) {
+        // In our token stream, whitespace is already consumed by the lexer.
+        // Only skip newlines in define context (defines are newline-sensitive).
+    }
+
+    // ---- Declarations ----
+
+    /// Try to parse a top-level declaration. Returns None if skipped.
+    fn try_parse_declaration(&mut self) -> Result<Option<Vec<CDecl>>, ParseError> {
+        let _start_pos = self.pos;
+
+        // Collect storage/qualifier prefixes
+        let mut is_typedef = false;
+        let mut is_static = false;
+        let mut is_extern = false;
+        let mut is_inline = false;
+
+        loop {
+            match self.peek() {
+                CTokenKind::Typedef => { is_typedef = true; self.advance(); }
+                CTokenKind::Static => { is_static = true; self.advance(); }
+                CTokenKind::Extern => { is_extern = true; self.advance(); }
+                CTokenKind::Inline => { is_inline = true; self.advance(); }
+                CTokenKind::Newline => { self.advance(); }
+                _ => break,
+            }
+        }
+
+        // struct/union/enum with possible tag
+        match self.peek() {
+            CTokenKind::Struct => {
+                self.advance();
+                return self.parse_struct_or_union_decl(true, is_typedef);
+            }
+            CTokenKind::Union => {
+                self.advance();
+                return self.parse_struct_or_union_decl(false, is_typedef);
+            }
+            CTokenKind::Enum => {
+                self.advance();
+                return self.parse_enum_decl(is_typedef);
+            }
+            _ => {}
+        }
+
+        // Parse base type
+        let base_ty = self.parse_type_specifier()?;
+
+        // If we just got a semi (e.g. bare `int;`), skip
+        if self.peek() == CTokenKind::Semi {
+            self.advance();
+            return Ok(None);
+        }
+
+        // Parse declarator(s)
+        let (ptr_ty, name) = self.parse_declarator(base_ty.clone())?;
+
+        // Function declaration?
+        if self.peek() == CTokenKind::LParen {
+            let func = self.parse_function_decl(name, ptr_ty, is_static, is_inline)?;
+            // Skip static/inline functions per spec (internal linkage)
+            if func.is_static {
+                return Ok(None);
+            }
+            return Ok(Some(vec![CDecl::Function(func)]));
+        }
+
+        // Typedef?
+        if is_typedef {
+            // Handle comma-separated typedefs: typedef int foo, *bar;
+            let mut decls = vec![CDecl::Typedef(CTypedef {
+                name: name.clone(),
+                target: ptr_ty.clone(),
+            })];
+
+            while self.match_token(&CTokenKind::Comma) {
+                let (next_ty, next_name) = self.parse_declarator(base_ty.clone())?;
+                decls.push(CDecl::Typedef(CTypedef {
+                    name: next_name,
+                    target: next_ty,
+                }));
+            }
+            self.expect(&CTokenKind::Semi)?;
+            return Ok(Some(decls));
+        }
+
+        // Variable declaration
+        // Skip to semicolon (we don't care about initializers)
+        self.skip_to_semi_or_brace();
+        if is_extern {
+            return Ok(Some(vec![CDecl::Variable(CVarDecl {
+                name,
+                ty: ptr_ty,
+                is_extern: true,
+                is_const: false,
+            })]));
+        }
+
+        // Non-extern global var — skip (implementation detail)
+        if is_static {
+            return Ok(None);
+        }
+
+        Ok(Some(vec![CDecl::Variable(CVarDecl {
+            name,
+            ty: ptr_ty,
+            is_extern: false,
+            is_const: false,
+        })]))
+    }
+
+    /// Parse type specifier: `int`, `unsigned long`, `const char`, `size_t`, etc.
+    fn parse_type_specifier(&mut self) -> Result<CType, ParseError> {
+        let mut is_const = false;
+        let mut is_signed: Option<bool> = None;
+        let mut base: Option<CType> = None;
+        let mut long_count = 0u8;
+        let mut is_short = false;
+
+        loop {
+            match self.peek() {
+                CTokenKind::Const => { is_const = true; self.advance(); }
+                CTokenKind::Volatile | CTokenKind::Restrict => { self.advance(); }
+                CTokenKind::Signed => { is_signed = Some(true); self.advance(); }
+                CTokenKind::Unsigned => { is_signed = Some(false); self.advance(); }
+                CTokenKind::Void => { base = Some(CType::Void); self.advance(); break; }
+                CTokenKind::Char => { base = Some(CType::Char); self.advance(); break; }
+                CTokenKind::Short => { is_short = true; self.advance(); }
+                CTokenKind::Int => { base = Some(CType::Int); self.advance(); break; }
+                CTokenKind::Long => {
+                    long_count += 1;
+                    self.advance();
+                    // `long int`, `long long`, `long double`
+                    continue;
+                }
+                CTokenKind::Float => { base = Some(CType::Float); self.advance(); break; }
+                CTokenKind::Double => { base = Some(CType::Double); self.advance(); break; }
+                CTokenKind::Bool => { base = Some(CType::Bool); self.advance(); break; }
+                CTokenKind::Struct => {
+                    self.advance();
+                    let tag = self.expect_ident()?;
+                    base = Some(CType::StructTag(tag));
+                    break;
+                }
+                CTokenKind::Union => {
+                    self.advance();
+                    let tag = self.expect_ident()?;
+                    base = Some(CType::UnionTag(tag));
+                    break;
+                }
+                CTokenKind::Enum => {
+                    self.advance();
+                    let tag = self.expect_ident()?;
+                    base = Some(CType::EnumTag(tag));
+                    break;
+                }
+                CTokenKind::Ident(ref name) => {
+                    // If we already have type modifiers (unsigned, long, short),
+                    // this ident is a declarator name, not a type name.
+                    if long_count > 0 || is_short || is_signed.is_some() {
+                        break;
+                    }
+                    let name = name.clone();
+                    // Resolve well-known typedefs
+                    base = Some(match name.as_str() {
+                        "size_t" => CType::SizeT,
+                        "ssize_t" | "ptrdiff_t" => CType::SSizeT,
+                        "int8_t" | "__int8_t" => CType::FixedInt { bits: 8, signed: true },
+                        "int16_t" | "__int16_t" => CType::FixedInt { bits: 16, signed: true },
+                        "int32_t" | "__int32_t" => CType::FixedInt { bits: 32, signed: true },
+                        "int64_t" | "__int64_t" => CType::FixedInt { bits: 64, signed: true },
+                        "uint8_t" | "__uint8_t" => CType::FixedInt { bits: 8, signed: false },
+                        "uint16_t" | "__uint16_t" => CType::FixedInt { bits: 16, signed: false },
+                        "uint32_t" | "__uint32_t" => CType::FixedInt { bits: 32, signed: false },
+                        "uint64_t" | "__uint64_t" => CType::FixedInt { bits: 64, signed: false },
+                        "intptr_t" => CType::IntPtr { signed: true },
+                        "uintptr_t" => CType::IntPtr { signed: false },
+                        "FILE" | "va_list" | "wchar_t" | "jmp_buf" => CType::Named(name),
+                        _ => CType::Named(name),
+                    });
+                    self.advance();
+                    break;
+                }
+                _ => break,
+            }
+        }
+
+        // Resolve combined specifiers
+        let ty = if let Some(base) = base {
+            match base {
+                CType::Char if is_signed == Some(true) => CType::SignedChar,
+                CType::Char if is_signed == Some(false) => CType::UnsignedChar,
+                CType::Double if long_count > 0 => CType::Double, // long double → f64 (approximate)
+                _ => base,
+            }
+        } else if is_short {
+            if is_signed == Some(false) {
+                CType::UnsignedShort
+            } else {
+                CType::Short
+            }
+        } else if long_count >= 2 {
+            if is_signed == Some(false) {
+                CType::UnsignedLongLong
+            } else {
+                CType::LongLong
+            }
+        } else if long_count == 1 {
+            if is_signed == Some(false) {
+                CType::UnsignedLong
+            } else {
+                CType::Long
+            }
+        } else if is_signed.is_some() {
+            // bare `signed` or `unsigned` → int
+            if is_signed == Some(false) {
+                CType::UnsignedInt
+            } else {
+                CType::Int
+            }
+        } else {
+            return Err(ParseError::new("expected type specifier".into(), self.line()));
+        };
+
+        // Skip trailing qualifiers
+        loop {
+            match self.peek() {
+                CTokenKind::Const | CTokenKind::Volatile | CTokenKind::Restrict => {
+                    if self.peek() == CTokenKind::Const {
+                        is_const = true;
+                    }
+                    self.advance();
+                }
+                _ => break,
+            }
+        }
+
+        if is_const {
+            Ok(CType::Const(Box::new(ty)))
+        } else {
+            Ok(ty)
+        }
+    }
+
+    /// Parse declarator: pointers, name, array suffixes, function pointer.
+    /// Returns (final_type, name).
+    fn parse_declarator(&mut self, base_ty: CType) -> Result<(CType, String), ParseError> {
+        // Pointer prefixes
+        let mut ty = base_ty;
+        while self.peek() == CTokenKind::Star {
+            self.advance();
+            ty = CType::Pointer(Box::new(ty));
+            // Skip const/volatile/restrict on pointer
+            loop {
+                match self.peek() {
+                    CTokenKind::Const => {
+                        self.advance();
+                        ty = CType::Const(Box::new(ty));
+                    }
+                    CTokenKind::Volatile | CTokenKind::Restrict => { self.advance(); }
+                    _ => break,
+                }
+            }
+        }
+
+        // Function pointer: (*name)(params)
+        if self.peek() == CTokenKind::LParen {
+            let saved = self.pos;
+            self.advance(); // (
+            if self.peek() == CTokenKind::Star {
+                self.advance(); // *
+                let name = if let CTokenKind::Ident(_) = self.peek() {
+                    self.expect_ident()?
+                } else {
+                    String::new()
+                };
+                self.expect(&CTokenKind::RParen)?;
+                // Parameter list
+                self.expect(&CTokenKind::LParen)?;
+                let (params, is_variadic) = self.parse_param_list()?;
+                self.expect(&CTokenKind::RParen)?;
+
+                let func_ptr = CType::FuncPtr {
+                    ret: Box::new(ty),
+                    params: params.into_iter().map(|p| p.ty).collect(),
+                    is_variadic,
+                };
+                return Ok((func_ptr, name));
+            }
+            // Not a function pointer — restore
+            self.pos = saved;
+        }
+
+        let name = if let CTokenKind::Ident(_) = self.peek() {
+            self.expect_ident()?
+        } else {
+            String::new()
+        };
+
+        // Array suffix: name[N]
+        while self.peek() == CTokenKind::LBracket {
+            self.advance();
+            let size = if self.peek() == CTokenKind::RBracket {
+                None
+            } else {
+                self.parse_const_expr_value()
+            };
+            self.expect(&CTokenKind::RBracket)?;
+            ty = CType::Array(Box::new(ty), size);
+        }
+
+        Ok((ty, name))
+    }
+
+    /// Parse function parameter list (already past opening paren).
+    fn parse_param_list(&mut self) -> Result<(Vec<CParam>, bool), ParseError> {
+        let mut params = Vec::new();
+        let mut is_variadic = false;
+
+        if self.peek() == CTokenKind::Void {
+            // `void)` means no parameters
+            let saved = self.pos;
+            self.advance();
+            if self.peek() == CTokenKind::RParen {
+                return Ok((params, false));
+            }
+            // It's `void *` or similar — restore
+            self.pos = saved;
+        }
+
+        if self.peek() == CTokenKind::RParen {
+            return Ok((params, false));
+        }
+
+        loop {
+            if self.peek() == CTokenKind::Ellipsis {
+                self.advance();
+                is_variadic = true;
+                break;
+            }
+
+            let ty = self.parse_type_specifier()?;
+            let (final_ty, name) = self.parse_declarator(ty)?;
+
+            params.push(CParam {
+                name: if name.is_empty() { None } else { Some(name) },
+                ty: final_ty,
+            });
+
+            if !self.match_token(&CTokenKind::Comma) {
+                break;
+            }
+        }
+
+        Ok((params, is_variadic))
+    }
+
+    /// Parse function declaration (name and return type already parsed).
+    fn parse_function_decl(
+        &mut self,
+        name: String,
+        ret_ty: CType,
+        is_static: bool,
+        is_inline: bool,
+    ) -> Result<CFuncDecl, ParseError> {
+        self.expect(&CTokenKind::LParen)?;
+        let (params, is_variadic) = self.parse_param_list()?;
+        self.expect(&CTokenKind::RParen)?;
+
+        // Skip function body if present
+        if self.peek() == CTokenKind::LBrace {
+            self.skip_brace_block();
+        } else {
+            // Might have trailing attributes, then semicolon
+            self.skip_newlines();
+            self.match_token(&CTokenKind::Semi);
+        }
+
+        Ok(CFuncDecl {
+            name,
+            params,
+            ret_ty,
+            is_variadic,
+            is_static,
+            is_inline,
+        })
+    }
+
+    fn skip_brace_block(&mut self) {
+        let mut depth = 0u32;
+        loop {
+            if self.at_eof() {
+                break;
+            }
+            match self.peek() {
+                CTokenKind::LBrace => { depth += 1; self.advance(); }
+                CTokenKind::RBrace => {
+                    depth -= 1;
+                    self.advance();
+                    if depth == 0 { break; }
+                }
+                _ => { self.advance(); }
+            }
+        }
+    }
+
+    /// Parse struct/union declaration. Handles:
+    /// - `struct tag { fields } var;`
+    /// - `struct tag;` (forward)
+    /// - `typedef struct { ... } name;`
+    /// - `typedef struct tag { ... } name;`
+    fn parse_struct_or_union_decl(
+        &mut self,
+        is_struct: bool,
+        is_typedef: bool,
+    ) -> Result<Option<Vec<CDecl>>, ParseError> {
+        let tag = if let CTokenKind::Ident(_) = self.peek() {
+            Some(self.expect_ident()?)
+        } else {
+            None
+        };
+
+        // Forward declaration: `struct tag;`
+        if self.peek() == CTokenKind::Semi {
+            self.advance();
+            if !is_typedef {
+                let decl = CStructDecl {
+                    tag,
+                    fields: Vec::new(),
+                    is_forward: true,
+                };
+                return Ok(Some(vec![if is_struct {
+                    CDecl::Struct(decl)
+                } else {
+                    CDecl::Union(decl)
+                }]));
+            }
+            return Ok(None);
+        }
+
+        // No body — this is a type specifier in a declaration, not a definition.
+        // e.g., `struct foo *ptr;`
+        if self.peek() != CTokenKind::LBrace {
+            if is_typedef {
+                // `typedef struct tag name;`
+                let name = self.expect_ident()?;
+                self.expect(&CTokenKind::Semi)?;
+                let tag_name = tag.unwrap_or_else(|| name.clone());
+                return Ok(Some(vec![CDecl::Typedef(CTypedef {
+                    name,
+                    target: if is_struct {
+                        CType::StructTag(tag_name)
+                    } else {
+                        CType::UnionTag(tag_name)
+                    },
+                })]));
+            }
+            // `struct tag <declarator>` — variable of struct type
+            // Rewind isn't clean here; skip to semicolon.
+            self.skip_to_semi_or_brace();
+            return Ok(None);
+        }
+
+        // Parse body
+        self.expect(&CTokenKind::LBrace)?;
+        let fields = self.parse_struct_fields()?;
+        self.expect(&CTokenKind::RBrace)?;
+
+        let decl = CStructDecl {
+            tag: tag.clone(),
+            fields,
+            is_forward: false,
+        };
+
+        let mut decls = Vec::new();
+
+        // Always emit the struct/union itself (if it has a tag)
+        if tag.is_some() {
+            decls.push(if is_struct {
+                CDecl::Struct(decl.clone())
+            } else {
+                CDecl::Union(decl.clone())
+            });
+        }
+
+        // `typedef struct { ... } name;` or `typedef struct tag { ... } name;`
+        if is_typedef {
+            // Parse typedef name(s)
+            let mut first = true;
+            loop {
+                self.skip_newlines();
+                if self.peek() == CTokenKind::Semi {
+                    self.advance();
+                    break;
+                }
+                if !first {
+                    self.expect(&CTokenKind::Comma)?;
+                }
+                first = false;
+
+                // Handle pointer typedefs: typedef struct foo *foo_ptr;
+                let mut td_ty = if let Some(ref t) = tag {
+                    if is_struct {
+                        CType::StructTag(t.clone())
+                    } else {
+                        CType::UnionTag(t.clone())
+                    }
+                } else {
+                    // Anonymous struct — embed the full type
+                    CType::Named(format!("__anon_{}", self.pos))
+                };
+
+                while self.peek() == CTokenKind::Star {
+                    self.advance();
+                    td_ty = CType::Pointer(Box::new(td_ty));
+                }
+
+                let name = self.expect_ident()?;
+                decls.push(CDecl::Typedef(CTypedef { name, target: td_ty }));
+            }
+
+            // If no tag, emit the struct with the first typedef name as tag
+            if tag.is_none() && !decls.is_empty() {
+                if let CDecl::Typedef(ref td) = decls[0] {
+                    let named_decl = CStructDecl {
+                        tag: Some(td.name.clone()),
+                        fields: decl.fields,
+                        is_forward: false,
+                    };
+                    decls.insert(0, if is_struct {
+                        CDecl::Struct(named_decl)
+                    } else {
+                        CDecl::Union(named_decl)
+                    });
+                }
+            }
+        } else {
+            // Might have variable declarations after the struct body
+            self.skip_newlines();
+            self.match_token(&CTokenKind::Semi);
+        }
+
+        Ok(Some(decls))
+    }
+
+    fn parse_struct_fields(&mut self) -> Result<Vec<CField>, ParseError> {
+        let mut fields = Vec::new();
+        loop {
+            self.skip_newlines();
+            if self.peek() == CTokenKind::RBrace || self.at_eof() {
+                break;
+            }
+
+            let ty = match self.parse_type_specifier() {
+                Ok(ty) => ty,
+                Err(_) => {
+                    self.skip_to_semi_or_brace();
+                    continue;
+                }
+            };
+
+            // Parse one or more field declarators
+            loop {
+                let (field_ty, name) = self.parse_declarator(ty.clone())?;
+
+                let bit_width = if self.match_token(&CTokenKind::Colon) {
+                    self.parse_const_expr_value().map(|v| v as u32)
+                } else {
+                    None
+                };
+
+                if !name.is_empty() {
+                    fields.push(CField { name, ty: field_ty, bit_width });
+                }
+
+                if !self.match_token(&CTokenKind::Comma) {
+                    break;
+                }
+            }
+
+            self.expect(&CTokenKind::Semi)?;
+        }
+        Ok(fields)
+    }
+
+    /// Parse enum declaration.
+    fn parse_enum_decl(
+        &mut self,
+        is_typedef: bool,
+    ) -> Result<Option<Vec<CDecl>>, ParseError> {
+        let tag = if let CTokenKind::Ident(_) = self.peek() {
+            Some(self.expect_ident()?)
+        } else {
+            None
+        };
+
+        // Forward declaration
+        if self.peek() == CTokenKind::Semi {
+            self.advance();
+            return Ok(Some(vec![CDecl::Enum(CEnumDecl {
+                tag,
+                variants: Vec::new(),
+                is_forward: true,
+            })]));
+        }
+
+        if self.peek() != CTokenKind::LBrace {
+            if is_typedef {
+                let name = self.expect_ident()?;
+                self.expect(&CTokenKind::Semi)?;
+                return Ok(Some(vec![CDecl::Typedef(CTypedef {
+                    name,
+                    target: CType::EnumTag(tag.unwrap_or_default()),
+                })]));
+            }
+            self.skip_to_semi_or_brace();
+            return Ok(None);
+        }
+
+        self.expect(&CTokenKind::LBrace)?;
+        let mut variants = Vec::new();
+        let mut next_value: i64 = 0;
+
+        loop {
+            self.skip_newlines();
+            if self.peek() == CTokenKind::RBrace || self.at_eof() {
+                break;
+            }
+
+            let name = self.expect_ident()?;
+            let value = if self.match_token(&CTokenKind::Eq) {
+                if let Some(v) = self.parse_const_expr_value() {
+                    next_value = v as i64 + 1;
+                    Some(v as i64)
+                } else {
+                    // Unparseable expression — skip to comma
+                    self.skip_to_comma_or_brace();
+                    let v = next_value;
+                    next_value += 1;
+                    Some(v)
+                }
+            } else {
+                let v = next_value;
+                next_value += 1;
+                Some(v)
+            };
+
+            variants.push(CEnumVariant { name, value });
+            self.match_token(&CTokenKind::Comma);
+        }
+        self.expect(&CTokenKind::RBrace)?;
+
+        let mut decls = Vec::new();
+        let decl = CEnumDecl { tag: tag.clone(), variants, is_forward: false };
+
+        if tag.is_some() {
+            decls.push(CDecl::Enum(decl.clone()));
+        }
+
+        if is_typedef {
+            loop {
+                self.skip_newlines();
+                if self.peek() == CTokenKind::Semi {
+                    self.advance();
+                    break;
+                }
+                let name = self.expect_ident()?;
+                decls.push(CDecl::Typedef(CTypedef {
+                    name: name.clone(),
+                    target: CType::EnumTag(tag.clone().unwrap_or(name)),
+                }));
+                if !self.match_token(&CTokenKind::Comma) {
+                    self.expect(&CTokenKind::Semi)?;
+                    break;
+                }
+            }
+
+            if tag.is_none() && decls.is_empty() {
+                // Unusual: `typedef enum { ... };` with no name
+            } else if tag.is_none() {
+                // Name the enum after first typedef
+                if let Some(CDecl::Typedef(ref td)) = decls.first() {
+                    let named = CEnumDecl {
+                        tag: Some(td.name.clone()),
+                        variants: decl.variants,
+                        is_forward: false,
+                    };
+                    decls.insert(0, CDecl::Enum(named));
+                }
+            }
+        } else {
+            self.skip_newlines();
+            self.match_token(&CTokenKind::Semi);
+            if tag.is_none() {
+                decls.push(CDecl::Enum(decl));
+            }
+        }
+
+        Ok(Some(decls))
+    }
+
+    fn skip_to_comma_or_brace(&mut self) {
+        loop {
+            if self.at_eof() { break; }
+            match self.peek() {
+                CTokenKind::Comma | CTokenKind::RBrace => break,
+                _ => { self.advance(); }
+            }
+        }
+    }
+
+    /// Try to evaluate a simple constant expression (for array sizes, enum values).
+    fn parse_const_expr_value(&mut self) -> Option<u64> {
+        match self.peek() {
+            CTokenKind::IntLit(v) => { self.advance(); Some(v as u64) }
+            CTokenKind::UIntLit(v) => { self.advance(); Some(v) }
+            CTokenKind::Ident(_) => {
+                // Named constant — can't resolve, skip
+                self.advance();
+                // Might be `sizeof(type)`
+                if self.peek() == CTokenKind::LParen {
+                    let mut depth = 0u32;
+                    loop {
+                        match self.peek() {
+                            CTokenKind::LParen => { depth += 1; self.advance(); }
+                            CTokenKind::RParen => {
+                                self.advance();
+                                depth -= 1;
+                                if depth == 0 { break; }
+                            }
+                            _ if self.at_eof() => break,
+                            _ => { self.advance(); }
+                        }
+                    }
+                }
+                None
+            }
+            CTokenKind::LParen => {
+                self.advance();
+                let val = self.parse_const_expr_value();
+                self.match_token(&CTokenKind::RParen);
+                val
+            }
+            _ => None,
+        }
+    }
+}

--- a/compiler/crates/rask-c-parse/src/tests.rs
+++ b/compiler/crates/rask-c-parse/src/tests.rs
@@ -1,0 +1,433 @@
+// SPDX-License-Identifier: (MIT OR Apache-2.0)
+
+use crate::*;
+use crate::translate;
+
+    fn parse(src: &str) -> CParseResult {
+        parse_c_header(src).expect("parse failed")
+    }
+
+    // ---- Lexer + Parser integration ----
+
+    #[test]
+    fn parse_function_decl() {
+        let r = parse("int printf(const char *fmt, ...);");
+        assert_eq!(r.decls.len(), 1);
+        match &r.decls[0] {
+            CDecl::Function(f) => {
+                assert_eq!(f.name, "printf");
+                assert!(f.is_variadic);
+                assert_eq!(f.ret_ty, CType::Int);
+                assert_eq!(f.params.len(), 1);
+            }
+            other => panic!("expected Function, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn parse_void_function() {
+        let r = parse("void exit(int status);");
+        match &r.decls[0] {
+            CDecl::Function(f) => {
+                assert_eq!(f.name, "exit");
+                assert_eq!(f.ret_ty, CType::Void);
+                assert!(!f.is_variadic);
+            }
+            other => panic!("expected Function, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn parse_struct_with_fields() {
+        let r = parse("struct Point { int x; int y; };");
+        let found_struct = r.decls.iter().find(|d| matches!(d, CDecl::Struct(_)));
+        match found_struct {
+            Some(CDecl::Struct(s)) => {
+                assert_eq!(s.tag.as_deref(), Some("Point"));
+                assert_eq!(s.fields.len(), 2);
+                assert_eq!(s.fields[0].name, "x");
+                assert_eq!(s.fields[1].name, "y");
+                assert!(!s.is_forward);
+            }
+            other => panic!("expected Struct, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn parse_forward_decl() {
+        let r = parse("struct Opaque;");
+        match &r.decls[0] {
+            CDecl::Struct(s) => {
+                assert_eq!(s.tag.as_deref(), Some("Opaque"));
+                assert!(s.is_forward);
+            }
+            other => panic!("expected forward Struct, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn parse_enum() {
+        let r = parse("enum Color { RED, GREEN = 5, BLUE };");
+        let found_enum = r.decls.iter().find(|d| matches!(d, CDecl::Enum(_)));
+        match found_enum {
+            Some(CDecl::Enum(e)) => {
+                assert_eq!(e.tag.as_deref(), Some("Color"));
+                assert_eq!(e.variants.len(), 3);
+                assert_eq!(e.variants[0].name, "RED");
+                assert_eq!(e.variants[0].value, Some(0));
+                assert_eq!(e.variants[1].name, "GREEN");
+                assert_eq!(e.variants[1].value, Some(5));
+                assert_eq!(e.variants[2].name, "BLUE");
+                assert_eq!(e.variants[2].value, Some(6));
+            }
+            other => panic!("expected Enum, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn parse_typedef_struct() {
+        let r = parse("typedef struct { int fd; } FileHandle;");
+        let has_struct = r.decls.iter().any(|d| matches!(d, CDecl::Struct(_)));
+        let has_typedef = r.decls.iter().any(|d| matches!(d, CDecl::Typedef(_)));
+        assert!(has_struct, "should emit struct");
+        assert!(has_typedef, "should emit typedef");
+    }
+
+    #[test]
+    fn parse_define_integer() {
+        let r = parse("#define MAX_SIZE 1024\n");
+        match &r.decls[0] {
+            CDecl::Define(d) => {
+                assert_eq!(d.name, "MAX_SIZE");
+                assert_eq!(d.kind, CDefineKind::Integer(1024));
+            }
+            other => panic!("expected Define, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn parse_define_string() {
+        let r = parse("#define VERSION \"1.0\"\n");
+        match &r.decls[0] {
+            CDecl::Define(d) => {
+                assert_eq!(d.name, "VERSION");
+                assert_eq!(d.kind, CDefineKind::String("1.0".into()));
+            }
+            other => panic!("expected Define, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn parse_define_function_macro() {
+        let r = parse("#define MAX(a, b) ((a) > (b) ? (a) : (b))\n");
+        match &r.decls[0] {
+            CDecl::Define(d) => {
+                assert_eq!(d.name, "MAX");
+                assert!(matches!(d.kind, CDefineKind::FunctionMacro { .. }));
+            }
+            other => panic!("expected Define, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn parse_typedef_pointer() {
+        let r = parse("typedef void *HANDLE;");
+        match &r.decls[0] {
+            CDecl::Typedef(td) => {
+                assert_eq!(td.name, "HANDLE");
+                assert_eq!(td.target, CType::Pointer(Box::new(CType::Void)));
+            }
+            other => panic!("expected Typedef, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn parse_unsigned_long_long() {
+        let r = parse("unsigned long long get_size(void);");
+        match &r.decls[0] {
+            CDecl::Function(f) => {
+                assert_eq!(f.ret_ty, CType::UnsignedLongLong);
+                assert!(f.params.is_empty());
+            }
+            other => panic!("expected Function, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn parse_stdint_types() {
+        let r = parse("uint32_t hash(const uint8_t *data, size_t len);");
+        match &r.decls[0] {
+            CDecl::Function(f) => {
+                assert_eq!(f.ret_ty, CType::FixedInt { bits: 32, signed: false });
+                assert_eq!(f.params.len(), 2);
+            }
+            other => panic!("expected Function, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn skip_static_function() {
+        let r = parse("static int helper(void) { return 0; }");
+        // Static functions should be skipped (per spec: internal linkage)
+        assert!(r.decls.is_empty(), "static functions should be skipped");
+    }
+
+    #[test]
+    fn skip_inline_body() {
+        let r = parse("inline int square(int x) { return x * x; }");
+        // Inline functions with bodies — kept as declaration, body discarded.
+        // (inline is not static, so it's imported)
+        match &r.decls[0] {
+            CDecl::Function(f) => {
+                assert_eq!(f.name, "square");
+                assert!(f.is_inline);
+            }
+            other => panic!("expected Function, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn comments_stripped() {
+        let r = parse("/* block */ int foo(void); // line comment\n");
+        match &r.decls[0] {
+            CDecl::Function(f) => assert_eq!(f.name, "foo"),
+            other => panic!("expected Function, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn parse_function_pointer_param() {
+        let r = parse("void qsort(void *base, size_t n, size_t size, int (*cmp)(const void *, const void *));");
+        match &r.decls[0] {
+            CDecl::Function(f) => {
+                assert_eq!(f.name, "qsort");
+                assert_eq!(f.params.len(), 4);
+                // Fourth param should be a function pointer
+                match &f.params[3].ty {
+                    CType::FuncPtr { ret, params, .. } => {
+                        assert_eq!(**ret, CType::Int);
+                        assert_eq!(params.len(), 2);
+                    }
+                    other => panic!("expected FuncPtr param, got {:?}", other),
+                }
+            }
+            other => panic!("expected Function, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn skip_preprocessor_conditionals() {
+        let src = r#"
+#ifdef _WIN32
+int win_only(void);
+#else
+int unix_only(void);
+#endif
+"#;
+        // Both branches visible (no real preprocessing — just skips directives)
+        let r = parse(src);
+        let funcs: Vec<_> = r.decls.iter().filter(|d| matches!(d, CDecl::Function(_))).collect();
+        assert_eq!(funcs.len(), 2);
+    }
+
+    #[test]
+    fn parse_extern_variable() {
+        let r = parse("extern int errno;");
+        match &r.decls[0] {
+            CDecl::Variable(v) => {
+                assert_eq!(v.name, "errno");
+                assert!(v.is_extern);
+                assert_eq!(v.ty, CType::Int);
+            }
+            other => panic!("expected Variable, got {:?}", other),
+        }
+    }
+
+    // ---- Translator tests ----
+
+    #[test]
+    fn translate_function() {
+        let r = parse("int open(const char *path, int flags);");
+        let decls = translate::translate(&r, &[]);
+        match &decls[0] {
+            translate::RaskCDecl::ExternFunc { name, params, ret_ty, .. } => {
+                assert_eq!(name, "open");
+                assert_eq!(ret_ty, "c_int");
+                assert_eq!(params[0].ty, "*u8");
+                assert_eq!(params[1].ty, "c_int");
+            }
+            other => panic!("expected ExternFunc, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn translate_struct() {
+        let r = parse("struct Point { int x; float y; };");
+        let decls = translate::translate(&r, &[]);
+        let found = decls.iter().find(|d| matches!(d, translate::RaskCDecl::ExternStruct { .. }));
+        match found {
+            Some(translate::RaskCDecl::ExternStruct { name, fields }) => {
+                assert_eq!(name, "Point");
+                assert_eq!(fields[0].ty, "c_int");
+                assert_eq!(fields[1].ty, "f32");
+            }
+            other => panic!("expected ExternStruct, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn translate_opaque() {
+        let r = parse("struct sqlite3;");
+        let decls = translate::translate(&r, &[]);
+        assert!(matches!(&decls[0], translate::RaskCDecl::OpaqueType { name } if name == "sqlite3"));
+    }
+
+    #[test]
+    fn translate_hiding() {
+        let r = parse("int keep(void);\nint hide(void);");
+        let decls = translate::translate(&r, &["hide".to_string()]);
+        assert_eq!(decls.len(), 1);
+        match &decls[0] {
+            translate::RaskCDecl::ExternFunc { name, .. } => assert_eq!(name, "keep"),
+            other => panic!("expected ExternFunc, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn translate_define_to_const() {
+        let r = parse("#define SQLITE_OK 0\n");
+        let decls = translate::translate(&r, &[]);
+        match &decls[0] {
+            translate::RaskCDecl::Const { name, ty, value } => {
+                assert_eq!(name, "SQLITE_OK");
+                assert_eq!(ty, "c_int");
+                assert_eq!(value, "0");
+            }
+            other => panic!("expected Const, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn translate_size_t() {
+        let r = parse("size_t strlen(const char *s);");
+        let decls = translate::translate(&r, &[]);
+        match &decls[0] {
+            translate::RaskCDecl::ExternFunc { ret_ty, .. } => {
+                assert_eq!(ret_ty, "c_size");
+            }
+            other => panic!("expected ExternFunc, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn translate_void_return() {
+        let r = parse("void free(void *ptr);");
+        let decls = translate::translate(&r, &[]);
+        match &decls[0] {
+            translate::RaskCDecl::ExternFunc { ret_ty, params, .. } => {
+                assert_eq!(ret_ty, "void");
+                assert_eq!(params[0].ty, "*void");
+            }
+            other => panic!("expected ExternFunc, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn render_rask_output() {
+        let r = parse("int add(int a, int b);");
+        let decls = translate::translate(&r, &[]);
+        let output = translate::render_rask(&decls);
+        assert!(output.contains("extern \"C\" func add("));
+        assert!(output.contains("c_int"));
+    }
+
+    // ---- Resilience ----
+
+    #[test]
+    fn recovers_from_unparseable() {
+        let src = r#"
+int good_func(void);
+this is garbage that should not parse;
+int another_good(int x);
+"#;
+        let r = parse(src);
+        let funcs: Vec<_> = r.decls.iter()
+            .filter(|d| matches!(d, CDecl::Function(_)))
+            .collect();
+        // Should recover and parse at least some functions
+        assert!(funcs.len() >= 1, "should recover from parse errors");
+    }
+
+    #[test]
+    fn hex_define() {
+        let r = parse("#define FLAGS 0xFF00\n");
+        match &r.decls[0] {
+            CDecl::Define(d) => {
+                assert_eq!(d.name, "FLAGS");
+                assert_eq!(d.kind, CDefineKind::UnsignedInteger(0xFF00));
+            }
+            other => panic!("expected Define, got {:?}", other),
+        }
+    }
+
+    // ---- End-to-end: realistic header ----
+
+    #[test]
+    fn realistic_header() {
+        let src = r#"
+#ifndef MYLIB_H
+#define MYLIB_H
+
+#include <stdint.h>
+
+#define MYLIB_VERSION "2.0"
+#define MYLIB_MAX_CONNS 128
+
+typedef struct mylib_ctx mylib_ctx;
+
+struct mylib_config {
+    int port;
+    const char *host;
+    uint32_t timeout_ms;
+};
+
+typedef enum {
+    MYLIB_OK = 0,
+    MYLIB_ERR_CONNECT = -1,
+    MYLIB_ERR_TIMEOUT = -2,
+} mylib_status;
+
+mylib_ctx *mylib_init(const struct mylib_config *cfg);
+void mylib_destroy(mylib_ctx *ctx);
+mylib_status mylib_send(mylib_ctx *ctx, const uint8_t *data, size_t len);
+
+#endif
+"#;
+        let r = parse(src);
+        let decls = translate::translate(&r, &[]);
+
+        // Should have: opaque type, struct, enum, 3 functions, 2 constants, typedef
+        let funcs: Vec<_> = decls.iter()
+            .filter(|d| matches!(d, translate::RaskCDecl::ExternFunc { .. }))
+            .collect();
+        let structs: Vec<_> = decls.iter()
+            .filter(|d| matches!(d, translate::RaskCDecl::ExternStruct { .. }))
+            .collect();
+        let enums: Vec<_> = decls.iter()
+            .filter(|d| matches!(d, translate::RaskCDecl::ExternEnum { .. }))
+            .collect();
+        let consts: Vec<_> = decls.iter()
+            .filter(|d| matches!(d, translate::RaskCDecl::Const { .. }))
+            .collect();
+
+        assert!(funcs.len() >= 3, "should have at least 3 functions, got {}", funcs.len());
+        assert!(structs.len() >= 1, "should have at least 1 struct, got {}", structs.len());
+        assert!(enums.len() >= 1, "should have at least 1 enum, got {}", enums.len());
+        assert!(consts.len() >= 2, "should have at least 2 constants, got {}", consts.len());
+
+        // Verify specific translation
+        let init_fn = funcs.iter().find(|d| {
+            matches!(d, translate::RaskCDecl::ExternFunc { name, .. } if name == "mylib_init")
+        });
+        assert!(init_fn.is_some(), "should have mylib_init");
+    }

--- a/compiler/crates/rask-c-parse/src/tests.rs
+++ b/compiler/crates/rask-c-parse/src/tests.rs
@@ -248,60 +248,66 @@ int unix_only(void);
     #[test]
     fn translate_function() {
         let r = parse("int open(const char *path, int flags);");
-        let decls = translate::translate(&r, &[]);
-        match &decls[0] {
-            translate::RaskCDecl::ExternFunc { name, params, ret_ty, .. } => {
-                assert_eq!(name, "open");
-                assert_eq!(ret_ty, "c_int");
-                assert_eq!(params[0].ty, "*u8");
-                assert_eq!(params[1].ty, "c_int");
+        let result = translate::translate(&r, &[]);
+        match &result.decls[0] {
+            translate::RaskCDecl::Function(f) => {
+                assert_eq!(f.name, "open");
+                assert_eq!(f.ret_ty, "c_int");
+                assert_eq!(f.params[0].ty, "*u8");
+                assert_eq!(f.params[1].ty, "c_int");
             }
-            other => panic!("expected ExternFunc, got {:?}", other),
+            other => panic!("expected Function, got {:?}", other),
         }
     }
 
     #[test]
     fn translate_struct() {
         let r = parse("struct Point { int x; float y; };");
-        let decls = translate::translate(&r, &[]);
-        let found = decls.iter().find(|d| matches!(d, translate::RaskCDecl::ExternStruct { .. }));
+        let result = translate::translate(&r, &[]);
+        let found = result.decls.iter().find(|d| matches!(d, translate::RaskCDecl::Struct(_)));
         match found {
-            Some(translate::RaskCDecl::ExternStruct { name, fields }) => {
-                assert_eq!(name, "Point");
-                assert_eq!(fields[0].ty, "c_int");
-                assert_eq!(fields[1].ty, "f32");
+            Some(translate::RaskCDecl::Struct(s)) => {
+                assert_eq!(s.name, "Point");
+                assert_eq!(s.fields[0].ty, "c_int");
+                assert_eq!(s.fields[1].ty, "f32");
             }
-            other => panic!("expected ExternStruct, got {:?}", other),
+            other => panic!("expected Struct, got {:?}", other),
         }
     }
 
     #[test]
     fn translate_opaque() {
         let r = parse("struct sqlite3;");
-        let decls = translate::translate(&r, &[]);
-        assert!(matches!(&decls[0], translate::RaskCDecl::OpaqueType { name } if name == "sqlite3"));
+        let result = translate::translate(&r, &[]);
+        match &result.decls[0] {
+            translate::RaskCDecl::Struct(s) => {
+                assert_eq!(s.name, "sqlite3");
+                assert!(s.is_opaque);
+            }
+            other => panic!("expected opaque Struct, got {:?}", other),
+        }
     }
 
     #[test]
     fn translate_hiding() {
         let r = parse("int keep(void);\nint hide(void);");
-        let decls = translate::translate(&r, &["hide".to_string()]);
-        assert_eq!(decls.len(), 1);
-        match &decls[0] {
-            translate::RaskCDecl::ExternFunc { name, .. } => assert_eq!(name, "keep"),
-            other => panic!("expected ExternFunc, got {:?}", other),
+        let result = translate::translate(&r, &["hide".to_string()]);
+        assert_eq!(result.decls.len(), 1);
+        match &result.decls[0] {
+            translate::RaskCDecl::Function(f) => assert_eq!(f.name, "keep"),
+            other => panic!("expected Function, got {:?}", other),
         }
     }
 
     #[test]
     fn translate_define_to_const() {
         let r = parse("#define SQLITE_OK 0\n");
-        let decls = translate::translate(&r, &[]);
-        match &decls[0] {
-            translate::RaskCDecl::Const { name, ty, value } => {
-                assert_eq!(name, "SQLITE_OK");
-                assert_eq!(ty, "c_int");
-                assert_eq!(value, "0");
+        let result = translate::translate(&r, &[]);
+        match &result.decls[0] {
+            translate::RaskCDecl::Const(c) => {
+                assert_eq!(c.name, "SQLITE_OK");
+                assert_eq!(c.ty, "c_int");
+                assert_eq!(c.value_repr, "0");
             }
             other => panic!("expected Const, got {:?}", other),
         }
@@ -310,33 +316,33 @@ int unix_only(void);
     #[test]
     fn translate_size_t() {
         let r = parse("size_t strlen(const char *s);");
-        let decls = translate::translate(&r, &[]);
-        match &decls[0] {
-            translate::RaskCDecl::ExternFunc { ret_ty, .. } => {
-                assert_eq!(ret_ty, "c_size");
+        let result = translate::translate(&r, &[]);
+        match &result.decls[0] {
+            translate::RaskCDecl::Function(f) => {
+                assert_eq!(f.ret_ty, "c_size");
             }
-            other => panic!("expected ExternFunc, got {:?}", other),
+            other => panic!("expected Function, got {:?}", other),
         }
     }
 
     #[test]
     fn translate_void_return() {
         let r = parse("void free(void *ptr);");
-        let decls = translate::translate(&r, &[]);
-        match &decls[0] {
-            translate::RaskCDecl::ExternFunc { ret_ty, params, .. } => {
-                assert_eq!(ret_ty, "void");
-                assert_eq!(params[0].ty, "*void");
+        let result = translate::translate(&r, &[]);
+        match &result.decls[0] {
+            translate::RaskCDecl::Function(f) => {
+                assert_eq!(f.ret_ty, "");
+                assert_eq!(f.params[0].ty, "*void");
             }
-            other => panic!("expected ExternFunc, got {:?}", other),
+            other => panic!("expected Function, got {:?}", other),
         }
     }
 
     #[test]
     fn render_rask_output() {
         let r = parse("int add(int a, int b);");
-        let decls = translate::translate(&r, &[]);
-        let output = translate::render_rask(&decls);
+        let result = translate::translate(&r, &[]);
+        let output = translate::render_rask(&result);
         assert!(output.contains("extern \"C\" func add("));
         assert!(output.contains("c_int"));
     }
@@ -404,20 +410,20 @@ mylib_status mylib_send(mylib_ctx *ctx, const uint8_t *data, size_t len);
 #endif
 "#;
         let r = parse(src);
-        let decls = translate::translate(&r, &[]);
+        let result = translate::translate(&r, &[]);
 
         // Should have: opaque type, struct, enum, 3 functions, 2 constants, typedef
-        let funcs: Vec<_> = decls.iter()
-            .filter(|d| matches!(d, translate::RaskCDecl::ExternFunc { .. }))
+        let funcs: Vec<_> = result.decls.iter()
+            .filter(|d| matches!(d, translate::RaskCDecl::Function(_)))
             .collect();
-        let structs: Vec<_> = decls.iter()
-            .filter(|d| matches!(d, translate::RaskCDecl::ExternStruct { .. }))
+        let structs: Vec<_> = result.decls.iter()
+            .filter(|d| matches!(d, translate::RaskCDecl::Struct(_)))
             .collect();
-        let enums: Vec<_> = decls.iter()
-            .filter(|d| matches!(d, translate::RaskCDecl::ExternEnum { .. }))
+        let enums: Vec<_> = result.decls.iter()
+            .filter(|d| matches!(d, translate::RaskCDecl::Enum(_)))
             .collect();
-        let consts: Vec<_> = decls.iter()
-            .filter(|d| matches!(d, translate::RaskCDecl::Const { .. }))
+        let consts: Vec<_> = result.decls.iter()
+            .filter(|d| matches!(d, translate::RaskCDecl::Const(_)))
             .collect();
 
         assert!(funcs.len() >= 3, "should have at least 3 functions, got {}", funcs.len());
@@ -427,7 +433,7 @@ mylib_status mylib_send(mylib_ctx *ctx, const uint8_t *data, size_t len);
 
         // Verify specific translation
         let init_fn = funcs.iter().find(|d| {
-            matches!(d, translate::RaskCDecl::ExternFunc { name, .. } if name == "mylib_init")
+            matches!(d, translate::RaskCDecl::Function(f) if f.name == "mylib_init")
         });
         assert!(init_fn.is_some(), "should have mylib_init");
     }

--- a/compiler/crates/rask-c-parse/src/translate.rs
+++ b/compiler/crates/rask-c-parse/src/translate.rs
@@ -1,0 +1,435 @@
+// SPDX-License-Identifier: (MIT OR Apache-2.0)
+
+//! Translates parsed C declarations into Rask-level representations.
+//!
+//! Follows the type mapping from struct.c-interop (TM1–TM3):
+//! - C `int` → `c_int`, `unsigned long` → `c_ulong`, etc.
+//! - `T*` → `*T`, `void*` → `*void`
+//! - `#define FOO 42` → const FOO: c_int = 42
+
+use crate::*;
+
+/// A Rask-level declaration translated from C.
+#[derive(Debug, Clone)]
+pub enum RaskCDecl {
+    /// `extern "C" func name(params...) -> ret`
+    ExternFunc {
+        name: String,
+        params: Vec<RaskCParam>,
+        ret_ty: String,
+        is_variadic: bool,
+    },
+    /// `extern "C" struct Name { fields... }`
+    ExternStruct {
+        name: String,
+        fields: Vec<RaskCField>,
+    },
+    /// `extern "C" union Name { fields... }`
+    ExternUnion {
+        name: String,
+        fields: Vec<RaskCField>,
+    },
+    /// `extern "C" enum Name { variants... }`
+    ExternEnum {
+        name: String,
+        variants: Vec<(String, Option<i64>)>,
+    },
+    /// `const NAME: type = value`
+    Const {
+        name: String,
+        ty: String,
+        value: String,
+    },
+    /// Type alias: `type name = target`
+    TypeAlias {
+        name: String,
+        target: String,
+    },
+    /// Opaque type (forward-declared struct/union).
+    OpaqueType {
+        name: String,
+    },
+    /// Warning about a skipped declaration.
+    Warning {
+        message: String,
+    },
+}
+
+#[derive(Debug, Clone)]
+pub struct RaskCParam {
+    pub name: String,
+    pub ty: String,
+}
+
+#[derive(Debug, Clone)]
+pub struct RaskCField {
+    pub name: String,
+    pub ty: String,
+}
+
+/// Translate C parse results into Rask declarations.
+///
+/// `hiding` is the set of symbol names to suppress (from `import c "..." hiding { ... }`).
+pub fn translate(result: &CParseResult, hiding: &[String]) -> Vec<RaskCDecl> {
+    let mut out = Vec::new();
+    let mut translator = Translator {
+        hiding,
+        typedefs: std::collections::HashMap::new(),
+    };
+
+    // First pass: collect typedefs for resolution
+    for decl in &result.decls {
+        if let CDecl::Typedef(td) = decl {
+            translator.typedefs.insert(td.name.clone(), td.target.clone());
+        }
+    }
+
+    for decl in &result.decls {
+        translator.translate_decl(decl, &mut out);
+    }
+
+    // Emit warnings
+    for w in &result.warnings {
+        out.push(RaskCDecl::Warning {
+            message: w.message.clone(),
+        });
+    }
+
+    out
+}
+
+struct Translator<'a> {
+    hiding: &'a [String],
+    typedefs: std::collections::HashMap<String, CType>,
+}
+
+impl<'a> Translator<'a> {
+    fn is_hidden(&self, name: &str) -> bool {
+        self.hiding.iter().any(|h| h == name)
+    }
+
+    fn translate_decl(&self, decl: &CDecl, out: &mut Vec<RaskCDecl>) {
+        match decl {
+            CDecl::Function(f) => {
+                if self.is_hidden(&f.name) { return; }
+                let params = f.params.iter().enumerate().map(|(i, p)| {
+                    RaskCParam {
+                        name: p.name.clone().unwrap_or_else(|| format!("arg{}", i)),
+                        ty: self.translate_type(&p.ty),
+                    }
+                }).collect();
+                out.push(RaskCDecl::ExternFunc {
+                    name: f.name.clone(),
+                    params,
+                    ret_ty: self.translate_type(&f.ret_ty),
+                    is_variadic: f.is_variadic,
+                });
+            }
+            CDecl::Struct(s) => {
+                let name = match &s.tag {
+                    Some(t) => t.clone(),
+                    None => return, // anonymous, handled via typedef
+                };
+                if self.is_hidden(&name) { return; }
+                if s.is_forward {
+                    out.push(RaskCDecl::OpaqueType { name });
+                    return;
+                }
+                let fields = s.fields.iter().map(|f| {
+                    RaskCField {
+                        name: f.name.clone(),
+                        ty: self.translate_type(&f.ty),
+                    }
+                }).collect();
+                out.push(RaskCDecl::ExternStruct { name, fields });
+            }
+            CDecl::Union(u) => {
+                let name = match &u.tag {
+                    Some(t) => t.clone(),
+                    None => return,
+                };
+                if self.is_hidden(&name) { return; }
+                if u.is_forward {
+                    out.push(RaskCDecl::OpaqueType { name });
+                    return;
+                }
+                let fields = u.fields.iter().map(|f| {
+                    RaskCField {
+                        name: f.name.clone(),
+                        ty: self.translate_type(&f.ty),
+                    }
+                }).collect();
+                out.push(RaskCDecl::ExternUnion { name, fields });
+            }
+            CDecl::Enum(e) => {
+                let name = match &e.tag {
+                    Some(t) => t.clone(),
+                    None => return,
+                };
+                if self.is_hidden(&name) { return; }
+                if e.is_forward { return; }
+                let variants = e.variants.iter().map(|v| {
+                    (v.name.clone(), v.value)
+                }).collect();
+                out.push(RaskCDecl::ExternEnum { name, variants });
+            }
+            CDecl::Typedef(td) => {
+                if self.is_hidden(&td.name) { return; }
+                // Don't emit typedef if it maps to a struct/union/enum tag with same name
+                match &td.target {
+                    CType::StructTag(t) | CType::UnionTag(t) | CType::EnumTag(t)
+                        if t == &td.name => return,
+                    _ => {}
+                }
+                out.push(RaskCDecl::TypeAlias {
+                    name: td.name.clone(),
+                    target: self.translate_type(&td.target),
+                });
+            }
+            CDecl::Define(d) => {
+                if self.is_hidden(&d.name) { return; }
+                match &d.kind {
+                    CDefineKind::Integer(v) => {
+                        out.push(RaskCDecl::Const {
+                            name: d.name.clone(),
+                            ty: "c_int".to_string(),
+                            value: v.to_string(),
+                        });
+                    }
+                    CDefineKind::UnsignedInteger(v) => {
+                        out.push(RaskCDecl::Const {
+                            name: d.name.clone(),
+                            ty: "c_uint".to_string(),
+                            value: v.to_string(),
+                        });
+                    }
+                    CDefineKind::Float(v) => {
+                        out.push(RaskCDecl::Const {
+                            name: d.name.clone(),
+                            ty: "f64".to_string(),
+                            value: format!("{}", v),
+                        });
+                    }
+                    CDefineKind::String(s) => {
+                        out.push(RaskCDecl::Const {
+                            name: d.name.clone(),
+                            ty: "*u8".to_string(),
+                            value: format!("c\"{}\"", s.replace('\\', "\\\\").replace('"', "\\\"")),
+                        });
+                    }
+                    CDefineKind::FunctionMacro { .. } => {
+                        out.push(RaskCDecl::Warning {
+                            message: format!("function-like macro `{}` cannot be auto-imported", d.name),
+                        });
+                    }
+                    CDefineKind::Unparseable => {
+                        // Silently skip — too many #defines are noise
+                    }
+                }
+            }
+            CDecl::Variable(v) => {
+                if self.is_hidden(&v.name) { return; }
+                if v.is_extern {
+                    // Extern globals become accessible via unsafe
+                    out.push(RaskCDecl::Const {
+                        name: v.name.clone(),
+                        ty: self.translate_type(&v.ty),
+                        value: String::new(), // extern — no value
+                    });
+                }
+            }
+        }
+    }
+
+    /// Translate a C type to its Rask string representation.
+    /// Follows TM1–TM3 from struct.c-interop.
+    fn translate_type(&self, ty: &CType) -> String {
+        match ty {
+            CType::Void => "void".to_string(),
+            CType::Char => "c_char".to_string(),
+            CType::SignedChar => "i8".to_string(),
+            CType::UnsignedChar => "u8".to_string(),
+            CType::Short => "c_short".to_string(),
+            CType::UnsignedShort => "c_ushort".to_string(),
+            CType::Int => "c_int".to_string(),
+            CType::UnsignedInt => "c_uint".to_string(),
+            CType::Long => "c_long".to_string(),
+            CType::UnsignedLong => "c_ulong".to_string(),
+            CType::LongLong => "c_longlong".to_string(),
+            CType::UnsignedLongLong => "c_ulonglong".to_string(),
+            CType::Float => "f32".to_string(),
+            CType::Double => "f64".to_string(),
+            CType::Bool => "bool".to_string(),
+            CType::SizeT => "c_size".to_string(),
+            CType::SSizeT => "c_ssize".to_string(),
+            CType::FixedInt { bits, signed } => {
+                if *signed {
+                    format!("i{}", bits)
+                } else {
+                    format!("u{}", bits)
+                }
+            }
+            CType::IntPtr { signed } => {
+                if *signed { "isize".to_string() } else { "usize".to_string() }
+            }
+            CType::Pointer(inner) => {
+                // `const char *` and `char *` → `*u8` (C string convention)
+                match inner.as_ref() {
+                    CType::Char | CType::SignedChar => return "*u8".to_string(),
+                    CType::Const(inner2) if matches!(inner2.as_ref(), CType::Char | CType::SignedChar) => {
+                        return "*u8".to_string();
+                    }
+                    CType::UnsignedChar => return "*u8".to_string(),
+                    _ => {}
+                }
+                let inner_str = self.translate_type(inner);
+                format!("*{}", inner_str)
+            }
+            CType::Const(inner) => {
+                // Drop const qualifier — Rask handles mutability via borrow checker.
+                self.translate_type(inner)
+            }
+            CType::Array(elem, Some(size)) => {
+                let elem_str = self.translate_type(elem);
+                format!("[{}; {}]", elem_str, size)
+            }
+            CType::Array(elem, None) => {
+                // Unsized array — treat as pointer
+                let elem_str = self.translate_type(elem);
+                format!("*{}", elem_str)
+            }
+            CType::Named(name) => {
+                // Check if it's a well-known typedef
+                match name.as_str() {
+                    "FILE" => "*void".to_string(),
+                    "va_list" => "*void".to_string(),
+                    _ => name.clone(),
+                }
+            }
+            CType::StructTag(tag) => tag.clone(),
+            CType::UnionTag(tag) => tag.clone(),
+            CType::EnumTag(tag) => tag.clone(),
+            CType::FuncPtr { ret, params, is_variadic } => {
+                let ret_str = self.translate_type(ret);
+                let param_strs: Vec<String> = params.iter()
+                    .map(|p| self.translate_type(p))
+                    .collect();
+                let mut sig = format!("*func({})", param_strs.join(", "));
+                if *is_variadic {
+                    if !param_strs.is_empty() {
+                        sig = format!("*func({}, ...)", param_strs.join(", "));
+                    } else {
+                        sig = "*func(...)".to_string();
+                    }
+                }
+                if ret_str != "void" {
+                    sig.push_str(&format!(" -> {}", ret_str));
+                }
+                sig
+            }
+        }
+    }
+}
+
+/// Render translated declarations as Rask source (for debugging / `rask c-header` command).
+pub fn render_rask(decls: &[RaskCDecl]) -> String {
+    let mut out = String::new();
+
+    for decl in decls {
+        match decl {
+            RaskCDecl::ExternFunc { name, params, ret_ty, is_variadic } => {
+                out.push_str("extern \"C\" func ");
+                out.push_str(name);
+                out.push('(');
+                let mut first = true;
+                for p in params {
+                    if !first { out.push_str(", "); }
+                    first = false;
+                    out.push_str(&p.name);
+                    out.push_str(": ");
+                    out.push_str(&p.ty);
+                }
+                if *is_variadic {
+                    if !first { out.push_str(", "); }
+                    out.push_str("...");
+                }
+                out.push(')');
+                if ret_ty != "void" {
+                    out.push_str(" -> ");
+                    out.push_str(ret_ty);
+                }
+                out.push('\n');
+            }
+            RaskCDecl::ExternStruct { name, fields } => {
+                out.push_str("extern \"C\" struct ");
+                out.push_str(name);
+                out.push_str(" {\n");
+                for f in fields {
+                    out.push_str("    ");
+                    out.push_str(&f.name);
+                    out.push_str(": ");
+                    out.push_str(&f.ty);
+                    out.push('\n');
+                }
+                out.push_str("}\n");
+            }
+            RaskCDecl::ExternUnion { name, fields } => {
+                out.push_str("extern \"C\" union ");
+                out.push_str(name);
+                out.push_str(" {\n");
+                for f in fields {
+                    out.push_str("    ");
+                    out.push_str(&f.name);
+                    out.push_str(": ");
+                    out.push_str(&f.ty);
+                    out.push('\n');
+                }
+                out.push_str("}\n");
+            }
+            RaskCDecl::ExternEnum { name, variants } => {
+                out.push_str("extern \"C\" enum ");
+                out.push_str(name);
+                out.push_str(" {\n");
+                for (vname, value) in variants {
+                    out.push_str("    ");
+                    out.push_str(vname);
+                    if let Some(v) = value {
+                        out.push_str(&format!(" = {}", v));
+                    }
+                    out.push('\n');
+                }
+                out.push_str("}\n");
+            }
+            RaskCDecl::Const { name, ty, value } => {
+                out.push_str("const ");
+                out.push_str(name);
+                out.push_str(": ");
+                out.push_str(ty);
+                if !value.is_empty() {
+                    out.push_str(" = ");
+                    out.push_str(value);
+                }
+                out.push('\n');
+            }
+            RaskCDecl::TypeAlias { name, target } => {
+                out.push_str("type ");
+                out.push_str(name);
+                out.push_str(" = ");
+                out.push_str(target);
+                out.push('\n');
+            }
+            RaskCDecl::OpaqueType { name } => {
+                out.push_str("extern \"C\" struct ");
+                out.push_str(name);
+                out.push('\n');
+            }
+            RaskCDecl::Warning { message } => {
+                out.push_str("// WARNING: ");
+                out.push_str(message);
+                out.push('\n');
+            }
+        }
+    }
+
+    out
+}

--- a/compiler/crates/rask-c-parse/src/translate.rs
+++ b/compiler/crates/rask-c-parse/src/translate.rs
@@ -1,248 +1,199 @@
 // SPDX-License-Identifier: (MIT OR Apache-2.0)
 
-//! Translates parsed C declarations into Rask-level representations.
+//! Translates parsed C declarations into Rask-level intermediate representations.
 //!
 //! Follows the type mapping from struct.c-interop (TM1–TM3):
 //! - C `int` → `c_int`, `unsigned long` → `c_ulong`, etc.
-//! - `T*` → `*T`, `void*` → `*void`
+//! - `T*` → `*T`, `void*` → `*void`, `const char*` → `*u8`
 //! - `#define FOO 42` → const FOO: c_int = 42
+//!
+//! Produces self-contained types that the resolver consumes without depending
+//! on rask-ast. Type names are Rask syntax strings (`*u8`, `c_int`, etc.).
 
 use crate::*;
 
-/// A Rask-level declaration translated from C.
-#[derive(Debug, Clone)]
+// ---------------------------------------------------------------------------
+// Output types
+// ---------------------------------------------------------------------------
+
+/// A translated Rask declaration from C.
+#[derive(Debug, Clone, PartialEq)]
 pub enum RaskCDecl {
-    /// `extern "C" func name(params...) -> ret`
-    ExternFunc {
-        name: String,
-        params: Vec<RaskCParam>,
-        ret_ty: String,
-        is_variadic: bool,
-    },
-    /// `extern "C" struct Name { fields... }`
-    ExternStruct {
-        name: String,
-        fields: Vec<RaskCField>,
-    },
-    /// `extern "C" union Name { fields... }`
-    ExternUnion {
-        name: String,
-        fields: Vec<RaskCField>,
-    },
-    /// `extern "C" enum Name { variants... }`
-    ExternEnum {
-        name: String,
-        variants: Vec<(String, Option<i64>)>,
-    },
-    /// `const NAME: type = value`
-    Const {
-        name: String,
-        ty: String,
-        value: String,
-    },
-    /// Type alias: `type name = target`
-    TypeAlias {
-        name: String,
-        target: String,
-    },
-    /// Opaque type (forward-declared struct/union).
-    OpaqueType {
-        name: String,
-    },
-    /// Warning about a skipped declaration.
-    Warning {
-        message: String,
-    },
+    Function(RaskCFunc),
+    Struct(RaskCStruct),
+    Union(RaskCStruct),
+    Enum(RaskCEnum),
+    Const(RaskCConst),
+    TypeAlias(RaskCTypeAlias),
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq)]
+pub struct RaskCFunc {
+    pub name: String,
+    pub params: Vec<RaskCParam>,
+    /// Rask type as string. Empty string means no return type (C `void`).
+    pub ret_ty: String,
+    pub is_variadic: bool,
+}
+
+#[derive(Debug, Clone, PartialEq)]
 pub struct RaskCParam {
     pub name: String,
     pub ty: String,
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq)]
+pub struct RaskCStruct {
+    pub name: String,
+    pub fields: Vec<RaskCField>,
+    /// Forward declaration = opaque type (pointer-only access).
+    pub is_opaque: bool,
+}
+
+#[derive(Debug, Clone, PartialEq)]
 pub struct RaskCField {
     pub name: String,
     pub ty: String,
 }
 
-/// Translate C parse results into Rask declarations.
+#[derive(Debug, Clone, PartialEq)]
+pub struct RaskCEnum {
+    pub name: String,
+    pub variants: Vec<(String, Option<i64>)>,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct RaskCConst {
+    pub name: String,
+    pub ty: String,
+    /// Literal representation of the value.
+    pub value_repr: String,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct RaskCTypeAlias {
+    pub name: String,
+    pub target: String,
+}
+
+#[derive(Debug, Clone)]
+pub struct TranslateResult {
+    pub decls: Vec<RaskCDecl>,
+    pub warnings: Vec<String>,
+}
+
+// ---------------------------------------------------------------------------
+// Main entry point
+// ---------------------------------------------------------------------------
+
+/// Translate parsed C declarations into Rask intermediate declarations.
 ///
-/// `hiding` is the set of symbol names to suppress (from `import c "..." hiding { ... }`).
-pub fn translate(result: &CParseResult, hiding: &[String]) -> Vec<RaskCDecl> {
-    let mut out = Vec::new();
-    let mut translator = Translator {
-        hiding,
-        typedefs: std::collections::HashMap::new(),
-    };
+/// Symbols whose names appear in `hiding` are excluded. Static functions are
+/// skipped (internal linkage). Mutable globals produce a warning.
+pub fn translate(result: &CParseResult, hiding: &[String]) -> TranslateResult {
+    let mut decls = Vec::new();
+    let mut warnings: Vec<String> = Vec::new();
 
-    // First pass: collect typedefs for resolution
-    for decl in &result.decls {
-        if let CDecl::Typedef(td) = decl {
-            translator.typedefs.insert(td.name.clone(), td.target.clone());
-        }
-    }
+    // Collect typedefs for potential resolution.
+    let typedefs: std::collections::HashMap<String, CType> = result
+        .decls
+        .iter()
+        .filter_map(|d| {
+            if let CDecl::Typedef(td) = d {
+                Some((td.name.clone(), td.target.clone()))
+            } else {
+                None
+            }
+        })
+        .collect();
 
-    for decl in &result.decls {
-        translator.translate_decl(decl, &mut out);
-    }
+    let translator = Translator { typedefs: &typedefs };
 
-    // Emit warnings
+    // Forward parse warnings.
     for w in &result.warnings {
-        out.push(RaskCDecl::Warning {
-            message: w.message.clone(),
-        });
+        warnings.push(format!("line {}: {}", w.line, w.message));
     }
 
-    out
-}
+    for cdecl in &result.decls {
+        let name = decl_name(cdecl);
+        if let Some(n) = &name {
+            if hiding.iter().any(|h| h == n) {
+                continue;
+            }
+        }
 
-struct Translator<'a> {
-    hiding: &'a [String],
-    typedefs: std::collections::HashMap<String, CType>,
-}
-
-impl<'a> Translator<'a> {
-    fn is_hidden(&self, name: &str) -> bool {
-        self.hiding.iter().any(|h| h == name)
-    }
-
-    fn translate_decl(&self, decl: &CDecl, out: &mut Vec<RaskCDecl>) {
-        match decl {
+        match cdecl {
             CDecl::Function(f) => {
-                if self.is_hidden(&f.name) { return; }
-                let params = f.params.iter().enumerate().map(|(i, p)| {
-                    RaskCParam {
-                        name: p.name.clone().unwrap_or_else(|| format!("arg{}", i)),
-                        ty: self.translate_type(&p.ty),
-                    }
-                }).collect();
-                out.push(RaskCDecl::ExternFunc {
-                    name: f.name.clone(),
-                    params,
-                    ret_ty: self.translate_type(&f.ret_ty),
-                    is_variadic: f.is_variadic,
-                });
+                // Static functions have internal linkage — not importable (struct.c-interop edge case).
+                if f.is_static {
+                    continue;
+                }
+                decls.push(RaskCDecl::Function(translator.translate_func(f)));
             }
             CDecl::Struct(s) => {
-                let name = match &s.tag {
-                    Some(t) => t.clone(),
-                    None => return, // anonymous, handled via typedef
-                };
-                if self.is_hidden(&name) { return; }
-                if s.is_forward {
-                    out.push(RaskCDecl::OpaqueType { name });
-                    return;
+                if let Some(rask) = translator.translate_struct(s) {
+                    decls.push(RaskCDecl::Struct(rask));
                 }
-                let fields = s.fields.iter().map(|f| {
-                    RaskCField {
-                        name: f.name.clone(),
-                        ty: self.translate_type(&f.ty),
-                    }
-                }).collect();
-                out.push(RaskCDecl::ExternStruct { name, fields });
             }
             CDecl::Union(u) => {
-                let name = match &u.tag {
-                    Some(t) => t.clone(),
-                    None => return,
-                };
-                if self.is_hidden(&name) { return; }
-                if u.is_forward {
-                    out.push(RaskCDecl::OpaqueType { name });
-                    return;
+                if let Some(rask) = translator.translate_struct(u) {
+                    decls.push(RaskCDecl::Union(rask));
                 }
-                let fields = u.fields.iter().map(|f| {
-                    RaskCField {
-                        name: f.name.clone(),
-                        ty: self.translate_type(&f.ty),
-                    }
-                }).collect();
-                out.push(RaskCDecl::ExternUnion { name, fields });
             }
             CDecl::Enum(e) => {
-                let name = match &e.tag {
-                    Some(t) => t.clone(),
-                    None => return,
-                };
-                if self.is_hidden(&name) { return; }
-                if e.is_forward { return; }
-                let variants = e.variants.iter().map(|v| {
-                    (v.name.clone(), v.value)
-                }).collect();
-                out.push(RaskCDecl::ExternEnum { name, variants });
+                if let Some(rask) = translator.translate_enum(e) {
+                    decls.push(RaskCDecl::Enum(rask));
+                }
             }
             CDecl::Typedef(td) => {
-                if self.is_hidden(&td.name) { return; }
-                // Don't emit typedef if it maps to a struct/union/enum tag with same name
+                // Skip self-referencing typedefs (`typedef struct foo foo`).
                 match &td.target {
                     CType::StructTag(t) | CType::UnionTag(t) | CType::EnumTag(t)
-                        if t == &td.name => return,
+                        if t == &td.name =>
+                    {
+                        continue;
+                    }
                     _ => {}
                 }
-                out.push(RaskCDecl::TypeAlias {
-                    name: td.name.clone(),
-                    target: self.translate_type(&td.target),
-                });
+                decls.push(RaskCDecl::TypeAlias(translator.translate_typedef(td)));
             }
             CDecl::Define(d) => {
-                if self.is_hidden(&d.name) { return; }
-                match &d.kind {
-                    CDefineKind::Integer(v) => {
-                        out.push(RaskCDecl::Const {
-                            name: d.name.clone(),
-                            ty: "c_int".to_string(),
-                            value: v.to_string(),
-                        });
-                    }
-                    CDefineKind::UnsignedInteger(v) => {
-                        out.push(RaskCDecl::Const {
-                            name: d.name.clone(),
-                            ty: "c_uint".to_string(),
-                            value: v.to_string(),
-                        });
-                    }
-                    CDefineKind::Float(v) => {
-                        out.push(RaskCDecl::Const {
-                            name: d.name.clone(),
-                            ty: "f64".to_string(),
-                            value: format!("{}", v),
-                        });
-                    }
-                    CDefineKind::String(s) => {
-                        out.push(RaskCDecl::Const {
-                            name: d.name.clone(),
-                            ty: "*u8".to_string(),
-                            value: format!("c\"{}\"", s.replace('\\', "\\\\").replace('"', "\\\"")),
-                        });
-                    }
-                    CDefineKind::FunctionMacro { .. } => {
-                        out.push(RaskCDecl::Warning {
-                            message: format!("function-like macro `{}` cannot be auto-imported", d.name),
-                        });
-                    }
-                    CDefineKind::Unparseable => {
-                        // Silently skip — too many #defines are noise
-                    }
+                if let Some(c) = translator.translate_define(d, &mut warnings) {
+                    decls.push(RaskCDecl::Const(c));
                 }
             }
             CDecl::Variable(v) => {
-                if self.is_hidden(&v.name) { return; }
-                if v.is_extern {
-                    // Extern globals become accessible via unsafe
-                    out.push(RaskCDecl::Const {
+                if v.is_const {
+                    decls.push(RaskCDecl::Const(RaskCConst {
                         name: v.name.clone(),
-                        ty: self.translate_type(&v.ty),
-                        value: String::new(), // extern — no value
-                    });
+                        ty: translator.translate_type(&v.ty),
+                        value_repr: String::new(), // extern — no initializer from header
+                    }));
+                } else {
+                    warnings.push(format!(
+                        "skipping mutable global `{}`: mutable C globals are not safe to import",
+                        v.name
+                    ));
                 }
             }
         }
     }
 
-    /// Translate a C type to its Rask string representation.
-    /// Follows TM1–TM3 from struct.c-interop.
+    TranslateResult { decls, warnings }
+}
+
+// ---------------------------------------------------------------------------
+// Internal translator
+// ---------------------------------------------------------------------------
+
+struct Translator<'a> {
+    typedefs: &'a std::collections::HashMap<String, CType>,
+}
+
+impl<'a> Translator<'a> {
+    // -- Type translation ---------------------------------------------------
+
+    /// Convert a `CType` to its Rask type string representation.
     fn translate_type(&self, ty: &CType) -> String {
         match ty {
             CType::Void => "void".to_string(),
@@ -270,23 +221,12 @@ impl<'a> Translator<'a> {
                 }
             }
             CType::IntPtr { signed } => {
-                if *signed { "isize".to_string() } else { "usize".to_string() }
+                if *signed { "isize" } else { "usize" }.to_string()
             }
-            CType::Pointer(inner) => {
-                // `const char *` and `char *` → `*u8` (C string convention)
-                match inner.as_ref() {
-                    CType::Char | CType::SignedChar => return "*u8".to_string(),
-                    CType::Const(inner2) if matches!(inner2.as_ref(), CType::Char | CType::SignedChar) => {
-                        return "*u8".to_string();
-                    }
-                    CType::UnsignedChar => return "*u8".to_string(),
-                    _ => {}
-                }
-                let inner_str = self.translate_type(inner);
-                format!("*{}", inner_str)
-            }
+            CType::Pointer(inner) => self.translate_pointer(inner),
             CType::Const(inner) => {
-                // Drop const qualifier — Rask handles mutability via borrow checker.
+                // Top-level const on a non-pointer: strip it. Rask handles
+                // mutability through const/let, not type qualifiers.
                 self.translate_type(inner)
             }
             CType::Array(elem, Some(size)) => {
@@ -294,103 +234,287 @@ impl<'a> Translator<'a> {
                 format!("[{}; {}]", elem_str, size)
             }
             CType::Array(elem, None) => {
-                // Unsized array — treat as pointer
+                // Unsized array decays to pointer.
                 let elem_str = self.translate_type(elem);
                 format!("*{}", elem_str)
             }
             CType::Named(name) => {
-                // Check if it's a well-known typedef
                 match name.as_str() {
-                    "FILE" => "*void".to_string(),
-                    "va_list" => "*void".to_string(),
+                    "FILE" | "va_list" => "*void".to_string(),
                     _ => name.clone(),
                 }
             }
             CType::StructTag(tag) => tag.clone(),
             CType::UnionTag(tag) => tag.clone(),
             CType::EnumTag(tag) => tag.clone(),
-            CType::FuncPtr { ret, params, is_variadic } => {
-                let ret_str = self.translate_type(ret);
-                let param_strs: Vec<String> = params.iter()
-                    .map(|p| self.translate_type(p))
-                    .collect();
-                let mut sig = format!("*func({})", param_strs.join(", "));
-                if *is_variadic {
-                    if !param_strs.is_empty() {
-                        sig = format!("*func({}, ...)", param_strs.join(", "));
-                    } else {
-                        sig = "*func(...)".to_string();
-                    }
+            CType::FuncPtr {
+                ret,
+                params,
+                is_variadic,
+            } => self.translate_func_ptr(ret, params, *is_variadic),
+        }
+    }
+
+    /// Translate `T*` → `*T`, with special cases:
+    /// - `const char*` → `*u8` (C string convention)
+    /// - `void*` → `*void`
+    /// - Strips outer `const` on pointer targets.
+    fn translate_pointer(&self, inner: &CType) -> String {
+        let stripped = strip_const(inner);
+        match stripped {
+            CType::Char | CType::SignedChar | CType::UnsignedChar => "*u8".to_string(),
+            CType::Void => "*void".to_string(),
+            CType::FuncPtr {
+                ret,
+                params,
+                is_variadic,
+            } => {
+                // Pointer-to-function-pointer collapses to the func ptr.
+                self.translate_func_ptr(ret, params, *is_variadic)
+            }
+            other => {
+                let inner_ty = self.translate_type(other);
+                format!("*{}", inner_ty)
+            }
+        }
+    }
+
+    /// Translate a C function pointer to Rask `*func(...) -> R` syntax.
+    fn translate_func_ptr(&self, ret: &CType, params: &[CType], is_variadic: bool) -> String {
+        let param_strs: Vec<String> = params.iter().map(|p| self.translate_type(p)).collect();
+        let mut sig = String::from("*func(");
+        if is_variadic {
+            if !param_strs.is_empty() {
+                sig.push_str(&param_strs.join(", "));
+                sig.push_str(", ...");
+            } else {
+                sig.push_str("...");
+            }
+        } else {
+            sig.push_str(&param_strs.join(", "));
+        }
+        sig.push(')');
+
+        let ret_str = self.translate_type(ret);
+        if ret_str != "void" {
+            sig.push_str(" -> ");
+            sig.push_str(&ret_str);
+        }
+        sig
+    }
+
+    // -- Declaration translators --------------------------------------------
+
+    fn translate_func(&self, f: &CFuncDecl) -> RaskCFunc {
+        let params: Vec<RaskCParam> = f
+            .params
+            .iter()
+            .enumerate()
+            .filter_map(|(i, p)| {
+                // C `f(void)` means no params — skip single unnamed void param.
+                if f.params.len() == 1 && p.name.is_none() && p.ty == CType::Void {
+                    return None;
                 }
-                if ret_str != "void" {
-                    sig.push_str(&format!(" -> {}", ret_str));
-                }
-                sig
+                let name = p.name.clone().unwrap_or_else(|| format!("p{}", i));
+                Some(RaskCParam {
+                    name,
+                    ty: self.translate_type(&p.ty),
+                })
+            })
+            .collect();
+
+        let ret_ty = match &f.ret_ty {
+            CType::Void => String::new(),
+            other => self.translate_type(other),
+        };
+
+        RaskCFunc {
+            name: f.name.clone(),
+            params,
+            ret_ty,
+            is_variadic: f.is_variadic,
+        }
+    }
+
+    fn translate_struct(&self, s: &CStructDecl) -> Option<RaskCStruct> {
+        // Anonymous structs without a tag are not importable.
+        let name = s.tag.as_ref()?;
+
+        let fields = s
+            .fields
+            .iter()
+            .map(|f| RaskCField {
+                name: f.name.clone(),
+                ty: self.translate_type(&f.ty),
+            })
+            .collect();
+
+        Some(RaskCStruct {
+            name: name.clone(),
+            fields,
+            is_opaque: s.is_forward,
+        })
+    }
+
+    fn translate_enum(&self, e: &CEnumDecl) -> Option<RaskCEnum> {
+        let name = e.tag.as_ref()?;
+        if e.is_forward {
+            return None;
+        }
+
+        let variants = e.variants.iter().map(|v| (v.name.clone(), v.value)).collect();
+
+        Some(RaskCEnum {
+            name: name.clone(),
+            variants,
+        })
+    }
+
+    fn translate_typedef(&self, td: &CTypedef) -> RaskCTypeAlias {
+        RaskCTypeAlias {
+            name: td.name.clone(),
+            target: self.translate_type(&td.target),
+        }
+    }
+
+    fn translate_define(
+        &self,
+        d: &CDefine,
+        warnings: &mut Vec<String>,
+    ) -> Option<RaskCConst> {
+        match &d.kind {
+            CDefineKind::Integer(v) => Some(RaskCConst {
+                name: d.name.clone(),
+                ty: "c_int".to_string(),
+                value_repr: v.to_string(),
+            }),
+            CDefineKind::UnsignedInteger(v) => Some(RaskCConst {
+                name: d.name.clone(),
+                ty: "c_uint".to_string(),
+                value_repr: v.to_string(),
+            }),
+            CDefineKind::Float(v) => Some(RaskCConst {
+                name: d.name.clone(),
+                ty: "f64".to_string(),
+                value_repr: format!("{}", v),
+            }),
+            CDefineKind::String(s) => Some(RaskCConst {
+                name: d.name.clone(),
+                ty: "*u8".to_string(),
+                value_repr: format!(
+                    "c\"{}\"",
+                    s.replace('\\', "\\\\").replace('"', "\\\"")
+                ),
+            }),
+            CDefineKind::FunctionMacro { .. } => {
+                warnings.push(format!(
+                    "skipping function-like macro `{}`",
+                    d.name
+                ));
+                None
+            }
+            CDefineKind::Unparseable => {
+                warnings.push(format!(
+                    "skipping unparseable macro `{}`",
+                    d.name
+                ));
+                None
             }
         }
     }
 }
 
-/// Render translated declarations as Rask source (for debugging / `rask c-header` command).
-pub fn render_rask(decls: &[RaskCDecl]) -> String {
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/// Strip one layer of `Const` wrapper.
+fn strip_const(ty: &CType) -> &CType {
+    match ty {
+        CType::Const(inner) => inner,
+        other => other,
+    }
+}
+
+/// Extract the primary name of a C declaration for hiding checks.
+fn decl_name(decl: &CDecl) -> Option<String> {
+    match decl {
+        CDecl::Function(f) => Some(f.name.clone()),
+        CDecl::Struct(s) => s.tag.clone(),
+        CDecl::Union(u) => u.tag.clone(),
+        CDecl::Enum(e) => e.tag.clone(),
+        CDecl::Typedef(td) => Some(td.name.clone()),
+        CDecl::Define(d) => Some(d.name.clone()),
+        CDecl::Variable(v) => Some(v.name.clone()),
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Rendering (for debugging / `rask c-header` command)
+// ---------------------------------------------------------------------------
+
+/// Render translated declarations as Rask source text.
+pub fn render_rask(result: &TranslateResult) -> String {
     let mut out = String::new();
 
-    for decl in decls {
+    for decl in &result.decls {
         match decl {
-            RaskCDecl::ExternFunc { name, params, ret_ty, is_variadic } => {
+            RaskCDecl::Function(f) => {
                 out.push_str("extern \"C\" func ");
-                out.push_str(name);
+                out.push_str(&f.name);
                 out.push('(');
                 let mut first = true;
-                for p in params {
-                    if !first { out.push_str(", "); }
+                for p in &f.params {
+                    if !first {
+                        out.push_str(", ");
+                    }
                     first = false;
                     out.push_str(&p.name);
                     out.push_str(": ");
                     out.push_str(&p.ty);
                 }
-                if *is_variadic {
-                    if !first { out.push_str(", "); }
+                if f.is_variadic {
+                    if !first {
+                        out.push_str(", ");
+                    }
                     out.push_str("...");
                 }
                 out.push(')');
-                if ret_ty != "void" {
+                if !f.ret_ty.is_empty() {
                     out.push_str(" -> ");
-                    out.push_str(ret_ty);
+                    out.push_str(&f.ret_ty);
                 }
                 out.push('\n');
             }
-            RaskCDecl::ExternStruct { name, fields } => {
-                out.push_str("extern \"C\" struct ");
-                out.push_str(name);
-                out.push_str(" {\n");
-                for f in fields {
-                    out.push_str("    ");
-                    out.push_str(&f.name);
-                    out.push_str(": ");
-                    out.push_str(&f.ty);
+            RaskCDecl::Struct(s) | RaskCDecl::Union(s) => {
+                let keyword = if matches!(decl, RaskCDecl::Union(_)) {
+                    "union"
+                } else {
+                    "struct"
+                };
+                out.push_str("extern \"C\" ");
+                out.push_str(keyword);
+                out.push(' ');
+                out.push_str(&s.name);
+                if s.is_opaque {
                     out.push('\n');
+                } else {
+                    out.push_str(" {\n");
+                    for f in &s.fields {
+                        out.push_str("    ");
+                        out.push_str(&f.name);
+                        out.push_str(": ");
+                        out.push_str(&f.ty);
+                        out.push('\n');
+                    }
+                    out.push_str("}\n");
                 }
-                out.push_str("}\n");
             }
-            RaskCDecl::ExternUnion { name, fields } => {
-                out.push_str("extern \"C\" union ");
-                out.push_str(name);
-                out.push_str(" {\n");
-                for f in fields {
-                    out.push_str("    ");
-                    out.push_str(&f.name);
-                    out.push_str(": ");
-                    out.push_str(&f.ty);
-                    out.push('\n');
-                }
-                out.push_str("}\n");
-            }
-            RaskCDecl::ExternEnum { name, variants } => {
+            RaskCDecl::Enum(e) => {
                 out.push_str("extern \"C\" enum ");
-                out.push_str(name);
+                out.push_str(&e.name);
                 out.push_str(" {\n");
-                for (vname, value) in variants {
+                for (vname, value) in &e.variants {
                     out.push_str("    ");
                     out.push_str(vname);
                     if let Some(v) = value {
@@ -400,36 +524,487 @@ pub fn render_rask(decls: &[RaskCDecl]) -> String {
                 }
                 out.push_str("}\n");
             }
-            RaskCDecl::Const { name, ty, value } => {
+            RaskCDecl::Const(c) => {
                 out.push_str("const ");
-                out.push_str(name);
+                out.push_str(&c.name);
                 out.push_str(": ");
-                out.push_str(ty);
-                if !value.is_empty() {
+                out.push_str(&c.ty);
+                if !c.value_repr.is_empty() {
                     out.push_str(" = ");
-                    out.push_str(value);
+                    out.push_str(&c.value_repr);
                 }
                 out.push('\n');
             }
-            RaskCDecl::TypeAlias { name, target } => {
+            RaskCDecl::TypeAlias(a) => {
                 out.push_str("type ");
-                out.push_str(name);
+                out.push_str(&a.name);
                 out.push_str(" = ");
-                out.push_str(target);
-                out.push('\n');
-            }
-            RaskCDecl::OpaqueType { name } => {
-                out.push_str("extern \"C\" struct ");
-                out.push_str(name);
-                out.push('\n');
-            }
-            RaskCDecl::Warning { message } => {
-                out.push_str("// WARNING: ");
-                out.push_str(message);
+                out.push_str(&a.target);
                 out.push('\n');
             }
         }
     }
 
+    for w in &result.warnings {
+        out.push_str("// WARNING: ");
+        out.push_str(w);
+        out.push('\n');
+    }
+
     out
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn empty_result(decls: Vec<CDecl>) -> CParseResult {
+        CParseResult {
+            decls,
+            warnings: vec![],
+        }
+    }
+
+    #[test]
+    fn translate_basic_function() {
+        let result = empty_result(vec![CDecl::Function(CFuncDecl {
+            name: "puts".into(),
+            params: vec![CParam {
+                name: Some("s".into()),
+                ty: CType::Pointer(Box::new(CType::Const(Box::new(CType::Char)))),
+            }],
+            ret_ty: CType::Int,
+            is_variadic: false,
+            is_static: false,
+            is_inline: false,
+        })]);
+
+        let out = translate(&result, &[]);
+        assert_eq!(out.decls.len(), 1);
+        match &out.decls[0] {
+            RaskCDecl::Function(f) => {
+                assert_eq!(f.name, "puts");
+                assert_eq!(f.params.len(), 1);
+                assert_eq!(f.params[0].name, "s");
+                assert_eq!(f.params[0].ty, "*u8");
+                assert_eq!(f.ret_ty, "c_int");
+                assert!(!f.is_variadic);
+            }
+            other => panic!("expected Function, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn translate_void_return() {
+        let result = empty_result(vec![CDecl::Function(CFuncDecl {
+            name: "free".into(),
+            params: vec![CParam {
+                name: Some("ptr".into()),
+                ty: CType::Pointer(Box::new(CType::Void)),
+            }],
+            ret_ty: CType::Void,
+            is_variadic: false,
+            is_static: false,
+            is_inline: false,
+        })]);
+
+        let out = translate(&result, &[]);
+        match &out.decls[0] {
+            RaskCDecl::Function(f) => {
+                assert_eq!(f.ret_ty, "");
+                assert_eq!(f.params[0].ty, "*void");
+            }
+            other => panic!("expected Function, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn translate_void_params() {
+        // C `int getpid(void)` — single void param means no params.
+        let result = empty_result(vec![CDecl::Function(CFuncDecl {
+            name: "getpid".into(),
+            params: vec![CParam {
+                name: None,
+                ty: CType::Void,
+            }],
+            ret_ty: CType::Int,
+            is_variadic: false,
+            is_static: false,
+            is_inline: false,
+        })]);
+
+        let out = translate(&result, &[]);
+        match &out.decls[0] {
+            RaskCDecl::Function(f) => {
+                assert!(f.params.is_empty());
+            }
+            other => panic!("expected Function, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn translate_variadic_function() {
+        let result = empty_result(vec![CDecl::Function(CFuncDecl {
+            name: "printf".into(),
+            params: vec![CParam {
+                name: Some("fmt".into()),
+                ty: CType::Pointer(Box::new(CType::Const(Box::new(CType::Char)))),
+            }],
+            ret_ty: CType::Int,
+            is_variadic: true,
+            is_static: false,
+            is_inline: false,
+        })]);
+
+        let out = translate(&result, &[]);
+        match &out.decls[0] {
+            RaskCDecl::Function(f) => {
+                assert!(f.is_variadic);
+            }
+            other => panic!("expected Function, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn skip_static_function() {
+        let result = empty_result(vec![CDecl::Function(CFuncDecl {
+            name: "internal_helper".into(),
+            params: vec![],
+            ret_ty: CType::Void,
+            is_variadic: false,
+            is_static: true,
+            is_inline: false,
+        })]);
+
+        let out = translate(&result, &[]);
+        assert!(out.decls.is_empty());
+    }
+
+    #[test]
+    fn translate_struct_and_opaque() {
+        let result = empty_result(vec![
+            CDecl::Struct(CStructDecl {
+                tag: Some("point".into()),
+                fields: vec![
+                    CField { name: "x".into(), ty: CType::Double, bit_width: None },
+                    CField { name: "y".into(), ty: CType::Double, bit_width: None },
+                ],
+                is_forward: false,
+            }),
+            CDecl::Struct(CStructDecl {
+                tag: Some("sqlite3".into()),
+                fields: vec![],
+                is_forward: true,
+            }),
+        ]);
+
+        let out = translate(&result, &[]);
+        assert_eq!(out.decls.len(), 2);
+
+        match &out.decls[0] {
+            RaskCDecl::Struct(s) => {
+                assert_eq!(s.name, "point");
+                assert!(!s.is_opaque);
+                assert_eq!(s.fields.len(), 2);
+                assert_eq!(s.fields[0].ty, "f64");
+            }
+            other => panic!("expected Struct, got {:?}", other),
+        }
+
+        match &out.decls[1] {
+            RaskCDecl::Struct(s) => {
+                assert_eq!(s.name, "sqlite3");
+                assert!(s.is_opaque);
+            }
+            other => panic!("expected Struct, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn translate_enum() {
+        let result = empty_result(vec![CDecl::Enum(CEnumDecl {
+            tag: Some("color".into()),
+            variants: vec![
+                CEnumVariant { name: "RED".into(), value: Some(0) },
+                CEnumVariant { name: "GREEN".into(), value: Some(1) },
+                CEnumVariant { name: "BLUE".into(), value: Some(2) },
+            ],
+            is_forward: false,
+        })]);
+
+        let out = translate(&result, &[]);
+        match &out.decls[0] {
+            RaskCDecl::Enum(e) => {
+                assert_eq!(e.name, "color");
+                assert_eq!(e.variants.len(), 3);
+                assert_eq!(e.variants[0], ("RED".into(), Some(0)));
+            }
+            other => panic!("expected Enum, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn translate_typedef() {
+        let result = empty_result(vec![CDecl::Typedef(CTypedef {
+            name: "size_t".into(),
+            target: CType::UnsignedLong,
+        })]);
+
+        let out = translate(&result, &[]);
+        match &out.decls[0] {
+            RaskCDecl::TypeAlias(a) => {
+                assert_eq!(a.name, "size_t");
+                assert_eq!(a.target, "c_ulong");
+            }
+            other => panic!("expected TypeAlias, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn translate_defines() {
+        let result = empty_result(vec![
+            CDecl::Define(CDefine {
+                name: "EXIT_SUCCESS".into(),
+                kind: CDefineKind::Integer(0),
+            }),
+            CDecl::Define(CDefine {
+                name: "VERSION".into(),
+                kind: CDefineKind::String("1.0".into()),
+            }),
+            CDecl::Define(CDefine {
+                name: "MAX".into(),
+                kind: CDefineKind::FunctionMacro {
+                    params: vec!["a".into(), "b".into()],
+                },
+            }),
+            CDecl::Define(CDefine {
+                name: "WEIRD".into(),
+                kind: CDefineKind::Unparseable,
+            }),
+        ]);
+
+        let out = translate(&result, &[]);
+        assert_eq!(out.decls.len(), 2); // integer + string only
+
+        match &out.decls[0] {
+            RaskCDecl::Const(c) => {
+                assert_eq!(c.name, "EXIT_SUCCESS");
+                assert_eq!(c.ty, "c_int");
+                assert_eq!(c.value_repr, "0");
+            }
+            other => panic!("expected Const, got {:?}", other),
+        }
+
+        // Two warnings for skipped macros.
+        assert_eq!(
+            out.warnings
+                .iter()
+                .filter(|w| w.contains("skipping"))
+                .count(),
+            2
+        );
+    }
+
+    #[test]
+    fn translate_variable_const_vs_mutable() {
+        let result = empty_result(vec![
+            CDecl::Variable(CVarDecl {
+                name: "errno".into(),
+                ty: CType::Int,
+                is_extern: true,
+                is_const: false,
+            }),
+            CDecl::Variable(CVarDecl {
+                name: "STDOUT".into(),
+                ty: CType::Int,
+                is_extern: true,
+                is_const: true,
+            }),
+        ]);
+
+        let out = translate(&result, &[]);
+        // Mutable skipped, const kept.
+        assert_eq!(out.decls.len(), 1);
+        match &out.decls[0] {
+            RaskCDecl::Const(c) => assert_eq!(c.name, "STDOUT"),
+            other => panic!("expected Const, got {:?}", other),
+        }
+        assert!(out.warnings.iter().any(|w| w.contains("errno")));
+    }
+
+    #[test]
+    fn hiding_filters_symbols() {
+        let result = empty_result(vec![
+            CDecl::Function(CFuncDecl {
+                name: "keep".into(),
+                params: vec![],
+                ret_ty: CType::Void,
+                is_variadic: false,
+                is_static: false,
+                is_inline: false,
+            }),
+            CDecl::Function(CFuncDecl {
+                name: "hide_me".into(),
+                params: vec![],
+                ret_ty: CType::Void,
+                is_variadic: false,
+                is_static: false,
+                is_inline: false,
+            }),
+        ]);
+
+        let out = translate(&result, &["hide_me".into()]);
+        assert_eq!(out.decls.len(), 1);
+        match &out.decls[0] {
+            RaskCDecl::Function(f) => assert_eq!(f.name, "keep"),
+            other => panic!("expected Function, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn translate_fixed_int_types() {
+        let t = Translator {
+            typedefs: &std::collections::HashMap::new(),
+        };
+        assert_eq!(
+            t.translate_type(&CType::FixedInt { bits: 8, signed: true }),
+            "i8"
+        );
+        assert_eq!(
+            t.translate_type(&CType::FixedInt {
+                bits: 32,
+                signed: false
+            }),
+            "u32"
+        );
+        assert_eq!(
+            t.translate_type(&CType::FixedInt {
+                bits: 64,
+                signed: true
+            }),
+            "i64"
+        );
+    }
+
+    #[test]
+    fn translate_func_ptr_type() {
+        let t = Translator {
+            typedefs: &std::collections::HashMap::new(),
+        };
+        let ty = CType::FuncPtr {
+            ret: Box::new(CType::Int),
+            params: vec![CType::Pointer(Box::new(CType::Void)), CType::Int],
+            is_variadic: false,
+        };
+        assert_eq!(t.translate_type(&ty), "*func(*void, c_int) -> c_int");
+    }
+
+    #[test]
+    fn translate_array_type() {
+        let t = Translator {
+            typedefs: &std::collections::HashMap::new(),
+        };
+        assert_eq!(
+            t.translate_type(&CType::Array(Box::new(CType::Int), Some(16))),
+            "[c_int; 16]"
+        );
+        assert_eq!(
+            t.translate_type(&CType::Array(Box::new(CType::Char), None)),
+            "*c_char"
+        );
+    }
+
+    #[test]
+    fn translate_unnamed_params() {
+        let result = empty_result(vec![CDecl::Function(CFuncDecl {
+            name: "memcpy".into(),
+            params: vec![
+                CParam {
+                    name: None,
+                    ty: CType::Pointer(Box::new(CType::Void)),
+                },
+                CParam {
+                    name: None,
+                    ty: CType::Pointer(Box::new(CType::Const(Box::new(CType::Void)))),
+                },
+                CParam {
+                    name: None,
+                    ty: CType::SizeT,
+                },
+            ],
+            ret_ty: CType::Pointer(Box::new(CType::Void)),
+            is_variadic: false,
+            is_static: false,
+            is_inline: false,
+        })]);
+
+        let out = translate(&result, &[]);
+        match &out.decls[0] {
+            RaskCDecl::Function(f) => {
+                assert_eq!(f.params[0].name, "p0");
+                assert_eq!(f.params[0].ty, "*void");
+                assert_eq!(f.params[1].name, "p1");
+                assert_eq!(f.params[1].ty, "*void"); // const stripped on pointer target
+                assert_eq!(f.params[2].name, "p2");
+                assert_eq!(f.params[2].ty, "c_size");
+                assert_eq!(f.ret_ty, "*void");
+            }
+            other => panic!("expected Function, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn self_referencing_typedef_skipped() {
+        let result = empty_result(vec![
+            CDecl::Struct(CStructDecl {
+                tag: Some("foo".into()),
+                fields: vec![CField {
+                    name: "x".into(),
+                    ty: CType::Int,
+                    bit_width: None,
+                }],
+                is_forward: false,
+            }),
+            CDecl::Typedef(CTypedef {
+                name: "foo".into(),
+                target: CType::StructTag("foo".into()),
+            }),
+        ]);
+
+        let out = translate(&result, &[]);
+        // Struct emitted, typedef suppressed.
+        assert_eq!(out.decls.len(), 1);
+        assert!(matches!(&out.decls[0], RaskCDecl::Struct(_)));
+    }
+
+    #[test]
+    fn render_round_trip() {
+        let result = empty_result(vec![
+            CDecl::Function(CFuncDecl {
+                name: "open".into(),
+                params: vec![
+                    CParam { name: Some("path".into()), ty: CType::Pointer(Box::new(CType::Const(Box::new(CType::Char)))) },
+                    CParam { name: Some("flags".into()), ty: CType::Int },
+                ],
+                ret_ty: CType::Int,
+                is_variadic: false,
+                is_static: false,
+                is_inline: false,
+            }),
+            CDecl::Struct(CStructDecl {
+                tag: Some("sqlite3".into()),
+                fields: vec![],
+                is_forward: true,
+            }),
+        ]);
+
+        let translated = translate(&result, &[]);
+        let rendered = render_rask(&translated);
+        assert!(rendered.contains("extern \"C\" func open(path: *u8, flags: c_int) -> c_int"));
+        assert!(rendered.contains("extern \"C\" struct sqlite3\n"));
+    }
 }

--- a/compiler/crates/rask-cli/Cargo.toml
+++ b/compiler/crates/rask-cli/Cargo.toml
@@ -30,4 +30,5 @@ rask-codegen = { path = "../rask-codegen" }
 rask-stdlib = { path = "../rask-stdlib" }
 rask-hidden-params = { path = "../rask-hidden-params" }
 rask-effects = { path = "../rask-effects" }
+rask-c-parse = { path = "../rask-c-parse" }
 colored = "3"

--- a/compiler/crates/rask-cli/src/commands/tools.rs
+++ b/compiler/crates/rask-cli/src/commands/tools.rs
@@ -213,6 +213,50 @@ pub fn cmd_lint(path: &str, format: Format, rules: Vec<String>, excludes: Vec<St
     }
 }
 
+pub fn cmd_c_header(path: &str) {
+    let source = match fs::read_to_string(path) {
+        Ok(s) => s,
+        Err(e) => {
+            eprintln!("{}: reading {}: {}", output::error_label(), output::file_path(path), e);
+            process::exit(1);
+        }
+    };
+
+    match rask_c_parse::parse_c_header(&source) {
+        Ok(result) => {
+            for w in &result.warnings {
+                eprintln!("{}: line {}: {}", "warning".yellow().bold(), w.line, w.message);
+            }
+            let translated = rask_c_parse::translate::translate(&result, &[]);
+            let rask_src = rask_c_parse::translate::render_rask(&translated);
+            print!("{}", rask_src);
+
+            let func_count = translated.iter().filter(|d| matches!(d, rask_c_parse::translate::RaskCDecl::ExternFunc { .. })).count();
+            let struct_count = translated.iter().filter(|d| matches!(d, rask_c_parse::translate::RaskCDecl::ExternStruct { .. })).count();
+            let enum_count = translated.iter().filter(|d| matches!(d, rask_c_parse::translate::RaskCDecl::ExternEnum { .. })).count();
+            let const_count = translated.iter().filter(|d| matches!(d, rask_c_parse::translate::RaskCDecl::Const { .. })).count();
+            let typedef_count = translated.iter().filter(|d| matches!(d, rask_c_parse::translate::RaskCDecl::TypeAlias { .. })).count();
+            let warning_count = translated.iter().filter(|d| matches!(d, rask_c_parse::translate::RaskCDecl::Warning { .. })).count();
+
+            eprintln!();
+            eprintln!(
+                "{} {} functions, {} structs, {} enums, {} constants, {} typedefs{}",
+                output::status_pass(),
+                func_count,
+                struct_count,
+                enum_count,
+                const_count,
+                typedef_count,
+                if warning_count > 0 { format!(", {} warnings", warning_count) } else { String::new() },
+            );
+        }
+        Err(e) => {
+            eprintln!("{}: parsing {}: {}", output::error_label(), output::file_path(path), e);
+            process::exit(1);
+        }
+    }
+}
+
 pub fn cmd_explain(code: &str) {
     use rask_diagnostics::codes::ErrorCodeRegistry;
 

--- a/compiler/crates/rask-cli/src/commands/tools.rs
+++ b/compiler/crates/rask-cli/src/commands/tools.rs
@@ -231,12 +231,16 @@ pub fn cmd_c_header(path: &str) {
             let rask_src = rask_c_parse::translate::render_rask(&translated);
             print!("{}", rask_src);
 
-            let func_count = translated.iter().filter(|d| matches!(d, rask_c_parse::translate::RaskCDecl::ExternFunc { .. })).count();
-            let struct_count = translated.iter().filter(|d| matches!(d, rask_c_parse::translate::RaskCDecl::ExternStruct { .. })).count();
-            let enum_count = translated.iter().filter(|d| matches!(d, rask_c_parse::translate::RaskCDecl::ExternEnum { .. })).count();
-            let const_count = translated.iter().filter(|d| matches!(d, rask_c_parse::translate::RaskCDecl::Const { .. })).count();
-            let typedef_count = translated.iter().filter(|d| matches!(d, rask_c_parse::translate::RaskCDecl::TypeAlias { .. })).count();
-            let warning_count = translated.iter().filter(|d| matches!(d, rask_c_parse::translate::RaskCDecl::Warning { .. })).count();
+            for w in &translated.warnings {
+                eprintln!("{}: {}", "warning".yellow().bold(), w);
+            }
+
+            let func_count = translated.decls.iter().filter(|d| matches!(d, rask_c_parse::translate::RaskCDecl::Function(_))).count();
+            let struct_count = translated.decls.iter().filter(|d| matches!(d, rask_c_parse::translate::RaskCDecl::Struct(_) | rask_c_parse::translate::RaskCDecl::Union(_))).count();
+            let enum_count = translated.decls.iter().filter(|d| matches!(d, rask_c_parse::translate::RaskCDecl::Enum(_))).count();
+            let const_count = translated.decls.iter().filter(|d| matches!(d, rask_c_parse::translate::RaskCDecl::Const(_))).count();
+            let typedef_count = translated.decls.iter().filter(|d| matches!(d, rask_c_parse::translate::RaskCDecl::TypeAlias(_))).count();
+            let warning_count = translated.warnings.len();
 
             eprintln!();
             eprintln!(

--- a/compiler/crates/rask-cli/src/main.rs
+++ b/compiler/crates/rask-cli/src/main.rs
@@ -623,6 +623,14 @@ fn main() {
             }
             commands::tools::cmd_explain(cmd_args[2]);
         }
+        "c-header" => {
+            if cmd_args.len() < 3 {
+                eprintln!("{}: missing header file argument", output::error_label());
+                eprintln!("{}: {} {} {}", "Usage".yellow(), output::command("rask"), output::command("c-header"), output::arg("<file.h>"));
+                process::exit(1);
+            }
+            commands::tools::cmd_c_header(cmd_args[2]);
+        }
         "keys" => {
             if cmd_args.contains(&"--help") || cmd_args.contains(&"-h") {
                 println!("Manage Ed25519 signing keys.\n");

--- a/compiler/crates/rask-cli/tests/compile_run.rs
+++ b/compiler/crates/rask-cli/tests/compile_run.rs
@@ -498,3 +498,284 @@ fn discover_to_string() {
         "func main() {\n    const s = 42.to_string()\n    println(s)\n}"
     ), "i32.to_string should pass type check");
 }
+
+// ─── C import tests (CI1–CI5) ──────────────────────────────
+// End-to-end: parse C header → translate → resolve → type-check.
+
+fn c_header_fixture(name: &str) -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR"))
+        .join("tests")
+        .join("fixtures")
+        .join("c_headers")
+        .join(name)
+}
+
+/// Write a temp .rk file that imports the given header and check it.
+fn check_c_import(header: &str, rask_body: &str) -> bool {
+    use std::sync::atomic::{AtomicU64, Ordering};
+    static COUNTER: AtomicU64 = AtomicU64::new(0);
+    let rask = rask_binary();
+    let id = COUNTER.fetch_add(1, Ordering::Relaxed);
+    let header_path = c_header_fixture(header);
+    let tmp = std::env::temp_dir().join(format!("rask_ctest_{}_{}.rk", std::process::id(), id));
+    let source = format!(
+        "import c \"{}\"\n\n{}",
+        header_path.display(),
+        rask_body,
+    );
+    std::fs::write(&tmp, &source).unwrap();
+
+    let out = Command::new(&rask)
+        .arg("check")
+        .arg(&tmp)
+        .output()
+        .expect("failed to run rask check");
+
+    let _ = std::fs::remove_file(&tmp);
+    out.status.success()
+}
+
+/// Run `rask check` and return stderr+stdout for assertion.
+fn check_c_import_output(header: &str, rask_body: &str) -> (bool, String) {
+    use std::sync::atomic::{AtomicU64, Ordering};
+    static COUNTER: AtomicU64 = AtomicU64::new(0);
+    let rask = rask_binary();
+    let id = COUNTER.fetch_add(1, Ordering::Relaxed);
+    let header_path = c_header_fixture(header);
+    let tmp = std::env::temp_dir().join(format!("rask_ctest_{}_{}.rk", std::process::id(), id));
+    let source = format!(
+        "import c \"{}\"\n\n{}",
+        header_path.display(),
+        rask_body,
+    );
+    std::fs::write(&tmp, &source).unwrap();
+
+    let out = Command::new(&rask)
+        .arg("check")
+        .arg(&tmp)
+        .output()
+        .expect("failed to run rask check");
+
+    let _ = std::fs::remove_file(&tmp);
+    let combined = format!(
+        "{}{}",
+        String::from_utf8_lossy(&out.stdout),
+        String::from_utf8_lossy(&out.stderr),
+    );
+    (out.status.success(), combined)
+}
+
+/// Run `rask resolve` and return stdout for symbol inspection.
+fn resolve_c_import(header: &str, rask_body: &str) -> String {
+    use std::sync::atomic::{AtomicU64, Ordering};
+    static COUNTER: AtomicU64 = AtomicU64::new(0);
+    let rask = rask_binary();
+    let id = COUNTER.fetch_add(1, Ordering::Relaxed);
+    let header_path = c_header_fixture(header);
+    let tmp = std::env::temp_dir().join(format!("rask_crestest_{}_{}.rk", std::process::id(), id));
+    let source = format!(
+        "import c \"{}\"\n\n{}",
+        header_path.display(),
+        rask_body,
+    );
+    std::fs::write(&tmp, &source).unwrap();
+
+    let out = Command::new(&rask)
+        .arg("resolve")
+        .arg(&tmp)
+        .output()
+        .expect("failed to run rask resolve");
+
+    let _ = std::fs::remove_file(&tmp);
+    String::from_utf8_lossy(&out.stdout).to_string()
+}
+
+// CI1: import c "header.h" creates namespace with symbols
+#[test]
+fn c_import_creates_namespace() {
+    let symbols = resolve_c_import("mylib.h", "func main() {}");
+    assert!(symbols.contains("CNamespace"), "should create c namespace: {}", symbols);
+    assert!(symbols.contains("mylib_add"), "should contain mylib_add: {}", symbols);
+    assert!(symbols.contains("mylib_noop"), "should contain mylib_noop: {}", symbols);
+}
+
+// CI1: Functions parsed with correct types
+#[test]
+fn c_import_function_types() {
+    let symbols = resolve_c_import("mylib.h", "func main() {}");
+    assert!(
+        symbols.contains("ExternFunction") && symbols.contains("mylib_add"),
+        "should have ExternFunction for mylib_add: {}", symbols
+    );
+}
+
+// CI1: Structs parsed with fields
+#[test]
+fn c_import_struct_fields() {
+    let symbols = resolve_c_import("mylib.h", "func main() {}");
+    assert!(
+        symbols.contains("mylib_point") && symbols.contains("Struct"),
+        "should have struct mylib_point: {}", symbols
+    );
+}
+
+// CI1: Enum variants accessible
+#[test]
+fn c_import_enum_variants() {
+    let symbols = resolve_c_import("mylib.h", "func main() {}");
+    assert!(symbols.contains("MYLIB_OK"), "should have MYLIB_OK variant: {}", symbols);
+    assert!(symbols.contains("MYLIB_ERR"), "should have MYLIB_ERR variant: {}", symbols);
+    assert!(symbols.contains("MYLIB_TIMEOUT"), "should have MYLIB_TIMEOUT: {}", symbols);
+}
+
+// CI1: #define integer constant imported
+#[test]
+fn c_import_define_constant() {
+    let symbols = resolve_c_import("mylib.h", "func main() {}");
+    assert!(symbols.contains("MYLIB_VERSION"), "should have MYLIB_VERSION: {}", symbols);
+}
+
+// CI1: Forward-declared struct becomes opaque
+#[test]
+fn c_import_opaque_struct() {
+    let symbols = resolve_c_import("mylib.h", "func main() {}");
+    // mylib_ctx is forward-declared — should still exist as a struct
+    assert!(symbols.contains("mylib_ctx"), "should have opaque mylib_ctx: {}", symbols);
+}
+
+// CI1: Static functions not imported (internal linkage)
+#[test]
+fn c_import_skips_static() {
+    let symbols = resolve_c_import("mylib.h", "func main() {}");
+    assert!(!symbols.contains("mylib_internal_helper"),
+        "should NOT import static function: {}", symbols);
+}
+
+// CI1: Calling C function through namespace type-checks
+#[test]
+fn c_import_call_typechecks() {
+    assert!(check_c_import("mylib.h",
+        "func main() {\n    unsafe {\n        c.mylib_noop()\n    }\n}"
+    ), "calling c.mylib_noop() should type-check");
+}
+
+// CI1: Multiple functions type-check
+#[test]
+fn c_import_call_with_args_typechecks() {
+    assert!(check_c_import("mylib.h",
+        "func main() {\n    unsafe {\n        c.mylib_add(1, 2)\n    }\n}"
+    ), "calling c.mylib_add(1, 2) should type-check");
+}
+
+// CI5: import c "header.h" hiding { symbol }
+#[test]
+fn c_import_hiding() {
+    use std::sync::atomic::{AtomicU64, Ordering};
+    static COUNTER: AtomicU64 = AtomicU64::new(0);
+    let rask = rask_binary();
+    let id = COUNTER.fetch_add(1, Ordering::Relaxed);
+    let header_path = c_header_fixture("mylib.h");
+    let tmp = std::env::temp_dir().join(format!("rask_chidetest_{}_{}.rk", std::process::id(), id));
+    let source = format!(
+        "import c \"{}\" hiding {{ mylib_add }}\n\nfunc main() {{}}\n",
+        header_path.display(),
+    );
+    std::fs::write(&tmp, &source).unwrap();
+
+    let out = Command::new(&rask)
+        .arg("resolve")
+        .arg(&tmp)
+        .output()
+        .expect("failed to run rask resolve");
+
+    let _ = std::fs::remove_file(&tmp);
+    let stdout = String::from_utf8_lossy(&out.stdout).to_string();
+
+    // mylib_noop should be present, mylib_add should be hidden
+    assert!(stdout.contains("mylib_noop"), "mylib_noop should still be visible");
+    // Check that mylib_add is NOT in the CNamespace members
+    // (it may still exist as a symbol, but not in the namespace)
+    let ns_line = stdout.lines().find(|l| l.contains("CNamespace"));
+    if let Some(line) = ns_line {
+        assert!(!line.contains("mylib_add"),
+            "mylib_add should be hidden from namespace: {}", line);
+    }
+}
+
+// CI1: Aliased import: import c "header.h" as mylib
+#[test]
+fn c_import_alias() {
+    use std::sync::atomic::{AtomicU64, Ordering};
+    static COUNTER: AtomicU64 = AtomicU64::new(0);
+    let rask = rask_binary();
+    let id = COUNTER.fetch_add(1, Ordering::Relaxed);
+    let header_path = c_header_fixture("mylib.h");
+    let tmp = std::env::temp_dir().join(format!("rask_caliastest_{}_{}.rk", std::process::id(), id));
+    let source = format!(
+        "import c \"{}\" as mylib\n\nfunc main() {{\n    unsafe {{\n        mylib.mylib_noop()\n    }}\n}}\n",
+        header_path.display(),
+    );
+    std::fs::write(&tmp, &source).unwrap();
+
+    let out = Command::new(&rask)
+        .arg("check")
+        .arg(&tmp)
+        .output()
+        .expect("failed to run rask check");
+
+    let _ = std::fs::remove_file(&tmp);
+    assert!(out.status.success(), "aliased import should type-check: {}{}",
+        String::from_utf8_lossy(&out.stdout),
+        String::from_utf8_lossy(&out.stderr));
+}
+
+// Error: header not found should produce clear error
+#[test]
+fn c_import_missing_header() {
+    let (ok, output) = check_c_import_output("nonexistent.h", "func main() {}");
+    assert!(!ok, "missing header should fail");
+    assert!(output.contains("not found") || output.contains("header"),
+        "should mention header not found: {}", output);
+}
+
+// CI1: rask c-header CLI command works
+#[test]
+fn c_header_cli_command() {
+    let rask = rask_binary();
+    let header_path = c_header_fixture("mylib.h");
+
+    let out = Command::new(&rask)
+        .arg("c-header")
+        .arg(&header_path)
+        .output()
+        .expect("failed to run rask c-header");
+
+    let stdout = String::from_utf8_lossy(&out.stdout).to_string();
+    assert!(out.status.success(), "c-header command should succeed: {}",
+        String::from_utf8_lossy(&out.stderr));
+    assert!(stdout.contains("extern \"C\" func mylib_add"), "should show mylib_add: {}", stdout);
+    assert!(stdout.contains("extern \"C\" struct mylib_point"), "should show struct: {}", stdout);
+    assert!(stdout.contains("MYLIB_VERSION"), "should show constant: {}", stdout);
+}
+
+// TM1: Type mapping verified through resolve output
+#[test]
+fn c_import_type_mapping() {
+    let symbols = resolve_c_import("mylib.h", "func main() {}");
+    // mylib_hash should have params with u32 return and *u8 + c_size params
+    assert!(symbols.contains("mylib_hash"), "should have mylib_hash");
+    // mylib_add should have c_int params
+    let add_line = symbols.lines().find(|l| l.contains("mylib_add"));
+    if let Some(line) = add_line {
+        assert!(line.contains("c_int"), "mylib_add should have c_int params: {}", line);
+    }
+}
+
+// Function-like macro produces warning, not error
+#[test]
+fn c_import_function_macro_warned() {
+    let (ok, output) = check_c_import_output("mylib.h", "func main() {}");
+    assert!(ok, "should still compile despite function-like macro");
+    assert!(output.contains("MYLIB_MAX") || output.contains("macro"),
+        "should warn about function-like macro: {}", output);
+}

--- a/compiler/crates/rask-cli/tests/fixtures/c_headers/mylib.h
+++ b/compiler/crates/rask-cli/tests/fixtures/c_headers/mylib.h
@@ -1,0 +1,40 @@
+#ifndef MYLIB_H
+#define MYLIB_H
+
+#include <stdint.h>
+
+#define MYLIB_VERSION 42
+#define MYLIB_NAME "mylib"
+#define MYLIB_MAX(a, b) ((a) > (b) ? (a) : (b))
+
+typedef struct mylib_ctx mylib_ctx;
+
+struct mylib_point {
+    int x;
+    int y;
+};
+
+typedef struct mylib_point mylib_point_t;
+
+union mylib_value {
+    int i;
+    float f;
+};
+
+typedef enum {
+    MYLIB_OK = 0,
+    MYLIB_ERR = -1,
+    MYLIB_TIMEOUT = -2,
+} mylib_status;
+
+int mylib_add(int a, int b);
+void mylib_noop(void);
+const char *mylib_version_string(void);
+mylib_status mylib_init(mylib_ctx *ctx, const char *name);
+uint32_t mylib_hash(const uint8_t *data, size_t len);
+
+static int mylib_internal_helper(void) { return 0; }
+
+extern int mylib_errno;
+
+#endif

--- a/compiler/crates/rask-diagnostics/src/convert.rs
+++ b/compiler/crates/rask-diagnostics/src/convert.rs
@@ -160,6 +160,24 @@ impl ToDiagnostic for rask_resolve::ResolveError {
                     .with_fix("use a different name")
                     .with_why("built-in types and functions are reserved — redefining them would break language semantics")
             }
+
+            CHeaderNotFound { header, detail } => {
+                Diagnostic::error(format!("C header not found: `{}`", header))
+                    .with_code("E0210")
+                    .with_primary(self.span, detail.as_str())
+                    .with_help("check the header path or install the library's development package")
+                    .with_fix("verify the header path and include directories")
+                    .with_why("import c requires the header file to exist in system or project include paths")
+            }
+
+            CParseError { header, detail } => {
+                Diagnostic::error(format!("failed to parse C header: `{}`", header))
+                    .with_code("E0211")
+                    .with_primary(self.span, detail.as_str())
+                    .with_help("check the header for C++ or non-standard extensions")
+                    .with_fix("use explicit `extern \"C\"` bindings for problematic declarations")
+                    .with_why("the built-in C parser handles standard C headers — use explicit bindings for edge cases")
+            }
         }
     }
 }

--- a/compiler/crates/rask-resolve/Cargo.toml
+++ b/compiler/crates/rask-resolve/Cargo.toml
@@ -8,6 +8,7 @@ edition.workspace = true
 rask-ast = { path = "../rask-ast" }
 rask-lexer = { path = "../rask-lexer" }
 rask-parser = { path = "../rask-parser" }
+rask-c-parse = { path = "../rask-c-parse" }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 thiserror.workspace = true

--- a/compiler/crates/rask-resolve/src/error.rs
+++ b/compiler/crates/rask-resolve/src/error.rs
@@ -82,6 +82,20 @@ impl ResolveError {
             span,
         }
     }
+
+    pub fn c_header_not_found(header: String, detail: String, span: Span) -> Self {
+        Self {
+            kind: ResolveErrorKind::CHeaderNotFound { header, detail },
+            span,
+        }
+    }
+
+    pub fn c_parse_error(header: String, detail: String, span: Span) -> Self {
+        Self {
+            kind: ResolveErrorKind::CParseError { header, detail },
+            span,
+        }
+    }
 }
 
 /// The kind of resolution error.
@@ -116,4 +130,10 @@ pub enum ResolveErrorKind {
 
     #[error("cannot define `{name}` because it shadows a built-in; built-in types and functions cannot be redefined")]
     ShadowsBuiltin { name: String },
+
+    #[error("C header not found: `{header}` ({detail})")]
+    CHeaderNotFound { header: String, detail: String },
+
+    #[error("C header parse error in `{header}`: {detail}")]
+    CParseError { header: String, detail: String },
 }

--- a/compiler/crates/rask-resolve/src/resolver.rs
+++ b/compiler/crates/rask-resolve/src/resolver.rs
@@ -2,7 +2,7 @@
 //! The name resolver implementation.
 
 use std::collections::{HashMap, HashSet};
-use rask_ast::decl::{Decl, DeclKind, FnDecl, StructDecl, EnumDecl, TraitDecl, ImplDecl, ImportDecl, ExportDecl, TypeParam, UnionDecl};
+use rask_ast::decl::{Decl, DeclKind, FnDecl, StructDecl, EnumDecl, TraitDecl, ImplDecl, ImportDecl, ExportDecl, CImportDecl, TypeParam, UnionDecl};
 use rask_ast::stmt::{ForBinding, Stmt, StmtKind};
 use rask_ast::expr::{BinOp, Expr, ExprKind, Pattern, UnaryOp};
 use rask_ast::{NodeId, Span};
@@ -723,7 +723,10 @@ impl Resolver {
                     }
                 }
                 DeclKind::Test(_) | DeclKind::Benchmark(_) => {}
-                DeclKind::Package(_) | DeclKind::CImport(_) => {}
+                DeclKind::Package(_) => {}
+                DeclKind::CImport(c_import) => {
+                    self.resolve_c_import(c_import, decl.span);
+                }
                 DeclKind::Union(union_decl) => {
                     self.declare_union(union_decl, decl.span);
                 }
@@ -1109,6 +1112,215 @@ impl Resolver {
                 .unwrap_or_else(|| path.last().unwrap());
             let _ = export_name;
         }
+    }
+
+    // =========================================================================
+    // C Import Resolution (CI1)
+    // =========================================================================
+
+    fn resolve_c_import(&mut self, c_import: &CImportDecl, span: Span) {
+        use rask_c_parse::translate;
+
+        let mut all_decls = Vec::new();
+
+        for header_path in &c_import.headers {
+            let source = match self.read_c_header(header_path) {
+                Ok(s) => s,
+                Err(msg) => {
+                    self.errors.push(ResolveError::c_header_not_found(
+                        header_path.clone(), msg, span,
+                    ));
+                    continue;
+                }
+            };
+
+            match rask_c_parse::parse_c_header(&source) {
+                Ok(result) => {
+                    for w in &result.warnings {
+                        eprintln!("warning: {}: {}", header_path, w.message);
+                    }
+                    let translated = translate::translate(&result, &c_import.hiding);
+                    all_decls.extend(translated);
+                }
+                Err(e) => {
+                    self.errors.push(ResolveError::c_parse_error(
+                        header_path.clone(),
+                        e.to_string(),
+                        span,
+                    ));
+                }
+            }
+        }
+
+        // Create symbols for each translated declaration
+        let mut members = HashMap::new();
+
+        for decl in &all_decls {
+            match decl {
+                translate::RaskCDecl::ExternFunc { name, params, ret_ty, .. } => {
+                    let param_types: Vec<String> = params.iter()
+                        .map(|p| p.ty.clone())
+                        .collect();
+                    let sym_id = self.symbols.insert(
+                        name.clone(),
+                        SymbolKind::ExternFunction {
+                            abi: "C".to_string(),
+                            params: param_types,
+                            ret_ty: if ret_ty == "void" { None } else { Some(ret_ty.clone()) },
+                        },
+                        None,
+                        span,
+                        false,
+                    );
+                    members.insert(name.clone(), sym_id);
+                }
+                translate::RaskCDecl::ExternStruct { name, fields } => {
+                    let mut field_syms = Vec::new();
+                    // Create a struct symbol first (with dummy SymbolId for fields)
+                    let struct_sym_id = self.symbols.insert(
+                        name.clone(),
+                        SymbolKind::Struct { fields: vec![] },
+                        None,
+                        span,
+                        false,
+                    );
+                    for f in fields {
+                        let f_sym = self.symbols.insert(
+                            f.name.clone(),
+                            SymbolKind::Field { parent: struct_sym_id },
+                            Some(f.ty.clone()),
+                            span,
+                            false,
+                        );
+                        field_syms.push((f.name.clone(), f_sym));
+                    }
+                    if let Some(sym) = self.symbols.get_mut(struct_sym_id) {
+                        sym.kind = SymbolKind::Struct { fields: field_syms };
+                    }
+                    members.insert(name.clone(), struct_sym_id);
+                }
+                translate::RaskCDecl::ExternUnion { name, fields } => {
+                    let mut field_syms = Vec::new();
+                    let union_sym_id = self.symbols.insert(
+                        name.clone(),
+                        SymbolKind::Struct { fields: vec![] },
+                        None,
+                        span,
+                        false,
+                    );
+                    for f in fields {
+                        let f_sym = self.symbols.insert(
+                            f.name.clone(),
+                            SymbolKind::Field { parent: union_sym_id },
+                            Some(f.ty.clone()),
+                            span,
+                            false,
+                        );
+                        field_syms.push((f.name.clone(), f_sym));
+                    }
+                    if let Some(sym) = self.symbols.get_mut(union_sym_id) {
+                        sym.kind = SymbolKind::Struct { fields: field_syms };
+                    }
+                    members.insert(name.clone(), union_sym_id);
+                }
+                translate::RaskCDecl::ExternEnum { name, variants } => {
+                    let enum_sym_id = self.symbols.insert(
+                        name.clone(),
+                        SymbolKind::Enum { variants: vec![] },
+                        None,
+                        span,
+                        false,
+                    );
+                    let mut variant_syms = Vec::new();
+                    for (vname, _value) in variants {
+                        let v_sym = self.symbols.insert(
+                            vname.clone(),
+                            SymbolKind::EnumVariant { enum_id: enum_sym_id },
+                            None,
+                            span,
+                            false,
+                        );
+                        variant_syms.push((vname.clone(), v_sym));
+                        // C enum constants are also accessible as top-level names
+                        members.insert(vname.clone(), v_sym);
+                    }
+                    if let Some(sym) = self.symbols.get_mut(enum_sym_id) {
+                        sym.kind = SymbolKind::Enum { variants: variant_syms };
+                    }
+                    members.insert(name.clone(), enum_sym_id);
+                }
+                translate::RaskCDecl::Const { name, ty, .. } => {
+                    let sym_id = self.symbols.insert(
+                        name.clone(),
+                        SymbolKind::Variable { mutable: false },
+                        Some(ty.clone()),
+                        span,
+                        false,
+                    );
+                    members.insert(name.clone(), sym_id);
+                }
+                translate::RaskCDecl::TypeAlias { name, target } => {
+                    let sym_id = self.symbols.insert(
+                        name.clone(),
+                        SymbolKind::TypeAlias { target: target.clone() },
+                        None,
+                        span,
+                        false,
+                    );
+                    members.insert(name.clone(), sym_id);
+                }
+                translate::RaskCDecl::OpaqueType { name } => {
+                    let sym_id = self.symbols.insert(
+                        name.clone(),
+                        SymbolKind::Struct { fields: vec![] },
+                        None,
+                        span,
+                        false,
+                    );
+                    members.insert(name.clone(), sym_id);
+                }
+                translate::RaskCDecl::Warning { message } => {
+                    eprintln!("warning: c-import: {}", message);
+                }
+            }
+        }
+
+        // Register the namespace under the alias
+        let ns_sym = self.symbols.insert(
+            c_import.alias.clone(),
+            SymbolKind::CNamespace { members },
+            None,
+            span,
+            false,
+        );
+        if let Err(e) = self.scopes.define(c_import.alias.clone(), ns_sym, span) {
+            self.errors.push(e);
+        }
+    }
+
+    /// Read a C header file, searching standard include paths.
+    fn read_c_header(&self, path: &str) -> Result<String, String> {
+        // Try relative to current directory first
+        if let Ok(contents) = std::fs::read_to_string(path) {
+            return Ok(contents);
+        }
+
+        // Search standard include paths
+        let search_paths = [
+            "/usr/include",
+            "/usr/local/include",
+            "/usr/include/x86_64-linux-gnu",
+            "/usr/include/aarch64-linux-gnu",
+        ];
+
+        for base in &search_paths {
+            let full = format!("{}/{}", base, path);
+            if let Ok(contents) = std::fs::read_to_string(&full) {
+                return Ok(contents);
+            }
+        }
+
+        Err(format!("header not found in search paths: {}", path))
     }
 
     // =========================================================================
@@ -1662,6 +1874,17 @@ impl Resolver {
                                 }
                                 return;
                             }
+                            if let SymbolKind::CNamespace { members } = &sym.kind {
+                                let members = members.clone();
+                                self.resolutions.insert(object.id, sym_id);
+                                if let Some(&method_sym) = members.get(method) {
+                                    self.resolutions.insert(expr.id, method_sym);
+                                }
+                                for arg in args {
+                                    self.resolve_expr(&arg.expr);
+                                }
+                                return;
+                            }
                         }
                     }
                 }
@@ -1683,6 +1906,14 @@ impl Resolver {
                                         self.resolutions.insert(expr.id, field_sym);
                                     }
                                     // No error for missing field — type checker handles it
+                                }
+                                return;
+                            }
+                            if let SymbolKind::CNamespace { members } = &sym.kind {
+                                let members = members.clone();
+                                self.resolutions.insert(object.id, sym_id);
+                                if let Some(&field_sym) = members.get(field) {
+                                    self.resolutions.insert(expr.id, field_sym);
                                 }
                                 return;
                             }
@@ -1808,6 +2039,10 @@ impl Resolver {
                                     if let Some(&struct_sym) = exports.get(parts[1]) {
                                         self.resolutions.insert(expr.id, struct_sym);
                                     }
+                                }
+                            } else if let SymbolKind::CNamespace { members } = &sym.kind {
+                                if let Some(&member_sym) = members.get(parts[1]) {
+                                    self.resolutions.insert(expr.id, member_sym);
                                 }
                             } else {
                                 self.resolutions.insert(expr.id, sym_id);

--- a/compiler/crates/rask-resolve/src/resolver.rs
+++ b/compiler/crates/rask-resolve/src/resolver.rs
@@ -1140,7 +1140,10 @@ impl Resolver {
                         eprintln!("warning: {}: {}", header_path, w.message);
                     }
                     let translated = translate::translate(&result, &c_import.hiding);
-                    all_decls.extend(translated);
+                    for w in &translated.warnings {
+                        eprintln!("warning: c-import: {}", w);
+                    }
+                    all_decls.extend(translated.decls);
                 }
                 Err(e) => {
                     self.errors.push(ResolveError::c_parse_error(
@@ -1157,58 +1160,68 @@ impl Resolver {
 
         for decl in &all_decls {
             match decl {
-                translate::RaskCDecl::ExternFunc { name, params, ret_ty, .. } => {
-                    let param_types: Vec<String> = params.iter()
+                translate::RaskCDecl::Function(f) => {
+                    let param_types: Vec<String> = f.params.iter()
                         .map(|p| p.ty.clone())
                         .collect();
                     let sym_id = self.symbols.insert(
-                        name.clone(),
+                        f.name.clone(),
                         SymbolKind::ExternFunction {
                             abi: "C".to_string(),
                             params: param_types,
-                            ret_ty: if ret_ty == "void" { None } else { Some(ret_ty.clone()) },
+                            ret_ty: if f.ret_ty.is_empty() { None } else { Some(f.ret_ty.clone()) },
                         },
                         None,
                         span,
                         false,
                     );
-                    members.insert(name.clone(), sym_id);
+                    members.insert(f.name.clone(), sym_id);
                 }
-                translate::RaskCDecl::ExternStruct { name, fields } => {
-                    let mut field_syms = Vec::new();
-                    // Create a struct symbol first (with dummy SymbolId for fields)
-                    let struct_sym_id = self.symbols.insert(
-                        name.clone(),
-                        SymbolKind::Struct { fields: vec![] },
-                        None,
-                        span,
-                        false,
-                    );
-                    for f in fields {
-                        let f_sym = self.symbols.insert(
-                            f.name.clone(),
-                            SymbolKind::Field { parent: struct_sym_id },
-                            Some(f.ty.clone()),
+                translate::RaskCDecl::Struct(s) => {
+                    if s.is_opaque {
+                        let sym_id = self.symbols.insert(
+                            s.name.clone(),
+                            SymbolKind::Struct { fields: vec![] },
+                            None,
                             span,
                             false,
                         );
-                        field_syms.push((f.name.clone(), f_sym));
+                        members.insert(s.name.clone(), sym_id);
+                    } else {
+                        let mut field_syms = Vec::new();
+                        let struct_sym_id = self.symbols.insert(
+                            s.name.clone(),
+                            SymbolKind::Struct { fields: vec![] },
+                            None,
+                            span,
+                            false,
+                        );
+                        for f in &s.fields {
+                            let f_sym = self.symbols.insert(
+                                f.name.clone(),
+                                SymbolKind::Field { parent: struct_sym_id },
+                                Some(f.ty.clone()),
+                                span,
+                                false,
+                            );
+                            field_syms.push((f.name.clone(), f_sym));
+                        }
+                        if let Some(sym) = self.symbols.get_mut(struct_sym_id) {
+                            sym.kind = SymbolKind::Struct { fields: field_syms };
+                        }
+                        members.insert(s.name.clone(), struct_sym_id);
                     }
-                    if let Some(sym) = self.symbols.get_mut(struct_sym_id) {
-                        sym.kind = SymbolKind::Struct { fields: field_syms };
-                    }
-                    members.insert(name.clone(), struct_sym_id);
                 }
-                translate::RaskCDecl::ExternUnion { name, fields } => {
+                translate::RaskCDecl::Union(s) => {
                     let mut field_syms = Vec::new();
                     let union_sym_id = self.symbols.insert(
-                        name.clone(),
+                        s.name.clone(),
                         SymbolKind::Struct { fields: vec![] },
                         None,
                         span,
                         false,
                     );
-                    for f in fields {
+                    for f in &s.fields {
                         let f_sym = self.symbols.insert(
                             f.name.clone(),
                             SymbolKind::Field { parent: union_sym_id },
@@ -1221,18 +1234,18 @@ impl Resolver {
                     if let Some(sym) = self.symbols.get_mut(union_sym_id) {
                         sym.kind = SymbolKind::Struct { fields: field_syms };
                     }
-                    members.insert(name.clone(), union_sym_id);
+                    members.insert(s.name.clone(), union_sym_id);
                 }
-                translate::RaskCDecl::ExternEnum { name, variants } => {
+                translate::RaskCDecl::Enum(e) => {
                     let enum_sym_id = self.symbols.insert(
-                        name.clone(),
+                        e.name.clone(),
                         SymbolKind::Enum { variants: vec![] },
                         None,
                         span,
                         false,
                     );
                     let mut variant_syms = Vec::new();
-                    for (vname, _value) in variants {
+                    for (vname, _value) in &e.variants {
                         let v_sym = self.symbols.insert(
                             vname.clone(),
                             SymbolKind::EnumVariant { enum_id: enum_sym_id },
@@ -1247,40 +1260,27 @@ impl Resolver {
                     if let Some(sym) = self.symbols.get_mut(enum_sym_id) {
                         sym.kind = SymbolKind::Enum { variants: variant_syms };
                     }
-                    members.insert(name.clone(), enum_sym_id);
+                    members.insert(e.name.clone(), enum_sym_id);
                 }
-                translate::RaskCDecl::Const { name, ty, .. } => {
+                translate::RaskCDecl::Const(c) => {
                     let sym_id = self.symbols.insert(
-                        name.clone(),
+                        c.name.clone(),
                         SymbolKind::Variable { mutable: false },
-                        Some(ty.clone()),
+                        Some(c.ty.clone()),
                         span,
                         false,
                     );
-                    members.insert(name.clone(), sym_id);
+                    members.insert(c.name.clone(), sym_id);
                 }
-                translate::RaskCDecl::TypeAlias { name, target } => {
+                translate::RaskCDecl::TypeAlias(a) => {
                     let sym_id = self.symbols.insert(
-                        name.clone(),
-                        SymbolKind::TypeAlias { target: target.clone() },
+                        a.name.clone(),
+                        SymbolKind::TypeAlias { target: a.target.clone() },
                         None,
                         span,
                         false,
                     );
-                    members.insert(name.clone(), sym_id);
-                }
-                translate::RaskCDecl::OpaqueType { name } => {
-                    let sym_id = self.symbols.insert(
-                        name.clone(),
-                        SymbolKind::Struct { fields: vec![] },
-                        None,
-                        span,
-                        false,
-                    );
-                    members.insert(name.clone(), sym_id);
-                }
-                translate::RaskCDecl::Warning { message } => {
-                    eprintln!("warning: c-import: {}", message);
+                    members.insert(a.name.clone(), sym_id);
                 }
             }
         }

--- a/compiler/crates/rask-resolve/src/symbol.rs
+++ b/compiler/crates/rask-resolve/src/symbol.rs
@@ -96,6 +96,11 @@ pub enum SymbolKind {
         /// The target type name.
         target: String,
     },
+    /// A C import namespace (`import c "header.h"` → `c.symbol`).
+    CNamespace {
+        /// Symbols parsed from C headers, keyed by name.
+        members: std::collections::HashMap<String, SymbolId>,
+    },
 }
 
 /// Built-in type kinds.


### PR DESCRIPTION
## Summary
Implements C header import functionality (`import c "header.h"`) for the Rask compiler, enabling safe interoperability with C libraries. This includes a complete C header parser, type translator, and resolver integration.

## Key Changes

### New C Parser Crate (`rask-c-parse`)
- **Lexer** (`lexer.rs`): Tokenizes preprocessed C source into a token stream, handling:
  - C keywords, literals (int, float, string, char), and punctuation
  - Preprocessor directives (#define, #include, #ifdef, etc.)
  - Line continuations and whitespace tracking for macro disambiguation
  
- **Parser** (`parser.rs`): Builds a C-level AST from tokens, supporting:
  - Function declarations with variadic parameters
  - Struct/union definitions and forward declarations
  - Enum declarations with auto-incrementing values
  - Typedef declarations
  - #define constants (integers, floats, strings, parenthesized expressions)
  - Global variable declarations
  - extern "C" blocks and ABI handling
  - Graceful error recovery with warnings
  
- **Translator** (`translate.rs`): Converts parsed C declarations to Rask intermediate types:
  - C type mapping: `int` → `c_int`, `unsigned long` → `c_ulong`, etc.
  - Pointer translation: `T*` → `*T`, with special cases (`const char*` → `*u8`, `void*` → `*void`)
  - Function pointer syntax: `*func(...) -> R`
  - Filters out static functions (internal linkage), function-like macros, and mutable globals
  - Skips self-referencing typedefs and anonymous structs

### Resolver Integration
- **C Import Resolution** (`rask-resolve/resolver.rs`): 
  - Reads C header files from disk
  - Parses and translates declarations
  - Creates a `CNamespace` symbol containing all imported symbols
  - Handles hiding lists to exclude specific symbols
  - Reports parse errors and warnings with proper diagnostics

### CLI Tools
- **`c-header` command** (`rask-cli/tools.rs`): Standalone tool to parse and inspect C headers
- **Test infrastructure** (`rask-cli/compile_run.rs`): End-to-end tests for C import functionality (CI1–CI5)
- **Test fixtures** (`c_headers/mylib.h`): Example C header for testing

### AST Extensions
- **CImportDecl** in `rask-ast`: Represents `import c "header.h"` declarations with header paths and hiding lists
- **CNamespace** symbol kind in resolver for organizing imported C symbols

## Implementation Details

- **No libclang dependency**: Self-contained parser handles the subset of C found in well-behaved library headers
- **Graceful degradation**: Unparseable constructs (complex macros, bitfields) generate warnings but don't fail the import
- **Type safety**: Translated types are Rask syntax strings that integrate seamlessly with the type checker
- **Error recovery**: Parser continues after errors, collecting warnings for user feedback
- **Preprocessor handling**: Skips most directives; only #define constants are translated to Rask consts

## Testing
Comprehensive test suite covering:
- Function declarations (variadic, void return)
- Struct/union definitions and forward declarations
- Enum variants with explicit values
- Typedef declarations and pointers
- #define constants (integers, strings, floats, negative values)
- Type translations and pointer handling

https://claude.ai/code/session_01TTT32M2PFJyEQvy17tMVwb