### PR TITLE
Fix bitwise ops for explicit integer types in type checker

### DIFF
--- a/compiler/crates/rask-stdlib/src/registry.rs
+++ b/compiler/crates/rask-stdlib/src/registry.rs
@@ -26,7 +26,9 @@ pub enum StdlibLayer {
 /// Classify a builtin type by its runtime requirements.
 pub fn type_layer(type_name: &str) -> StdlibLayer {
     match type_name {
-        "i64" | "i128" | "u128" | "f64" | "bool" | "char" | "string"
+        "i8" | "i16" | "i32" | "i64" | "i128"
+        | "u8" | "u16" | "u32" | "u64" | "u128"
+        | "f64" | "bool" | "char" | "string"
         | "Vec" | "Map" | "Pool" | "Handle"
         | "Result" | "Option"
         | "f32x4" | "f32x8" | "f64x2" | "f64x4" | "i32x4" | "i32x8"
@@ -58,12 +60,21 @@ pub fn module_layer(module: &str) -> StdlibLayer {
 // Instance methods by type
 // ---------------------------------------------------------------------------
 
-const I64_METHODS: &[&str] = &[
+const SIGNED_INT_METHODS: &[&str] = &[
     "add", "sub", "mul", "div", "rem", "neg",
     "eq", "lt", "le", "gt", "ge",
     "bit_and", "bit_or", "bit_xor", "shl", "shr", "bit_not",
     "abs", "min", "max", "to_string", "to_float",
 ];
+
+const UNSIGNED_INT_METHODS: &[&str] = &[
+    "add", "sub", "mul", "div", "rem",
+    "eq", "lt", "le", "gt", "ge",
+    "bit_and", "bit_or", "bit_xor", "shl", "shr", "bit_not",
+    "min", "max", "to_string", "to_float",
+];
+
+const I64_METHODS: &[&str] = SIGNED_INT_METHODS;
 
 const I128_METHODS: &[&str] = &[
     "add", "sub", "mul", "div", "rem", "neg",
@@ -242,7 +253,9 @@ const CLI_METHODS: &[&str] = &["args", "parse"];
 
 /// All types with registered instance methods.
 pub const REGISTERED_TYPES: &[&str] = &[
-    "i64", "i128", "u128", "f64", "bool", "char", "string",
+    "i8", "i16", "i32", "i64", "i128",
+    "u8", "u16", "u32", "u64", "u128",
+    "f64", "bool", "char", "string",
     "Vec", "Map", "Pool", "Handle",
     "Result", "Option",
     "File", "Metadata",
@@ -265,7 +278,8 @@ pub const REGISTERED_MODULES: &[&str] = &[
 /// Get implemented method names for a type.
 pub fn type_method_names(type_name: &str) -> &'static [&'static str] {
     match type_name {
-        "i64" => I64_METHODS,
+        "i8" | "i16" | "i32" | "i64" => SIGNED_INT_METHODS,
+        "u8" | "u16" | "u32" | "u64" => UNSIGNED_INT_METHODS,
         "i128" => I128_METHODS,
         "u128" => U128_METHODS,
         "f64" => F64_METHODS,

--- a/compiler/crates/rask-types/src/checker/resolve.rs
+++ b/compiler/crates/rask-types/src/checker/resolve.rs
@@ -575,6 +575,15 @@ impl TypeChecker {
                     })
                 }
             }
+            // Primitive integer types — resolve operator methods directly
+            Type::I8 | Type::I16 | Type::I32 | Type::I64 | Type::I128
+            | Type::U8 | Type::U16 | Type::U32 | Type::U64 | Type::U128 => {
+                self.resolve_integer_method(&ty, &method, &args, &ret, span)
+            }
+            // Primitive float types
+            Type::F32 | Type::F64 => {
+                self.resolve_float_method(&ty, &method, &args, &ret, span)
+            }
             Type::Option(inner) => {
                 let inner = *inner.clone();
                 self.resolve_option_method(&inner, &method, &args, &ret, span)
@@ -2195,6 +2204,82 @@ impl TypeChecker {
             }
             _ => Err(TypeError::NoSuchMethod {
                 ty: self_ty,
+                method: method.to_string(),
+                span,
+            }),
+        }
+    }
+
+    /// Resolve methods on primitive integer types (i8..i128, u8..u128).
+    /// Desugared operators (add, bit_and, etc.) resolve here instead of
+    /// bouncing through HasMethod → unsolved constraint suppression.
+    pub(super) fn resolve_integer_method(
+        &mut self,
+        ty: &Type,
+        method: &str,
+        args: &[Type],
+        ret: &Type,
+        span: Span,
+    ) -> Result<bool, TypeError> {
+        let is_signed = matches!(ty, Type::I8 | Type::I16 | Type::I32 | Type::I64 | Type::I128);
+        match method {
+            // Binary arithmetic → same type
+            "add" | "sub" | "mul" | "div" | "rem"
+            | "bit_and" | "bit_or" | "bit_xor" | "shl" | "shr"
+            | "min" | "max" if args.len() == 1 => {
+                let _ = self.unify(&args[0], ty, span);
+                self.unify(ret, ty, span)
+            }
+            // Unary → same type
+            "neg" if args.is_empty() && is_signed => self.unify(ret, ty, span),
+            "bit_not" | "abs" if args.is_empty() => self.unify(ret, ty, span),
+            // Comparison → bool
+            "eq" | "ne" | "lt" | "le" | "gt" | "ge" if args.len() == 1 => {
+                let _ = self.unify(&args[0], ty, span);
+                self.unify(ret, &Type::Bool, span)
+            }
+            "compare" if args.len() == 1 => {
+                let _ = self.unify(&args[0], ty, span);
+                self.unify(ret, &Type::UnresolvedNamed("Ordering".to_string()), span)
+            }
+            "to_float" if args.is_empty() => self.unify(ret, &Type::F64, span),
+            _ => Err(TypeError::NoSuchMethod {
+                ty: ty.clone(),
+                method: method.to_string(),
+                span,
+            }),
+        }
+    }
+
+    /// Resolve methods on primitive float types (f32, f64).
+    pub(super) fn resolve_float_method(
+        &mut self,
+        ty: &Type,
+        method: &str,
+        args: &[Type],
+        ret: &Type,
+        span: Span,
+    ) -> Result<bool, TypeError> {
+        match method {
+            "add" | "sub" | "mul" | "div"
+            | "min" | "max" | "pow" if args.len() == 1 => {
+                let _ = self.unify(&args[0], ty, span);
+                self.unify(ret, ty, span)
+            }
+            "neg" | "abs" | "floor" | "ceil" | "round" | "sqrt" if args.is_empty() => {
+                self.unify(ret, ty, span)
+            }
+            "eq" | "ne" | "lt" | "le" | "gt" | "ge" if args.len() == 1 => {
+                let _ = self.unify(&args[0], ty, span);
+                self.unify(ret, &Type::Bool, span)
+            }
+            "compare" if args.len() == 1 => {
+                let _ = self.unify(&args[0], ty, span);
+                self.unify(ret, &Type::UnresolvedNamed("Ordering".to_string()), span)
+            }
+            "to_int" if args.is_empty() => self.unify(ret, &Type::I64, span),
+            _ => Err(TypeError::NoSuchMethod {
+                ty: ty.clone(),
                 method: method.to_string(),
                 span,
             }),

--- a/compiler/crates/rask-types/src/checker/unify.rs
+++ b/compiler/crates/rask-types/src/checker/unify.rs
@@ -97,7 +97,8 @@ impl TypeChecker {
             "add" | "sub" | "mul" | "div" | "rem"
             | "eq" | "ne" | "lt" | "gt" | "le" | "ge"
             | "neg" | "not" | "and" | "or"
-            | "bitand" | "bitor" | "bitxor" | "shl" | "shr"
+            | "bit_and" | "bit_or" | "bit_xor" | "shl" | "shr" | "bit_not"
+            | "abs" | "min" | "max" | "to_float" | "compare"
         )
     }
 

--- a/tests/suite/t24_bitwise_ops.rk
+++ b/tests/suite/t24_bitwise_ops.rk
@@ -148,4 +148,41 @@ test "underscore separators" {
     assert 0b1111_0000 == 0xF0
 }
 
+// --- explicit integer types (BW1) ---
+// Bitwise ops must work on all integer types, not just i64.
+
+test "bitwise on i32" {
+    const a: i32 = 0xFF
+    const b: i32 = 0x0F
+    assert (a & b) == 0x0F
+    assert (a | b) == 0xFF
+    assert (a ^ b) == 0xF0
+    assert (b << 4) == 0xF0
+    assert (a >> 4) == 0x0F
+    assert ~b == -16
+}
+
+test "bitwise on u8" {
+    const a: u8 = 0xAA
+    const b: u8 = 0x55
+    assert (a & b) == 0
+    assert (a | b) == 0xFF
+    assert (a ^ b) == 0xFF
+}
+
+test "bitwise on u64" {
+    const a: u64 = 0xFF00FF00
+    const b: u64 = 0x0F0F0F0F
+    assert (a & b) == 0x0F000F00
+    assert (a | b) == 0xFF0FFF0F
+}
+
+test "bitwise on i128" {
+    const a: i128 = 0xFF
+    const b: i128 = 0x0F
+    assert (a & b) == 0x0F
+    assert (a | b) == 0xFF
+    assert ~b == -16
+}
+
 func main() {}


### PR DESCRIPTION
Three issues fixed:

1. is_operator_on_primitive had wrong method names (bitand/bitor/bitxor
   instead of bit_and/bit_or/bit_xor) and was missing bit_not, abs, min,
   max, to_float, compare. This caused false NoSuchMethod errors on all
   primitive integer types for bitwise operations.

2. resolve_method had no arm for primitive integer/float types — they fell
   through to the catch-all which deferred the constraint forever, relying
   on the (broken) suppression in is_operator_on_primitive.
   Added resolve_integer_method and resolve_float_method that properly
   unify return types for all operator methods.

3. stdlib registry only registered i64/i128/u128 — added i8, i16, i32,
   u8, u16, u32, u64 with appropriate signed/unsigned method lists.

https://claude.ai/code/session_01VePQQwxVEqCS2wfwhuAGEE