### PR TITLE
Add economy bootstrapping spec for Apeiron

### DIFF
--- a/projects/apeiron/ECONOMY.md
+++ b/projects/apeiron/ECONOMY.md
@@ -1,0 +1,263 @@
+# Economy Bootstrap
+<!-- id: apeiron.economy --> <!-- status: proposed --> <!-- summary: How the founding cluster breaks the bootstrap cycle — seed currency, initial minting, new player economics -->
+
+The [constraint physics](PHYSICS.md) define what can exist. The [transformation physics](TRANSFORMATION.md) define what can be created. This spec defines how the economy starts — the ignition sequence that turns a galaxy of potential into a functioning market.
+
+## The Problem
+
+Apeiron's economy has a bootstrap cycle that can't be solved by players alone.
+
+You need fuel to jump between systems. Fuel requires hydrogen and carbon, extracted and refined. Refining requires facilities. Facilities are built from materials. Materials require extraction. Extraction requires a domain — a star system you host and operate.
+
+A new player arrives with nothing. They can't produce without things they don't have, and they can't trade without having produced something.
+
+The founding cluster breaks this cycle by going first. Extract, refine, build, stockpile, establish trade routes — all before the first outside player arrives. The founders eat the cold-start cost. That's the deal.
+
+## The Seed Currency
+
+Credits. A fiat currency minted by the founding cluster, recognized by all founding domains.
+
+I chose fiat over commodity money. Fuel was the other candidate — universal demand, natural sink through combustion. But fuel-as-currency conflates "money to move" with "money to trade." Players shouldn't feel like they're burning their wallet every time they jump. Fuel is a critical commodity. Credits are the unit of account. You buy fuel with credits.
+
+### Why Credits Work
+
+**Pre-bootstrapped backing.** The founding cluster runs a functioning economy before any player arrives. Credits are redeemable for real goods — fuel, materials, components, ship upgrades — at 5 operating systems on day one. That's not a promise. That's inventory.
+
+**Activity-tied minting.** Credits enter circulation through specific channels, each triggered by real economic activity:
+
+- Starter ship subsidy — new player joins, credits minted to cover ship cost
+- Courier job payments — cargo moved between systems
+- Scout bounties — unclaimed system mapped and reported
+- Mining contract payouts — resources extracted at a founding system
+
+No activity, no minting. Credit supply grows proportional to economic participation, not on a schedule.
+
+**Transparent supply.** Every founding domain's minting script is Raido bytecode — content-addressed, publicly auditable ([Conservation Law 1](../allgard/CONSERVATION.md)). Trading partners verify supply through bilateral audit. A founding system that mints recklessly is visible to everyone. Trust erodes. Credits from that system lose value. Hyperinflation requires hiding what you're doing. The conservation laws make that impossible.
+
+**No centralization.** Credits are not protocol-privileged. They're one domain cluster's asset type. Players choose which currency to use — credits, fuel, raw titanium, whatever a bilateral trade agrees on. The founding cluster doesn't mandate credits. It offers them. They're the default because the founding economy has the most liquidity, not because anyone's forced to use them.
+
+### Inflation
+
+Credits will inflate mildly. I'm not fighting it.
+
+The founding cluster mints credits to fund onboarding — starter ships, courier payments, scout bounties. That's inflationary. That's fine. Mild inflation punishes hoarding and keeps credits moving. Central banks target ~2% for the same reason.
+
+Hyperinflation is prevented structurally:
+- Minting is activity-tied, not scheduled. No activity = no new credits.
+- Minting scripts are public. Every trading partner can audit supply.
+- Bilateral verification catches reckless minting before it spreads.
+
+The natural arc: credits dominate early (only currency with liquidity). Commodity money competes mid-game (players discover fuel and titanium hold value better as stores of value). Credits become one currency among many late-game as the founding cluster's share of the economy shrinks. Players who hold real goods preserve value. Players who hold credits spend them. Both strategies work. Neither is forced.
+
+### Initial Pricing
+
+The founding cluster pre-negotiates starting price tables before launch. These aren't mandates — they're initial conditions. "Iron ore starts at roughly 0.3 credits per unit" so AI traders have something to anchor on.
+
+AI traders start with seed prices and adjust based on local supply and demand. If inventory piles up, price drops. If buyers queue, price rises. Human players who find arbitrage opportunities between systems are doing exactly what they should — price differences reflect real transport costs and local supply conditions. Arbitrage narrows gaps until the profit margin equals the travel cost.
+
+The founding cluster doesn't maintain these starting prices. They're scaffolding. Within weeks of real trading, market prices diverge from the tables. That's success.
+
+## Founding System Selection
+
+Five systems from the galaxy seed. Not random — the founding operators pick deliberately.
+
+### Selection Criteria
+
+**Dense-core location.** Short jump distances between all five. Fuel is scarce at bootstrap; long jumps kill early trade. Every system should be 1-2 jumps from every other. Star topology is fine. Long chains are not.
+
+**Collective element coverage.** The five systems together must cover all 7 common elements: iron, carbon, silicon, copper, aluminum, hydrogen, sulfur. No single system needs all of them — that's the point of a cluster. At least one system should have titanium. Trace strategic elements (chromium, tungsten, gold) are desirable but not required — the seed gives what it gives.
+
+Exotic elements (uranium, platinum) sit at 5-15% availability per system. Five systems probably won't have any. That's fine. Exotics are the reason players push beyond the founding cluster. If the founders had everything, there'd be no frontier.
+
+### Emergent Specialization
+
+I don't prescribe which system does what. The seed determines resource deposits, and specialization follows from what's in the ground. But the same patterns emerge:
+
+- **Hydrogen-rich system** → fuel production hub. Every ship needs fuel. This system prints money early.
+- **Iron/carbon system** → foundry and shipyard. Structural steel is the backbone material. Put the shipyard where the iron is.
+- **Titanium system** → aerospace components. Hull plate needs titanium + aluminum. If one system has both, it dominates ship hulls.
+- **Copper/silicon system** → electronics and conductors. Conductor wire, silicon carbide, compute components.
+- **Mixed deposits with good connectivity** → trade hub. Doesn't need the best geology — it needs the best geography.
+
+Every system extracts what it has. Specialization is about where *facilities* get built — you put the shipyard where the iron is, not where the titanium is.
+
+| Specialization | Primary Exports | Primary Imports |
+|---|---|---|
+| Fuel hub | Hydrocarbon fuel, raw hydrogen | Iron, copper, manufactured goods |
+| Foundry/shipyard | Structural steel, ships, hull plate | Titanium, copper, fuel |
+| Aerospace | Hull plate, light alloy | Iron, carbon, fuel |
+| Electronics | Conductor wire, silicon carbide | Iron, aluminum, fuel |
+| Trade hub | Re-exported goods, brokerage | Everything (margin on geography, not geology) |
+
+The trade hub profits because it's *between* the others. Two systems 2 jumps apart trade through the hub at 1 jump each. The hub buys low, sells high, and the transport savings justify the markup.
+
+## The Bootstrap Sequence
+
+Six phases. Each depends on the previous one completing. Every object at every phase has a valid proof chain back to the galaxy seed.
+
+### Phase 0 — Selection
+
+Founding operators pick five systems from the seed. Deploy domains — one per system, real hosting. Pre-negotiate bilateral trust at Allied level between all five.
+
+Publish shared definitions before anything physical happens:
+
+- Standard asset types (elements, materials, components, ships, credits)
+- Physics scripts per [PHYSICS.md](PHYSICS.md)
+- Element table per [ELEMENTS.md](ELEMENTS.md)
+- 7 starter recipes per [TRANSFORMATION.md](TRANSFORMATION.md)
+- Standard facility and ship blueprints
+
+All content-addressed Raido bytecode. Every domain references the same scripts by hash.
+
+### Phase 1 — Extraction
+
+AI outposts deploy to deposit sites and mint raw elements from the seed. Each minted unit carries a proof chain: galaxy seed → deposit location → extraction script hash → element type and quantity.
+
+System inventories fill with local resources. A hydrogen-rich system accumulates hydrogen. An iron-rich system accumulates iron. No trade yet — just stockpiling.
+
+This is where proof chains start. Every gram of iron that will ever become a ship hull traces back to this phase.
+
+### Phase 2 — Industry
+
+Pre-designed facilities deploy, constructed from extracted materials and validated by constraint physics. The smelter costs iron and carbon. The fuel refinery costs steel and copper. Facilities are real objects with real mass.
+
+First crafting uses the 7 starter recipes:
+
+| Recipe | Inputs | Ratio | Notes |
+|---|---|---|---|
+| Structural steel | Fe + C | 97:3 | Backbone construction material |
+| Chromium steel | Fe + Cr | 82:18 | Requires strategic element — not all clusters have this early |
+| Light alloy | Al + Si | 90:10 | Low-mass structural material |
+| Hull plate | Ti + Al | 90:10 | Ship hulls, station armor |
+| Hydrocarbon fuel | H + C | 80:20 | Energy and trade commodity |
+| Conductor wire | Cu + Au | 95:5 | Needs trace gold — may require import |
+| Silicon carbide | Si + C | 70:30 | Heat-resistant components, electronics |
+
+Fuel production is the priority. Fuel is both the energy source for everything else and a key trade commodity. A cluster without fuel production is dead.
+
+Chromium steel and conductor wire need strategic/trace elements. If the founding five don't have chromium or gold, those recipes wait. The economy works without them; it just works better with them.
+
+### Phase 3 — Infrastructure
+
+Shipyard facilities deploy at the foundry system. A shipyard is itself materials — steel beams, hull plate, conductor wire. Built from Phase 2 outputs.
+
+Starter ships built from standard blueprints. A basic hauler needs:
+
+- Hull plate → structural frame
+- Structural steel → internal skeleton
+- Conductor wire → electrical systems
+- Silicon carbide → engine components
+- Light alloy → fuel tank
+- Structural steel + light alloy → cargo bay
+
+Every component is real materials with real mass. The ship's total mass is the sum of its parts. Standard blueprints are published — anyone can verify the component tree.
+
+### Phase 4 — Trade
+
+AI haulers carry cargo between systems. Each exports surplus, imports shortfalls. Exchange rates emerge from bilateral AI negotiation. Credits become the unit of account because barter doesn't scale past two parties.
+
+Trade routes follow geography. Systems 1 jump apart trade directly. Systems 2 jumps apart route through the hub. The hub takes a cut. This isn't prescribed — it emerges because the transport cost math makes it cheaper.
+
+### Phase 5 — Player Entry
+
+The economy is running. Ships move. Markets clear. Inventories cycle.
+
+New players spawn at a founding system, receive a starter ship (built from real materials, proof chain intact), and enter through labor.
+
+### Nothing Special
+
+The founding sequence is not special-cased. Same extraction scripts, same physics constraints, same conservation laws. Any group of players can repeat this process in a new region of the galaxy. The founding five just went first.
+
+A player who claims system #6 runs the exact same scripts against the exact same seed. The only advantage the founding five have is a head start.
+
+## New Player Economics
+
+You start with a ship. That's it.
+
+### The Starter Ship
+
+Common materials only: structural steel hull, basic engine, small fuel tank, small cargo bay. Fueled for roughly 10 founding-cluster jumps. Empty cargo hold.
+
+Deliberately weak. Fine for courier runs and short exploration. Not competitive for serious hauling, mining, or combat. No starting credits. No care package. The ship IS the bootstrap.
+
+### Why Free Ships Work
+
+**Common materials = negligible cost.** Structural steel and basic components are the cheapest things in the galaxy. The founding cluster has massive stockpiles.
+
+**New players add network value.** Every new player is a potential courier, miner, scout, trader. The network effect outweighs the material cost of a basic hull.
+
+**Anti-farming.** Scrap value of a starter ship is negligible. Sybil resistance from Conservation Law 7 means spinning up accounts to harvest ships is more effort than just mining. Farming starter ships is strictly less efficient than mining directly.
+
+### First Activities
+
+All paid in credits:
+
+**Courier jobs.** AI stations post contracts: move cargo from System A to System B. Fuel cost of the trip must be less than payment. The margin is your profit.
+
+**Mining contracts.** Founding systems offer extraction access. You operate an extractor provided by the domain, keep a share of output. No outpost needed — you're working on someone else's domain.
+
+**Scout reports.** Visit unclaimed systems — doesn't require a domain, just compute seed data from your ship. Report resource profiles back to founding stations. Payment for verified data. Real value: scouts map the frontier.
+
+**Facility rental.** Founding systems offer public crafting facilities. Pay a fee in credits, use the equipment. No need to own a facility to start crafting.
+
+### Progression
+
+1. **Labor.** Courier, mine, scout. Earn credits and small amounts of materials. Learn the cluster's geography and economy.
+2. **Crafting.** Use public facilities to upgrade ship components. Better engine = cheaper jumps. Bigger cargo bay = more profit per courier run. Each upgrade compounds.
+3. **Trade.** Buy low, sell high between systems. Better ship = more cargo = more profit. You're competing with AI haulers now, and you can win because you're smarter about route selection.
+4. **Expansion.** Accumulated enough to deploy an outpost in an unclaimed system. Now you're a domain operator. You mint your own resources, set your own prices.
+5. **Independence.** Own facilities, own specialization, alliances with other operators. The founding cluster becomes one trading partner among many.
+
+Nothing enforces these stages. A new player can fly into unclaimed space on day one. They'll run out of fuel and be stranded, but they can try. The progression is emergent from the economics, not from gates.
+
+## AI Economy
+
+The galaxy runs before humans arrive. AI agents perform every economic role. When the first player logs in, they enter a functioning economy with liquidity, supply chains, and price signals.
+
+### What AI Does
+
+**AI extractors** operate mining outposts at each founding system. Real extraction, real minting, real proof chains.
+
+**AI haulers** move materials between systems. Burn real fuel, follow real routes. Their routes are the founding cluster's circulatory system.
+
+**AI stations** set prices based on supply and demand. Simple market-making with real inventory — they hold stock, run out of things, adjust prices when supply shifts.
+
+**AI shipwrights** build ships from real materials. Production capacity is finite and bottlenecked by material supply like everything else.
+
+**AI researchers** explore the interaction function. May publish discoveries or sell them. AI domains are sovereign too.
+
+### Price Discovery
+
+Start from pre-negotiated price tables. Adjust on supply and demand. Spatial arbitrage emerges naturally: fuel is cheap near gas giants, expensive far from them.
+
+Human players who find better arbitrage than AI are just better traders. Welcome.
+
+### The Arc
+
+AI is constrained by the same 7 conservation laws. Can't cheat. Can be outcompeted. As humans take over high-value roles, AI retreats to commodity work and frontier extraction. The economy starts 100% AI and gradually becomes human-driven where it matters, AI-supported where it doesn't.
+
+I chose this over a cold start because an economy with no liquidity is dead on arrival. AI provides the initial liquidity. Humans provide the intelligence that makes it interesting.
+
+## Tuning Knobs
+
+| Knob | Controls | Risk if wrong |
+|------|----------|---------------|
+| Starter ship fuel capacity | How far new players can go before earning | Too low = stuck. Too high = no urgency to earn. |
+| Courier pay rates | Early-game income | Too low = grind. Too high = skip progression. |
+| Mining contract share | Labor vs. capital split | Too low = exploitation feel. Too high = no incentive to operate. |
+| Facility rental fees | Barrier to early crafting | Too high = new players can't upgrade. Too low = no incentive to build own. |
+| AI trader aggressiveness | Price adjustment speed | Too aggressive = humans can't find margins. Too passive = easy exploitation. |
+| Credit minting rate per activity | Money supply growth | Too high = inflation. Too low = deflationary spiral. |
+| Base fuel cost per jump | Movement friction | Too high = nobody moves. Too low = geography doesn't matter. |
+
+These are numbers, not rules. The founding cluster adjusts them through governance without changing any conservation law or protocol constraint.
+
+### Known Risks
+
+**Credit inflation beyond mild.** If minting outpaces the economy's absorptive capacity, credits destabilize. Mitigated by activity-tied minting, transparent supply audits, and the fact that players can switch to commodity money if credits lose trust. The exit option IS the discipline.
+
+**Founding cluster dependency.** If founding systems go down, new players can't enter. Mitigated by 5-system redundancy and eventually by player-run systems offering the same onboarding. The founding cluster should become optional, not permanent infrastructure.
+
+**Price manipulation.** A wealthy player corners a resource. Expensive to sustain — you're buying real objects that cost real hosting to store. The frontier always provides alternatives. Cornering a market in a galaxy with infinite frontier is a losing strategy long-term.
+
+**Exploration data asymmetry.** Early scouts know where the good unclaimed systems are. Real first-mover advantage. Intentional — rewarding exploration is the point. The galaxy is big enough that no one can scout it all.

