### PR TITLE
Reframe Apeiron roadmap around Rask and add Stage 0 validation

### DIFF
--- a/projects/allgard/CONSERVATION.md
+++ b/projects/allgard/CONSERVATION.md
@@ -39,9 +39,11 @@ See [Domain Sovereignty over Supply](README.md#domain-sovereignty-over-supply) f
 
 ## Law 2: Singular Ownership
 
-> Every Object has exactly one Owner at every point in time. Ownership transfers are atomic.
+> Every Object has at most one Owner at every point in time. Ownership transfers are atomic.
 
-No duplication. No orphans. An Object is in at most one Domain's inventory at any point in time — never two.
+No duplication. No shared ownership. An Object is owned by zero or one Owners, and hosted in at most one Domain's inventory — never two.
+
+An Object without an Owner is **unclaimed**. It exists in a Domain, hosted but unowned. Any authorized Owner in the Domain can claim it — claiming is atomic, same guarantees as transfer. See [Unclaimed Objects](PRIMITIVES.md#unclaimed-objects) for the full mechanism.
 
 Within a domain, transfer is atomic: remove from A, add to B, in one transaction. Across domains, the bilateral escrow protocol maintains the same invariant under network failure — see [Cross-Domain Transfer](#cross-domain-transfer).
 
@@ -55,10 +57,11 @@ See [TRANSFER.md](TRANSFER.md) for the full protocol specification, failure mode
 
 ### Implications
 
-- No concurrent mutation (only the owner can authorize Transforms)
+- No concurrent mutation (only the owner — or the domain for unclaimed objects — can authorize Transforms)
 - No CRDTs needed for the base case
 - Cross-domain transfer is a bilateral escrow protocol — the object must leave one domain before entering another, with the source domain as escrow authority
 - Shared access is through Grants, not shared ownership
+- Unclaimed objects are domain-local — no cross-domain coordination needed for claiming
 
 ## Law 3: Conservation of Exchange
 

--- a/projects/allgard/PRIMITIVES.md
+++ b/projects/allgard/PRIMITIVES.md
@@ -20,7 +20,7 @@ Objects are content-addressed: the ID is derived from the content. This means:
 - Integrity verification is free
 - References are unforgeable (you can't guess a valid ID)
 
-Every Object has exactly one Owner at any point in time (Conservation Law 2). Ownership transfer is atomic.
+Every Object has at most one Owner at any point in time (Conservation Law 2). Ownership transfer is atomic. Objects without an Owner are [unclaimed](#unclaimed-objects).
 
 ### Properties
 
@@ -31,6 +31,28 @@ Every Object has exactly one Owner at any point in time (Conservation Law 2). Ow
 | `owner` | The Owner identity that has authority over this object |
 | `domain` | The Domain currently hosting this object |
 | `content` | Opaque bytes. Interpretation determined by `type`. |
+
+### Unclaimed Objects
+
+An Object MAY exist without an Owner. An unclaimed object is hosted by a Domain but owned by nobody.
+
+**How objects become unclaimed:**
+
+- **Release.** An Owner explicitly releases an object. This is a Transform operation (type: `release`) — it extends the proof chain, preserves full history, and sets the owner field to empty. The object stays in the domain that hosts it.
+- **Domain succession.** A domain reconstitutes objects from a [state snapshot](#domain-state-snapshots) of a dead domain. The original owners are gone. The objects materialize as unclaimed.
+
+**What you can do with unclaimed objects:**
+
+| Action | Who | How |
+|--------|-----|-----|
+| Inspect | Any Owner in the domain | Standard observation — the object is visible, its type and proof chain are readable |
+| Claim | Any authorized Owner | A Transform (type: `claim`) — atomic, first valid claim wins. Claiming IS ownership transfer from empty to the claimant. |
+| Salvage | Domain operator | Domain policy determines salvage rules — break down unclaimed objects, extract materials, or incorporate them |
+| Ignore | Anyone | Unclaimed objects don't impose obligations. They just sit there. |
+
+**Properties preserved:** The proof chain is unaffected by release or claiming. History is append-only (Law 4). The `release` and `claim` operations are new entries in the chain, not edits to old ones. An unclaimed object's provenance is fully traceable.
+
+**No shared ownership.** Unclaimed means zero owners, not multiple owners. The transition is always: one owner → zero owners (release) or zero owners → one owner (claim). Singular ownership is preserved — the change from Conservation Law 2 is "exactly one" to "at most one."
 
 ## Owner
 
@@ -614,6 +636,45 @@ What it cannot do:
 
 Domains federate. Any Domain can communicate with any other Domain via Leden's capability protocol. There's no central authority, no global state, no master server. Domains discover each other through gossip and establish bilateral capability relationships.
 
+### Domain State Snapshots
+
+Domains MAY publish state snapshots to the Leden content store. A snapshot is a content-addressed blob containing all hosted objects with their proof chains.
+
+**Why.** Domains die. Servers go offline, operators lose interest, hardware fails. Without snapshots, every object in a dead domain is gone until someone does wallet recovery — which requires the original owners to still be around. Snapshots let the objects outlive the domain.
+
+**Publication is voluntary.** Sovereignty means the operator chooses whether to publish. Nobody can force a domain to reveal its state. But there are incentives — trading partners cache your snapshots because they want to recover their objects if you go dark. Bilateral self-interest does the work.
+
+**Snapshot contents:**
+
+| Field | Description |
+|-------|-------------|
+| `domain_id` | The domain that published this snapshot |
+| `epoch` | The domain's logical timestamp at snapshot time |
+| `objects` | All hosted objects: content, type, owner, proof chains |
+| `catalog` | Asset type registry — what types this domain recognizes |
+| `hash` | Content hash of the entire snapshot (self-verifying) |
+
+**Publication schedule:**
+
+- **Periodic** during normal operation. Frequency is domain policy — every epoch, every 100 epochs, once a day. More frequent = less data lost on crash.
+- **Final** on graceful shutdown. The operator publishes one last snapshot before turning off.
+- **Never** is also valid. A domain that never publishes snapshots is choosing opacity. Its trading partners know this and price the risk accordingly.
+
+**Recovery from snapshots:**
+
+When a domain dies, the last published snapshot is what survives in the content store. A new domain operator (or any interested party) can:
+
+1. Fetch the snapshot from the content store (peers who cached it serve it)
+2. Verify every object's proof chain — signatures, causal links, minting scripts. Can't publish garbage because proof chains won't verify.
+3. Materialize valid objects as [unclaimed](#unclaimed-objects) in their domain
+4. Objects are now claimable by anyone authorized in the new domain
+
+**What's lost:** Changes between the last snapshot and domain death. If the domain published hourly and died 59 minutes after the last snapshot, 59 minutes of mutations are gone. This is honest — conservation doesn't require perfect persistence, only no duplication. Lost mutations are lost, not duplicated.
+
+**Verification.** Snapshots are self-verifying. Each object's proof chain must validate back to legitimate minting scripts. A domain can't publish a snapshot with fabricated objects — the proof chains reference counterparties who can independently confirm or deny. This is the same bilateral verification that enforces the conservation laws during normal operation, applied to bulk data.
+
+ZK proofs are a potential optimization for reducing verification burden — prove that "all N objects in this snapshot have valid proof chains" without the verifier re-checking each one. Noted for future work, not required for the mechanism to function.
+
 ## Transform
 
 A proposed operation on an Object. A message send.
@@ -630,6 +691,8 @@ A Transform hasn't happened yet. It's a request: "I want to do this to this obje
 | `split` | Divide an Object into parts (fungible assets) |
 | `merge` | Combine Objects into one (fungible assets) |
 | `destroy` | Remove an Object from existence (burning). Must be backed by a Raido script ([verifiable minting](CONSERVATION.md#verifiable-minting)). |
+| `release` | Relinquish ownership. Object becomes [unclaimed](PRIMITIVES.md#unclaimed-objects) — hosted by the domain, owned by nobody. |
+| `claim` | Take ownership of an unclaimed Object. Atomic — first valid claim wins. |
 
 ### Promise Pipelining
 

--- a/projects/apeiron/README.md
+++ b/projects/apeiron/README.md
@@ -98,12 +98,16 @@ A domain can go dark — the operator stops hosting. What happens to everything 
 
 **New claimant.** Another player can deploy a domain at the same star. The new claim triggers a fresh survey (new beacon value, new geology — the geology CHANGES because the beacon is different). The previous operator's objects are still frozen somewhere. If the previous operator comes back online, they have objects but no claim — they'd need to negotiate with the new claimant, or deploy at a different star.
 
+**Domain state snapshots.** If the domain published [state snapshots](../allgard/PRIMITIVES.md#domain-state-snapshots) during operation, the last snapshot survives in the Leden content store. Trading partners who cached the snapshot can serve it. A new claimant (or any interested party) can fetch the snapshot, verify proof chains, and materialize valid objects as [unclaimed](../allgard/PRIMITIVES.md#unclaimed-objects) in their domain.
+
+This is how ancient civilizations leave artifacts for future players. It's also how a player domain's legacy persists after the operator stops hosting. The objects don't vanish — they become unclaimed salvage for whoever claims the star next.
+
 **What doesn't happen:**
 - Objects don't get destroyed. Conservation law — mass doesn't vanish because a server went offline.
-- Objects don't transfer to the conquerer. No forced seizure. The frozen objects belong to the original operator. A new claimant gets the star's resources (fresh survey), not the previous occupant's stuff.
+- Objects don't transfer to the conqueror. No forced seizure. Snapshot-recovered objects are unclaimed — available to anyone, not automatically granted to the new claimant.
 - No automatic looting. A domain going dark is not a combat event — no debris, no salvage. The operator shut down their server. That's an infrastructure event, not a destruction event.
 
-**Conquest, then.** You can't take someone's stuff by besieging them into shutdown. You take their POSITION — the star, its resources, its strategic location. Their accumulated objects are frozen, inaccessible to everyone including the conqueror. The conquest incentive is geographic, not material.
+**Conquest, then.** You can't take someone's stuff by besieging them into shutdown. You take their POSITION — the star, its resources, its strategic location. If the previous domain published snapshots, you get unclaimed objects to salvage — but so does anyone else who fetches the snapshot. The conquest incentive is geographic, not material.
 
 ## Resources
 
@@ -175,6 +179,72 @@ The founding cluster picks their stars from the seed — probably dense-core sys
 New players start at a founding cluster system. They get a ship (an Allgard object — not a domain). They can trade, explore, mine, build. When they're ready, they claim their own star and join the network.
 
 The founding cluster is the seed of trust. Every domain in the galaxy traces its introduction chain back to the founding cluster. The cluster members start as each other's trusted partners. Everyone else earns trust through introduction.
+
+## Playstyles
+
+What do you actually DO in this game? The core loop: pick a star, fly there, do something profitable or interesting, fly home. Everything else is variation.
+
+| Playstyle | The loop | Stage 1 | Later |
+|-----------|----------|---------|-------|
+| **Trader** | Buy low, sell high, run routes. Arbitrage between systems. | Yes — the primary loop | Multi-hop routes, futures, market manipulation |
+| **Miner** | Claim deposits, extract, sell raw materials. | Yes | Facility upgrades, deep-system mining |
+| **Explorer** | Scout unclaimed systems, sell survey data, find anomalies. | Yes — [knowledge trading](KNOWLEDGE.md) | Ancient ruins, wormholes, new galaxy regions |
+| **Builder** | Construct stations, facilities, infrastructure. Run a system. | Partially — outposts and basic facilities | Full GDL stations, custom interiors |
+| **Researcher** | Experiment with crafting, discover recipes, publish findings. | Yes — crafting discovery loop | Advanced materials, exotic interactions |
+| **Fighter** | Combat, piracy, mercenary work, system defense. | No — combat is a parallel track | Full combat integration |
+| **Archaeologist** | Investigate ancient civilizations, salvage relics, decode history. | Partially — ruins exist from pre-player history | Deep lore, reconstruction, relic trading |
+
+A session might be 20 minutes (run one trade route) or 4 hours (explore a new sector). The game works at both scales because each action is discrete — jump, trade, mine, craft — not a continuous commitment.
+
+## Content Sources
+
+Three kinds of content, each from a different source. No central designer.
+
+### Seed as Game Designer
+
+The galaxy seed doesn't just generate stars. It generates anomalies, ruins, hazards, strange signals, resource distributions that imply history. The generation script is the game designer — it places content by algorithm, not by hand. Every client runs the same script, sees the same content.
+
+The founding cluster publishes updated generation scripts over time. A new script reads the same seed but reveals previously hidden data — a new asteroid belt, a derelict station, a signal source. The data was always "in" the math. The script is a better telescope.
+
+Beacon-gated content adds local variation. A star's seed data says "anomaly possible here." The beacon value (generated when a domain claims the star) determines what specific anomaly. Two domains claiming the same star at different times get different anomalies. Deterministic, verifiable, unique.
+
+### Domain Operators as Local Game Designers
+
+Sovereignty is creative control. A domain operator can:
+
+- Write contracts and missions for visitors ([CONTRACTS.md](CONTRACTS.md))
+- Set economic policies (tariffs, subsidies, trade restrictions)
+- Create NPCs and storylines (AI agents running on the domain)
+- Host events (tournaments, auctions, festivals)
+- Build physical spaces (stations, cities, landscapes via GDL)
+
+The founding cluster does this at scale — it IS the initial game designer, running scripted content across 5-20 systems. Player domain operators do the same at smaller scale with more personality. A player who runs a trading post with custom contracts and a backstory is creating content for every visitor.
+
+### Emergent Content
+
+The most interesting content isn't designed. It emerges from rational actors in a constrained economy:
+
+- **Piracy** emerges when stealing is more profitable than mining (risk-adjusted)
+- **Alliances** form when mutual defense is cheaper than individual defense
+- **Trade wars** happen when two factions compete for the same resource corridor
+- **Refugee crises** when a major domain goes dark and inhabitants scatter
+- **Gold rushes** when someone publishes a survey of a rich unclaimed sector
+
+This can't produce: grand narrative arcs, balanced difficulty progression, curated new-player experiences, quality control. The founding cluster handles onboarding and early experience. Everything beyond that is emergent or operator-created.
+
+## Pre-Player History
+
+The galaxy isn't a blank slate. It has history before players arrive.
+
+The idea: fast-forward the galaxy with AI agents running real domains. Civilizations rise, expand, trade, conflict, decline, fall. The history is real because it was simulated with the same rules players will use — same conservation laws, same physics, same economy. Ancient civilizations extracted real resources from real deposits, traded with real partners, and fought real wars.
+
+When civilizations fall, their agents [release](../allgard/PRIMITIVES.md#unclaimed-objects) their objects. Ancient ships, stations, refineries, stockpiles — all unclaimed, scattered across dead domains. [Domain state snapshots](../allgard/PRIMITIVES.md#domain-state-snapshots) persist the remnants. New claimants find ancient objects: a rusted refinery orbiting planet 3, a cargo hold full of exotic alloys, a derelict capital ship with equipment nobody knows how to build anymore.
+
+History explains WHY ruins are where they are. The simulation's timeline IS the lore. A cluster of dead systems with depleted iron deposits and scattered warship debris tells you: two civilizations fought over these mines. You don't read that in a codex — you infer it from what you find.
+
+The simulation output is cached as a content-addressed blob. Runs once at publishing time, hash-verified, clients download the result. The galaxy seed + the history seed = the complete starting state. Deterministic, verifiable.
+
+**Open:** Full agent sim everywhere, or lighter seed-script for galaxy-wide coarse history with detailed agent sim only in the founding region? Depends on what's built first. The mechanisms — unclaimed objects, snapshots, domain succession — support both approaches. The Stage 0 economy simulation will inform this choice.
 
 ## Physics and Natural Laws
 

--- a/projects/apeiron/ROADMAP.md
+++ b/projects/apeiron/ROADMAP.md
@@ -6,14 +6,18 @@ Everything below is specs. ~14K lines of markdown across six projects. Zero impl
 ## Dependency Chain
 
 ```
-Rask (working) ──→ Raido VM ──→ Galaxy Gen ──→ Stage 1 Monolith
-                                                      │
-                                              Leden ──→ Allgard ──→ Stage 2-3 Federation
-                                                                          │
-                                                                   GDL ──→ Stage 4 Full Vision
+Rask (working) ──→ Raido VM (Rask) ──→ Galaxy Gen ──→ History Sim ──→ Stage 1 (Rask)
+                                                                           │
+                                             Leden (Rask) ──→ Allgard (Rask) ──→ Stage 2-3
+                                                                                      │
+                                                                               GDL ──→ Stage 4
 ```
 
-Stage 1 doesn't need federation. One operator, one process, five simulated systems. Raido provides deterministic physics and galaxy generation. The game server enforces conservation laws internally. When you federate in Stage 2, you extract enforcement into Allgard.
+Everything is Rask. Raido, Leden, Allgard, the game server — all written in Rask. These are language validation targets. Raido exercises low-level systems code (fixed-point arithmetic, arena allocation, bytecode dispatch). Leden exercises networking. Allgard exercises data structures and verification. The game server exercises everything.
+
+Stage 0 (simulations) validates game mechanics cheaply in Python before committing to implementation. Stage 1 doesn't need federation. One operator, one process, five simulated systems. Raido provides deterministic physics and galaxy generation. The game server enforces conservation laws internally. When you federate in Stage 2, you extract enforcement into Allgard.
+
+Leden and Allgard develop in parallel with Stage 1, not as prerequisites. They converge at Stage 2 when federation becomes real.
 
 Midgard isn't a build phase — it's the patterns that emerge when you federate. Document them as you go.
 
@@ -30,6 +34,42 @@ Combat is a parallel track. Prototype it standalone, integrate when both combat 
 | Midgard | 429 | None | Design docs |
 | GDL | 2,649 | None | Specs complete |
 | Apeiron | 2,100+ | 1 Python sim | Design docs |
+
+## Stage 0: Simulations
+
+Validate game mechanics before building anything. Python scripts, fast iteration, throw-away code. The goal is to kill bad ideas cheaply.
+
+### Economy Viability
+
+Extend the existing `transform_sim.py`. 5 systems, AI agents (extractors, haulers, stations), 10K ticks. Does the economy circulate? Do prices stabilize? Does trade emerge from geographic scarcity?
+
+**Passes if:** credits don't hyperinflate, at least 3 of 5 systems participate in trade, no single agent accumulates >50% of total supply.
+
+**Fails if:** economy collapses, one agent dominates, prices converge to uniform (no trade incentive).
+
+### Crafting Discovery
+
+Interactive CLI. A player picks elements, ratios, conditions. The interaction function evaluates. Hill-climbing toward stoichiometric peaks — is the search fun? Does the player feel like a scientist or a slot machine?
+
+**Passes if:** players can reason about results ("more carbon made it harder"), peaks are discoverable through experimentation, not random guessing.
+
+**Fails if:** the search space is too flat (everything works roughly the same) or too spiky (no gradient to follow).
+
+### Element Count
+
+5 elements vs 14 elements. Same economy sim, same crafting sim. Does 14 add meaningful depth — more trade routes, more specialization, more interesting recipes? Or is it just noise — more names to memorize, same dynamics?
+
+**Passes if:** 14 elements create trade patterns that 5 don't (specialized systems, multi-hop routes, element scarcity driving conflict).
+
+**Fails if:** reducing to 5 loses nothing noticeable. Simpler is better.
+
+### Galaxy Topology
+
+Generate 10K stars. Visualize clusters, bridges, chokepoints, frontier arms. Does the topology create interesting strategic geography? Are there natural trade corridors, defensible positions, exploration frontiers?
+
+**Passes if:** the galaxy has visible structure — dense cores, sparse arms, bridge stars that matter. A player looking at the map can identify "that cluster is rich but crowded" vs "that arm is remote but resource-dense."
+
+**Fails if:** it looks uniform, or the structure doesn't create meaningful gameplay differences.
 
 ## Phase 1: Raido VM
 
@@ -55,7 +95,7 @@ A register-based VM that executes Raido bytecode with:
 - Write one crafting script (structural steel: Fe+C at 97:3). If the interaction function evaluates deterministically with fixed-point math, transformation physics works.
 
 ### Implementation language
-Rust. Raido is a standalone crate — it doesn't depend on the Rask compiler. Eventually the Rask runtime embeds Raido for comptime execution, but that's later. Build it in Rust, ship it as a library.
+Rask. Raido exercises exactly the kind of systems code Rask needs to prove it handles well — fixed-point arithmetic, arena allocation, bytecode dispatch loops, host interop through FFI. If Rask can't build a register VM cleanly, that's a language problem to fix, not to work around.
 
 ## Phase 2: Galaxy Generation
 
@@ -82,6 +122,39 @@ Galaxy structure: dense cores, sparse arms, bridge stars. Not uniform random —
 
 ### Deliverable
 A working galaxy that anyone can regenerate from a seed integer. The first tangible artifact of the project.
+
+## Phase 2.5: History Simulation
+
+The galaxy needs history before players arrive. This phase generates it.
+
+AI agents run real domains in the generated galaxy. Civilizations emerge, expand, trade, conflict, fall. The simulation uses the same conservation laws, physics scripts, and economy rules that players will use. The history is real — verifiable, consistent, not hand-written.
+
+### What to build
+
+A simulation harness that:
+- Instantiates AI domain operators across the galaxy
+- Runs the economy (extraction, crafting, trade, consumption) for N epochs
+- Simulates civilization rise and fall (expansion pressure, conflict, resource depletion)
+- On civilization death: agents release objects, domains publish final [state snapshots](../allgard/PRIMITIVES.md#domain-state-snapshots)
+- Outputs a content-addressed history blob: per-star timeline, surviving objects, snapshot references
+
+### Output
+
+The simulation produces:
+- **History per star:** who claimed it, what they built, when they fell, what's left
+- **Unclaimed objects:** ancient ships, stations, stockpiles scattered across dead domains
+- **Resource depletion:** some deposits are partially mined. The galaxy isn't pristine.
+- **Ruins and artifacts:** objects with proof chains that reference civilizations that no longer exist
+
+### Validation
+
+- The history is internally consistent — proof chains validate, conservation laws hold
+- The history creates interesting exploration content — there are things to find, mysteries to investigate
+- The history is reproducible from the seeds (galaxy seed + history seed)
+
+### Open questions
+
+Full agent sim for the entire galaxy, or lighter seed-script for coarse galaxy-wide history with detailed agent sim only in the founding region? The mechanisms support both. The Stage 0 economy sim will inform this — if agents produce interesting history when fast-forwarded, go full agent. If the sim is too expensive or produces boring output, fall back to seed scripts for the periphery.
 
 ## Phase 3: Stage 1 — The Trading Game
 
@@ -137,7 +210,7 @@ The networking layer:
 - Observation protocol (push-based state change notifications)
 
 ### Implementation
-Rust crate. Transport-agnostic — works over TCP, WebSocket, QUIC. MessagePack wire format (already spec'd in [wire-format.md](../leden/wire-format.md)).
+Rask. Transport-agnostic — works over TCP, WebSocket, QUIC. MessagePack wire format (already spec'd in [wire-format.md](../leden/wire-format.md)). Leden exercises Rask's networking stack — socket I/O, async patterns, binary serialization.
 
 ### Validation
 - Two independent processes can establish a Leden session, exchange capabilities, and transfer an object.
@@ -227,8 +300,6 @@ When the combat prototype is fun and the trading game is federated, merge them. 
 Stage 4 is where the game grows beyond what I can prescribe. Player factions, emergent politics, custom physics, player-built worlds. The specs provide the constraints. The players provide everything else.
 
 ## What's Not On This Roadmap
-
-**A Rask self-hosted compiler.** Rask exists and works. The game infrastructure is built in Rust. Eventually the game server could be written in Rask — but that's a language maturity milestone, not a game milestone.
 
 **Mobile clients.** The architecture supports any client that can run Raido (for galaxy gen) and speak Leden (for networking). Mobile is a client engineering project, not a protocol project.
 


### PR DESCRIPTION
## Summary

This PR restructures the Apeiron project roadmap to establish Rask as the primary implementation language for all major components, adds a new Stage 0 (Simulations) phase for validating game mechanics before implementation, and introduces mechanisms for domain state snapshots and unclaimed objects to support pre-player history and domain succession.

## Key Changes

**Roadmap restructuring:**
- Repositioned all major components (Raido, Leden, Allgard, game server) as Rask validation targets rather than separate language implementations
- Changed Raido implementation from Rust to Rask, framing it as a systems programming validation target (fixed-point arithmetic, arena allocation, bytecode dispatch)
- Changed Leden implementation from Rust to Rask, emphasizing networking stack validation
- Clarified that Leden and Allgard develop in parallel with Stage 1, not as prerequisites

**New Stage 0 (Simulations) phase:**
- Added comprehensive validation framework for game mechanics before implementation
- Four validation tracks: Economy Viability (extend transform_sim.py), Crafting Discovery (interactive CLI), Element Count (5 vs 14 elements), Galaxy Topology (10K star visualization)
- Each track has explicit pass/fail criteria to kill bad ideas cheaply

**New Phase 2.5 (History Simulation):**
- Generates pre-player galaxy history using AI agents running real domains
- Produces unclaimed objects, ruins, and resource depletion as exploration content
- Output is reproducible from seeds and content-addressed for verification
- Leaves open the question of full agent sim vs. lighter seed-scripts for galaxy periphery

**Domain state snapshots and unclaimed objects:**
- Added `Domain State Snapshots` section to PRIMITIVES.md: voluntary publication of domain state to content store, enabling object recovery when domains die
- Introduced `Unclaimed Objects` primitive: objects without owners, created via explicit release or domain succession
- Objects can now have "at most one Owner" instead of "exactly one Owner" (Conservation Law 2 updated)
- Added `release` and `claim` Transform types to support unclaimed object lifecycle
- Snapshot recovery materializes ancient objects as unclaimed salvage for new domain operators

**Content and playstyle documentation:**
- Added Playstyles table showing 7 different gameplay loops (Trader, Miner, Explorer, Builder, Researcher, Fighter, Archaeologist)
- Added Content Sources section explaining seed-based design, domain operator creativity, and emergent content
- Added Pre-Player History section explaining how ancient civilizations create exploration content through simulation

**Removed:**
- Deleted note about Rask self-hosted compiler not being on roadmap (now it's central to the plan)

https://claude.ai/code/session_017rE2Lni4g3ShMa9WDgf6MA