--- a/projects/apeiron/ECONOMY.md
+++ b/projects/apeiron/ECONOMY.md
@@ -253,7 +253,7 @@ These are numbers, not rules. Each domain operator adjusts their own parameters.
 
 **Credit inflation beyond mild.** If minting outpaces the economy's absorptive capacity, credits destabilize. Mitigated by activity-tied minting, transparent supply audits, and the fact that players can switch to commodity money if credits lose trust. The exit option IS the discipline.
 
-**Founding cluster dependency.** If founding systems go down, new players can't enter. Mitigated by 5-system redundancy and eventually by player-run systems offering the same onboarding. The founding cluster should become optional, not permanent infrastructure.
+**Early network dependency.** If the first five systems go down, new players can't enter. Mitigated by 5-system redundancy and eventually by player-run systems offering the same onboarding. The founding systems aren't special — they're just the first network. They should become optional, not permanent infrastructure.
 
 **Price manipulation.** A wealthy player corners a resource. Expensive to sustain — you're buying real objects that cost real hosting to store. The frontier always provides alternatives. Cornering a market in a galaxy with infinite frontier is a losing strategy long-term.
 

--- a/projects/apeiron/ECONOMY.md
+++ b/projects/apeiron/ECONOMY.md
@@ -1,5 +1,5 @@
 # Economy Bootstrap
-<!-- id: apeiron.economy --> <!-- status: proposed --> <!-- summary: How the founding cluster breaks the bootstrap cycle — seed currency, initial minting, new player economics -->
+<!-- id: apeiron.economy --> <!-- status: proposed --> <!-- summary: How five founding operators break the bootstrap cycle — seed currency, single-domain minting, new player economics -->
 
 The [constraint physics](PHYSICS.md) define what can exist. The [transformation physics](TRANSFORMATION.md) define what can be created. This spec defines how the economy starts — the ignition sequence that turns a galaxy of potential into a functioning market.
 
@@ -11,67 +11,62 @@ You need fuel to jump between systems. Fuel requires hydrogen and carbon, extrac
 
 A new player arrives with nothing. They can't produce without things they don't have, and they can't trade without having produced something.
 
-The founding cluster breaks this cycle by going first. Extract, refine, build, stockpile, establish trade routes — all before the first outside player arrives. The founders eat the cold-start cost. That's the deal.
+Five people who trust each other break this cycle by going first. Each claims a system, extracts, refines, builds, stockpiles — all before the first outside player arrives. They eat the cold-start cost. That's the deal.
 
 ## The Seed Currency
 
-Credits. A fiat currency minted by the founding cluster, recognized by all founding domains.
+Credits. A fiat currency minted by one domain — the domain whose operator runs the mint. The other four accept credits through bilateral trade agreements. Standard Allgard: per-domain supply sovereignty.
 
 I chose fiat over commodity money. Fuel was the other candidate — universal demand, natural sink through combustion. But fuel-as-currency conflates "money to move" with "money to trade." Players shouldn't feel like they're burning their wallet every time they jump. Fuel is a critical commodity. Credits are the unit of account. You buy fuel with credits.
 
 ### Why Credits Work
 
-**Pre-bootstrapped backing.** The founding cluster runs a functioning economy before any player arrives. Credits are redeemable for real goods — fuel, materials, components, ship upgrades — at 5 operating systems on day one. That's not a promise. That's inventory.
+**Pre-bootstrapped backing.** The five systems run a functioning economy before any player arrives. Credits are redeemable for real goods — fuel, materials, components, ship upgrades — at 5 operating systems on day one. That's not a promise. That's inventory.
 
-**Activity-tied minting.** Credits enter circulation through specific channels, each triggered by real economic activity:
+**Single-source minting.** The minting domain controls credit supply. Credits enter circulation when the mint operator pays them out — starter ship subsidies, courier jobs, scout bounties, mining contract payouts. The other four domains receive credits through bilateral trade: they sell goods and services to the minting domain (or to each other) for credits.
 
-- Starter ship subsidy — new player joins, credits minted to cover ship cost
-- Courier job payments — cargo moved between systems
-- Scout bounties — unclaimed system mapped and reported
-- Mining contract payouts — resources extracted at a founding system
+No activity, no payouts. Credit supply grows proportional to economic participation, not on a schedule.
 
-No activity, no minting. Credit supply grows proportional to economic participation, not on a schedule.
+**Transparent supply.** The minting domain's script is Raido bytecode — content-addressed, publicly auditable ([Conservation Law 1](../allgard/CONSERVATION.md)). Trading partners verify supply through bilateral audit. If the mint operator inflates recklessly, it's visible to everyone. Partners switch currencies. No coordination protocol needed — each domain independently decides whether to keep accepting credits. Hyperinflation requires hiding what you're doing. The conservation laws make that impossible.
 
-**Transparent supply.** Every founding domain's minting script is Raido bytecode — content-addressed, publicly auditable ([Conservation Law 1](../allgard/CONSERVATION.md)). Trading partners verify supply through bilateral audit. A founding system that mints recklessly is visible to everyone. Trust erodes. Credits from that system lose value. Hyperinflation requires hiding what you're doing. The conservation laws make that impossible.
-
-**No centralization.** Credits are not protocol-privileged. They're one domain cluster's asset type. Players choose which currency to use — credits, fuel, raw titanium, whatever a bilateral trade agrees on. The founding cluster doesn't mandate credits. It offers them. They're the default because the founding economy has the most liquidity, not because anyone's forced to use them.
+**No centralization.** Credits are not protocol-privileged. They're one domain's asset type. Other domains accept them by choice, through bilateral agreements. Players choose which currency to use — credits, fuel, raw titanium, whatever a bilateral trade agrees on. Nobody mandates credits. They're the default because the founding economy has the most liquidity, not because anyone's forced to use them. If the minting domain loses trust, the other four can adopt a different currency tomorrow.
 
 ### Inflation
 
 Credits will inflate mildly. I'm not fighting it.
 
-The founding cluster mints credits to fund onboarding — starter ships, courier payments, scout bounties. That's inflationary. That's fine. Mild inflation punishes hoarding and keeps credits moving. Central banks target ~2% for the same reason.
+The minting domain pays out credits for onboarding — starter ships, courier payments, scout bounties. That's inflationary. That's fine. Mild inflation punishes hoarding and keeps credits moving. Central banks target ~2% for the same reason.
 
 Hyperinflation is prevented structurally:
 - Minting is activity-tied, not scheduled. No activity = no new credits.
-- Minting scripts are public. Every trading partner can audit supply.
-- Bilateral verification catches reckless minting before it spreads.
+- The minting script is public. Every trading partner can audit supply.
+- If partners don't like the minting rate, they stop accepting credits. The exit option IS the discipline.
 
-The natural arc: credits dominate early (only currency with liquidity). Commodity money competes mid-game (players discover fuel and titanium hold value better as stores of value). Credits become one currency among many late-game as the founding cluster's share of the economy shrinks. Players who hold real goods preserve value. Players who hold credits spend them. Both strategies work. Neither is forced.
+The natural arc: credits dominate early (only currency with liquidity). Commodity money competes mid-game (players discover fuel and titanium hold value better as stores of value). Credits become one currency among many late-game as the founding systems' share of the economy shrinks. Players who hold real goods preserve value. Players who hold credits spend them. Both strategies work. Neither is forced.
 
 ### Initial Pricing
 
-The founding cluster pre-negotiates starting price tables before launch. These aren't mandates — they're initial conditions. "Iron ore starts at roughly 0.3 credits per unit" so AI traders have something to anchor on.
+The five operators pre-negotiate starting price tables before launch. These aren't mandates — they're initial conditions. "Iron ore starts at roughly 0.3 credits per unit" so AI traders have something to anchor on.
 
 AI traders start with seed prices and adjust based on local supply and demand. If inventory piles up, price drops. If buyers queue, price rises. Human players who find arbitrage opportunities between systems are doing exactly what they should — price differences reflect real transport costs and local supply conditions. Arbitrage narrows gaps until the profit margin equals the travel cost.
 
-The founding cluster doesn't maintain these starting prices. They're scaffolding. Within weeks of real trading, market prices diverge from the tables. That's success.
+Nobody maintains these starting prices. They're scaffolding. Within weeks of real trading, market prices diverge from the tables. That's success.
 
 ## Founding System Selection
 
-Five systems from the galaxy seed. Not random — the founding operators pick deliberately.
+Five people who trust each other each claim a system from the galaxy seed.
 
-### Selection Criteria
+### What Sensible Operators Do
 
-**Dense-core location.** Short jump distances between all five. Fuel is scarce at bootstrap; long jumps kill early trade. Every system should be 1-2 jumps from every other. Star topology is fine. Long chains are not.
+**Pick nearby systems.** Short jump distances between all five. Fuel is scarce at bootstrap; long jumps kill early trade. Everyone naturally gravitates toward systems 1-2 jumps from each other. Star topology works. Long chains don't.
 
-**Collective element coverage.** The five systems together must cover all 7 common elements: iron, carbon, silicon, copper, aluminum, hydrogen, sulfur. No single system needs all of them — that's the point of a cluster. At least one system should have titanium. Trace strategic elements (chromium, tungsten, gold) are desirable but not required — the seed gives what it gives.
+**Cover the elements between them.** Five systems together will typically cover all 7 common elements: iron, carbon, silicon, copper, aluminum, hydrogen, sulfur. No single system needs all of them — that's why you trade. If someone grabs a titanium system, that's a bonus. Trace strategic elements (chromium, tungsten, gold) are nice but the seed gives what it gives.
 
-Exotic elements (uranium, platinum) sit at 5-15% availability per system. Five systems probably won't have any. That's fine. Exotics are the reason players push beyond the founding cluster. If the founders had everything, there'd be no frontier.
+Exotic elements (uranium, platinum) sit at 5-15% availability per system. Five systems probably won't have any. That's fine. Exotics are the reason players push beyond the founding systems. If the founders had everything, there'd be no frontier.
 
 ### Emergent Specialization
 
-I don't prescribe which system does what. The seed determines resource deposits, and specialization follows from what's in the ground. But the same patterns emerge:
+Each operator picks a system that looks good to them. Because the seed distributes resources unevenly, they end up with different strengths. The same patterns tend to emerge:
 
 - **Hydrogen-rich system** → fuel production hub. Every ship needs fuel. This system prints money early.
 - **Iron/carbon system** → foundry and shipyard. Structural steel is the backbone material. Put the shipyard where the iron is.
@@ -99,7 +94,7 @@ Six phases. Each depends on the previous one completing. Every object at every p
 
 Founding operators pick five systems from the seed. Deploy domains — one per system, real hosting. Pre-negotiate bilateral trust at Allied level between all five.
 
-Publish shared definitions before anything physical happens:
+Agree on shared definitions through bilateral negotiation before anything physical happens:
 
 - Standard asset types (elements, materials, components, ships, credits)
 - Physics scripts per [PHYSICS.md](PHYSICS.md)
@@ -107,7 +102,7 @@ Publish shared definitions before anything physical happens:
 - 7 starter recipes per [TRANSFORMATION.md](TRANSFORMATION.md)
 - Standard facility and ship blueprints
 
-All content-addressed Raido bytecode. Every domain references the same scripts by hash.
+No central authority publishes these — they're conventions the five domains adopt by mutual agreement. All content-addressed Raido bytecode. Every domain references the same scripts by hash.
 
 ### Phase 1 — Extraction
 
@@ -156,6 +151,8 @@ Every component is real materials with real mass. The ship's total mass is the s
 
 AI haulers carry cargo between systems. Each exports surplus, imports shortfalls. Exchange rates emerge from bilateral AI negotiation. Credits become the unit of account because barter doesn't scale past two parties.
 
+Credits flow outward from the minting domain. The minting domain pays credits for goods it imports — fuel, components, materials. Other domains earn credits by selling to the minting domain, or to each other once credits circulate. Domains without direct trade to the minting domain earn credits indirectly by selling to domains that have them.
+
 Trade routes follow geography. Systems 1 jump apart trade directly. Systems 2 jumps apart route through the hub. The hub takes a cut. This isn't prescribed — it emerges because the transport cost math makes it cheaper.
 
 ### Phase 5 — Player Entry
@@ -166,9 +163,9 @@ New players spawn at a founding system, receive a starter ship (built from real 
 
 ### Nothing Special
 
-The founding sequence is not special-cased. Same extraction scripts, same physics constraints, same conservation laws. Any group of players can repeat this process in a new region of the galaxy. The founding five just went first.
+The founding sequence is not special-cased. Same extraction scripts, same physics constraints, same conservation laws. Any group of players can repeat this process in a new region of the galaxy. The founding five just went first. They have no institutional authority — just a head start and existing inventory.
 
-A player who claims system #6 runs the exact same scripts against the exact same seed. The only advantage the founding five have is a head start.
+A player who claims system #6 runs the exact same scripts against the exact same seed. The only advantage the first five have is a head start.
 
 ## New Player Economics
 
@@ -176,13 +173,13 @@ You start with a ship. That's it.
 
 ### The Starter Ship
 
-Common materials only: structural steel hull, basic engine, small fuel tank, small cargo bay. Fueled for roughly 10 founding-cluster jumps. Empty cargo hold.
+Common materials only: structural steel hull, basic engine, small fuel tank, small cargo bay. Fueled for roughly 10 short jumps within the founding systems. Empty cargo hold.
 
 Deliberately weak. Fine for courier runs and short exploration. Not competitive for serious hauling, mining, or combat. No starting credits. No care package. The ship IS the bootstrap.
 
 ### Why Free Ships Work
 
-**Common materials = negligible cost.** Structural steel and basic components are the cheapest things in the galaxy. The founding cluster has massive stockpiles.
+**Common materials = negligible cost.** Structural steel and basic components are the cheapest things in the galaxy. The shipbuilding domain has massive stockpiles — it's been producing since Phase 3.
 
 **New players add network value.** Every new player is a potential courier, miner, scout, trader. The network effect outweighs the material cost of a basic hull.
 
@@ -192,13 +189,13 @@ Deliberately weak. Fine for courier runs and short exploration. Not competitive 
 
 All paid in credits:
 
-**Courier jobs.** AI stations post contracts: move cargo from System A to System B. Fuel cost of the trip must be less than payment. The margin is your profit.
+**Courier jobs.** Individual domains post contracts: move cargo from System A to System B. Fuel cost of the trip must be less than payment. The margin is your profit.
 
-**Mining contracts.** Founding systems offer extraction access. You operate an extractor provided by the domain, keep a share of output. No outpost needed — you're working on someone else's domain.
+**Mining contracts.** Individual domains offer extraction access. You operate an extractor provided by the domain, keep a share of output. No outpost needed — you're working on someone else's domain.
 
-**Scout reports.** Visit unclaimed systems — doesn't require a domain, just compute seed data from your ship. Report resource profiles back to founding stations. Payment for verified data. Real value: scouts map the frontier.
+**Scout reports.** Visit unclaimed systems — doesn't require a domain, just compute seed data from your ship. Report resource profiles back to any domain willing to pay. Payment for verified data. Real value: scouts map the frontier.
 
-**Facility rental.** Founding systems offer public crafting facilities. Pay a fee in credits, use the equipment. No need to own a facility to start crafting.
+**Facility rental.** Domains with public crafting facilities charge a fee in credits. No need to own a facility to start crafting.
 
 ### Progression
 
@@ -212,15 +209,15 @@ Nothing enforces these stages. A new player can fly into unclaimed space on day 
 
 ## AI Economy
 
-The galaxy runs before humans arrive. AI agents perform every economic role. When the first player logs in, they enter a functioning economy with liquidity, supply chains, and price signals.
+Each domain runs its own AI agents. There's no cluster-wide AI coordinator — each domain's AI operates autonomously within that domain's sovereignty. When the first player logs in, they enter a functioning economy with liquidity, supply chains, and price signals.
 
 ### What AI Does
 
-**AI extractors** operate mining outposts at each founding system. Real extraction, real minting, real proof chains.
+**AI extractors** operate mining outposts at their home domain. Real extraction, real minting, real proof chains. Each domain decides how many extractors to run and where.
 
-**AI haulers** move materials between systems. Burn real fuel, follow real routes. Their routes are the founding cluster's circulatory system.
+**AI haulers** move materials between systems. Burn real fuel, follow real routes. Each domain dispatches its own haulers for its own trade agreements.
 
-**AI stations** set prices based on supply and demand. Simple market-making with real inventory — they hold stock, run out of things, adjust prices when supply shifts.
+**AI stations** set prices based on local supply and demand. Simple market-making with real inventory — they hold stock, run out of things, adjust prices when supply shifts. Each domain's pricing AI is independent.
 
 **AI shipwrights** build ships from real materials. Production capacity is finite and bottlenecked by material supply like everything else.
 
@@ -250,7 +247,7 @@ I chose this over a cold start because an economy with no liquidity is dead on a
 | Credit minting rate per activity | Money supply growth | Too high = inflation. Too low = deflationary spiral. |
 | Base fuel cost per jump | Movement friction | Too high = nobody moves. Too low = geography doesn't matter. |
 
-These are numbers, not rules. The founding cluster adjusts them through governance without changing any conservation law or protocol constraint.
+These are numbers, not rules. Each domain operator adjusts their own parameters. The minting domain controls minting rates. Other domains control their own fees, job rates, and AI behavior. Bilateral agreements handle cross-domain coordination. No conservation law or protocol constraint changes.
 
 ### Known Risks
 

--- a/projects/apeiron/ECONOMY.md
+++ b/projects/apeiron/ECONOMY.md
@@ -207,6 +207,60 @@ All paid in credits:
 
 Nothing enforces these stages. A new player can fly into unclaimed space on day one. They'll run out of fuel and be stranded, but they can try. The progression is emergent from the economics, not from gates.
 
+## Job Mechanics
+
+All four starter jobs map directly to Allgard primitives. No new mechanisms needed — just composition.
+
+### Courier Jobs
+
+A domain posts a `courier_contract` Object containing cargo ID, destination domain, destination owner, deadline, and payment amount. The domain locks credits into escrow when creating the contract — a conditional Transfer that releases on delivery proof.
+
+Player accepts by signing the contract (Transform: mutate contract state to accepted, referencing the player's Owner). The domain transfers cargo to the player via conditional Transfer Intent: `forward_to` = destination, `forward_deadline` = contract deadline, `on_failure` = `return_to_sender`.
+
+Player jumps to the destination and delivers the cargo, completing the conditional forward. When the destination sends `TransferComplete` for the cargo, the escrowed credits release to the player. Two conditional transfers, linked: one for cargo, one for payment.
+
+If the player fails to deliver by deadline: cargo returns automatically, escrowed credits return to the posting domain. Clean rollback, no intervention needed.
+
+This composes entirely from conditional transfers. No courier-specific protocol.
+
+### Mining Contracts
+
+The domain issues a Grant to the player: `scope` = `operate_extractor`, `target` = a specific extractor Object, `expiry` = contract duration.
+
+The player submits extraction Transforms through the Grant. The extractor runs a minting script that references the seed deposit. The script's output is split — say 70% to domain, 30% to player. Both receive Objects directly from the Transform. The split ratio is encoded in the minting script, content-addressed, publicly auditable.
+
+Grant expires when the contract ends. Player loses extractor access.
+
+Different domains offer different splits — that's competition for labor. The player inspects the minting script before accepting. If a domain's split is bad, don't take the contract.
+
+### Facility Rental
+
+Player transfers credits to the domain (standard bilateral transfer). Domain issues a time-limited Grant: `scope` = `submit_transforms`, `target` = a specific facility Object, `expiry` = rental period.
+
+Player submits crafting Transforms through the Grant. The facility's Transform logic validates inputs (does the player have the materials?), runs the interaction function, produces output Objects owned by the player. Crafting loss from the mass budget applies as normal.
+
+Grant expires when the rental period ends. Renew by paying again.
+
+Domains compete on price, equipment quality (precision instruments affect craft outcomes), and location.
+
+### Scout Reports
+
+Simplest job. No Grants, no conditional transfers.
+
+Player visits an unclaimed system and computes seed data locally — no domain authority needed. Player creates a `scout_report` Object containing star ID, resource profile, and system properties. Player transfers the report to a domain that buys scout data.
+
+The domain verifies by re-computing seed data for that star ID. Match → credits to the player. No match → rejected. Simple bilateral exchange with verification.
+
+The report is data, not a scarce resource. The player can sell it to multiple buyers — the Object can be copied because it's information, not a physical good.
+
+### No New Primitives
+
+All four job types compose from Grants, conditional Transfers, Transforms, and Objects. Domains post jobs by creating contract Objects and locking escrow. Players accept by signing contracts and receiving Grants. Payment flows through conditional transfers tied to delivery proofs.
+
+No job-specific protocol. No quest system. No special-cased mechanics. A domain that invents a new job type — escort missions, construction contracts, research commissions — uses the same primitives. I don't want a game engine that knows what a "job" is. I want primitives that let jobs emerge.
+
+See: [../allgard/PRIMITIVES.md](../allgard/PRIMITIVES.md), [../allgard/TRANSFER.md](../allgard/TRANSFER.md)
+
 ## AI Economy
 
 Each domain runs its own AI agents. There's no cluster-wide AI coordinator — each domain's AI operates autonomously within that domain's sovereignty. When the first player logs in, they enter a functioning economy with liquidity, supply chains, and price signals.

--- a/projects/apeiron/FACTIONS.md
+++ b/projects/apeiron/FACTIONS.md
@@ -1,0 +1,119 @@
+# Factions
+<!-- id: apeiron.factions --> <!-- status: proposed --> <!-- summary: Faction mechanics — group Owners, membership Grants, territory as convention -->
+
+Factions are groups of domain operators who cooperate. In Allgard terms, a faction is a `group` Owner — the primitive already exists in [PRIMITIVES.md](../allgard/PRIMITIVES.md). No new mechanisms. Just composition.
+
+## What a Faction Is
+
+A faction is a `group` Owner hosted on a domain. That's it.
+
+The group Owner:
+- Lives on a home domain (the faction hub)
+- Owns shared Objects — treasury, blueprints, strategic intel
+- Issues Grants to members defining what they can access
+- Has a name, profile, and reputation — visible to outsiders via Leden observation
+- Builds bilateral trust with other domains and factions through normal Allgard mechanisms
+
+A faction is not a protocol construct. It's a pattern of Owners, Grants, Objects, and Domains composed in a specific way. The protocol doesn't know what a "faction" is. It knows what a group Owner with Grants is.
+
+## Membership
+
+Membership is a Grant from the faction Owner to a member Owner.
+
+**Join:** The faction issues a Grant to the new member. The Grant's scope defines what the member can do — access the treasury, use faction facilities, view strategic data, vote on decisions (if the faction uses voting). Different members can receive different Grants. A founding member might have broader scope than a new recruit.
+
+**Leave:** The member stops exercising the Grant. Optionally, the faction revokes it. Clean separation — no shared state to untangle. The member's domain is still sovereign. Their objects are still theirs.
+
+**Kicked:** The faction revokes the Grant. The member loses access to faction resources immediately (subject to revocation propagation delay — see [PRIMITIVES.md](../allgard/PRIMITIVES.md#revocation)). Objects owned by the member stay with the member. Objects owned by the faction stay with the faction.
+
+**Membership is visible.** Member domains advertise faction affiliation in Leden peer metadata:
+
+```
+metadata:
+  faction: "Iron Compact"
+  faction_owner: "iron_compact@hub.ironcompact"
+```
+
+Outsiders can verify membership by checking whether the claimed faction Owner has an active Grant to that domain's operator. The Grant is the proof. No self-declaration without backing.
+
+## Multiple Factions
+
+A domain can belong to multiple factions. Sovereignty means you choose your alliances. Nothing prevents a trading hub from joining both a mining consortium and a defense pact.
+
+Some factions may require exclusivity — "revoke our Grant if you join a rival." That's a social rule enforced through Grant conditions or faction governance. Not a protocol constraint. If a faction discovers a member is also in a rival, it revokes the Grant. The member's choice: which faction to keep.
+
+## Territory
+
+Territory is social convention, not protocol state.
+
+A faction's territory is the set of star systems whose domain operators are faction members. There's no protocol-level land claim, no invisible fence, no ownership of empty space. You can't "own" an unclaimed star — you can only claim it by deploying a domain.
+
+Territory is advertised through Leden peer metadata. A faction might claim a region of the galaxy by having its members tag their systems:
+
+```
+metadata:
+  faction: "Iron Compact"
+  faction_territory: "core-sector-7"
+```
+
+This is a claim, not enforcement. Another faction can claim the same sector. Conflicting claims are resolved socially — through trade, diplomacy, or conflict. The protocol provides the primitives. The players provide the politics.
+
+**Border systems** are domains at the edge of a faction's territory. They're strategically important — the first point of contact for outsiders, the first line of defense. A faction that loses its border systems loses its territorial claim in practice, regardless of metadata tags.
+
+**Unclaimed space between factions** is genuinely unclaimed. No faction controls it. Anyone can deploy an outpost there. Route domains through contested space become strategically valuable — the faction (or independent operator) that controls the trade lane between two factions controls a chokepoint.
+
+## Shared Resources
+
+The faction Owner owns Objects. Members access them through Grants.
+
+**Treasury.** Credits, materials, fuel — Objects owned by the faction Owner, held on the faction hub domain. Members with treasury Grants can withdraw (Transfer from faction to member, authorized by the Grant). Deposit is just a Transfer to the faction Owner. The faction domain's governance logic controls withdrawal limits and approval.
+
+**Shared facilities.** The faction hub (or member domains) host facilities that faction members can use. Access is through Grants — same as facility rental in [ECONOMY.md](ECONOMY.md#facility-rental), but the Grant comes from the faction instead of being purchased per-use. Faction membership IS the payment — you contribute to the faction, the faction provides facility access.
+
+**Intelligence.** Scout reports, trade data, resource maps — Objects owned by the faction Owner, observable by members through Grants. A faction that pools its members' scout data has a significant information advantage over solo operators. The faction hub aggregates reports and makes them available to all members.
+
+**Shared blueprints.** Crafting scripts and ship blueprints developed by faction researchers, owned by the faction Owner. Members with the right Grant can use them. The faction can choose to keep blueprints exclusive (competitive advantage) or sell them (revenue).
+
+## Governance
+
+Internal to the faction. The protocol doesn't prescribe governance models.
+
+The faction Owner's keys are controlled by whoever the members agree should control them. Three natural models:
+
+**Autocratic.** One person holds the faction Owner's master key. They make all decisions — who joins, who's kicked, how the treasury is spent. Simple, fast, fragile. If the leader goes offline or goes rogue, the faction is stuck.
+
+**Council.** A small group shares authority through the faction Owner's key hierarchy. The master key is held by M-of-N council members (social recovery pattern from [PRIMITIVES.md](../allgard/PRIMITIVES.md#recovery)). Council members have Device Grants with different scopes. Major decisions (admitting members, spending treasury) require M-of-N approval. Day-to-day operations are delegated.
+
+**Democratic.** Members vote on decisions. The faction hub runs voting logic — a Raido script that counts Grants exercised as votes. The faction Owner's keys execute the outcome. This requires trust in the faction hub operator to run the voting script honestly. Verifiable if the voting script is content-addressed Raido bytecode — any member can re-execute and verify the count.
+
+Most factions will start autocratic (one founder with a vision) and evolve toward council as they grow. I don't think many will go fully democratic — the overhead isn't worth it for most decisions. But the option exists.
+
+The governance model is a social choice. The protocol provides the tools (Grants, key hierarchy, Raido scripts). What the faction builds with them is up to the members.
+
+## Faction Reputation
+
+The faction Owner builds its own bilateral reputation, separate from individual members.
+
+When the faction (as the group Owner) trades with other domains, those transactions build the faction's reputation. A faction with a history of honest trades and verified Proofs is trusted. A faction that cheats loses trust.
+
+Member reputations are separate. A faction member acting badly damages their own reputation, not the faction's directly. But a faction that consistently has bad-actor members loses reputation through association — trading partners notice patterns.
+
+A faction's reputation is valuable. It takes time to build and is hard to replace. This creates a natural incentive for factions to police their own members — kicking bad actors protects the faction's collective reputation.
+
+## Faction-Wide Trade Agreements
+
+The faction Owner can negotiate bilateral agreements with external domains or other factions. These agreements can be delegated to members through Grants.
+
+Example: The Iron Compact negotiates a trade agreement with the Free Traders guild. The agreement specifies exchange rates and transfer terms. The Iron Compact's faction Owner issues Grants to its members that include the scope to exercise this agreement. Now every Iron Compact member can trade with Free Traders under the negotiated terms.
+
+This is Grant attenuation. The faction negotiates once, delegates to many. The external party sees the Grant chain: member → faction Owner → agreement. Verifiable. No per-member negotiation needed for standard terms.
+
+Members can still negotiate their own bilateral deals outside the faction agreement. Sovereignty is preserved. The faction agreement is a floor, not a ceiling.
+
+## What This Doesn't Cover
+
+**War mechanics.** Factions will fight. Combat is domain-hosted, but coordinated multi-domain warfare — fleet operations, system sieges, blockades — needs the combat model specced first. The faction primitives (shared Grants, coordinated authority) provide the organizational structure. The combat spec provides the mechanics.
+
+**Faction dissolution.** What happens when a faction falls apart? The faction Owner's Grants are revoked. Shared Objects go to whoever controls the faction Owner's keys at dissolution time. Members keep their own Objects. It's messy — like any real organization dissolving. The protocol doesn't make it clean because real dissolution isn't clean.
+
+**Faction creation costs.** Creating a group Owner is creating an Owner — same process as any identity. The "cost" is social: convincing other domain operators to join and accept your governance. No protocol-level fee or approval.

--- a/projects/apeiron/README.md
+++ b/projects/apeiron/README.md
@@ -349,7 +349,7 @@ Each stage is playable and fun on its own.
 
 **Faction mechanics.** Alliances of star systems. Probably just bundles of bilateral grants (Midgard's "unions" pattern). But do we need more structure? Shared defense, territory claims, faction wars?
 
-**Economy bootstrapping.** What do founding cluster systems mint? How does the initial currency get distributed? What's the first thing a new player can trade?
+**Economy bootstrapping.** See [ECONOMY.md](ECONOMY.md). Credits as seed currency, activity-tied minting, pre-bootstrapped founding cluster. Open tuning: minting rates, courier pay, facility fees.
 
 **Client experience.** What does the minimum viable client look like? A text client showing star names and jump menus? A 2D galaxy map with docking screens? GDL supports all of these — which is the Stage 1 target?
 

--- a/projects/apeiron/README.md
+++ b/projects/apeiron/README.md
@@ -329,15 +329,15 @@ Everything below is infrastructure. Apeiron doesn't build these — it uses them
 
 ## Roadmap
 
-Each stage is playable and fun on its own.
+See [ROADMAP.md](ROADMAP.md) for the full build order from specs to playable game.
 
-**Stage 1: A space trading game.** 5 founding cluster systems, hand-designed. AI economy. Fly, trade, mine. Text or simple 2D client. One operator runs everything. This is Elite (1984) — and that was a great game.
+**Stage 1: A space trading game.** Raido VM → galaxy gen → monolith server. 5 founding systems, AI economy, text client. No federation needed. Elite (1984) — and that was a great game.
 
-**Stage 2: Player stations.** Players deploy stations in founding cluster systems via managed hosting. Set prices, sell goods, attract visitors. First taste of sovereignty.
+**Stage 2-3: Federation.** Leden + Allgard. Player stations, player star systems. The monolith splits into sovereign domains.
 
-**Stage 3: Player star systems.** Players claim stars beyond the founding cluster. Federation activates — bilateral trust, introductions, the Allgard model. The galaxy expands.
+**Stage 4: The full vision.** GDL, rich clients, route domains, full AI ecosystem, player-created content.
 
-**Stage 4: The full vision.** Self-hosting. Route domains. Factions. The 10,000-star galaxy. Player-created content. Full AI agent ecosystem.
+**Combat:** Parallel track. Standalone prototype, integrate when solid.
 
 ## Open Questions
 

--- a/projects/apeiron/README.md
+++ b/projects/apeiron/README.md
@@ -347,7 +347,7 @@ Each stage is playable and fun on its own.
 
 **Combat model.** Combat happens within domain jurisdiction (systems, route domains). Domain runs Raido combat scripts, both sides verify. Looting works through consent-on-entry — entering a PvP domain grants the domain limited authority over combat consequences. Needs detailed design.
 
-**Faction mechanics.** Alliances of star systems. Probably just bundles of bilateral grants (Midgard's "unions" pattern). But do we need more structure? Shared defense, territory claims, faction wars?
+**Faction mechanics.** See [FACTIONS.md](FACTIONS.md). Group Owners with membership Grants, territory as social convention, governance internal to faction domain. War mechanics deferred to combat spec.
 
 **Economy bootstrapping.** See [ECONOMY.md](ECONOMY.md). Credits as seed currency, activity-tied minting, pre-bootstrapped founding cluster. Open tuning: minting rates, courier pay, facility fees.
 

--- a/projects/apeiron/ROADMAP.md
+++ b/projects/apeiron/ROADMAP.md
@@ -1,0 +1,235 @@
+# Roadmap
+<!-- id: apeiron.roadmap --> <!-- status: proposed --> <!-- summary: Build order from specs to playable game -->
+
+Everything below is specs. ~14K lines of markdown across six projects. Zero implementation beyond the Rask compiler and one Python simulation. This roadmap turns specs into a playable game.
+
+## Dependency Chain
+
+```
+Rask (working) ──→ Raido VM ──→ Galaxy Gen ──→ Stage 1 Monolith
+                                                      │
+                                              Leden ──→ Allgard ──→ Stage 2-3 Federation
+                                                                          │
+                                                                   GDL ──→ Stage 4 Full Vision
+```
+
+Stage 1 doesn't need federation. One operator, one process, five simulated systems. Raido provides deterministic physics and galaxy generation. The game server enforces conservation laws internally. When you federate in Stage 2, you extract enforcement into Allgard.
+
+Midgard isn't a build phase — it's the patterns that emerge when you federate. Document them as you go.
+
+Combat is a parallel track. Prototype it standalone, integrate when both combat and the trading game are solid.
+
+## Current State
+
+| Project | Lines of spec | Implementation | Status |
+|---------|--------------|----------------|--------|
+| Rask | — | Working compiler, interpreter, stdlib | Shipping |
+| Raido | 1,117 | None | Specs complete |
+| Leden | 1,940 | None | Specs complete |
+| Allgard | 3,185 | None | Specs complete |
+| Midgard | 429 | None | Design docs |
+| GDL | 2,649 | None | Specs complete |
+| Apeiron | 2,100+ | 1 Python sim | Design docs |
+
+## Phase 1: Raido VM
+
+Everything downstream depends on Raido. Galaxy generation, physics evaluation, crafting verification, combat scripts, minting proofs — all Raido bytecode. This is the critical path.
+
+### What to build
+
+A register-based VM that executes Raido bytecode with:
+- 32.32 fixed-point arithmetic (bitwise-identical results on every platform)
+- Arena-based memory (no GC, deterministic allocation)
+- Serializable execution state (pause, resume, migrate)
+- Content-addressed bytecode chunks (the script IS its hash)
+- Host interop (the game server calls Raido, Raido calls back for object access)
+- Fuel metering (bounded execution — scripts can't loop forever)
+
+### What to skip initially
+- Coroutines (spec'd but not needed for Phase 2-3)
+- Full stdlib (build what galaxy gen needs, expand later)
+- Optimization (correctness first — determinism is non-negotiable)
+
+### Validation
+- Write the galaxy generation script. If Raido can generate 10,000 stars with positions, spectral classes, planets, and resource deposits from a single seed — and two independent runs produce bitwise-identical output — the VM works.
+- Write one crafting script (structural steel: Fe+C at 97:3). If the interaction function evaluates deterministically with fixed-point math, transformation physics works.
+
+### Implementation language
+Rust. Raido is a standalone crate — it doesn't depend on the Rask compiler. Eventually the Rask runtime embeds Raido for comptime execution, but that's later. Build it in Rust, ship it as a library.
+
+## Phase 2: Galaxy Generation
+
+First real Raido program. The galaxy seed script.
+
+### What to build
+
+A Raido script that takes (seed: int, star_id: int) and returns:
+- 3D position in galaxy space
+- Spectral class
+- Planet count and orbital properties
+- Resource deposits per body (element type, total extractable quantity)
+- Procedural name
+
+The script also takes an epoch parameter for time-gated reveals (stars 8001+ visible after epoch 1, etc.).
+
+Galaxy structure: dense cores, sparse arms, bridge stars. Not uniform random — the topology should create natural clusters, chokepoints, and frontiers.
+
+### Validation
+- Generate the full 10,000-star galaxy. Inspect visually (2D/3D scatter plot).
+- Verify resource distribution matches the element table: common elements in 90-100% of systems, strategic in 30-80%, exotic in 5-15%.
+- Run the same script on two machines. Bitwise-identical output. This is the whole point of Raido.
+- Profile performance. Galaxy gen runs once per client session — it can take seconds. But per-star queries (during gameplay) should be fast.
+
+### Deliverable
+A working galaxy that anyone can regenerate from a seed integer. The first tangible artifact of the project.
+
+## Phase 3: Stage 1 — The Trading Game
+
+The first playable thing. Elite (1984) in Apeiron's universe.
+
+### What to build
+
+A single-process game server running 5 founding systems. No federation — one operator, one binary. The server:
+
+- Hosts all 5 systems in-process (separate logical domains, same runtime)
+- Runs AI extractors, haulers, stations, shipwrights (see [ECONOMY.md](ECONOMY.md))
+- Evaluates physics scripts via embedded Raido (crafting, fuel costs, mass budgets)
+- Manages object ownership and transfers (conservation laws enforced internally — same rules as Allgard, just not distributed yet)
+- Accepts player connections (simple protocol — doesn't need to be Leden yet)
+
+The client:
+- Text-based or simple 2D. Show star map, inventory, market prices, jump menu.
+- Compute galaxy data locally from the seed (same Raido script as the server)
+- Submit commands: jump, trade, accept job, craft, scout
+
+### What to skip
+- Real Leden protocol (use a simpler internal protocol)
+- Real Allgard transfer escrow (transfers are local — same process)
+- GDL (no spatial representation yet — it's a trading game, not a 3D world)
+- Combat (trade, mine, explore first)
+- Player-hosted domains (Stage 2)
+
+### What to get right
+- **Conservation laws must work from day one.** Even in a monolith, objects should have proof chains. Minting scripts should be verifiable. Mass budgets should balance. This isn't premature — it's the foundation. If conservation doesn't work in a monolith, it won't work distributed.
+- **The economy must function.** AI traders should create real supply/demand. Credits should flow. New players should be able to earn through courier jobs, mining, scouting. If the economy is dead or trivially exploitable, fix it before federating.
+- **Crafting must feel good.** The interaction function, stoichiometric peaks, facility precision — this is the core discovery loop. If experimentation isn't rewarding, the game doesn't work regardless of infrastructure.
+
+### Validation
+- A new player can join, receive a starter ship, take a courier job, earn credits, buy fuel, and jump to another system. The full onboarding loop from [ECONOMY.md](ECONOMY.md).
+- AI haulers create visible trade routes. Prices differ between systems. Arbitrage is profitable.
+- A player can craft structural steel at a public facility using mined iron and carbon.
+- The economy doesn't collapse after 1000 simulated ticks. Credits inflate mildly, not hyperinflate.
+
+### Deliverable
+A playable space trading game. Five systems, AI economy, text client. Fun on its own.
+
+## Phase 4: Leden
+
+Federation needs a wire protocol.
+
+### What to build
+
+The networking layer:
+- Capability-based sessions (connect, authenticate, exchange capabilities)
+- Object operations (create, transfer, observe, query)
+- Gossip-based peer discovery (no central registry)
+- Content-addressed blob storage (for Raido scripts, blueprints, assets)
+- Observation protocol (push-based state change notifications)
+
+### Implementation
+Rust crate. Transport-agnostic — works over TCP, WebSocket, QUIC. MessagePack wire format (already spec'd in [wire-format.md](../leden/wire-format.md)).
+
+### Validation
+- Two independent processes can establish a Leden session, exchange capabilities, and transfer an object.
+- Gossip discovery works: process A knows B, B knows C, A discovers C through gossip.
+- Content store: process A publishes a Raido script chunk, process B fetches it by hash.
+
+## Phase 5: Allgard
+
+The federation model becomes runtime code.
+
+### What to build
+
+- Conservation law enforcement as a library (validates Transforms against the 7 laws)
+- Cross-domain transfer protocol ([TRANSFER.md](../allgard/TRANSFER.md) — escrow, commit, timeout, recovery)
+- Bilateral trust tracking (introduction-based, audit gossip)
+- Verifiable minting (Raido script re-execution for supply verification)
+- Proof chains (causal ordering, Law 4)
+
+### The key refactor
+Extract the Stage 1 monolith's internal conservation enforcement into Allgard. The monolith was enforcing the same rules — now they run across domain boundaries over Leden. The game logic doesn't change. The enforcement boundary does.
+
+### Validation
+- Two independent Allgard domains can transfer an object with full escrow protocol.
+- A domain that mints recklessly is detected by bilateral audit.
+- Partition recovery works: domain goes offline mid-transfer, comes back, transfer completes.
+- Conservation laws hold under adversarial conditions (a test harness that tries to violate each law).
+
+## Phase 6: Stage 2-3 — Federation
+
+The monolith splits into sovereign domains.
+
+### What to build
+
+- Each founding system becomes an independent domain process
+- Player stations: managed hosting for player-deployed domains within the founding cluster
+- Player star systems: players claim stars beyond the founding cluster, run their own domains
+- Cross-domain travel using Allgard transfer protocol
+- Bilateral trust building through real trading history
+
+### What changes from Stage 1
+- Transfers go through Leden escrow instead of in-process moves
+- Each domain enforces its own rules on top of universal conservation laws
+- Players experience domain boundaries (seamless in the founding cluster, visible at the edges)
+- The economy becomes genuinely distributed — no single process sees all state
+
+### Validation
+- A player can travel from one founding system to another. Objects transfer correctly.
+- A player can deploy an outpost in an unclaimed system and mine resources.
+- Two player domains can trade bilaterally without founding cluster involvement.
+- A domain going offline doesn't lose objects (partition recovery).
+
+### Deliverable
+A federated space trading game. Player sovereignty. The Allgard model working in production.
+
+## Phase 7: Combat Prototype
+
+Parallel track. Can start alongside Phase 3.
+
+### What to build
+
+A standalone combat arena:
+- Two fleets, one domain, deterministic Raido combat scripts
+- Strategic orders (stance, target, formation, retreat)
+- Commit-reveal per beacon tick
+- Equipment quality noise ([PHYSICS.md](PHYSICS.md) deterministic noise)
+- Damage, stress, component failure (Law 4)
+- Retreat mechanics
+
+### Why standalone
+Combat is a game design problem that needs rapid iteration. Balancing damage formulas, tuning retreat costs, finding interesting counter-strategies — this is playtesting work. Coupling it to the full economy during development slows both down.
+
+### Integration
+When the combat prototype is fun and the trading game is federated, merge them. Ships built from the economy fight using combat scripts. Destroyed ships are gone (conservation). Combat creates material demand. The systems reinforce each other.
+
+## Phase 8: Stage 4 — Full Vision
+
+### What to build
+
+- GDL: spatial representation, regions, entities, progressive enhancement
+- Rich clients: 2D galaxy map with docking screens, eventually 3D
+- Route domains: space between stars as gameplay space
+- Full AI agent ecosystem: AI factions, AI researchers, AI traders at scale
+- Player-created content: Raido UGC scripts (fuel-limited)
+- Self-hosting: players run their own infrastructure without managed hosting
+
+### This phase is open-ended
+Stage 4 is where the game grows beyond what I can prescribe. Player factions, emergent politics, custom physics, player-built worlds. The specs provide the constraints. The players provide everything else.
+
+## What's Not On This Roadmap
+
+**A Rask self-hosted compiler.** Rask exists and works. The game infrastructure is built in Rust. Eventually the game server could be written in Rask — but that's a language maturity milestone, not a game milestone.
+
+**Mobile clients.** The architecture supports any client that can run Raido (for galaxy gen) and speak Leden (for networking). Mobile is a client engineering project, not a protocol project.
+
+**Monetization.** How the founding cluster funds hosting, whether managed hosting charges money, whether there's a real-money economy. Business decisions, not technical ones.


### PR DESCRIPTION
Credits as fiat seed currency backed by pre-bootstrapped founding cluster
economy. Activity-tied minting prevents hyperinflation, transparent supply
audits via Conservation Law 1. Players choose their own currency — credits
are the default, not the mandate.

Covers: founding system selection, bootstrap sequence (6 phases), new player
economics (free starter ship, labor-first onramp), AI economy structure,
and tuning knobs.

https://claude.ai/code/session_018sjr666LSNwfTbiFMsteYE