### PR TITLE
Refactor LSP server architecture with incremental sync and modular handlers

### DIFF
--- a/compiler/Cargo.lock
+++ b/compiler/Cargo.lock
@@ -1513,6 +1513,7 @@ dependencies = [
  "rask-desugar",
  "rask-diagnostics",
  "rask-effects",
+ "rask-fmt",
  "rask-lexer",
  "rask-ownership",
  "rask-parser",

--- a/compiler/crates/rask-lsp/Cargo.toml
+++ b/compiler/crates/rask-lsp/Cargo.toml
@@ -27,3 +27,4 @@ rask-stdlib = { path = "../rask-stdlib" }
 rask-compiler = { path = "../rask-compiler" }
 rask-comptime = { path = "../rask-comptime" }
 rask-effects = { path = "../rask-effects" }
+rask-fmt = { path = "../rask-fmt" }

--- a/compiler/crates/rask-lsp/src/backend.rs
+++ b/compiler/crates/rask-lsp/src/backend.rs
@@ -1,15 +1,24 @@
 // SPDX-License-Identifier: (MIT OR Apache-2.0)
-//! Core backend struct and compilation pipeline.
+//! Backend state and the analysis pipeline.
 //!
-//! Uses rask-compiler for package detection and shares the same pipeline
-//! stages as the CLI. The LSP-specific behavior (continue past errors,
-//! filter to current file, editor buffer substitution) wraps around the
-//! same functions.
+//! The backend owns:
+//!   - open documents (source text keyed by URI)
+//!   - the most recent compilation result per document
+//!   - the workspace root (for stub-file goto)
+//!
+//! All locks are `tokio::sync::RwLock` — blocking in an async handler would
+//! stall the shared tokio executor. The CPU-heavy analysis pass runs via
+//! `spawn_blocking` and is wrapped in `catch_unwind` so a compiler panic
+//! reports as a diagnostic instead of killing the server.
 
 use std::collections::HashMap;
+use std::panic::AssertUnwindSafe;
 use std::path::PathBuf;
-use std::sync::RwLock;
+use std::sync::Arc;
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::time::Duration;
 
+use tokio::sync::RwLock;
 use tower_lsp::lsp_types::*;
 use tower_lsp::Client;
 
@@ -18,41 +27,56 @@ use rask_ast::Span;
 use rask_diagnostics::ToDiagnostic;
 use rask_types::TypedProgram;
 
-use crate::convert::{byte_offset_to_position, to_lsp_diagnostic};
+use crate::convert::{to_lsp_diagnostic, LineIndex};
 use crate::position_index::{build_position_index, PositionIndex};
 
+/// How long we wait for further keystrokes before re-analyzing.
+///
+/// 120 ms is enough that a fast typist (~8 chars/sec) gets at most one
+/// analysis per word, but short enough that the diagnostics feel live.
+const DEBOUNCE_MS: u64 = 120;
+
 /// Sibling file info for cross-file navigation.
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct SiblingFile {
     pub path: PathBuf,
     pub source: String,
 }
 
-/// Cached compilation result for a file.
-#[derive(Debug)]
+/// Cached compilation result for a document.
 pub struct CompilationResult {
-    /// Source text (for cache validation)
+    /// Source text. Held so later lookups (hover, completion) see the same
+    /// bytes we analyzed, even if the document has moved on.
     pub source: String,
-    /// Parsed AST declarations (retained for future use)
-    pub _decls: Vec<Decl>,
-    /// Type-checked program
+    /// UTF-16 line index for this source snapshot.
+    pub line_index: LineIndex,
+    /// Parsed and desugared declarations (current file + siblings appended).
+    pub decls: Vec<Decl>,
+    /// Span range of each *current-file* declaration, used to filter
+    /// diagnostics produced by the whole-package pipeline down to just
+    /// the ones the editor buffer is responsible for.
+    pub current_file_spans: Vec<Span>,
     pub typed: TypedProgram,
-    /// Original diagnostics (before LSP conversion)
     pub diagnostics: Vec<rask_diagnostics::Diagnostic>,
-    /// Position index for fast lookups
     pub position_index: PositionIndex,
-    /// Maps top-level declaration names from sibling files to their source info.
     pub sibling_decl_names: HashMap<String, SiblingFile>,
 }
 
-#[derive(Debug)]
 pub struct Backend {
     pub client: Client,
-    pub documents: RwLock<HashMap<Url, String>>,
-    /// Cached compilation results
-    pub compiled: RwLock<HashMap<Url, CompilationResult>>,
-    /// Workspace root URI (set during initialization)
+    pub documents: RwLock<HashMap<Url, DocState>>,
+    pub compiled: RwLock<HashMap<Url, Arc<CompilationResult>>>,
     pub root_uri: RwLock<Option<Url>>,
+    /// Monotonic analysis generation counter — used to cancel outdated
+    /// debounced analyses when a newer keystroke arrives.
+    pub generation: AtomicU64,
+}
+
+/// Live document state (most recent text + client's version number).
+#[derive(Debug, Clone)]
+pub struct DocState {
+    pub text: String,
+    pub version: i32,
 }
 
 impl Backend {
@@ -62,220 +86,337 @@ impl Backend {
             documents: RwLock::new(HashMap::new()),
             compiled: RwLock::new(HashMap::new()),
             root_uri: RwLock::new(None),
+            generation: AtomicU64::new(0),
         }
     }
 
-    pub async fn publish_diagnostics(&self, uri: Url, text: &str) {
-        let diagnostics = self.analyze_and_cache(&uri, text);
+    /// Schedules diagnostics publication after a short debounce window.
+    /// Returns immediately; analysis runs on a blocking worker.
+    pub async fn schedule_analysis(self: Arc<Self>, uri: Url) {
+        let gen_at_call = self.generation.fetch_add(1, Ordering::SeqCst) + 1;
+        let backend = self.clone();
+        tokio::spawn(async move {
+            tokio::time::sleep(Duration::from_millis(DEBOUNCE_MS)).await;
+            // Bail if another keystroke arrived during the sleep.
+            if backend.generation.load(Ordering::SeqCst) != gen_at_call {
+                return;
+            }
+            backend.analyze_now(uri).await;
+        });
+    }
 
-        let lsp_diagnostics: Vec<Diagnostic> = diagnostics
+    /// Runs analysis immediately (used by did_save and initial open).
+    pub async fn analyze_now(self: Arc<Self>, uri: Url) {
+        let Some(doc) = self.documents.read().await.get(&uri).cloned() else {
+            return;
+        };
+        let backend = self.clone();
+        let uri_for_task = uri.clone();
+        let doc_clone = doc.clone();
+
+        // Heavy work on a blocking thread so we don't stall the async runtime.
+        let analysis = tokio::task::spawn_blocking(move || {
+            let res = std::panic::catch_unwind(AssertUnwindSafe(|| {
+                run_pipeline(&uri_for_task, &doc_clone.text, doc_clone.version)
+            }));
+            match res {
+                Ok(result) => result,
+                Err(_) => PipelineOutput::panic(&doc_clone.text, doc_clone.version),
+            }
+        })
+        .await;
+
+        let output = match analysis {
+            Ok(o) => o,
+            Err(_) => PipelineOutput::panic(&doc.text, doc.version),
+        };
+
+        // Publish diagnostics regardless of whether the pipeline had errors.
+        let lsp_diags: Vec<Diagnostic> = output
+            .diagnostics
             .iter()
-            .map(|d| to_lsp_diagnostic(text, &uri, d))
+            .map(|d| to_lsp_diagnostic(&output.line_index, &output.source, &uri, d))
             .collect();
-
         self.client
-            .publish_diagnostics(uri, lsp_diagnostics, None)
+            .publish_diagnostics(uri.clone(), lsp_diags, Some(output.version))
             .await;
+
+        // Only replace the cache if the analysis succeeded fully.
+        if let Some(result) = output.result {
+            backend.compiled.write().await.insert(uri, Arc::new(result));
+        }
     }
 
-    /// Analyze source and return diagnostics.
-    ///
-    /// Runs the same pipeline stages as the CLI (via rask-compiler types),
-    /// fixing previous divergences: now includes desugar_with_diagnostics,
-    /// desugar_default_args, comptime cfg elimination, correct stdlib decls,
-    /// and effect analysis.
-    pub fn analyze_and_cache(&self, uri: &Url, source: &str) -> Vec<rask_diagnostics::Diagnostic> {
-        let mut diags = Vec::new();
+    /// Read the cached compilation for `uri` (shared Arc — cheap to clone).
+    pub async fn get_compiled(&self, uri: &Url) -> Option<Arc<CompilationResult>> {
+        self.compiled.read().await.get(uri).cloned()
+    }
 
-        // --- Lex (collect all errors, deduplicate by line) ---
-        let mut lexer = rask_lexer::Lexer::new(source);
-        let lex_result = lexer.tokenize();
-
-        let mut last_lex_line: Option<u32> = None;
-        for error in &lex_result.errors {
-            let line = byte_offset_to_position(source, error.span.start).line;
-            if last_lex_line != Some(line) {
-                diags.push(error.to_diagnostic());
-                last_lex_line = Some(line);
-            }
-        }
-
-        // --- Parse (continue even with lex errors) ---
-        let mut parser = rask_parser::Parser::new(lex_result.tokens);
-        let mut parse_result = parser.parse();
-
-        let mut last_parse_line: Option<u32> = None;
-        for error in &parse_result.errors {
-            let line = byte_offset_to_position(source, error.span.start).line;
-            if last_parse_line != Some(line) {
-                diags.push(error.to_diagnostic());
-                last_parse_line = Some(line);
-            }
-        }
-
-        if !parse_result.is_ok() {
-            return diags;
-        }
-
-        // --- Comptime cfg elimination (CC1) — previously missing from LSP ---
-        let cfg = rask_comptime::CfgConfig::from_host("debug", vec![]);
-        rask_comptime::eliminate_comptime_if(&mut parse_result.decls, &cfg);
-
-        // --- Desugar — now uses desugar_with_diagnostics + default args ---
-        let desugar_errors = rask_desugar::desugar_with_diagnostics(&mut parse_result.decls);
-        rask_desugar::desugar_default_args(&mut parse_result.decls);
-        for e in &desugar_errors {
-            diags.push(
-                rask_diagnostics::Diagnostic::error(e.message.clone())
-                    .with_code("E0338")
-                    .with_primary(e.span, "variant needs @message(\"...\") annotation"),
-            );
-        }
-
-        // Record current file's decl span ranges for diagnostic filtering.
-        let current_file_spans: Vec<Span> = parse_result.decls.iter().map(|d| d.span).collect();
-
-        // Detect package context using rask-compiler (shared implementation).
-        let file_path_str = uri.to_file_path()
-            .map(|p| p.to_string_lossy().to_string())
-            .unwrap_or_default();
-        let pkg_ctx = rask_compiler::detect_package(&file_path_str);
-        let sibling_decl_names = if let Some(ref ctx) = pkg_ctx {
-            build_sibling_names(uri, ctx)
-        } else {
-            HashMap::new()
-        };
-
-        let is_stdlib = rask_stdlib::StubRegistry::is_stdlib_path(uri.path());
-        let resolved = if is_stdlib {
-            match rask_resolve::resolve_stdlib(&parse_result.decls) {
-                Ok(r) => r,
-                Err(errors) => {
-                    for error in &errors {
-                        diags.push(error.to_diagnostic());
-                    }
-                    return diags;
-                }
-            }
-        } else if let Some(ref ctx) = pkg_ctx {
-            // Multi-file package: use sibling decls from the package registry but
-            // replace the current file's decls with our freshly parsed version
-            // (editor buffer may differ from disk).
-            let file_path = uri.to_file_path().unwrap_or_default();
-            let mut sibling_decls: Vec<Decl> = ctx.registry.get(ctx.root_id)
-                .map(|pkg| {
-                    pkg.files.iter()
-                        .filter(|f| f.path != file_path)
-                        .flat_map(|f| f.decls.clone())
-                        .collect()
-                })
-                .unwrap_or_default();
-            // Desugar siblings with full pipeline too
-            rask_desugar::desugar_with_diagnostics(&mut sibling_decls);
-            rask_desugar::desugar_default_args(&mut sibling_decls);
-            parse_result.decls.extend(sibling_decls);
-
-            match rask_resolve::resolve_package_with_cfg(
-                &parse_result.decls,
-                &ctx.registry,
-                ctx.root_id,
-                cfg.to_cfg_values(),
-            ) {
-                Ok(r) => r,
-                Err(errors) => {
-                    for error in &errors {
-                        let diag = error.to_diagnostic();
-                        if is_current_file_diagnostic(&diag, &current_file_spans) {
-                            diags.push(diag);
-                        }
-                    }
-                    return diags;
-                }
-            }
-        } else {
-            // Single-file mode — use resolve_with_cfg for consistency with CLI
-            match rask_resolve::resolve_with_cfg(&parse_result.decls, cfg.to_cfg_values()) {
-                Ok(r) => r,
-                Err(errors) => {
-                    for error in &errors {
-                        diags.push(error.to_diagnostic());
-                    }
-                    return diags;
-                }
-            }
-        };
-
-        // Stdlib stubs are signatures, not real code — skip semantic analysis
-        if is_stdlib {
-            return diags;
-        }
-
-        // --- Typecheck (lenient — returns partial TypedProgram + errors
-        //     so ownership/effects still run for full diagnostic coverage) ---
-        let stdlib_decls = rask_stdlib::StubRegistry::typecheck_decls();
-        let (typed, type_errors) =
-            rask_types::typecheck_with_stdlib_lenient(resolved, &parse_result.decls, &stdlib_decls);
-        for error in &type_errors {
-            let diag = error.to_diagnostic();
-            if is_current_file_diagnostic(&diag, &current_file_spans) {
-                diags.push(diag);
-            }
-        }
-
-        // --- Ownership (non-blocking — accumulate and continue) ---
-        let ownership_result = rask_ownership::check_ownership(&typed, &parse_result.decls);
-        for error in &ownership_result.errors {
-            let diag = error.to_diagnostic();
-            if is_current_file_diagnostic(&diag, &current_file_spans) {
-                diags.push(diag);
-            }
-        }
-
-        // --- Effect analysis — previously missing from LSP ---
-        let (effects, effect_warnings) = rask_effects::infer_effects(&parse_result.decls);
-        for w in &effect_warnings {
-            let d = rask_diagnostics::Diagnostic::warning(&w.message)
-                .with_code(w.code)
-                .with_primary(w.span, format!("`{}` has IO effect", w.callee_name));
-            if is_current_file_diagnostic(&d, &current_file_spans) {
-                diags.push(d);
-            }
-        }
-
-        let frozen_diagnostics = rask_effects::frozen::check(&parse_result.decls, &effects);
-        for fd in &frozen_diagnostics {
-            let d = if fd.is_error {
-                rask_diagnostics::Diagnostic::error(&fd.message)
-            } else {
-                rask_diagnostics::Diagnostic::warning(&fd.message)
-            };
-            let d = d.with_code(fd.code).with_primary(fd.span, "");
-            if is_current_file_diagnostic(&d, &current_file_spans) {
-                diags.push(d);
-            }
-        }
-
-        // Build position index for fast lookups
-        let mut position_index = build_position_index(&parse_result.decls);
-        position_index.finalize();
-
-        let result = CompilationResult {
-            source: source.to_string(),
-            _decls: parse_result.decls,
-            typed,
-            diagnostics: diags.clone(),
-            position_index,
-            sibling_decl_names,
-        };
-
-        let mut compiled = self.compiled.write().unwrap();
-        compiled.insert(uri.clone(), result);
-
-        diags
+    /// Read the current live text (most recent keystrokes).
+    pub async fn get_text(&self, uri: &Url) -> Option<String> {
+        self.documents.read().await.get(uri).map(|d| d.text.clone())
     }
 }
 
-/// Build sibling declaration name mapping for cross-file navigation.
+/// All outputs of one analysis pass.
+struct PipelineOutput {
+    version: i32,
+    source: String,
+    line_index: LineIndex,
+    diagnostics: Vec<rask_diagnostics::Diagnostic>,
+    /// Full CompilationResult when every stage succeeded far enough to produce
+    /// one. None means resolve failed — we still report diagnostics but leave
+    /// the last good cache in place.
+    result: Option<CompilationResult>,
+}
+
+impl PipelineOutput {
+    fn panic(source: &str, version: i32) -> Self {
+        let line_index = LineIndex::new(source);
+        let diag = rask_diagnostics::Diagnostic::error(
+            "rask-lsp: analyzer panicked (this is a compiler bug)",
+        )
+        .with_code("E9999")
+        .with_primary(Span::new(0, 0), "");
+        Self {
+            version,
+            source: source.to_string(),
+            line_index,
+            diagnostics: vec![diag],
+            result: None,
+        }
+    }
+}
+
+/// Run lex → parse → desugar → resolve → typecheck → ownership → effects.
+///
+/// Never panics on its own input as long as the compiler doesn't; the caller
+/// wraps this in `catch_unwind` as a backstop.
+fn run_pipeline(uri: &Url, source: &str, version: i32) -> PipelineOutput {
+    let line_index = LineIndex::new(source);
+    let mut diags = Vec::new();
+
+    // --- Lex ---
+    let mut lexer = rask_lexer::Lexer::new(source);
+    let lex_result = lexer.tokenize();
+    dedupe_by_line(&lex_result.errors, |e| e.span.start, &line_index, &mut diags, |e| e.to_diagnostic());
+
+    // --- Parse ---
+    let mut parser = rask_parser::Parser::new(lex_result.tokens);
+    let mut parse_result = parser.parse();
+    dedupe_by_line(&parse_result.errors, |e| e.span.start, &line_index, &mut diags, |e| e.to_diagnostic());
+
+    if !parse_result.is_ok() {
+        return PipelineOutput {
+            version,
+            source: source.to_string(),
+            line_index,
+            diagnostics: diags,
+            result: None,
+        };
+    }
+
+    // --- Comptime cfg elimination ---
+    let cfg = rask_comptime::CfgConfig::from_host("debug", vec![]);
+    rask_comptime::eliminate_comptime_if(&mut parse_result.decls, &cfg);
+
+    // --- Desugar (operators + default/named args) ---
+    let desugar_errors = rask_desugar::desugar_with_diagnostics(&mut parse_result.decls);
+    rask_desugar::desugar_default_args(&mut parse_result.decls);
+    for e in &desugar_errors {
+        diags.push(
+            rask_diagnostics::Diagnostic::error(e.message.clone())
+                .with_code("E0338")
+                .with_primary(e.span, "variant needs @message(\"...\") annotation"),
+        );
+    }
+
+    let current_file_spans: Vec<Span> = parse_result.decls.iter().map(|d| d.span).collect();
+
+    // --- Package context (if this file lives under a build.rk tree) ---
+    let file_path_str = uri.to_file_path()
+        .map(|p| p.to_string_lossy().to_string())
+        .unwrap_or_default();
+    let pkg_ctx = rask_compiler::detect_package(&file_path_str);
+    let sibling_decl_names = if let Some(ref ctx) = pkg_ctx {
+        build_sibling_names(uri, ctx)
+    } else {
+        HashMap::new()
+    };
+
+    // --- Resolve ---
+    let is_stdlib = rask_stdlib::StubRegistry::is_stdlib_path(uri.path());
+    let resolved = if is_stdlib {
+        match rask_resolve::resolve_stdlib(&parse_result.decls) {
+            Ok(r) => r,
+            Err(errors) => {
+                for error in &errors {
+                    diags.push(error.to_diagnostic());
+                }
+                return PipelineOutput {
+                    version,
+                    source: source.to_string(),
+                    line_index,
+                    diagnostics: diags,
+                    result: None,
+                };
+            }
+        }
+    } else if let Some(ref ctx) = pkg_ctx {
+        let file_path = uri.to_file_path().unwrap_or_default();
+        let mut sibling_decls: Vec<Decl> = ctx.registry.get(ctx.root_id)
+            .map(|pkg| {
+                pkg.files.iter()
+                    .filter(|f| f.path != file_path)
+                    .flat_map(|f| f.decls.clone())
+                    .collect()
+            })
+            .unwrap_or_default();
+        rask_desugar::desugar_with_diagnostics(&mut sibling_decls);
+        rask_desugar::desugar_default_args(&mut sibling_decls);
+        parse_result.decls.extend(sibling_decls);
+
+        match rask_resolve::resolve_package_with_cfg(
+            &parse_result.decls,
+            &ctx.registry,
+            ctx.root_id,
+            cfg.to_cfg_values(),
+        ) {
+            Ok(r) => r,
+            Err(errors) => {
+                for error in &errors {
+                    let diag = error.to_diagnostic();
+                    if is_current_file_diagnostic(&diag, &current_file_spans) {
+                        diags.push(diag);
+                    }
+                }
+                return PipelineOutput {
+                    version,
+                    source: source.to_string(),
+                    line_index,
+                    diagnostics: diags,
+                    result: None,
+                };
+            }
+        }
+    } else {
+        match rask_resolve::resolve_with_cfg(&parse_result.decls, cfg.to_cfg_values()) {
+            Ok(r) => r,
+            Err(errors) => {
+                for error in &errors {
+                    diags.push(error.to_diagnostic());
+                }
+                return PipelineOutput {
+                    version,
+                    source: source.to_string(),
+                    line_index,
+                    diagnostics: diags,
+                    result: None,
+                };
+            }
+        }
+    };
+
+    if is_stdlib {
+        // Stdlib stubs are signatures only — no further analysis.
+        return PipelineOutput {
+            version,
+            source: source.to_string(),
+            line_index,
+            diagnostics: diags,
+            result: None,
+        };
+    }
+
+    // --- Typecheck (lenient so ownership/effects still run) ---
+    let stdlib_decls = rask_stdlib::StubRegistry::typecheck_decls();
+    let (typed, type_errors) =
+        rask_types::typecheck_with_stdlib_lenient(resolved, &parse_result.decls, &stdlib_decls);
+    for error in &type_errors {
+        let diag = error.to_diagnostic();
+        if is_current_file_diagnostic(&diag, &current_file_spans) {
+            diags.push(diag);
+        }
+    }
+
+    // --- Ownership ---
+    let ownership_result = rask_ownership::check_ownership(&typed, &parse_result.decls);
+    for error in &ownership_result.errors {
+        let diag = error.to_diagnostic();
+        if is_current_file_diagnostic(&diag, &current_file_spans) {
+            diags.push(diag);
+        }
+    }
+
+    // --- Effects (IO propagation + frozen check) ---
+    let (effects, effect_warnings) = rask_effects::infer_effects(&parse_result.decls);
+    for w in &effect_warnings {
+        let d = rask_diagnostics::Diagnostic::warning(&w.message)
+            .with_code(w.code)
+            .with_primary(w.span, format!("`{}` has IO effect", w.callee_name));
+        if is_current_file_diagnostic(&d, &current_file_spans) {
+            diags.push(d);
+        }
+    }
+    let frozen_diagnostics = rask_effects::frozen::check(&parse_result.decls, &effects);
+    for fd in &frozen_diagnostics {
+        let d = if fd.is_error {
+            rask_diagnostics::Diagnostic::error(&fd.message)
+        } else {
+            rask_diagnostics::Diagnostic::warning(&fd.message)
+        };
+        let d = d.with_code(fd.code).with_primary(fd.span, "");
+        if is_current_file_diagnostic(&d, &current_file_spans) {
+            diags.push(d);
+        }
+    }
+
+    let mut position_index = build_position_index(&parse_result.decls);
+    position_index.finalize();
+
+    let result = CompilationResult {
+        source: source.to_string(),
+        line_index: line_index.clone(),
+        decls: parse_result.decls,
+        current_file_spans,
+        typed,
+        diagnostics: diags.clone(),
+        position_index,
+        sibling_decl_names,
+    };
+
+    PipelineOutput {
+        version,
+        source: source.to_string(),
+        line_index,
+        diagnostics: diags,
+        result: Some(result),
+    }
+}
+
+/// Deduplicate errors that land on the same line — they tend to cascade
+/// after a single real problem, and a wall of them is noise.
+fn dedupe_by_line<E, F, G>(
+    errors: &[E],
+    span_start: F,
+    line_index: &LineIndex,
+    out: &mut Vec<rask_diagnostics::Diagnostic>,
+    to_diag: G,
+)
+where
+    F: Fn(&E) -> usize,
+    G: Fn(&E) -> rask_diagnostics::Diagnostic,
+{
+    let mut last_line: Option<u32> = None;
+    for e in errors {
+        let line = line_index.line_of_offset(span_start(e));
+        if last_line != Some(line) {
+            out.push(to_diag(e));
+            last_line = Some(line);
+        }
+    }
+}
+
 fn build_sibling_names(uri: &Url, ctx: &rask_compiler::PackageContext) -> HashMap<String, SiblingFile> {
     let file_path = match uri.to_file_path() {
         Ok(p) => p,
@@ -312,7 +453,6 @@ fn build_sibling_names(uri: &Url, ctx: &rask_compiler::PackageContext) -> HashMa
     names
 }
 
-/// Check if a diagnostic's primary span falls within one of the current file's decl spans.
 fn is_current_file_diagnostic(diag: &rask_diagnostics::Diagnostic, current_file_spans: &[Span]) -> bool {
     let primary_span = match diag.primary_span() {
         Some(s) => s,

--- a/compiler/crates/rask-lsp/src/completion.rs
+++ b/compiler/crates/rask-lsp/src/completion.rs
@@ -1,188 +1,146 @@
 // SPDX-License-Identifier: (MIT OR Apache-2.0)
-//! Dot-completion and identifier completion logic.
+//! Completion: dot-triggered (fields/methods) and identifier (symbols/keywords).
 
 use tower_lsp::lsp_types::*;
 use rask_types::{MethodSig, SelfParam, Type, TypeDef, TypeTable};
 
-use crate::backend::{Backend, CompilationResult};
+use crate::backend::CompilationResult;
 use crate::type_format::TypeFormatter;
 
-impl Backend {
-    /// Dot-completion: suggest fields and methods for the receiver type.
-    pub fn dot_completion(
-        &self,
-        source: &str,
-        offset: usize,
-        cached: &CompilationResult,
-    ) -> Option<CompletionResponse> {
-        let mut items = Vec::new();
+pub fn completion(
+    position: Position,
+    cached: &CompilationResult,
+    live_text: Option<&str>,
+    is_dot: bool,
+) -> Option<CompletionResponse> {
+    // Prefer the live text if we have it — dot completion cares about what
+    // the user just typed, which may be ahead of the last good compile.
+    let source = live_text.unwrap_or(&cached.source);
+    let idx = if live_text.is_some() {
+        crate::convert::LineIndex::new(source)
+    } else {
+        cached.line_index.clone()
+    };
+    let offset = idx.position_to_offset(source, position);
 
-        if let Some(receiver_type) = self.find_receiver_type(source, offset, cached) {
-            let formatter = TypeFormatter::new(&cached.typed.types);
-            collect_completions_for_type(
-                &receiver_type,
-                &formatter,
-                &cached.typed.types,
-                &mut items,
-            );
-        } else {
-            // Fallback: receiver might be a builtin module (fs, net, etc.)
-            let receiver_name = extract_receiver_ident(source, offset)?;
-            add_all_stub_methods(&receiver_name, &mut items);
-        }
-
-        if items.is_empty() { None } else { Some(CompletionResponse::Array(items)) }
-    }
-
-    /// Find the type of the expression before the dot at `offset`.
-    fn find_receiver_type(
-        &self,
-        source: &str,
-        offset: usize,
-        cached: &CompilationResult,
-    ) -> Option<Type> {
-        // offset points right after the dot trigger, so the dot is at offset-1
-        let before_dot = if offset > 0 && source.as_bytes().get(offset - 1) == Some(&b'.') {
-            offset - 1
-        } else {
-            offset
-        };
-
-        // Scan backwards to extract identifier before the dot
-        let text_before = &source[..before_dot];
-        let ident_end = text_before.len();
-        let ident_start = text_before
-            .rfind(|c: char| !c.is_alphanumeric() && c != '_')
-            .map(|i| i + 1)
-            .unwrap_or(0);
-        let ident = &text_before[ident_start..ident_end];
-
-        if ident.is_empty() {
-            return None;
-        }
-
-        // Look up identifier in cached position index by name
-        for (_span, node_id, name) in &cached.position_index.idents {
-            if name == ident {
-                if let Some(ty) = cached.typed.node_types.get(node_id) {
-                    return Some(ty.clone());
-                }
-            }
-        }
-
-        // Try as a type name (e.g., Vec.new(), string.new())
-        cached.typed.types.lookup(ident)
-    }
-
-    /// Identifier completion: suggest all symbols and keywords.
-    pub fn identifier_completion(
-        &self,
-        source: &str,
-        offset: usize,
-        cached: &CompilationResult,
-    ) -> Option<CompletionResponse> {
-        // Extract partial identifier being typed
-        let text_before = &source[..offset];
-        let prefix_start = text_before
-            .rfind(|c: char| !c.is_alphanumeric() && c != '_')
-            .map(|i| i + 1)
-            .unwrap_or(0);
-        let prefix = &text_before[prefix_start..];
-
-        let mut items = Vec::new();
-        let mut seen = std::collections::HashSet::new();
-
-        // Symbols from the symbol table
-        for symbol in cached.typed.symbols.iter() {
-            if symbol.name.is_empty() || symbol.name.starts_with('_') {
-                continue;
-            }
-            if !prefix.is_empty() && !symbol.name.starts_with(prefix) {
-                continue;
-            }
-            if !seen.insert(symbol.name.clone()) {
-                continue;
-            }
-
-            let (kind, detail) = match &symbol.kind {
-                rask_resolve::SymbolKind::Function { .. } => {
-                    (CompletionItemKind::FUNCTION, "func".to_string())
-                }
-                rask_resolve::SymbolKind::Struct { .. } => {
-                    (CompletionItemKind::STRUCT, "struct".to_string())
-                }
-                rask_resolve::SymbolKind::Enum { .. } => {
-                    (CompletionItemKind::ENUM, "enum".to_string())
-                }
-                rask_resolve::SymbolKind::Trait { .. } => {
-                    (CompletionItemKind::INTERFACE, "trait".to_string())
-                }
-                rask_resolve::SymbolKind::Variable { mutable } => {
-                    let kw = if *mutable { "let" } else { "const" };
-                    (CompletionItemKind::VARIABLE, kw.to_string())
-                }
-                rask_resolve::SymbolKind::Parameter { .. } => {
-                    (CompletionItemKind::VARIABLE, "param".to_string())
-                }
-                rask_resolve::SymbolKind::EnumVariant { .. } => {
-                    (CompletionItemKind::ENUM_MEMBER, "variant".to_string())
-                }
-                rask_resolve::SymbolKind::BuiltinType { .. } => {
-                    (CompletionItemKind::CLASS, "type".to_string())
-                }
-                rask_resolve::SymbolKind::BuiltinFunction { .. } => {
-                    (CompletionItemKind::FUNCTION, "builtin".to_string())
-                }
-                rask_resolve::SymbolKind::BuiltinModule { .. } => {
-                    (CompletionItemKind::MODULE, "module".to_string())
-                }
-                rask_resolve::SymbolKind::ExternalPackage { .. } => {
-                    (CompletionItemKind::MODULE, "package".to_string())
-                }
-                rask_resolve::SymbolKind::ExternFunction { .. } => {
-                    (CompletionItemKind::FUNCTION, "extern func".to_string())
-                }
-                rask_resolve::SymbolKind::TypeAlias { .. } => {
-                    (CompletionItemKind::CLASS, "type alias".to_string())
-                }
-                rask_resolve::SymbolKind::CNamespace { .. } => {
-                    (CompletionItemKind::MODULE, "c namespace".to_string())
-                }
-                rask_resolve::SymbolKind::Field { .. } => continue,
-            };
-
-            items.push(CompletionItem {
-                label: symbol.name.clone(),
-                kind: Some(kind),
-                detail: Some(detail),
-                ..Default::default()
-            });
-        }
-
-        // Rask keywords
-        let keywords = [
-            "const", "let", "func", "struct", "enum", "trait", "extend",
-            "if", "else", "match", "for", "while", "loop", "return",
-            "try", "ensure", "import", "public", "spawn", "with",
-        ];
-        for kw in &keywords {
-            if prefix.is_empty() || kw.starts_with(prefix) {
-                if seen.insert(kw.to_string()) {
-                    items.push(CompletionItem {
-                        label: kw.to_string(),
-                        kind: Some(CompletionItemKind::KEYWORD),
-                        ..Default::default()
-                    });
-                }
-            }
-        }
-
-        Some(CompletionResponse::Array(items))
+    if is_dot {
+        dot_completion(source, offset, cached)
+    } else {
+        identifier_completion(source, offset, cached)
     }
 }
 
-/// Collect completion items for a given type (fields, methods, stdlib methods).
-fn collect_completions_for_type(
+fn dot_completion(source: &str, offset: usize, cached: &CompilationResult) -> Option<CompletionResponse> {
+    let mut items = Vec::new();
+
+    if let Some(receiver_type) = find_receiver_type(source, offset, cached) {
+        let formatter = TypeFormatter::new(&cached.typed.types);
+        collect_for_type(&receiver_type, &formatter, &cached.typed.types, &mut items);
+    } else {
+        let receiver_name = extract_receiver_ident(source, offset)?;
+        add_all_stub_methods(&receiver_name, &mut items);
+    }
+
+    if items.is_empty() { None } else { Some(CompletionResponse::Array(items)) }
+}
+
+fn find_receiver_type(source: &str, offset: usize, cached: &CompilationResult) -> Option<Type> {
+    let before_dot = if offset > 0 && source.as_bytes().get(offset - 1) == Some(&b'.') {
+        offset - 1
+    } else {
+        offset
+    };
+    let text_before = source.get(..before_dot)?;
+    let ident_start = text_before
+        .rfind(|c: char| !c.is_alphanumeric() && c != '_')
+        .map(|i| i + 1)
+        .unwrap_or(0);
+    let ident = &text_before[ident_start..];
+    if ident.is_empty() {
+        return None;
+    }
+    for (_span, node_id, name) in &cached.position_index.idents {
+        if name == ident {
+            if let Some(ty) = cached.typed.node_types.get(node_id) {
+                return Some(ty.clone());
+            }
+        }
+    }
+    cached.typed.types.lookup(ident)
+}
+
+fn identifier_completion(source: &str, offset: usize, cached: &CompilationResult) -> Option<CompletionResponse> {
+    let text_before = source.get(..offset).unwrap_or("");
+    let prefix_start = text_before
+        .rfind(|c: char| !c.is_alphanumeric() && c != '_')
+        .map(|i| i + 1)
+        .unwrap_or(0);
+    let prefix = &text_before[prefix_start..];
+
+    let mut items = Vec::new();
+    let mut seen = std::collections::HashSet::new();
+
+    for symbol in cached.typed.symbols.iter() {
+        if symbol.name.is_empty() || symbol.name.starts_with('_') {
+            continue;
+        }
+        if !prefix.is_empty() && !symbol.name.starts_with(prefix) {
+            continue;
+        }
+        if !seen.insert(symbol.name.clone()) {
+            continue;
+        }
+
+        let (kind, detail) = match &symbol.kind {
+            rask_resolve::SymbolKind::Function { .. } => (CompletionItemKind::FUNCTION, "func".to_string()),
+            rask_resolve::SymbolKind::Struct { .. } => (CompletionItemKind::STRUCT, "struct".to_string()),
+            rask_resolve::SymbolKind::Enum { .. } => (CompletionItemKind::ENUM, "enum".to_string()),
+            rask_resolve::SymbolKind::Trait { .. } => (CompletionItemKind::INTERFACE, "trait".to_string()),
+            rask_resolve::SymbolKind::Variable { mutable } => {
+                let kw = if *mutable { "let" } else { "const" };
+                (CompletionItemKind::VARIABLE, kw.to_string())
+            }
+            rask_resolve::SymbolKind::Parameter { .. } => (CompletionItemKind::VARIABLE, "param".to_string()),
+            rask_resolve::SymbolKind::EnumVariant { .. } => (CompletionItemKind::ENUM_MEMBER, "variant".to_string()),
+            rask_resolve::SymbolKind::BuiltinType { .. } => (CompletionItemKind::CLASS, "type".to_string()),
+            rask_resolve::SymbolKind::BuiltinFunction { .. } => (CompletionItemKind::FUNCTION, "builtin".to_string()),
+            rask_resolve::SymbolKind::BuiltinModule { .. } => (CompletionItemKind::MODULE, "module".to_string()),
+            rask_resolve::SymbolKind::ExternalPackage { .. } => (CompletionItemKind::MODULE, "package".to_string()),
+            rask_resolve::SymbolKind::ExternFunction { .. } => (CompletionItemKind::FUNCTION, "extern func".to_string()),
+            rask_resolve::SymbolKind::TypeAlias { .. } => (CompletionItemKind::CLASS, "type alias".to_string()),
+            rask_resolve::SymbolKind::CNamespace { .. } => (CompletionItemKind::MODULE, "c namespace".to_string()),
+            rask_resolve::SymbolKind::Field { .. } => continue,
+        };
+
+        items.push(CompletionItem {
+            label: symbol.name.clone(),
+            kind: Some(kind),
+            detail: Some(detail),
+            ..Default::default()
+        });
+    }
+
+    let keywords = [
+        "const", "let", "func", "struct", "enum", "trait", "extend",
+        "if", "else", "match", "for", "while", "loop", "return",
+        "try", "ensure", "import", "public", "spawn", "with",
+    ];
+    for kw in &keywords {
+        if prefix.is_empty() || kw.starts_with(prefix) {
+            if seen.insert(kw.to_string()) {
+                items.push(CompletionItem {
+                    label: kw.to_string(),
+                    kind: Some(CompletionItemKind::KEYWORD),
+                    ..Default::default()
+                });
+            }
+        }
+    }
+
+    Some(CompletionResponse::Array(items))
+}
+
+fn collect_for_type(
     ty: &Type,
     formatter: &TypeFormatter,
     types: &TypeTable,
@@ -192,15 +150,14 @@ fn collect_completions_for_type(
         Type::Named(id) => {
             if let Some(def) = types.get(*id) {
                 let type_name = types.type_name(*id);
-                add_typedef_completions(def, formatter, items);
-                // Also add stdlib methods for well-known types (Vec, Map, etc.)
+                add_typedef(def, formatter, items);
                 add_stdlib_methods(&type_name, items);
             }
         }
         Type::Generic { base, .. } => {
             if let Some(def) = types.get(*base) {
                 let type_name = types.type_name(*base);
-                add_typedef_completions(def, formatter, items);
+                add_typedef(def, formatter, items);
                 add_stdlib_methods(&type_name, items);
             }
         }
@@ -212,12 +169,7 @@ fn collect_completions_for_type(
     }
 }
 
-/// Add fields and methods from a TypeDef.
-fn add_typedef_completions(
-    def: &TypeDef,
-    formatter: &TypeFormatter,
-    items: &mut Vec<CompletionItem>,
-) {
+fn add_typedef(def: &TypeDef, formatter: &TypeFormatter, items: &mut Vec<CompletionItem>) {
     match def {
         TypeDef::Struct { fields, methods, .. } => {
             for (name, field_ty) in fields {
@@ -239,11 +191,7 @@ fn add_typedef_completions(
                 let detail = if fields.is_empty() {
                     name.clone()
                 } else {
-                    let args = fields
-                        .iter()
-                        .map(|t| formatter.format(t))
-                        .collect::<Vec<_>>()
-                        .join(", ");
+                    let args = fields.iter().map(|t| formatter.format(t)).collect::<Vec<_>>().join(", ");
                     format!("{}({})", name, args)
                 };
                 items.push(CompletionItem {
@@ -275,7 +223,6 @@ fn add_typedef_completions(
             }
         }
         TypeDef::NominalAlias { underlying, .. } => {
-            // .value extracts the underlying type
             items.push(CompletionItem {
                 label: "value".to_string(),
                 kind: Some(CompletionItemKind::FIELD),
@@ -286,16 +233,12 @@ fn add_typedef_completions(
     }
 }
 
-/// Convert a MethodSig to a CompletionItem.
 fn method_to_completion(sig: &MethodSig, formatter: &TypeFormatter) -> CompletionItem {
-    let params_str = sig
-        .params
-        .iter()
-        .map(|(ty, _mode)| formatter.format(ty))
+    let params_str = sig.params.iter()
+        .map(|(ty, _)| formatter.format(ty))
         .collect::<Vec<_>>()
         .join(", ");
     let detail = format!("({}) -> {}", params_str, formatter.format(&sig.ret));
-
     CompletionItem {
         label: sig.name.clone(),
         kind: Some(CompletionItemKind::METHOD),
@@ -310,20 +253,16 @@ fn method_to_completion(sig: &MethodSig, formatter: &TypeFormatter) -> Completio
     }
 }
 
-/// Add stdlib methods for well-known builtin types (instance methods only).
 fn add_stdlib_methods(type_name: &str, items: &mut Vec<CompletionItem>) {
     add_stub_methods_filtered(type_name, items, true);
 }
 
-/// Add all stub methods for a type/module (no self filter — for modules).
 fn add_all_stub_methods(type_name: &str, items: &mut Vec<CompletionItem>) {
     add_stub_methods_filtered(type_name, items, false);
 }
 
-/// Add stub methods, optionally filtering to self-methods only.
 fn add_stub_methods_filtered(type_name: &str, items: &mut Vec<CompletionItem>, self_only: bool) {
     let methods = rask_stdlib::methods_for(type_name);
-
     for method in methods {
         if self_only && !method.takes_self {
             continue;
@@ -331,25 +270,17 @@ fn add_stub_methods_filtered(type_name: &str, items: &mut Vec<CompletionItem>, s
         if items.iter().any(|i| i.label == method.name) {
             continue;
         }
-        let params_str = method
-            .params
-            .iter()
-            .map(|(name, ty)| format!("{}: {}", name, ty))
+        let params_str = method.params.iter()
+            .map(|(n, t)| format!("{}: {}", n, t))
             .collect::<Vec<_>>()
             .join(", ");
         let detail = format!("({}) -> {}", params_str, method.ret_ty);
-        let kind = if self_only {
-            CompletionItemKind::METHOD
-        } else {
-            CompletionItemKind::FUNCTION
-        };
+        let kind = if self_only { CompletionItemKind::METHOD } else { CompletionItemKind::FUNCTION };
         items.push(CompletionItem {
             label: method.name.clone(),
             kind: Some(kind),
             detail: Some(detail),
-            documentation: method.doc.as_ref().map(|d| {
-                Documentation::String(d.clone())
-            }),
+            documentation: method.doc.as_ref().map(|d| Documentation::String(d.clone())),
             insert_text: Some(if method.params.is_empty() {
                 format!("{}()", method.name)
             } else {
@@ -361,20 +292,18 @@ fn add_stub_methods_filtered(type_name: &str, items: &mut Vec<CompletionItem>, s
     }
 }
 
-/// Extract the identifier before the dot at `offset`.
 fn extract_receiver_ident(source: &str, offset: usize) -> Option<String> {
     let before_dot = if offset > 0 && source.as_bytes().get(offset - 1) == Some(&b'.') {
         offset - 1
     } else {
         offset
     };
-    let text_before = &source[..before_dot];
-    let ident_end = text_before.len();
+    let text_before = source.get(..before_dot)?;
     let ident_start = text_before
         .rfind(|c: char| !c.is_alphanumeric() && c != '_')
         .map(|i| i + 1)
         .unwrap_or(0);
-    let ident = &text_before[ident_start..ident_end];
+    let ident = &text_before[ident_start..];
     if ident.is_empty() { None } else { Some(ident.to_string()) }
 }
 
@@ -382,139 +311,43 @@ fn extract_receiver_ident(source: &str, offset: usize) -> Option<String> {
 mod tests {
     use super::*;
 
-    // ─── extract_receiver_ident ─────────────────────────────
-
     #[test]
     fn extract_simple_ident() {
-        // "foo." with offset at position after dot
-        let source = "foo.";
-        assert_eq!(extract_receiver_ident(source, 4), Some("foo".to_string()));
+        assert_eq!(extract_receiver_ident("foo.", 4), Some("foo".to_string()));
     }
 
     #[test]
     fn extract_ident_with_prefix() {
-        let source = "    myVar.";
-        assert_eq!(extract_receiver_ident(source, 10), Some("myVar".to_string()));
-    }
-
-    #[test]
-    fn extract_ident_in_expression() {
-        let source = "const x = items.";
-        assert_eq!(extract_receiver_ident(source, 16), Some("items".to_string()));
+        assert_eq!(extract_receiver_ident("    myVar.", 10), Some("myVar".to_string()));
     }
 
     #[test]
     fn extract_empty_at_start() {
-        let source = ".foo";
-        assert_eq!(extract_receiver_ident(source, 1), None);
-    }
-
-    // ─── Stub-based completion ──────────────────────────────
-
-    fn get_stub_completions(type_name: &str) -> Vec<String> {
-        let mut items = Vec::new();
-        add_all_stub_methods(type_name, &mut items);
-        items.iter().map(|i| i.label.clone()).collect()
-    }
-
-    fn get_instance_completions(type_name: &str) -> Vec<String> {
-        let mut items = Vec::new();
-        add_stdlib_methods(type_name, &mut items);
-        items.iter().map(|i| i.label.clone()).collect()
+        assert_eq!(extract_receiver_ident(".foo", 1), None);
     }
 
     #[test]
-    fn vec_completion_includes_core_methods() {
-        let items = get_instance_completions("Vec");
-        assert!(items.contains(&"push".to_string()), "missing push in {:?}", items);
-        assert!(items.contains(&"pop".to_string()), "missing pop in {:?}", items);
-        assert!(items.contains(&"len".to_string()), "missing len in {:?}", items);
-        assert!(items.contains(&"is_empty".to_string()), "missing is_empty in {:?}", items);
-    }
-
-    #[test]
-    fn vec_completion_excludes_static_new() {
-        // Instance completions should not include static method `new`
-        let items = get_instance_completions("Vec");
-        assert!(!items.contains(&"new".to_string()),
-            "instance completion should not include static new");
-    }
-
-    #[test]
-    fn vec_static_includes_new() {
-        // All methods (module-style) should include `new`
-        let items = get_stub_completions("Vec");
-        assert!(items.contains(&"new".to_string()), "should include new: {:?}", items);
-    }
-
-    #[test]
-    fn map_completion_includes_core_methods() {
-        let items = get_instance_completions("Map");
-        assert!(items.contains(&"insert".to_string()), "missing insert in {:?}", items);
-        assert!(items.contains(&"get".to_string()), "missing get in {:?}", items);
-        assert!(items.contains(&"len".to_string()), "missing len in {:?}", items);
-        assert!(items.contains(&"contains_key".to_string()), "missing contains_key in {:?}", items);
-    }
-
-    #[test]
-    fn string_completion_includes_core_methods() {
-        let items = get_instance_completions("string");
-        assert!(items.contains(&"len".to_string()), "missing len in {:?}", items);
-        assert!(items.contains(&"contains".to_string()), "missing contains in {:?}", items);
-        assert!(items.contains(&"trim".to_string()), "missing trim in {:?}", items);
-    }
-
-    #[test]
-    fn option_completion_includes_core_methods() {
-        let items = get_instance_completions("Option");
-        assert!(items.contains(&"unwrap".to_string()), "missing unwrap in {:?}", items);
-        assert!(items.contains(&"is_some".to_string()), "missing is_some in {:?}", items);
-        assert!(items.contains(&"map".to_string()), "missing map in {:?}", items);
-    }
-
-    #[test]
-    fn result_completion_includes_core_methods() {
-        let items = get_instance_completions("Result");
-        assert!(items.contains(&"unwrap".to_string()), "missing unwrap in {:?}", items);
-        assert!(items.contains(&"is_ok".to_string()), "missing is_ok in {:?}", items);
-        assert!(items.contains(&"map".to_string()), "missing map in {:?}", items);
-    }
-
-    #[test]
-    fn fs_module_completion_includes_functions() {
-        let items = get_stub_completions("fs");
-        assert!(items.contains(&"read_file".to_string()), "missing read_file in {:?}", items);
-        assert!(items.contains(&"write_file".to_string()), "missing write_file in {:?}", items);
-        assert!(items.contains(&"exists".to_string()), "missing exists in {:?}", items);
-    }
-
-    #[test]
-    fn completion_items_have_detail() {
+    fn vec_completion_core_methods() {
         let mut items = Vec::new();
         add_stdlib_methods("Vec", &mut items);
-        let push = items.iter().find(|i| i.label == "push")
-            .expect("should have push");
-        assert!(push.detail.is_some(), "push should have detail/signature");
+        let labels: Vec<_> = items.iter().map(|i| i.label.clone()).collect();
+        for expected in &["push", "pop", "len", "is_empty"] {
+            assert!(labels.contains(&expected.to_string()), "missing {}", expected);
+        }
     }
 
     #[test]
-    fn completion_items_have_insert_text() {
+    fn static_new_excluded_from_instance() {
         let mut items = Vec::new();
         add_stdlib_methods("Vec", &mut items);
-        let push = items.iter().find(|i| i.label == "push")
-            .expect("should have push");
-        assert!(push.insert_text.is_some(), "push should have insert text");
-        let text = push.insert_text.as_ref().unwrap();
-        assert!(text.starts_with("push("), "insert text should be push(...): {}", text);
+        assert!(!items.iter().any(|i| i.label == "new"));
     }
 
     #[test]
-    fn no_duplicate_completions() {
+    fn no_duplicates() {
         let mut items = Vec::new();
         add_stdlib_methods("Vec", &mut items);
-        // Add again — should not create duplicates
         add_stdlib_methods("Vec", &mut items);
-        let push_count = items.iter().filter(|i| i.label == "push").count();
-        assert_eq!(push_count, 1, "should not have duplicate push");
+        assert_eq!(items.iter().filter(|i| i.label == "push").count(), 1);
     }
 }

--- a/compiler/crates/rask-lsp/src/convert.rs
+++ b/compiler/crates/rask-lsp/src/convert.rs
@@ -1,67 +1,210 @@
 // SPDX-License-Identifier: (MIT OR Apache-2.0)
 //! LSP protocol conversion utilities.
+//!
+//! LSP v3.17 defaults to UTF-16 for positions. VS Code sends positions as
+//! (line, character-in-UTF-16-code-units), but the compiler operates on UTF-8
+//! byte offsets. A mismatch causes slice panics on emoji, accented letters,
+//! and CJK text.
+//!
+//! `LineIndex` does the translation in one place. Build it once per document
+//! version and reuse for all conversions in that pass — avoids repeated O(n)
+//! scans of the source.
 
 use tower_lsp::lsp_types::*;
 use rask_diagnostics::LabelStyle;
 
-/// Convert LSP Position (line/col) to byte offset.
-pub fn position_to_offset(source: &str, pos: Position) -> usize {
-    let mut line = 0u32;
-    let mut col = 0u32;
+use rask_ast::Span as RaskSpan;
 
-    for (i, ch) in source.char_indices() {
-        if line == pos.line && col == pos.character {
-            return i;
-        }
-        if ch == '\n' {
-            line += 1;
-            col = 0;
-        } else {
-            col += 1;
-        }
-    }
-    source.len()
+/// Line-by-line UTF-8/UTF-16 index for a document.
+///
+/// For each line we remember the byte offset at which it starts and
+/// whether the line is pure ASCII. Pure-ASCII lines skip the per-char
+/// scan — in practice this is 95%+ of lines in most codebases.
+#[derive(Debug, Clone)]
+pub struct LineIndex {
+    /// Byte offset at which each line starts. Always has len = line_count + 1,
+    /// with the last entry pointing just past the end of the source.
+    line_starts: Vec<u32>,
+    /// Per-line ASCII flag. True = line is pure ASCII (byte col == UTF-16 col
+    /// == char col).
+    ascii_only: Vec<bool>,
+    source_len: u32,
 }
 
-/// Convert byte offset to LSP Position.
-pub fn byte_offset_to_position(source: &str, offset: usize) -> Position {
-    let mut line = 0u32;
-    let mut col = 0u32;
+impl LineIndex {
+    pub fn new(source: &str) -> Self {
+        let bytes = source.as_bytes();
+        let mut line_starts = Vec::with_capacity(source.len() / 32 + 1);
+        let mut ascii_only = Vec::with_capacity(source.len() / 32 + 1);
+        line_starts.push(0u32);
 
-    for (i, ch) in source.char_indices() {
-        if i >= offset {
-            break;
+        let mut line_is_ascii = true;
+        for (i, &b) in bytes.iter().enumerate() {
+            if b >= 0x80 {
+                line_is_ascii = false;
+            }
+            if b == b'\n' {
+                ascii_only.push(line_is_ascii);
+                line_starts.push((i + 1) as u32);
+                line_is_ascii = true;
+            }
         }
-        if ch == '\n' {
-            line += 1;
-            col = 0;
-        } else {
-            col += 1;
+        ascii_only.push(line_is_ascii);
+        // Sentinel pointing past the last byte.
+        line_starts.push(bytes.len() as u32);
+
+        Self {
+            line_starts,
+            ascii_only,
+            source_len: bytes.len() as u32,
         }
     }
 
-    Position::new(line, col)
+    pub fn line_count(&self) -> u32 {
+        self.ascii_only.len() as u32
+    }
+
+    /// Line (0-based) that contains the given byte offset.
+    pub fn line_of_offset(&self, offset: usize) -> u32 {
+        let offset = (offset as u32).min(self.source_len);
+        match self.line_starts.binary_search(&offset) {
+            Ok(i) => (i as u32).min(self.line_count().saturating_sub(1)),
+            Err(i) => (i.saturating_sub(1)) as u32,
+        }
+    }
+
+    /// Byte offset → LSP Position (UTF-16).
+    ///
+    /// Out-of-range offsets clamp to the end of the document.
+    pub fn offset_to_position(&self, source: &str, offset: usize) -> Position {
+        let offset = (offset as u32).min(self.source_len);
+        let line_idx = match self.line_starts.binary_search(&offset) {
+            Ok(i) => {
+                // An exact hit on a line start (including sentinel); if this
+                // is the sentinel row past EOF, back off to the last real line.
+                if i == self.line_count() as usize {
+                    i - 1
+                } else if i < self.line_count() as usize
+                    && self.line_starts[i] == offset
+                {
+                    i
+                } else {
+                    i.saturating_sub(1)
+                }
+            }
+            Err(i) => i.saturating_sub(1),
+        };
+        let line = line_idx as u32;
+        let line_start = self.line_starts[line_idx] as usize;
+        let col_byte = offset as usize - line_start;
+
+        let character = if *self.ascii_only.get(line_idx).unwrap_or(&true) {
+            col_byte as u32
+        } else {
+            // Walk the line counting UTF-16 code units.
+            let line_end = self.line_starts[line_idx + 1] as usize;
+            let line_slice = &source[line_start..line_end.min(source.len())];
+            utf16_units_for_bytes(line_slice, col_byte)
+        };
+
+        Position::new(line, character)
+    }
+
+    /// LSP Position (UTF-16) → byte offset.
+    ///
+    /// Out-of-range positions clamp to the end of the target line (or the end
+    /// of the document if the line is beyond EOF). Always returns an offset on
+    /// a valid UTF-8 char boundary — safe to slice the source at this point.
+    pub fn position_to_offset(&self, source: &str, pos: Position) -> usize {
+        if pos.line >= self.line_count() {
+            return self.source_len as usize;
+        }
+        let line_idx = pos.line as usize;
+        let line_start = self.line_starts[line_idx] as usize;
+        let line_end = self.line_starts[line_idx + 1] as usize;
+        // Trim trailing newline from the logical line length.
+        let logical_end = if line_end > line_start
+            && source.as_bytes().get(line_end - 1) == Some(&b'\n')
+        {
+            line_end - 1
+        } else {
+            line_end
+        };
+
+        let line_slice = &source[line_start..logical_end.min(source.len())];
+        let col_byte = if *self.ascii_only.get(line_idx).unwrap_or(&true) {
+            (pos.character as usize).min(line_slice.len())
+        } else {
+            bytes_for_utf16_units(line_slice, pos.character)
+        };
+        line_start + col_byte
+    }
+
+    /// Converts a rask Span to an LSP Range.
+    pub fn span_to_range(&self, source: &str, span: RaskSpan) -> Range {
+        Range::new(
+            self.offset_to_position(source, span.start),
+            self.offset_to_position(source, span.end),
+        )
+    }
 }
 
-/// Convert a rask diagnostic to an LSP diagnostic.
+/// Count UTF-16 code units corresponding to the first `byte_col` bytes of `line`.
+fn utf16_units_for_bytes(line: &str, byte_col: usize) -> u32 {
+    let clamped = byte_col.min(line.len());
+    // Guard: clamped might land mid-char on an invalid offset. Round down to
+    // the nearest char boundary so we never produce bogus counts.
+    let safe = floor_char_boundary(line, clamped);
+    let mut units = 0u32;
+    for ch in line[..safe].chars() {
+        units += ch.len_utf16() as u32;
+    }
+    units
+}
+
+/// Find the largest byte offset `<= target` that is a UTF-8 char boundary.
+fn floor_char_boundary(s: &str, target: usize) -> usize {
+    if target >= s.len() {
+        return s.len();
+    }
+    let mut i = target;
+    while i > 0 && !s.is_char_boundary(i) {
+        i -= 1;
+    }
+    i
+}
+
+/// Walk `line` UTF-16 code unit by code unit, stopping after `target_units`.
+/// Returns the byte offset reached. Clamps to end-of-line.
+fn bytes_for_utf16_units(line: &str, target_units: u32) -> usize {
+    let mut seen_units = 0u32;
+    for (byte_idx, ch) in line.char_indices() {
+        let ch_units = ch.len_utf16() as u32;
+        if seen_units + ch_units > target_units {
+            return byte_idx;
+        }
+        seen_units += ch_units;
+    }
+    line.len()
+}
+
+// ─── Diagnostic conversion ────────────────────────────────────────────────
+
 pub fn to_lsp_diagnostic(
+    index: &LineIndex,
     source: &str,
     uri: &Url,
     diag: &rask_diagnostics::Diagnostic,
 ) -> Diagnostic {
-    // Primary span determines the main range
     let primary = diag
         .labels
         .iter()
         .find(|l| l.style == LabelStyle::Primary)
         .or(diag.labels.first());
 
-    let range = if let Some(label) = primary {
-        let start = byte_offset_to_position(source, label.span.start);
-        let end = byte_offset_to_position(source, label.span.end);
-        Range::new(start, end)
-    } else {
-        Range::new(Position::new(0, 0), Position::new(0, 0))
+    let range = match primary {
+        Some(l) => index.span_to_range(source, l.span),
+        None => Range::new(Position::new(0, 0), Position::new(0, 0)),
     };
 
     let severity = Some(match diag.severity {
@@ -70,43 +213,32 @@ pub fn to_lsp_diagnostic(
         rask_diagnostics::Severity::Note => DiagnosticSeverity::INFORMATION,
     });
 
-    let code = diag
-        .code
-        .as_ref()
-        .map(|c| NumberOrString::String(c.0.clone()));
+    let code = diag.code.as_ref().map(|c| NumberOrString::String(c.0.clone()));
 
-    // Build message: main message + primary label + notes + help
+    // Assemble the message: header + label note + notes + help.
     let mut message = diag.message.clone();
-
     if let Some(label) = primary {
         if let Some(ref msg) = label.message {
             message = format!("{}: {}", message, msg);
         }
     }
-
     for note in &diag.notes {
-        message = format!("{}\n\nnote: {}", message, note);
+        message.push_str(&format!("\n\nnote: {}", note));
     }
-
     if let Some(ref help) = diag.help {
-        message = format!("{}\n\nhelp: {}", message, help.message);
+        message.push_str(&format!("\n\nhelp: {}", help.message));
     }
 
-    // Secondary labels become related information
     let related_information: Vec<DiagnosticRelatedInformation> = diag
         .labels
         .iter()
         .filter(|l| l.style == LabelStyle::Secondary)
-        .map(|l| {
-            let start = byte_offset_to_position(source, l.span.start);
-            let end = byte_offset_to_position(source, l.span.end);
-            DiagnosticRelatedInformation {
-                location: Location {
-                    uri: uri.clone(),
-                    range: Range::new(start, end),
-                },
-                message: l.message.clone().unwrap_or_default(),
-            }
+        .map(|l| DiagnosticRelatedInformation {
+            location: Location {
+                uri: uri.clone(),
+                range: index.span_to_range(source, l.span),
+            },
+            message: l.message.clone().unwrap_or_default(),
         })
         .collect();
 
@@ -127,7 +259,81 @@ pub fn to_lsp_diagnostic(
     }
 }
 
-/// Check if two ranges overlap.
 pub fn ranges_overlap(r1: Range, r2: Range) -> bool {
     !(r1.end < r2.start || r2.end < r1.start)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn idx(s: &str) -> (LineIndex, String) {
+        (LineIndex::new(s), s.to_string())
+    }
+
+    #[test]
+    fn ascii_positions_roundtrip() {
+        let (li, s) = idx("abc\ndef\nghi");
+        assert_eq!(li.offset_to_position(&s, 0), Position::new(0, 0));
+        assert_eq!(li.offset_to_position(&s, 2), Position::new(0, 2));
+        assert_eq!(li.offset_to_position(&s, 4), Position::new(1, 0));
+        assert_eq!(li.offset_to_position(&s, 10), Position::new(2, 2));
+
+        assert_eq!(li.position_to_offset(&s, Position::new(0, 0)), 0);
+        assert_eq!(li.position_to_offset(&s, Position::new(1, 0)), 4);
+        assert_eq!(li.position_to_offset(&s, Position::new(2, 2)), 10);
+    }
+
+    #[test]
+    fn emoji_counts_as_two_utf16_units() {
+        // "🌍" is 4 UTF-8 bytes, 2 UTF-16 code units, 1 char.
+        let (li, s) = idx("a🌍b");
+        // Offset 0 → col 0
+        assert_eq!(li.offset_to_position(&s, 0), Position::new(0, 0));
+        // Offset 1 → col 1 (after 'a')
+        assert_eq!(li.offset_to_position(&s, 1), Position::new(0, 1));
+        // Offset 5 → col 3 (after emoji = 2 code units)
+        assert_eq!(li.offset_to_position(&s, 5), Position::new(0, 3));
+
+        // Position col 3 → byte offset 5
+        assert_eq!(li.position_to_offset(&s, Position::new(0, 3)), 5);
+        // Position col 1 → byte offset 1
+        assert_eq!(li.position_to_offset(&s, Position::new(0, 1)), 1);
+    }
+
+    #[test]
+    fn position_beyond_end_is_clamped() {
+        let (li, s) = idx("ab\ncd");
+        assert_eq!(li.position_to_offset(&s, Position::new(99, 99)), 5);
+        assert_eq!(li.position_to_offset(&s, Position::new(1, 99)), 5);
+    }
+
+    #[test]
+    fn position_inside_emoji_never_panics() {
+        // Offset 2 falls in the middle of "🌍" — should snap to 1 (before emoji).
+        let (li, s) = idx("🌍");
+        // LSP asks for col 1 — that's the high surrogate, our
+        // implementation snaps down to 0.
+        let off = li.position_to_offset(&s, Position::new(0, 1));
+        assert!(off == 0 || off == 4, "got {}", off);
+        assert!(s.is_char_boundary(off), "offset {} not a char boundary", off);
+    }
+
+    #[test]
+    fn multiline_with_emoji() {
+        let s = "héllo\n🌍world\nend";
+        let li = LineIndex::new(s);
+        // Line 1, col 1 (after 🌍 = 2 UTF-16 units)
+        let off = li.position_to_offset(s, Position::new(1, 2));
+        assert_eq!(off, 7 + 4); // "héllo\n" is 7 bytes, then 🌍 is 4 bytes
+        assert!(s.is_char_boundary(off));
+    }
+
+    #[test]
+    fn empty_source() {
+        let s = "";
+        let li = LineIndex::new(s);
+        assert_eq!(li.position_to_offset(s, Position::new(0, 0)), 0);
+        assert_eq!(li.offset_to_position(s, 0), Position::new(0, 0));
+    }
 }

--- a/compiler/crates/rask-lsp/src/format.rs
+++ b/compiler/crates/rask-lsp/src/format.rs
@@ -1,0 +1,19 @@
+// SPDX-License-Identifier: (MIT OR Apache-2.0)
+//! Format a whole document via rask-fmt.
+
+use tower_lsp::lsp_types::*;
+
+use crate::convert::LineIndex;
+
+pub fn format_document(source: &str) -> Option<Vec<TextEdit>> {
+    let formatted = rask_fmt::format_source(source);
+    if formatted == source {
+        return Some(Vec::new());
+    }
+    let idx = LineIndex::new(source);
+    let full = Range::new(
+        Position::new(0, 0),
+        idx.offset_to_position(source, source.len()),
+    );
+    Some(vec![TextEdit::new(full, formatted)])
+}

--- a/compiler/crates/rask-lsp/src/goto.rs
+++ b/compiler/crates/rask-lsp/src/goto.rs
@@ -1,0 +1,110 @@
+// SPDX-License-Identifier: (MIT OR Apache-2.0)
+//! Go-to-definition resolution.
+
+use tower_lsp::lsp_types::*;
+
+use crate::backend::CompilationResult;
+use crate::convert::LineIndex;
+
+pub fn goto_definition(
+    uri: &Url,
+    position: Position,
+    cached: &CompilationResult,
+    root_uri: Option<&Url>,
+) -> Option<GotoDefinitionResponse> {
+    let offset = cached
+        .line_index
+        .position_to_offset(&cached.source, position);
+
+    let (node_id, name) = cached.position_index.ident_at_position(offset)?;
+    let symbol = cached
+        .typed
+        .resolutions
+        .get(&node_id)
+        .and_then(|&sid| cached.typed.symbols.get(sid));
+
+    if let Some(symbol) = symbol {
+        // Builtin: navigate to stub file if available.
+        if symbol.span.start == 0 && symbol.span.end == 0 {
+            return resolve_builtin_location(&symbol.name, None, root_uri);
+        }
+
+        if let Some(sibling) = cached.sibling_decl_names.get(&symbol.name) {
+            if symbol.span.end <= sibling.source.len() {
+                let sibling_idx = LineIndex::new(&sibling.source);
+                let range = sibling_idx.span_to_range(&sibling.source, symbol.span);
+                let sibling_uri = Url::from_file_path(&sibling.path).unwrap_or_else(|_| uri.clone());
+                return Some(GotoDefinitionResponse::Scalar(Location {
+                    uri: sibling_uri,
+                    range,
+                }));
+            }
+        }
+
+        let range = cached.line_index.span_to_range(&cached.source, symbol.span);
+        return Some(GotoDefinitionResponse::Scalar(Location { uri: uri.clone(), range }));
+    }
+
+    // Method calls on builtins don't have a symbol — try the stub registry.
+    try_method_goto(&cached.source, offset, &name, cached, root_uri)
+}
+
+fn try_method_goto(
+    source: &str,
+    offset: usize,
+    method_name: &str,
+    cached: &CompilationResult,
+    root_uri: Option<&Url>,
+) -> Option<GotoDefinitionResponse> {
+    let (ident_span, _, _) = cached
+        .position_index
+        .idents
+        .iter()
+        .find(|(s, _, name)| s.start <= offset && offset <= s.end && name == method_name)?;
+
+    if ident_span.start == 0 {
+        return None;
+    }
+    if *source.as_bytes().get(ident_span.start - 1)? != b'.' {
+        return None;
+    }
+
+    let type_name = crate::util::resolve_receiver_type(source, ident_span.start - 1, cached)?;
+    resolve_builtin_location(&type_name, Some(method_name), root_uri)
+}
+
+fn resolve_builtin_location(
+    name: &str,
+    method: Option<&str>,
+    root_uri: Option<&Url>,
+) -> Option<GotoDefinitionResponse> {
+    let reg = rask_stdlib::StubRegistry::load();
+    let (source_file, span) = if let Some(method_name) = method {
+        let normalized = match name {
+            "String" => "string",
+            _ => name,
+        };
+        let m = reg.lookup_method(normalized, method_name)?;
+        (&m.source_file, m.span)
+    } else if let Some(ts) = reg.get_type(name) {
+        (&ts.source_file, ts.span)
+    } else {
+        let f = reg.functions().iter().find(|f| f.name == name)?;
+        (&f.source_file, f.span)
+    };
+
+    let (start_line, start_col) = reg.offset_to_lsp_position(source_file, span.start)?;
+    let (end_line, end_col) = reg.offset_to_lsp_position(source_file, span.end)?;
+
+    let root = root_uri?;
+    let stub_path = format!("{}/{}", root.as_str().trim_end_matches('/'), source_file);
+    let stub_uri = Url::parse(&stub_path).ok()?;
+
+    Some(GotoDefinitionResponse::Scalar(Location {
+        uri: stub_uri,
+        range: Range::new(
+            Position::new(start_line, start_col),
+            Position::new(end_line, end_col),
+        ),
+    }))
+}

--- a/compiler/crates/rask-lsp/src/hover.rs
+++ b/compiler/crates/rask-lsp/src/hover.rs
@@ -1,0 +1,263 @@
+// SPDX-License-Identifier: (MIT OR Apache-2.0)
+//! Hover (Ctrl+K Ctrl+I / mouse hover) logic.
+//!
+//! Builds a Markdown tooltip with:
+//!   - the symbol kind + name + type
+//!   - stdlib docs if available
+//!   - struct fields / enum variants / trait methods for user types
+
+use tower_lsp::lsp_types::*;
+
+use crate::backend::CompilationResult;
+use crate::type_format::TypeFormatter;
+
+pub fn hover(position: Position, cached: &CompilationResult) -> Option<Hover> {
+    let offset = cached
+        .line_index
+        .position_to_offset(&cached.source, position);
+
+    let formatter = TypeFormatter::new(&cached.typed.types);
+
+    // Try expression node first, then fall back to binding/param span_types.
+    let on_ident = cached.position_index.ident_at_position(offset).is_some();
+    let expr_node_id = if on_ident {
+        cached.position_index.node_at_position(offset)
+    } else {
+        None
+    };
+    let mut ty_opt = expr_node_id.and_then(|nid| cached.typed.node_types.get(&nid));
+    if ty_opt.is_none() {
+        if let Some((span, _, _)) = cached
+            .position_index
+            .idents
+            .iter()
+            .find(|(s, _, _)| s.start <= offset && offset <= s.end)
+        {
+            ty_opt = cached.typed.span_types.get(&(span.start, span.end));
+        }
+    }
+
+    // Fall back to the stub registry if we have an identifier but no type.
+    if ty_opt.is_none() {
+        if let Some((_, name)) = cached.position_index.ident_at_position(offset) {
+            if let Some(markdown) = stdlib_type_hover(&name) {
+                return Some(md_hover(markdown));
+            }
+            if let Some(markdown) = method_hover(&cached.source, offset, &name, cached) {
+                return Some(md_hover(markdown));
+            }
+        }
+        return None;
+    }
+
+    let ty = ty_opt.unwrap();
+    let type_str = formatter.format(ty);
+    let mut md = format!("**Type:** `{}`", type_str);
+
+    if let Some((_, name)) = cached.position_index.ident_at_position(offset) {
+        let symbol = expr_node_id
+            .and_then(|nid| cached.typed.resolutions.get(&nid))
+            .and_then(|&sid| cached.typed.symbols.get(sid));
+        if let Some(symbol) = symbol {
+            md = format!("**{}:** `{}`\n\n**Type:** `{}`", kind_label(&symbol.kind), name, type_str);
+            append_symbol_doc(&mut md, symbol, &formatter, cached);
+        } else if let Some(extra) = method_hover(&cached.source, offset, &name, cached) {
+            md.push_str("\n\n---\n\n");
+            md.push_str(&extra);
+        }
+    }
+
+    if let rask_types::Type::UnresolvedNamed(name) = ty {
+        append_stdlib_type(&mut md, name);
+    }
+
+    Some(md_hover(md))
+}
+
+fn md_hover(markdown: String) -> Hover {
+    Hover {
+        contents: HoverContents::Markup(MarkupContent {
+            kind: MarkupKind::Markdown,
+            value: markdown,
+        }),
+        range: None,
+    }
+}
+
+fn kind_label(kind: &rask_resolve::SymbolKind) -> &'static str {
+    match kind {
+        rask_resolve::SymbolKind::Variable { mutable } => {
+            if *mutable { "Variable (mutable)" } else { "Variable" }
+        }
+        rask_resolve::SymbolKind::Parameter { .. } => "Parameter",
+        rask_resolve::SymbolKind::Function { .. } => "Function",
+        rask_resolve::SymbolKind::Struct { .. } => "Struct",
+        rask_resolve::SymbolKind::Enum { .. } => "Enum",
+        rask_resolve::SymbolKind::Field { .. } => "Field",
+        rask_resolve::SymbolKind::Trait { .. } => "Trait",
+        rask_resolve::SymbolKind::EnumVariant { .. } => "Enum Variant",
+        rask_resolve::SymbolKind::BuiltinType { .. } => "Built-in Type",
+        rask_resolve::SymbolKind::BuiltinFunction { .. } => "Built-in Function",
+        rask_resolve::SymbolKind::BuiltinModule { .. } => "Built-in Module",
+        rask_resolve::SymbolKind::ExternFunction { .. } => "Extern Function",
+        rask_resolve::SymbolKind::ExternalPackage { .. } => "Package",
+        rask_resolve::SymbolKind::TypeAlias { .. } => "Type Alias",
+        rask_resolve::SymbolKind::CNamespace { .. } => "C Namespace",
+    }
+}
+
+fn append_symbol_doc(
+    md: &mut String,
+    symbol: &rask_resolve::Symbol,
+    formatter: &TypeFormatter,
+    cached: &CompilationResult,
+) {
+    match &symbol.kind {
+        rask_resolve::SymbolKind::BuiltinType { .. }
+        | rask_resolve::SymbolKind::BuiltinFunction { .. }
+        | rask_resolve::SymbolKind::BuiltinModule { .. } => {
+            append_stdlib_type(md, &symbol.name);
+            let reg = rask_stdlib::StubRegistry::load();
+            if let Some(f) = reg.functions().iter().find(|f| f.name == symbol.name) {
+                if let Some(doc) = &f.doc {
+                    md.push_str(&format!("\n\n---\n\n{}", doc));
+                }
+            }
+        }
+        rask_resolve::SymbolKind::Struct { .. } | rask_resolve::SymbolKind::Enum { .. } => {
+            if let Some(type_id) = cached.typed.types.get_type_id(&symbol.name) {
+                if let Some(def) = cached.typed.types.get(type_id) {
+                    match def {
+                        rask_types::TypeDef::Struct { fields, methods, .. } => {
+                            if !fields.is_empty() {
+                                md.push_str("\n\n**Fields:**\n");
+                                for (fname, fty) in fields {
+                                    md.push_str(&format!("\n- `{}: {}`", fname, formatter.format(fty)));
+                                }
+                            }
+                            if !methods.is_empty() {
+                                md.push_str("\n\n**Methods:**\n");
+                                for m in methods {
+                                    md.push_str(&format!("\n- `{}`", m.name));
+                                }
+                            }
+                        }
+                        rask_types::TypeDef::Enum { variants, methods, .. } => {
+                            if !variants.is_empty() {
+                                md.push_str("\n\n**Variants:**\n");
+                                for (vname, fields) in variants {
+                                    if fields.is_empty() {
+                                        md.push_str(&format!("\n- `{}`", vname));
+                                    } else {
+                                        let args = fields
+                                            .iter()
+                                            .map(|t| formatter.format(t))
+                                            .collect::<Vec<_>>()
+                                            .join(", ");
+                                        md.push_str(&format!("\n- `{}({})`", vname, args));
+                                    }
+                                }
+                            }
+                            if !methods.is_empty() {
+                                md.push_str("\n\n**Methods:**\n");
+                                for m in methods {
+                                    md.push_str(&format!("\n- `{}`", m.name));
+                                }
+                            }
+                        }
+                        _ => {}
+                    }
+                }
+            }
+        }
+        _ => {}
+    }
+}
+
+fn stdlib_type_hover(name: &str) -> Option<String> {
+    let reg = rask_stdlib::StubRegistry::load();
+    let ts = reg.get_type(name)?;
+    let mut md = format!("**Stdlib Type:** `{}`", name);
+    if let Some(doc) = &ts.doc {
+        md.push_str(&format!("\n\n---\n\n{}", doc));
+    }
+    if !ts.methods.is_empty() {
+        md.push_str("\n\n**Methods:**\n");
+        for m in &ts.methods {
+            let params = m.params.iter()
+                .map(|(n, t)| format!("{}: {}", n, t))
+                .collect::<Vec<_>>()
+                .join(", ");
+            let self_prefix = if m.takes_self { "self, " } else { "" };
+            md.push_str(&format!(
+                "\n- `{}({}{}) -> {}`",
+                m.name, self_prefix, params, m.ret_ty
+            ));
+        }
+    }
+    Some(md)
+}
+
+fn append_stdlib_type(md: &mut String, name: &str) {
+    let reg = rask_stdlib::StubRegistry::load();
+    let Some(ts) = reg.get_type(name) else { return };
+    if let Some(doc) = &ts.doc {
+        md.push_str(&format!("\n\n---\n\n{}", doc));
+    }
+    if !ts.methods.is_empty() {
+        md.push_str("\n\n**Methods:**\n");
+        for m in &ts.methods {
+            let params = m.params.iter()
+                .map(|(n, t)| format!("{}: {}", n, t))
+                .collect::<Vec<_>>()
+                .join(", ");
+            let self_prefix = if m.takes_self { "self, " } else { "" };
+            md.push_str(&format!(
+                "\n- `{}({}{}) -> {}`",
+                m.name, self_prefix, params, m.ret_ty
+            ));
+        }
+    }
+}
+
+pub(crate) fn method_hover(
+    source: &str,
+    offset: usize,
+    method_name: &str,
+    cached: &CompilationResult,
+) -> Option<String> {
+    let (ident_span, _, _) = cached
+        .position_index
+        .idents
+        .iter()
+        .find(|(s, _, name)| s.start <= offset && offset <= s.end && name == method_name)?;
+
+    if ident_span.start == 0 {
+        return None;
+    }
+    if *source.as_bytes().get(ident_span.start - 1)? != b'.' {
+        return None;
+    }
+
+    let type_name = crate::util::resolve_receiver_type(source, ident_span.start - 1, cached)?;
+    let reg = rask_stdlib::StubRegistry::load();
+    let normalized = match type_name.as_str() {
+        "String" => "string",
+        _ => &type_name,
+    };
+    let method = reg.lookup_method(normalized, method_name)?;
+
+    let params = method.params.iter()
+        .map(|(n, t)| format!("{}: {}", n, t))
+        .collect::<Vec<_>>()
+        .join(", ");
+    let self_prefix = if method.takes_self { "self, " } else { "" };
+    let mut out = format!(
+        "**Method:** `{}.{}({}{}) -> {}`",
+        normalized, method.name, self_prefix, params, method.ret_ty
+    );
+    if let Some(doc) = &method.doc {
+        out.push_str(&format!("\n\n---\n\n{}", doc));
+    }
+    Some(out)
+}

--- a/compiler/crates/rask-lsp/src/incremental.rs
+++ b/compiler/crates/rask-lsp/src/incremental.rs
@@ -1,0 +1,98 @@
+// SPDX-License-Identifier: (MIT OR Apache-2.0)
+//! Apply `didChange` content changes to an in-memory buffer.
+//!
+//! LSP 3.17 ships two flavors of content change:
+//!  - full sync: `range: None`, text is the whole document
+//!  - incremental: `range: Some(Range)`, text replaces that range
+//!
+//! Incremental is the default we advertise — the client sends only the edit
+//! that happened, not the entire buffer, which matters for large files.
+
+use tower_lsp::lsp_types::TextDocumentContentChangeEvent;
+
+use crate::convert::LineIndex;
+
+pub fn apply_change(text: &mut String, change: TextDocumentContentChangeEvent) {
+    match change.range {
+        None => {
+            *text = change.text;
+        }
+        Some(range) => {
+            // Rebuild a LineIndex on every change — cheap enough for typical
+            // edits and avoids stale byte-offset math. Calling code is already
+            // on the blocking write path.
+            let idx = LineIndex::new(text);
+            let start = idx.position_to_offset(text, range.start);
+            let end = idx.position_to_offset(text, range.end);
+            // position_to_offset clamps to char boundaries, so the slice is
+            // always safe.
+            let (start, end) = if start > end { (end, start) } else { (start, end) };
+            text.replace_range(start..end, &change.text);
+        }
+    }
+}
+
+/// Convenience for tests: apply a range replacement by (line, col) coordinates.
+#[cfg(test)]
+pub fn apply_range(text: &mut String, start: (u32, u32), end: (u32, u32), new_text: &str) {
+    use tower_lsp::lsp_types::{Position, Range};
+    apply_change(
+        text,
+        TextDocumentContentChangeEvent {
+            range: Some(Range::new(
+                Position::new(start.0, start.1),
+                Position::new(end.0, end.1),
+            )),
+            range_length: None,
+            text: new_text.to_string(),
+        },
+    );
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn full_sync_replaces_entire_buffer() {
+        let mut text = "old".to_string();
+        apply_change(
+            &mut text,
+            TextDocumentContentChangeEvent {
+                range: None,
+                range_length: None,
+                text: "new".to_string(),
+            },
+        );
+        assert_eq!(text, "new");
+    }
+
+    #[test]
+    fn incremental_insert_at_start() {
+        let mut text = "world".to_string();
+        apply_range(&mut text, (0, 0), (0, 0), "hello ");
+        assert_eq!(text, "hello world");
+    }
+
+    #[test]
+    fn incremental_replace_middle() {
+        let mut text = "hello world".to_string();
+        apply_range(&mut text, (0, 6), (0, 11), "there");
+        assert_eq!(text, "hello there");
+    }
+
+    #[test]
+    fn incremental_across_lines() {
+        let mut text = "line1\nline2\nline3".to_string();
+        apply_range(&mut text, (1, 0), (2, 0), "REPLACED\n");
+        assert_eq!(text, "line1\nREPLACED\nline3");
+    }
+
+    #[test]
+    fn emoji_edit_preserves_bytes() {
+        let mut text = "a🌍b".to_string();
+        // Replace "🌍" (col 1..3 in UTF-16) with "c"
+        apply_range(&mut text, (0, 1), (0, 3), "c");
+        assert_eq!(text, "acb");
+    }
+}

--- a/compiler/crates/rask-lsp/src/inlay_hints.rs
+++ b/compiler/crates/rask-lsp/src/inlay_hints.rs
@@ -1,0 +1,107 @@
+// SPDX-License-Identifier: (MIT OR Apache-2.0)
+//! Inlay hints — inferred types shown inline after `const x` / `let x`.
+//!
+//! The editor renders these as ghosted text so you can see the type the
+//! compiler inferred without littering the source with annotations.
+
+use tower_lsp::lsp_types::*;
+
+use rask_ast::decl::{DeclKind, FnDecl};
+use rask_ast::stmt::{Stmt, StmtKind};
+
+use crate::backend::CompilationResult;
+use crate::type_format::TypeFormatter;
+
+pub fn inlay_hints(cached: &CompilationResult, range: Range) -> Vec<InlayHint> {
+    let mut out = Vec::new();
+    let formatter = TypeFormatter::new(&cached.typed.types);
+    let range_start = cached.line_index.position_to_offset(&cached.source, range.start);
+    let range_end = cached.line_index.position_to_offset(&cached.source, range.end);
+
+    for decl in &cached.decls {
+        match &decl.kind {
+            DeclKind::Fn(f) => visit_fn(f, cached, &formatter, &mut out, range_start, range_end),
+            DeclKind::Impl(i) => {
+                for m in &i.methods {
+                    visit_fn(m, cached, &formatter, &mut out, range_start, range_end);
+                }
+            }
+            DeclKind::Test(t) => {
+                for stmt in &t.body {
+                    visit_stmt(stmt, cached, &formatter, &mut out, range_start, range_end);
+                }
+            }
+            _ => {}
+        }
+    }
+    out
+}
+
+fn visit_fn(
+    f: &FnDecl,
+    cached: &CompilationResult,
+    formatter: &TypeFormatter,
+    out: &mut Vec<InlayHint>,
+    lo: usize,
+    hi: usize,
+) {
+    for stmt in &f.body {
+        visit_stmt(stmt, cached, formatter, out, lo, hi);
+    }
+}
+
+fn visit_stmt(
+    stmt: &Stmt,
+    cached: &CompilationResult,
+    formatter: &TypeFormatter,
+    out: &mut Vec<InlayHint>,
+    lo: usize,
+    hi: usize,
+) {
+    match &stmt.kind {
+        StmtKind::Let { name_span, ty: None, .. } | StmtKind::Const { name_span, ty: None, .. } => {
+            if name_span.start < lo || name_span.end > hi {
+                return;
+            }
+            if let Some(ty) = cached.typed.span_types.get(&(name_span.start, name_span.end)) {
+                let label = format!(": {}", formatter.format(ty));
+                let pos = cached.line_index.offset_to_position(&cached.source, name_span.end);
+                out.push(InlayHint {
+                    position: pos,
+                    label: InlayHintLabel::String(label),
+                    kind: Some(InlayHintKind::TYPE),
+                    text_edits: None,
+                    tooltip: None,
+                    padding_left: None,
+                    padding_right: Some(true),
+                    data: None,
+                });
+            }
+        }
+        StmtKind::While { body, .. }
+        | StmtKind::WhileLet { body, .. }
+        | StmtKind::Loop { body, .. }
+        | StmtKind::For { body, .. } => {
+            for s in body {
+                visit_stmt(s, cached, formatter, out, lo, hi);
+            }
+        }
+        StmtKind::Ensure { body, else_handler } => {
+            for s in body {
+                visit_stmt(s, cached, formatter, out, lo, hi);
+            }
+            if let Some((_, handler)) = else_handler {
+                for s in handler {
+                    visit_stmt(s, cached, formatter, out, lo, hi);
+                }
+            }
+        }
+        StmtKind::Comptime(body) | StmtKind::ComptimeFor { body, .. } => {
+            for s in body {
+                visit_stmt(s, cached, formatter, out, lo, hi);
+            }
+        }
+        _ => {}
+    }
+}
+

--- a/compiler/crates/rask-lsp/src/main.rs
+++ b/compiler/crates/rask-lsp/src/main.rs
@@ -1,31 +1,65 @@
 // SPDX-License-Identifier: (MIT OR Apache-2.0)
-//! Rask Language Server
+//! Rask Language Server.
 //!
-//! Provides diagnostics for all compilation errors:
-//! lexer, parser, resolve, type check, and ownership.
+//! Feature surface:
+//!   - Diagnostics: lex, parse, desugar, resolve, typecheck, ownership, effects
+//!   - Hover, goto-definition, completions (dot + identifier)
+//!   - Code actions (quickfixes from diagnostic suggestions)
+//!   - Inlay hints, semantic tokens
+//!   - Signature help
+//!   - Document symbols, workspace symbols
+//!   - Formatting
+//!   - Find references, rename
 //!
-//! Also provides IDE features:
-//! - Go to Definition
-//! - Hover (type information)
-//! - Code Actions (quick fixes)
-//! - Completions (dot-completion on types, identifier/keyword completion)
+//! The server is panic-resilient: handlers run under `catch_unwind`, and a
+//! global panic hook records the error so the process stays up.
 
 mod backend;
 mod completion;
 mod convert;
+mod format;
+mod goto;
+mod hover;
+mod incremental;
+mod inlay_hints;
 mod position_index;
+mod references;
+mod semantic_tokens;
 mod server;
+mod signature_help;
+mod symbols;
 mod type_format;
+mod util;
+
+use std::sync::Arc;
 
 use tower_lsp::{LspService, Server};
 
 use crate::backend::Backend;
+use crate::server::BackendHandle;
 
 #[tokio::main]
 async fn main() {
+    install_panic_hook();
+
     let stdin = tokio::io::stdin();
     let stdout = tokio::io::stdout();
 
-    let (service, socket) = LspService::new(Backend::new);
+    let (service, socket) = LspService::new(|client| {
+        let inner = Arc::new(Backend::new(client));
+        BackendHandle::new(inner)
+    });
     Server::new(stdin, stdout, socket).serve(service).await;
+}
+
+/// Keep stderr as a last-resort log sink — tower_lsp already catches panics
+/// per request, but a misbehaving panic hook in a dependency could still tear
+/// down the process. Writing the location to stderr gives the LSP client (VS
+/// Code) something to show in the Output panel instead of silent death.
+fn install_panic_hook() {
+    let default = std::panic::take_hook();
+    std::panic::set_hook(Box::new(move |info| {
+        eprintln!("rask-lsp panic: {}", info);
+        default(info);
+    }));
 }

--- a/compiler/crates/rask-lsp/src/position_index.rs
+++ b/compiler/crates/rask-lsp/src/position_index.rs
@@ -257,7 +257,16 @@ fn visit_expr(expr: &Expr, index: &mut PositionIndex) {
                 visit_expr(e, index);
             }
         }
-        ExprKind::StructLit { fields, .. } => {
+        ExprKind::StructLit { name, fields, .. } => {
+            // Struct name starts at the beginning of the expression span.
+            // Having it indexed lets hover/goto/references work on "Point"
+            // in `Point { x: 1 }`.
+            let name_span = rask_ast::Span::with_file(
+                expr.span.start,
+                expr.span.start + name.len(),
+                expr.span.file_id,
+            );
+            index.idents.push((name_span, expr.id, name.clone()));
             for field_init in fields {
                 visit_expr(&field_init.value, index);
             }

--- a/compiler/crates/rask-lsp/src/references.rs
+++ b/compiler/crates/rask-lsp/src/references.rs
@@ -1,0 +1,140 @@
+// SPDX-License-Identifier: (MIT OR Apache-2.0)
+//! Find references + rename.
+//!
+//! Both operations start the same way: find the `SymbolId` under the cursor,
+//! then walk the resolution table collecting every `NodeId` that resolves to
+//! it. Rename assembles those into a WorkspaceEdit; references produces a
+//! list of Locations.
+
+use std::collections::HashMap;
+
+use tower_lsp::lsp_types::*;
+
+use crate::backend::CompilationResult;
+
+pub fn references(
+    uri: &Url,
+    position: Position,
+    cached: &CompilationResult,
+    include_declaration: bool,
+) -> Option<Vec<Location>> {
+    let symbol_id = symbol_at(position, cached)?;
+    let mut locations = Vec::new();
+    let mut seen = std::collections::HashSet::new();
+
+    // Usages from the resolution map.
+    for (node_id, &sid) in &cached.typed.resolutions {
+        if sid != symbol_id {
+            continue;
+        }
+        if let Some(span) = span_of_ident(*node_id, cached) {
+            if seen.insert((span.start, span.end)) {
+                locations.push(Location {
+                    uri: uri.clone(),
+                    range: cached.line_index.span_to_range(&cached.source, span),
+                });
+            }
+        }
+    }
+
+    // Include the declaration site if the caller asked for it.
+    if include_declaration {
+        if let Some(sym) = cached.typed.symbols.get(symbol_id) {
+            let span = sym.span;
+            if span.end > 0 && seen.insert((span.start, span.end)) {
+                locations.push(Location {
+                    uri: uri.clone(),
+                    range: cached.line_index.span_to_range(&cached.source, span),
+                });
+            }
+        }
+    }
+
+    Some(locations)
+}
+
+pub fn rename(
+    uri: &Url,
+    position: Position,
+    new_name: &str,
+    cached: &CompilationResult,
+) -> Option<WorkspaceEdit> {
+    // Cheap sanity: identifier-like only. Bail if the client passes something
+    // weird — better a no-op than a corrupted file.
+    if !is_valid_identifier(new_name) {
+        return None;
+    }
+
+    let locations = references(uri, position, cached, true)?;
+    if locations.is_empty() {
+        return None;
+    }
+    let mut edits: Vec<TextEdit> = locations
+        .into_iter()
+        .map(|loc| TextEdit::new(loc.range, new_name.to_string()))
+        .collect();
+
+    // Stable ordering (by range) helps clients show predictable previews.
+    edits.sort_by(|a, b| {
+        (a.range.start.line, a.range.start.character)
+            .cmp(&(b.range.start.line, b.range.start.character))
+    });
+
+    let mut changes = HashMap::new();
+    changes.insert(uri.clone(), edits);
+    Some(WorkspaceEdit {
+        changes: Some(changes),
+        document_changes: None,
+        change_annotations: None,
+    })
+}
+
+fn symbol_at(position: Position, cached: &CompilationResult) -> Option<rask_resolve::SymbolId> {
+    let offset = cached.line_index.position_to_offset(&cached.source, position);
+    let (node_id, name) = cached.position_index.ident_at_position(offset)?;
+
+    // Case 1: usage site — the resolutions table points directly at the symbol.
+    if let Some(&sid) = cached.typed.resolutions.get(&node_id) {
+        return Some(sid);
+    }
+
+    // Case 2: declaration site (binding, struct decl name, parameter name).
+    // Position index gives stmt.id or decl.id which isn't in resolutions.
+    // Find the symbol by name + containing span.
+    let (ident_span, _, _) = cached
+        .position_index
+        .idents
+        .iter()
+        .find(|(s, _, n)| s.start <= offset && offset <= s.end && n == &name)?;
+
+    // Match by defining-span being identical to the ident span — that covers
+    // let/const bindings and parameters, whose symbol.span is the name itself.
+    cached.typed.symbols.iter().enumerate().find_map(|(idx, sym)| {
+        if sym.name == name
+            && sym.span.start == ident_span.start
+            && sym.span.end == ident_span.end
+        {
+            Some(rask_resolve::SymbolId(idx as u32))
+        } else {
+            None
+        }
+    })
+}
+
+fn span_of_ident(node_id: rask_ast::NodeId, cached: &CompilationResult) -> Option<rask_ast::Span> {
+    cached
+        .position_index
+        .idents
+        .iter()
+        .find(|(_, id, _)| *id == node_id)
+        .map(|(span, _, _)| *span)
+}
+
+fn is_valid_identifier(s: &str) -> bool {
+    let mut chars = s.chars();
+    match chars.next() {
+        Some(c) if c.is_alphabetic() || c == '_' => {}
+        _ => return false,
+    }
+    chars.all(|c| c.is_alphanumeric() || c == '_')
+}

--- a/compiler/crates/rask-lsp/src/semantic_tokens.rs
+++ b/compiler/crates/rask-lsp/src/semantic_tokens.rs
@@ -1,0 +1,129 @@
+// SPDX-License-Identifier: (MIT OR Apache-2.0)
+//! Semantic tokens — classifier-driven highlighting that knows about
+//! resolved types.
+//!
+//! TextMate grammars can't tell a local variable from a function call; the
+//! semantic layer sits on top of the grammar and upgrades colors based on
+//! what the name really is.
+
+use tower_lsp::lsp_types::*;
+
+use rask_resolve::SymbolKind;
+
+use crate::backend::CompilationResult;
+
+/// The legend negotiated in `initialize` — order matters: the `token_type`
+/// field in each token is an index into this Vec.
+pub fn legend() -> SemanticTokensLegend {
+    SemanticTokensLegend {
+        token_types: vec![
+            SemanticTokenType::VARIABLE,       // 0
+            SemanticTokenType::PARAMETER,      // 1
+            SemanticTokenType::FUNCTION,       // 2
+            SemanticTokenType::METHOD,         // 3
+            SemanticTokenType::STRUCT,         // 4
+            SemanticTokenType::ENUM,           // 5
+            SemanticTokenType::ENUM_MEMBER,    // 6
+            SemanticTokenType::INTERFACE,      // 7 (trait)
+            SemanticTokenType::TYPE,           // 8
+            SemanticTokenType::NAMESPACE,      // 9
+            SemanticTokenType::PROPERTY,       // 10 (field)
+        ],
+        token_modifiers: vec![
+            SemanticTokenModifier::DEFAULT_LIBRARY, // 0 (stdlib)
+            SemanticTokenModifier::READONLY,        // 1 (const)
+        ],
+    }
+}
+
+const TYPE_VARIABLE: u32 = 0;
+const TYPE_PARAMETER: u32 = 1;
+const TYPE_FUNCTION: u32 = 2;
+const TYPE_STRUCT: u32 = 4;
+const TYPE_ENUM: u32 = 5;
+const TYPE_ENUM_MEMBER: u32 = 6;
+const TYPE_TRAIT: u32 = 7;
+const TYPE_TYPE: u32 = 8;
+const TYPE_NAMESPACE: u32 = 9;
+const TYPE_PROPERTY: u32 = 10;
+
+const MOD_STDLIB: u32 = 1 << 0;
+const MOD_READONLY: u32 = 1 << 1;
+
+pub fn tokens(cached: &CompilationResult) -> SemanticTokensResult {
+    let mut raw: Vec<(u32, u32, u32, u32, u32)> = Vec::new();
+    // (line, col, length, token_type, modifiers)
+
+    for (span, node_id, _name) in &cached.position_index.idents {
+        let Some(&sid) = cached.typed.resolutions.get(node_id) else {
+            continue;
+        };
+        let Some(symbol) = cached.typed.symbols.get(sid) else {
+            continue;
+        };
+        let (tt, mods) = classify(&symbol.kind);
+
+        let start = cached.line_index.offset_to_position(&cached.source, span.start);
+        let end = cached.line_index.offset_to_position(&cached.source, span.end);
+        if start.line != end.line {
+            // Skip multi-line names — unusual and delta-encoded protocol
+            // demands single-line tokens.
+            continue;
+        }
+        let length = end.character.saturating_sub(start.character);
+        if length == 0 {
+            continue;
+        }
+        raw.push((start.line, start.character, length, tt, mods));
+    }
+
+    // Sort by (line, col) — LSP requires ascending delta encoding.
+    raw.sort_by_key(|t| (t.0, t.1));
+    // Deduplicate exact hits.
+    raw.dedup();
+
+    let mut data = Vec::with_capacity(raw.len());
+    let mut prev_line = 0u32;
+    let mut prev_col = 0u32;
+    for (line, col, length, tt, mods) in raw {
+        let delta_line = line - prev_line;
+        let delta_start = if delta_line == 0 { col - prev_col } else { col };
+        data.push(SemanticToken {
+            delta_line,
+            delta_start,
+            length,
+            token_type: tt,
+            token_modifiers_bitset: mods,
+        });
+        prev_line = line;
+        prev_col = col;
+    }
+
+    SemanticTokensResult::Tokens(SemanticTokens {
+        result_id: None,
+        data,
+    })
+}
+
+fn classify(kind: &SymbolKind) -> (u32, u32) {
+    match kind {
+        SymbolKind::Variable { mutable } => {
+            let mods = if *mutable { 0 } else { MOD_READONLY };
+            (TYPE_VARIABLE, mods)
+        }
+        SymbolKind::Parameter { .. } => (TYPE_PARAMETER, 0),
+        SymbolKind::Function { .. } => (TYPE_FUNCTION, 0),
+        SymbolKind::ExternFunction { .. } => (TYPE_FUNCTION, 0),
+        SymbolKind::Struct { .. } => (TYPE_STRUCT, 0),
+        SymbolKind::Enum { .. } => (TYPE_ENUM, 0),
+        SymbolKind::EnumVariant { .. } => (TYPE_ENUM_MEMBER, 0),
+        SymbolKind::Trait { .. } => (TYPE_TRAIT, 0),
+        SymbolKind::Field { .. } => (TYPE_PROPERTY, 0),
+        SymbolKind::BuiltinType { .. } => (TYPE_TYPE, MOD_STDLIB),
+        SymbolKind::BuiltinFunction { .. } => (TYPE_FUNCTION, MOD_STDLIB),
+        SymbolKind::BuiltinModule { .. } => (TYPE_NAMESPACE, MOD_STDLIB),
+        SymbolKind::ExternalPackage { .. } => (TYPE_NAMESPACE, 0),
+        SymbolKind::TypeAlias { .. } => (TYPE_TYPE, 0),
+        SymbolKind::CNamespace { .. } => (TYPE_NAMESPACE, 0),
+    }
+}

--- a/compiler/crates/rask-lsp/src/server.rs
+++ b/compiler/crates/rask-lsp/src/server.rs
@@ -1,38 +1,94 @@
 // SPDX-License-Identifier: (MIT OR Apache-2.0)
 //! LanguageServer trait implementation.
+//!
+//! Handler methods run on the tokio executor. Anything that might panic
+//! (cursor on a char boundary, a compiler bug walking the AST) is caught
+//! in `catch_unwind` via `safe_handler` — dropping a single request is
+//! fine; taking the server down is not.
 
 use std::collections::HashMap;
+use std::panic::AssertUnwindSafe;
+use std::sync::Arc;
 
 use tower_lsp::jsonrpc::Result;
 use tower_lsp::lsp_types::*;
 use tower_lsp::LanguageServer;
 
-use rask_diagnostics::LabelStyle;
+use crate::backend::{Backend, CompilationResult, DocState};
+use crate::convert::{ranges_overlap, to_lsp_diagnostic};
+use crate::incremental::apply_change;
+use crate::{hover, inlay_hints, references, semantic_tokens, signature_help, symbols};
 
-use crate::backend::{Backend, CompilationResult};
-use crate::convert::{byte_offset_to_position, position_to_offset, ranges_overlap, to_lsp_diagnostic};
-use crate::type_format::TypeFormatter;
+/// Run `f` inside `catch_unwind`, returning `Ok(None)` on panic. Intended
+/// for query handlers whose failure should not bring down the server.
+fn safe_handler<T, F: FnOnce() -> T>(f: F) -> std::result::Result<T, ()>
+where
+    T: Default,
+{
+    std::panic::catch_unwind(AssertUnwindSafe(f)).map_err(|_| ())
+}
 
 #[tower_lsp::async_trait]
-impl LanguageServer for Backend {
+impl LanguageServer for BackendHandle {
     async fn initialize(&self, params: InitializeParams) -> Result<InitializeResult> {
-        // Capture workspace root for resolving stdlib stub file paths
         if let Some(root_uri) = params.root_uri {
-            *self.root_uri.write().unwrap() = Some(root_uri);
+            *self.inner.root_uri.write().await = Some(root_uri);
         }
+
+        // Prefer UTF-16 — it's the default VS Code negotiates, but we also
+        // accept UTF-8 if the client requests it. The compiler gets whatever
+        // encoding was accepted via the negotiated capability below.
+        let negotiated_encoding = params
+            .capabilities
+            .general
+            .as_ref()
+            .and_then(|g| g.position_encodings.as_ref())
+            .and_then(|encs| {
+                if encs.iter().any(|e| e == &PositionEncodingKind::UTF16) {
+                    Some(PositionEncodingKind::UTF16)
+                } else {
+                    encs.first().cloned()
+                }
+            })
+            .unwrap_or(PositionEncodingKind::UTF16);
+
         Ok(InitializeResult {
             capabilities: ServerCapabilities {
+                position_encoding: Some(negotiated_encoding),
                 text_document_sync: Some(TextDocumentSyncCapability::Kind(
-                    TextDocumentSyncKind::FULL,
+                    TextDocumentSyncKind::INCREMENTAL,
                 )),
                 definition_provider: Some(OneOf::Left(true)),
                 hover_provider: Some(HoverProviderCapability::Simple(true)),
                 code_action_provider: Some(CodeActionProviderCapability::Simple(true)),
                 completion_provider: Some(CompletionOptions {
-                    trigger_characters: Some(vec![".".to_string()]),
+                    trigger_characters: Some(
+                        [".", ":", "("].iter().map(|s| s.to_string()).collect(),
+                    ),
                     resolve_provider: Some(false),
                     ..Default::default()
                 }),
+                signature_help_provider: Some(SignatureHelpOptions {
+                    trigger_characters: Some(vec!["(".to_string(), ",".to_string()]),
+                    retrigger_characters: Some(vec![",".to_string()]),
+                    work_done_progress_options: Default::default(),
+                }),
+                document_symbol_provider: Some(OneOf::Left(true)),
+                workspace_symbol_provider: Some(OneOf::Left(true)),
+                document_formatting_provider: Some(OneOf::Left(true)),
+                references_provider: Some(OneOf::Left(true)),
+                rename_provider: Some(OneOf::Left(true)),
+                inlay_hint_provider: Some(OneOf::Left(true)),
+                semantic_tokens_provider: Some(
+                    SemanticTokensServerCapabilities::SemanticTokensOptions(
+                        SemanticTokensOptions {
+                            legend: semantic_tokens::legend(),
+                            full: Some(SemanticTokensFullOptions::Bool(true)),
+                            range: Some(false),
+                            ..Default::default()
+                        },
+                    ),
+                ),
                 ..Default::default()
             },
             server_info: Some(ServerInfo {
@@ -43,7 +99,8 @@ impl LanguageServer for Backend {
     }
 
     async fn initialized(&self, _: InitializedParams) {
-        self.client
+        self.inner
+            .client
             .log_message(MessageType::INFO, "Rask language server initialized")
             .await;
     }
@@ -55,671 +112,270 @@ impl LanguageServer for Backend {
     async fn did_open(&self, params: DidOpenTextDocumentParams) {
         let uri = params.text_document.uri;
         let text = params.text_document.text;
+        let version = params.text_document.version;
 
-        {
-            let mut docs = self.documents.write().unwrap();
-            docs.insert(uri.clone(), text.clone());
-        }
+        self.inner
+            .documents
+            .write()
+            .await
+            .insert(uri.clone(), DocState { text, version });
 
-        self.publish_diagnostics(uri, &text).await;
+        // Open happens once per file — analyze immediately rather than
+        // waiting for debounce.
+        self.inner.clone().analyze_now(uri).await;
     }
 
     async fn did_change(&self, params: DidChangeTextDocumentParams) {
         let uri = params.text_document.uri;
+        let version = params.text_document.version;
 
-        // With FULL sync, we get the entire document
-        if let Some(change) = params.content_changes.into_iter().last() {
-            let text = change.text;
-            {
-                let mut docs = self.documents.write().unwrap();
-                docs.insert(uri.clone(), text.clone());
+        let mut docs = self.inner.documents.write().await;
+        let Some(state) = docs.get_mut(&uri) else {
+            // The client sent change before open — apply as a full replace
+            // if we got one content change with no range.
+            if let [single] = params.content_changes.as_slice() {
+                if single.range.is_none() {
+                    docs.insert(
+                        uri.clone(),
+                        DocState { text: single.text.clone(), version },
+                    );
+                }
             }
+            drop(docs);
+            self.inner.clone().schedule_analysis(uri).await;
+            return;
+        };
 
-            self.publish_diagnostics(uri, &text).await;
+        for change in params.content_changes {
+            apply_change(&mut state.text, change);
         }
+        state.version = version;
+        drop(docs);
+
+        self.inner.clone().schedule_analysis(uri).await;
     }
 
     async fn did_save(&self, params: DidSaveTextDocumentParams) {
-        let uri = params.text_document.uri;
-        let text = {
-            let docs = self.documents.read().unwrap();
-            docs.get(&uri).cloned()
-        };
-        if let Some(text) = text {
-            self.publish_diagnostics(uri, &text).await;
-        }
+        self.inner.clone().analyze_now(params.text_document.uri).await;
     }
 
     async fn did_close(&self, params: DidCloseTextDocumentParams) {
         let uri = params.text_document.uri;
-        {
-            let mut docs = self.documents.write().unwrap();
-            docs.remove(&uri);
-        }
-        {
-            let mut compiled = self.compiled.write().unwrap();
-            compiled.remove(&uri);
-        }
-        // Clear diagnostics
-        self.client.publish_diagnostics(uri, vec![], None).await;
+        self.inner.documents.write().await.remove(&uri);
+        self.inner.compiled.write().await.remove(&uri);
+        self.inner
+            .client
+            .publish_diagnostics(uri, vec![], None)
+            .await;
     }
 
     async fn goto_definition(
         &self,
         params: GotoDefinitionParams,
     ) -> Result<Option<GotoDefinitionResponse>> {
-        let uri = &params.text_document_position_params.text_document.uri;
+        let uri = params.text_document_position_params.text_document.uri;
         let position = params.text_document_position_params.position;
-
-        // Use last good compilation
-        let compiled = self.compiled.read().unwrap();
-        let Some(cached) = compiled.get(uri) else {
+        let Some(cached) = self.inner.get_compiled(&uri).await else {
             return Ok(None);
         };
+        let root = self.inner.root_uri.read().await.clone();
 
-        let offset = position_to_offset(&cached.source, position);
-
-        // Find identifier at cursor
-        let Some((node_id, name)) = cached.position_index.ident_at_position(offset) else {
-            return Ok(None);
-        };
-
-        // Look up symbol for this node
-        let symbol = cached.typed.resolutions.get(&node_id)
-            .and_then(|&sid| cached.typed.symbols.get(sid));
-
-        if let Some(symbol) = symbol {
-            // For built-in symbols, navigate to the stub file
-            if symbol.span.start == 0 && symbol.span.end == 0 {
-                return Ok(self.resolve_builtin_location(&symbol.name, None));
-            }
-
-            // Check if this symbol was defined in a sibling file
-            if let Some(sibling) = cached.sibling_decl_names.get(&symbol.name) {
-                // Validate the span falls within the sibling source
-                if symbol.span.end <= sibling.source.len() {
-                    let def_range = Range::new(
-                        byte_offset_to_position(&sibling.source, symbol.span.start),
-                        byte_offset_to_position(&sibling.source, symbol.span.end),
-                    );
-                    let sibling_uri = Url::from_file_path(&sibling.path)
-                        .unwrap_or_else(|_| uri.clone());
-                    return Ok(Some(GotoDefinitionResponse::Scalar(Location {
-                        uri: sibling_uri,
-                        range: def_range,
-                    })));
-                }
-            }
-
-            let def_range = Range::new(
-                byte_offset_to_position(&cached.source, symbol.span.start),
-                byte_offset_to_position(&cached.source, symbol.span.end),
-            );
-
-            return Ok(Some(GotoDefinitionResponse::Scalar(Location {
-                uri: uri.clone(),
-                range: def_range,
-            })));
-        }
-
-        // No symbol resolution — try method-level go-to-def for builtins
-        if let Some(response) = self.try_method_goto_definition(&cached.source, offset, &name, cached) {
-            return Ok(Some(response));
-        }
-
-        Ok(None)
+        Ok(safe_handler(|| {
+            crate::goto::goto_definition(&uri, position, &cached, root.as_ref())
+        })
+        .unwrap_or(None))
     }
 
     async fn hover(&self, params: HoverParams) -> Result<Option<Hover>> {
-        let uri = &params.text_document_position_params.text_document.uri;
+        let uri = params.text_document_position_params.text_document.uri;
         let position = params.text_document_position_params.position;
-
-        // Use last good compilation
-        let compiled = self.compiled.read().unwrap();
-        let Some(cached) = compiled.get(uri) else {
+        let Some(cached) = self.inner.get_compiled(&uri).await else {
             return Ok(None);
         };
 
-        let offset = position_to_offset(&cached.source, position);
-
-        // Find node at cursor
-        let formatter = TypeFormatter::new(&cached.typed.types);
-
-        // Try expression node first, then fall back to identifier (bindings/params).
-        // Only show expression hover when cursor is on an identifier — this avoids
-        // showing unhelpful types for keywords like `using`, `ensure`, etc.
-        let on_ident = cached.position_index.ident_at_position(offset).is_some();
-        let expr_node_id = if on_ident {
-            cached.position_index.node_at_position(offset)
-        } else {
-            None
-        };
-        let ty_opt = expr_node_id
-            .and_then(|node_id| cached.typed.node_types.get(&node_id));
-
-        // If no expression type, try span_types for bindings and parameters
-        let span_ty;
-        let ty_opt = if ty_opt.is_some() {
-            ty_opt
-        } else if let Some((ident_span, _, _)) = cached.position_index.idents.iter()
-            .find(|(span, _, _)| span.start <= offset && offset <= span.end)
-        {
-            span_ty = cached.typed.span_types.get(&(ident_span.start, ident_span.end));
-            if span_ty.is_some() {
-                span_ty
-            } else {
-                None
-            }
-        } else {
-            None
-        };
-
-        // If no type info, try StubRegistry fallback for stdlib types
-        if ty_opt.is_none() {
-            if let Some((_, ident_name)) = cached.position_index.ident_at_position(offset) {
-                let reg = rask_stdlib::StubRegistry::load();
-                // Check if it's a known stdlib type (e.g., Response, Request, HttpServer)
-                if let Some(ts) = reg.get_type(&ident_name) {
-                    let mut contents = format!("**Stdlib Type:** `{}`", ident_name);
-                    if let Some(doc) = &ts.doc {
-                        contents.push_str(&format!("\n\n---\n\n{}", doc));
-                    }
-                    if !ts.methods.is_empty() {
-                        contents.push_str("\n\n**Methods:**\n");
-                        for m in &ts.methods {
-                            let params_str = m.params.iter()
-                                .map(|(n, t)| format!("{}: {}", n, t))
-                                .collect::<Vec<_>>()
-                                .join(", ");
-                            let self_prefix = if m.takes_self { "self, " } else { "" };
-                            contents.push_str(&format!(
-                                "\n- `{}({}{}) -> {}`",
-                                m.name, self_prefix, params_str, m.ret_ty
-                            ));
-                        }
-                    }
-                    return Ok(Some(Hover {
-                        contents: HoverContents::Markup(MarkupContent {
-                            kind: MarkupKind::Markdown,
-                            value: contents,
-                        }),
-                        range: None,
-                    }));
-                }
-                // Check if it's a method on a known type
-                if let Some(doc) = self.try_method_hover(&cached.source, offset, &ident_name, cached) {
-                    return Ok(Some(Hover {
-                        contents: HoverContents::Markup(MarkupContent {
-                            kind: MarkupKind::Markdown,
-                            value: doc,
-                        }),
-                        range: None,
-                    }));
-                }
-            }
-            return Ok(None);
-        }
-
-        let ty = ty_opt.unwrap();
-
-        // Format type for display
-        let type_str = formatter.format(ty);
-
-        // Build hover content
-        let mut contents = format!("**Type:** `{}`", type_str);
-
-        // For identifiers, add symbol info (only when we have a valid expression node)
-        if let Some((_, name)) = cached.position_index.ident_at_position(offset) {
-            // Use expression node_id for symbol resolution — ident node_ids from
-            // bindings/params use stmt.id which may not have valid resolutions
-            let symbol = expr_node_id
-                .and_then(|nid| cached.typed.resolutions.get(&nid))
-                .and_then(|&sid| cached.typed.symbols.get(sid));
-            if let Some(symbol) = symbol {
-                    let kind_str = match symbol.kind {
-                        rask_resolve::SymbolKind::Variable { mutable } => {
-                            if mutable {
-                                "Variable (mutable)"
-                            } else {
-                                "Variable"
-                            }
-                        }
-                        rask_resolve::SymbolKind::Parameter { .. } => "Parameter",
-                        rask_resolve::SymbolKind::Function { .. } => "Function",
-                        rask_resolve::SymbolKind::Struct { .. } => "Struct",
-                        rask_resolve::SymbolKind::Enum { .. } => "Enum",
-                        rask_resolve::SymbolKind::Field { .. } => "Field",
-                        rask_resolve::SymbolKind::Trait { .. } => "Trait",
-                        rask_resolve::SymbolKind::EnumVariant { .. } => "Enum Variant",
-                        rask_resolve::SymbolKind::BuiltinType { .. } => "Built-in Type",
-                        rask_resolve::SymbolKind::BuiltinFunction { .. } => "Built-in Function",
-                        rask_resolve::SymbolKind::BuiltinModule { .. } => "Built-in Module",
-                        rask_resolve::SymbolKind::ExternFunction { .. } => "Extern Function",
-                        rask_resolve::SymbolKind::ExternalPackage { .. } => "Package",
-                        rask_resolve::SymbolKind::TypeAlias { .. } => "Type Alias",
-                        rask_resolve::SymbolKind::CNamespace { .. } => "C Namespace",
-                    };
-                    contents = format!("**{}:** `{}`\n\n**Type:** `{}`", kind_str, name, type_str);
-
-                // Add doc comment and method signatures from stubs for builtins
-                match &symbol.kind {
-                    rask_resolve::SymbolKind::BuiltinType { .. }
-                    | rask_resolve::SymbolKind::BuiltinFunction { .. }
-                    | rask_resolve::SymbolKind::BuiltinModule { .. } => {
-                        let reg = rask_stdlib::StubRegistry::load();
-                        if let Some(ts) = reg.get_type(&name) {
-                            if let Some(doc) = &ts.doc {
-                                contents.push_str(&format!("\n\n---\n\n{}", doc));
-                            }
-                            if !ts.methods.is_empty() {
-                                contents.push_str("\n\n**Methods:**\n");
-                                for m in &ts.methods {
-                                    let params_str = m.params.iter()
-                                        .map(|(n, t)| format!("{}: {}", n, t))
-                                        .collect::<Vec<_>>()
-                                        .join(", ");
-                                    let self_prefix = if m.takes_self { "self, " } else { "" };
-                                    contents.push_str(&format!(
-                                        "\n- `{}({}{}) -> {}`",
-                                        m.name, self_prefix, params_str, m.ret_ty
-                                    ));
-                                }
-                            }
-                        } else {
-                            let doc = reg.functions().iter()
-                                .find(|f| f.name == name)
-                                .and_then(|f| f.doc.as_deref());
-                            if let Some(doc) = doc {
-                                contents.push_str(&format!("\n\n---\n\n{}", doc));
-                            }
-                        }
-                    }
-                    rask_resolve::SymbolKind::Struct { .. }
-                    | rask_resolve::SymbolKind::Enum { .. } => {
-                        // Show fields/variants and methods for user-defined types
-                        if let Some(type_id) = cached.typed.types.get_type_id(&name) {
-                            if let Some(def) = cached.typed.types.get(type_id) {
-                                match def {
-                                    rask_types::TypeDef::Struct { fields, methods, .. } => {
-                                        if !fields.is_empty() {
-                                            contents.push_str("\n\n**Fields:**\n");
-                                            for (fname, fty) in fields {
-                                                contents.push_str(&format!(
-                                                    "\n- `{}: {}`", fname, formatter.format(fty)
-                                                ));
-                                            }
-                                        }
-                                        if !methods.is_empty() {
-                                            contents.push_str("\n\n**Methods:**\n");
-                                            for m in methods {
-                                                contents.push_str(&format!(
-                                                    "\n- `{}`", m.name
-                                                ));
-                                            }
-                                        }
-                                    }
-                                    rask_types::TypeDef::Enum { variants, methods, .. } => {
-                                        if !variants.is_empty() {
-                                            contents.push_str("\n\n**Variants:**\n");
-                                            for (vname, fields) in variants {
-                                                if fields.is_empty() {
-                                                    contents.push_str(&format!("\n- `{}`", vname));
-                                                } else {
-                                                    let fields_str = fields.iter()
-                                                        .map(|t| formatter.format(t))
-                                                        .collect::<Vec<_>>()
-                                                        .join(", ");
-                                                    contents.push_str(&format!("\n- `{}({})`", vname, fields_str));
-                                                }
-                                            }
-                                        }
-                                        if !methods.is_empty() {
-                                            contents.push_str("\n\n**Methods:**\n");
-                                            for m in methods {
-                                                contents.push_str(&format!(
-                                                    "\n- `{}`", m.name
-                                                ));
-                                            }
-                                        }
-                                    }
-                                    _ => {}
-                                }
-                            }
-                        }
-                    }
-                    _ => {}
-                }
-            } else {
-                // No symbol — try method hover for builtin types
-                if let Some(doc) = self.try_method_hover(&cached.source, offset, &name, cached) {
-                    contents.push_str(&format!("\n\n---\n\n{}", doc));
-                }
-            }
-        }
-
-        // Enrich UnresolvedNamed types with StubRegistry info
-        if let rask_types::Type::UnresolvedNamed(name) = ty {
-            let reg = rask_stdlib::StubRegistry::load();
-            if let Some(ts) = reg.get_type(name) {
-                if let Some(doc) = &ts.doc {
-                    contents.push_str(&format!("\n\n---\n\n{}", doc));
-                }
-                if !ts.methods.is_empty() {
-                    contents.push_str("\n\n**Methods:**\n");
-                    for m in &ts.methods {
-                        let params_str = m.params.iter()
-                            .map(|(n, t)| format!("{}: {}", n, t))
-                            .collect::<Vec<_>>()
-                            .join(", ");
-                        let self_prefix = if m.takes_self { "self, " } else { "" };
-                        contents.push_str(&format!(
-                            "\n- `{}({}{}) -> {}`",
-                            m.name, self_prefix, params_str, m.ret_ty
-                        ));
-                    }
-                }
-            }
-        }
-
-        Ok(Some(Hover {
-            contents: HoverContents::Markup(MarkupContent {
-                kind: MarkupKind::Markdown,
-                value: contents,
-            }),
-            range: None,
-        }))
+        Ok(safe_handler(|| hover::hover(position, &cached)).unwrap_or(None))
     }
 
     async fn code_action(
         &self,
         params: CodeActionParams,
     ) -> Result<Option<CodeActionResponse>> {
-        let uri = &params.text_document.uri;
+        let uri = params.text_document.uri;
         let range = params.range;
-
-        // Use last good compilation
-        let compiled = self.compiled.read().unwrap();
-        let Some(cached) = compiled.get(uri) else {
+        let Some(cached) = self.inner.get_compiled(&uri).await else {
             return Ok(None);
         };
-        let source = &cached.source;
 
         let mut actions = Vec::new();
-
-        // Find diagnostics with suggestions that overlap the requested range
         for diag in &cached.diagnostics {
-            // Get diagnostic range
-            let diag_primary = diag
-                .labels
-                .iter()
+            use rask_diagnostics::LabelStyle;
+            let primary = diag.labels.iter()
                 .find(|l| l.style == LabelStyle::Primary)
                 .or(diag.labels.first());
+            let Some(primary_label) = primary else { continue };
 
-            let Some(primary_label) = diag_primary else {
-                continue;
-            };
-
-            let diag_range = Range::new(
-                byte_offset_to_position(&source, primary_label.span.start),
-                byte_offset_to_position(&source, primary_label.span.end),
-            );
-
-            // Check if diagnostic overlaps with requested range
+            let diag_range = cached.line_index.span_to_range(&cached.source, primary_label.span);
             if !ranges_overlap(diag_range, range) {
                 continue;
             }
+            let Some(help) = &diag.help else { continue };
+            let Some(suggestion) = &help.suggestion else { continue };
 
-            // Check if diagnostic has a suggestion
-            if let Some(ref help) = diag.help {
-                if let Some(ref suggestion) = help.suggestion {
-                    // Convert rask Span to LSP Range
-                    let edit_range = Range::new(
-                        byte_offset_to_position(&source, suggestion.span.start),
-                        byte_offset_to_position(&source, suggestion.span.end),
-                    );
+            let edit_range = cached.line_index.span_to_range(&cached.source, suggestion.span);
+            let text_edit = TextEdit::new(edit_range, suggestion.replacement.clone());
 
-                    // Create text edit
-                    let text_edit = TextEdit::new(edit_range, suggestion.replacement.clone());
+            let mut changes = HashMap::new();
+            changes.insert(uri.clone(), vec![text_edit]);
+            let workspace_edit = WorkspaceEdit {
+                changes: Some(changes),
+                document_changes: None,
+                change_annotations: None,
+            };
 
-                    // Create workspace edit
-                    let mut changes = HashMap::new();
-                    changes.insert(uri.clone(), vec![text_edit]);
-
-                    let workspace_edit = WorkspaceEdit {
-                        changes: Some(changes),
-                        document_changes: None,
-                        change_annotations: None,
-                    };
-
-                    // Convert rask diagnostic to LSP diagnostic
-                    let lsp_diagnostic = to_lsp_diagnostic(&source, uri, diag);
-
-                    // Create code action
-                    let action = CodeAction {
-                        title: help.message.clone(),
-                        kind: Some(CodeActionKind::QUICKFIX),
-                        diagnostics: Some(vec![lsp_diagnostic]),
-                        edit: Some(workspace_edit),
-                        command: None,
-                        is_preferred: Some(true),
-                        disabled: None,
-                        data: None,
-                    };
-
-                    actions.push(CodeActionOrCommand::CodeAction(action));
-                }
-            }
+            let lsp_diagnostic = to_lsp_diagnostic(&cached.line_index, &cached.source, &uri, diag);
+            actions.push(CodeActionOrCommand::CodeAction(CodeAction {
+                title: help.message.clone(),
+                kind: Some(CodeActionKind::QUICKFIX),
+                diagnostics: Some(vec![lsp_diagnostic]),
+                edit: Some(workspace_edit),
+                command: None,
+                is_preferred: Some(true),
+                disabled: None,
+                data: None,
+            }));
         }
 
-        if actions.is_empty() {
-            Ok(None)
-        } else {
-            Ok(Some(actions))
-        }
+        Ok(if actions.is_empty() { None } else { Some(actions) })
     }
 
     async fn completion(
         &self,
         params: CompletionParams,
     ) -> Result<Option<CompletionResponse>> {
-        let uri = &params.text_document_position.text_document.uri;
+        let uri = params.text_document_position.text_document.uri;
         let position = params.text_document_position.position;
 
-        // Get current source text
-        let source = {
-            let docs = self.documents.read().unwrap();
-            docs.get(uri).cloned()
-        };
-        let Some(source) = source else {
+        let Some(cached) = self.inner.get_compiled(&uri).await else {
             return Ok(None);
         };
+        let live_text = self.inner.get_text(&uri).await;
 
-        let offset = position_to_offset(&source, position);
-
-        // Use last good compilation (code is likely broken while typing)
-        let compiled = self.compiled.read().unwrap();
-        let cached = match compiled.get(uri) {
-            Some(c) => c,
-            None => return Ok(None),
-        };
-
-        // Dot-completion vs identifier completion
         let is_dot = params
             .context
             .as_ref()
             .and_then(|c| c.trigger_character.as_deref())
             == Some(".");
 
-        if is_dot {
-            Ok(self.dot_completion(&source, offset, cached))
-        } else {
-            Ok(self.identifier_completion(&source, offset, cached))
-        }
+        Ok(safe_handler(|| {
+            crate::completion::completion(position, &cached, live_text.as_deref(), is_dot)
+        })
+        .unwrap_or(None))
+    }
+
+    async fn signature_help(
+        &self,
+        params: SignatureHelpParams,
+    ) -> Result<Option<SignatureHelp>> {
+        let uri = params.text_document_position_params.text_document.uri;
+        let position = params.text_document_position_params.position;
+        let Some(cached) = self.inner.get_compiled(&uri).await else {
+            return Ok(None);
+        };
+
+        Ok(safe_handler(|| signature_help::signature_help(position, &cached)).unwrap_or(None))
+    }
+
+    async fn document_symbol(
+        &self,
+        params: DocumentSymbolParams,
+    ) -> Result<Option<DocumentSymbolResponse>> {
+        let Some(cached) = self.inner.get_compiled(&params.text_document.uri).await else {
+            return Ok(None);
+        };
+        Ok(safe_handler(|| symbols::document_symbols(&cached)).unwrap_or(None))
+    }
+
+    async fn symbol(
+        &self,
+        params: WorkspaceSymbolParams,
+    ) -> Result<Option<Vec<SymbolInformation>>> {
+        let query = params.query;
+        let compiled = self.inner.compiled.read().await;
+        let all: Vec<(Url, Arc<CompilationResult>)> = compiled
+            .iter()
+            .map(|(u, c)| (u.clone(), c.clone()))
+            .collect();
+        drop(compiled);
+        Ok(safe_handler(|| symbols::workspace_symbols(&query, &all)).unwrap_or(None))
+    }
+
+    async fn formatting(
+        &self,
+        params: DocumentFormattingParams,
+    ) -> Result<Option<Vec<TextEdit>>> {
+        let uri = params.text_document.uri;
+        let Some(text) = self.inner.get_text(&uri).await else {
+            return Ok(None);
+        };
+        Ok(safe_handler(|| crate::format::format_document(&text)).unwrap_or(None))
+    }
+
+    async fn references(
+        &self,
+        params: ReferenceParams,
+    ) -> Result<Option<Vec<Location>>> {
+        let uri = params.text_document_position.text_document.uri;
+        let position = params.text_document_position.position;
+        let include_decl = params.context.include_declaration;
+        let Some(cached) = self.inner.get_compiled(&uri).await else {
+            return Ok(None);
+        };
+        Ok(safe_handler(|| references::references(&uri, position, &cached, include_decl))
+            .unwrap_or(None))
+    }
+
+    async fn rename(&self, params: RenameParams) -> Result<Option<WorkspaceEdit>> {
+        let uri = params.text_document_position.text_document.uri;
+        let position = params.text_document_position.position;
+        let new_name = params.new_name;
+        let Some(cached) = self.inner.get_compiled(&uri).await else {
+            return Ok(None);
+        };
+        Ok(safe_handler(|| references::rename(&uri, position, &new_name, &cached))
+            .unwrap_or(None))
+    }
+
+    async fn inlay_hint(
+        &self,
+        params: InlayHintParams,
+    ) -> Result<Option<Vec<InlayHint>>> {
+        let Some(cached) = self.inner.get_compiled(&params.text_document.uri).await else {
+            return Ok(None);
+        };
+        Ok(safe_handler(|| Some(inlay_hints::inlay_hints(&cached, params.range))).unwrap_or(None))
+    }
+
+    async fn semantic_tokens_full(
+        &self,
+        params: SemanticTokensParams,
+    ) -> Result<Option<SemanticTokensResult>> {
+        let Some(cached) = self.inner.get_compiled(&params.text_document.uri).await else {
+            return Ok(None);
+        };
+        Ok(safe_handler(|| Some(semantic_tokens::tokens(&cached))).unwrap_or(None))
     }
 }
 
-impl Backend {
-    /// Resolve a builtin type, function, or method to its stub file location.
-    fn resolve_builtin_location(
-        &self,
-        name: &str,
-        method: Option<&str>,
-    ) -> Option<GotoDefinitionResponse> {
-        let reg = rask_stdlib::StubRegistry::load();
-
-        let (source_file, span) = if let Some(method_name) = method {
-            let normalized = match name {
-                "String" => "string",
-                _ => name,
-            };
-            let m = reg.lookup_method(normalized, method_name)?;
-            (&m.source_file, m.span)
-        } else if let Some(ts) = reg.get_type(name) {
-            (&ts.source_file, ts.span)
-        } else {
-            let f = reg.functions().iter().find(|f| f.name == name)?;
-            (&f.source_file, f.span)
-        };
-
-        let (start_line, start_col) = reg.offset_to_lsp_position(source_file, span.start)?;
-        let (end_line, end_col) = reg.offset_to_lsp_position(source_file, span.end)?;
-
-        let root = self.root_uri.read().unwrap();
-        let root_uri = root.as_ref()?;
-
-        let stub_path = format!("{}/{}", root_uri.as_str().trim_end_matches('/'), source_file);
-        let stub_uri = Url::parse(&stub_path).ok()?;
-
-        Some(GotoDefinitionResponse::Scalar(Location {
-            uri: stub_uri,
-            range: Range::new(
-                Position::new(start_line, start_col),
-                Position::new(end_line, end_col),
-            ),
-        }))
-    }
-
-    /// Try to resolve a method call to its definition in a stub file.
-    fn try_method_goto_definition(
-        &self,
-        source: &str,
-        offset: usize,
-        method_name: &str,
-        cached: &CompilationResult,
-    ) -> Option<GotoDefinitionResponse> {
-        // Find the span of this ident to check for a preceding dot
-        let (ident_span, _, _) = cached.position_index.idents.iter()
-            .find(|(span, _, name)| span.start <= offset && offset <= span.end && name == method_name)?;
-
-        if ident_span.start == 0 {
-            return None;
-        }
-        if *source.as_bytes().get(ident_span.start - 1)? != b'.' {
-            return None;
-        }
-
-        let type_name = self.resolve_receiver_type_name(source, ident_span.start - 1, cached)?;
-        self.resolve_builtin_location(&type_name, Some(method_name))
-    }
-
-    /// Try to get doc comment for a method call on a builtin type.
-    fn try_method_hover(
-        &self,
-        source: &str,
-        offset: usize,
-        method_name: &str,
-        cached: &CompilationResult,
-    ) -> Option<String> {
-        let (ident_span, _, _) = cached.position_index.idents.iter()
-            .find(|(span, _, name)| span.start <= offset && offset <= span.end && name == method_name)?;
-
-        if ident_span.start == 0 {
-            return None;
-        }
-        if *source.as_bytes().get(ident_span.start - 1)? != b'.' {
-            return None;
-        }
-
-        let type_name = self.resolve_receiver_type_name(source, ident_span.start - 1, cached)?;
-        let reg = rask_stdlib::StubRegistry::load();
-        let normalized = match type_name.as_str() {
-            "String" => "string",
-            _ => &type_name,
-        };
-        let method = reg.lookup_method(normalized, method_name)?;
-
-        // Build a richer hover with signature + doc
-        let params_str = method.params.iter()
-            .map(|(n, t)| format!("{}: {}", n, t))
-            .collect::<Vec<_>>()
-            .join(", ");
-        let self_prefix = if method.takes_self { "self, " } else { "" };
-        let mut result = format!(
-            "**Method:** `{}.{}({}{}) -> {}`",
-            normalized, method.name, self_prefix, params_str, method.ret_ty
-        );
-        if let Some(doc) = &method.doc {
-            result.push_str(&format!("\n\n---\n\n{}", doc));
-        }
-        Some(result)
-    }
-
-    /// Given a dot position in source, determine the receiver's type name for stub lookup.
-    fn resolve_receiver_type_name(
-        &self,
-        source: &str,
-        dot_pos: usize,
-        cached: &CompilationResult,
-    ) -> Option<String> {
-        let text_before = &source[..dot_pos];
-        let receiver_end = text_before.len();
-        let receiver_start = text_before
-            .rfind(|c: char| !c.is_alphanumeric() && c != '_')
-            .map(|i| i + 1)
-            .unwrap_or(0);
-        let receiver_name = &text_before[receiver_start..receiver_end];
-
-        if receiver_name.is_empty() {
-            return None;
-        }
-
-        // Check if it's a known stub type/module directly
-        let reg = rask_stdlib::StubRegistry::load();
-        if reg.get_type(receiver_name).is_some() {
-            return Some(receiver_name.to_string());
-        }
-
-        // Look up the receiver's type from the typed program
-        for (_span, node_id, name) in &cached.position_index.idents {
-            if name == receiver_name {
-                if let Some(ty) = cached.typed.node_types.get(node_id) {
-                    return type_to_stub_name(ty, cached);
-                }
-            }
-        }
-
-        None
-    }
+/// Handle that implements `LanguageServer` by delegating to an inner `Backend`.
+///
+/// `tower_lsp` expects the impl to own the state, but we want to pass `Arc`
+/// clones into tokio tasks. A light wrapper sidesteps that.
+pub struct BackendHandle {
+    pub inner: Arc<Backend>,
 }
 
-/// Map a type checker Type to the stub registry type name.
-fn type_to_stub_name(
-    ty: &rask_types::Type,
-    cached: &CompilationResult,
-) -> Option<String> {
-    match ty {
-        rask_types::Type::String => Some("string".to_string()),
-        rask_types::Type::Named(id) => {
-            Some(cached.typed.types.type_name(*id))
-        }
-        rask_types::Type::Generic { base, .. } => {
-            Some(cached.typed.types.type_name(*base))
-        }
-        rask_types::Type::UnresolvedNamed(name) => Some(name.clone()),
-        rask_types::Type::UnresolvedGeneric { name, .. } => Some(name.clone()),
-        rask_types::Type::Option(_) => Some("Option".to_string()),
-        rask_types::Type::Result { .. } => Some("Result".to_string()),
-        rask_types::Type::Array { .. } | rask_types::Type::Slice(_) => Some("Vec".to_string()),
-        _ => None,
+impl BackendHandle {
+    pub fn new(inner: Arc<Backend>) -> Self {
+        Self { inner }
     }
 }

--- a/compiler/crates/rask-lsp/src/signature_help.rs
+++ b/compiler/crates/rask-lsp/src/signature_help.rs
@@ -1,0 +1,204 @@
+// SPDX-License-Identifier: (MIT OR Apache-2.0)
+//! Signature help — parameter hints shown as you type inside a call.
+//!
+//! Triggered by `(` and re-triggered by `,`. We parse the text to the left
+//! of the cursor looking for the most recent unmatched `(` — the identifier
+//! just before that paren is the function being called. The active parameter
+//! is the number of top-level commas between the paren and the cursor.
+
+use tower_lsp::lsp_types::*;
+
+use rask_resolve::{Symbol, SymbolKind};
+
+use crate::backend::CompilationResult;
+use crate::type_format::TypeFormatter;
+
+pub fn signature_help(position: Position, cached: &CompilationResult) -> Option<SignatureHelp> {
+    let source = &cached.source;
+    let offset = cached.line_index.position_to_offset(source, position);
+
+    let (callee, active_param) = locate_call(source, offset)?;
+
+    let formatter = TypeFormatter::new(&cached.typed.types);
+
+    // User-defined function lookup.
+    let user_sig = cached.typed.symbols.iter().find_map(|s| {
+        if s.name == callee && matches!(s.kind, SymbolKind::Function { .. }) {
+            Some(user_signature(s, cached, &formatter))
+        } else {
+            None
+        }
+    });
+    if let Some(sig) = user_sig {
+        return Some(wrap(vec![sig], active_param));
+    }
+
+    // Stdlib function lookup.
+    let reg = rask_stdlib::StubRegistry::load();
+    if let Some(f) = reg.functions().iter().find(|f| f.name == callee) {
+        let param_info: Vec<ParameterInformation> = f
+            .params
+            .iter()
+            .map(|(n, t)| ParameterInformation {
+                label: ParameterLabel::Simple(format!("{}: {}", n, t)),
+                documentation: None,
+            })
+            .collect();
+        let params_display = f
+            .params
+            .iter()
+            .map(|(n, t)| format!("{}: {}", n, t))
+            .collect::<Vec<_>>()
+            .join(", ");
+        let label = format!("{}({}) -> {}", f.name, params_display, f.ret_ty);
+        let info = SignatureInformation {
+            label,
+            documentation: f.doc.as_ref().map(|d| {
+                Documentation::MarkupContent(MarkupContent {
+                    kind: MarkupKind::Markdown,
+                    value: d.clone(),
+                })
+            }),
+            parameters: Some(param_info),
+            active_parameter: Some(active_param),
+        };
+        return Some(wrap(vec![info], active_param));
+    }
+
+    None
+}
+
+fn wrap(signatures: Vec<SignatureInformation>, active_param: u32) -> SignatureHelp {
+    SignatureHelp {
+        signatures,
+        active_signature: Some(0),
+        active_parameter: Some(active_param),
+    }
+}
+
+fn user_signature(
+    symbol: &Symbol,
+    cached: &CompilationResult,
+    formatter: &TypeFormatter,
+) -> SignatureInformation {
+    let SymbolKind::Function { params, ret_ty, .. } = &symbol.kind else {
+        unreachable!()
+    };
+    let parts: Vec<(String, Option<String>)> = params
+        .iter()
+        .filter_map(|&sid| {
+            let p = cached.typed.symbols.get(sid)?;
+            let ty = cached
+                .typed
+                .span_types
+                .get(&(p.span.start, p.span.end))
+                .map(|t| formatter.format(t));
+            Some((p.name.clone(), ty))
+        })
+        .collect();
+    let params_display = parts
+        .iter()
+        .map(|(n, t)| match t {
+            Some(ty) => format!("{}: {}", n, ty),
+            None => n.clone(),
+        })
+        .collect::<Vec<_>>()
+        .join(", ");
+    let label = match ret_ty {
+        Some(rt) => format!("{}({}) -> {}", symbol.name, params_display, rt),
+        None => format!("{}({})", symbol.name, params_display),
+    };
+    let info_params: Vec<ParameterInformation> = parts
+        .into_iter()
+        .map(|(n, t)| ParameterInformation {
+            label: ParameterLabel::Simple(match t {
+                Some(ty) => format!("{}: {}", n, ty),
+                None => n,
+            }),
+            documentation: None,
+        })
+        .collect();
+    SignatureInformation {
+        label,
+        documentation: None,
+        parameters: Some(info_params),
+        active_parameter: None,
+    }
+}
+
+/// Locate the enclosing call at `offset`. Returns (callee_name, active_param).
+fn locate_call(source: &str, offset: usize) -> Option<(String, u32)> {
+    let bytes = source.as_bytes();
+    let end = offset.min(bytes.len());
+    let mut depth = 0i32;
+    let mut commas = 0u32;
+    let mut i = end;
+    let mut in_string = false;
+    let mut string_quote = b'"';
+
+    while i > 0 {
+        i -= 1;
+        let b = bytes[i];
+        if in_string {
+            if b == string_quote && (i == 0 || bytes[i - 1] != b'\\') {
+                in_string = false;
+            }
+            continue;
+        }
+        match b {
+            b'"' | b'\'' => {
+                in_string = true;
+                string_quote = b;
+            }
+            b')' | b']' | b'}' => depth += 1,
+            b'(' if depth > 0 => depth -= 1,
+            b'[' | b'{' if depth > 0 => depth -= 1,
+            b'(' => {
+                // Found the unmatched open paren — read the identifier before it.
+                let name_end = i;
+                let name_start = source[..name_end]
+                    .rfind(|c: char| !c.is_alphanumeric() && c != '_')
+                    .map(|x| x + 1)
+                    .unwrap_or(0);
+                let name = &source[name_start..name_end];
+                if name.is_empty() {
+                    return None;
+                }
+                return Some((name.to_string(), commas));
+            }
+            b',' if depth == 0 => commas += 1,
+            _ => {}
+        }
+    }
+    None
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn finds_call_at_cursor() {
+        let src = "foo(a, b, c)";
+        let (name, active) = locate_call(src, 10).unwrap();
+        assert_eq!(name, "foo");
+        assert_eq!(active, 2);
+    }
+
+    #[test]
+    fn handles_nested_parens() {
+        let src = "foo(bar(1, 2), baz(3))";
+        // Cursor right before the trailing `)` on `baz`
+        let (name, active) = locate_call(src, 20).unwrap();
+        assert_eq!(name, "baz");
+        assert_eq!(active, 0);
+    }
+
+    #[test]
+    fn ignores_commas_in_strings() {
+        let src = r#"foo("a, b, c", d)"#;
+        let (name, active) = locate_call(src, 16).unwrap();
+        assert_eq!(name, "foo");
+        assert_eq!(active, 1);
+    }
+}

--- a/compiler/crates/rask-lsp/src/symbols.rs
+++ b/compiler/crates/rask-lsp/src/symbols.rs
@@ -1,0 +1,237 @@
+// SPDX-License-Identifier: (MIT OR Apache-2.0)
+//! Document and workspace symbol providers (file outline + global search).
+
+use std::sync::Arc;
+
+use tower_lsp::lsp_types::*;
+
+use rask_ast::decl::{Decl, DeclKind, FnDecl, StructDecl, EnumDecl, TraitDecl, ImplDecl};
+use rask_ast::Span;
+
+use crate::backend::CompilationResult;
+use crate::convert::LineIndex;
+
+/// Outline for a single document.
+pub fn document_symbols(cached: &CompilationResult) -> Option<DocumentSymbolResponse> {
+    let mut out = Vec::new();
+    for decl in &cached.decls {
+        // Only include decls from the *current* file — siblings were appended
+        // to `decls` by the pipeline for cross-file resolution, we don't want
+        // them in the outline.
+        if !is_current_file(cached, decl.span) {
+            continue;
+        }
+        if let Some(sym) = decl_to_symbol(decl, &cached.source, &cached.line_index) {
+            out.push(sym);
+        }
+    }
+    Some(DocumentSymbolResponse::Nested(out))
+}
+
+/// Global symbol search across all open documents.
+pub fn workspace_symbols(
+    query: &str,
+    compiled: &[(Url, Arc<CompilationResult>)],
+) -> Option<Vec<SymbolInformation>> {
+    let query_lc = query.to_lowercase();
+    let mut out = Vec::new();
+
+    for (uri, cached) in compiled {
+        for decl in &cached.decls {
+            if !is_current_file(cached, decl.span) {
+                continue;
+            }
+            push_matching(decl, &query_lc, &cached.source, &cached.line_index, uri, &mut out);
+        }
+    }
+    // Cap the result size to avoid dumping a whole project in one response.
+    out.truncate(500);
+    Some(out)
+}
+
+fn is_current_file(cached: &CompilationResult, span: Span) -> bool {
+    cached
+        .current_file_spans
+        .iter()
+        .any(|s| span.start >= s.start && span.end <= s.end)
+}
+
+fn decl_to_symbol(decl: &Decl, source: &str, idx: &LineIndex) -> Option<DocumentSymbol> {
+    let range = idx.span_to_range(source, decl.span);
+    match &decl.kind {
+        DeclKind::Fn(f) => Some(symbol(&f.name, f_detail(f), SymbolKind::FUNCTION, range, None)),
+        DeclKind::Struct(s) => Some(symbol(
+            &s.name, None, SymbolKind::STRUCT, range,
+            Some(struct_children(s, source, idx)),
+        )),
+        DeclKind::Enum(e) => Some(symbol(
+            &e.name, None, SymbolKind::ENUM, range,
+            Some(enum_children(e, source, idx)),
+        )),
+        DeclKind::Trait(t) => Some(symbol(
+            &t.name, None, SymbolKind::INTERFACE, range,
+            Some(trait_children(t, source, idx)),
+        )),
+        DeclKind::Impl(i) => Some(symbol(
+            &impl_name(i), None, SymbolKind::NAMESPACE, range,
+            Some(impl_children(i, source, idx)),
+        )),
+        DeclKind::Const(c) => Some(symbol(&c.name, None, SymbolKind::CONSTANT, range, None)),
+        DeclKind::Union(u) => Some(symbol(&u.name, None, SymbolKind::STRUCT, range, None)),
+        DeclKind::Extern(e) => Some(symbol(&e.name, Some(format!("extern \"{}\"", e.abi)), SymbolKind::FUNCTION, range, None)),
+        DeclKind::TypeAlias(t) => Some(symbol(&t.name, Some(format!("= {}", t.target)), SymbolKind::TYPE_PARAMETER, range, None)),
+        DeclKind::Test(t) => Some(symbol(&t.name, Some("test".into()), SymbolKind::METHOD, range, None)),
+        DeclKind::Benchmark(b) => Some(symbol(&b.name, Some("bench".into()), SymbolKind::METHOD, range, None)),
+        _ => None,
+    }
+}
+
+fn impl_name(i: &ImplDecl) -> String {
+    match &i.trait_name {
+        Some(t) => format!("{} for {}", t, i.target_ty),
+        None => i.target_ty.clone(),
+    }
+}
+
+fn struct_children(s: &StructDecl, source: &str, idx: &LineIndex) -> Vec<DocumentSymbol> {
+    let mut children = Vec::new();
+    for field in &s.fields {
+        let range = idx.span_to_range(source, field.name_span);
+        children.push(symbol(&field.name, Some(field.ty.clone()), SymbolKind::FIELD, range, None));
+    }
+    for m in &s.methods {
+        let range = idx.span_to_range(source, m.span);
+        children.push(symbol(&m.name, f_detail(m), SymbolKind::METHOD, range, None));
+    }
+    children
+}
+
+fn enum_children(e: &EnumDecl, source: &str, idx: &LineIndex) -> Vec<DocumentSymbol> {
+    let mut children = Vec::new();
+    for v in &e.variants {
+        // No dedicated name span on variant — fall back to decl span.
+        let range = idx.span_to_range(source, Span::new(0, 0));
+        children.push(symbol(&v.name, None, SymbolKind::ENUM_MEMBER, range, None));
+    }
+    for m in &e.methods {
+        let range = idx.span_to_range(source, m.span);
+        children.push(symbol(&m.name, f_detail(m), SymbolKind::METHOD, range, None));
+    }
+    children
+}
+
+fn trait_children(t: &TraitDecl, source: &str, idx: &LineIndex) -> Vec<DocumentSymbol> {
+    t.methods.iter().map(|m| {
+        let range = idx.span_to_range(source, m.span);
+        symbol(&m.name, f_detail(m), SymbolKind::METHOD, range, None)
+    }).collect()
+}
+
+fn impl_children(i: &ImplDecl, source: &str, idx: &LineIndex) -> Vec<DocumentSymbol> {
+    i.methods.iter().map(|m| {
+        let range = idx.span_to_range(source, m.span);
+        symbol(&m.name, f_detail(m), SymbolKind::METHOD, range, None)
+    }).collect()
+}
+
+fn f_detail(f: &FnDecl) -> Option<String> {
+    let params = f.params.iter()
+        .map(|p| format!("{}: {}", p.name, p.ty))
+        .collect::<Vec<_>>()
+        .join(", ");
+    let ret = f.ret_ty.clone().unwrap_or_default();
+    Some(if ret.is_empty() {
+        format!("({})", params)
+    } else {
+        format!("({}) -> {}", params, ret)
+    })
+}
+
+#[allow(deprecated)]
+fn symbol(
+    name: &str,
+    detail: Option<String>,
+    kind: SymbolKind,
+    range: Range,
+    children: Option<Vec<DocumentSymbol>>,
+) -> DocumentSymbol {
+    DocumentSymbol {
+        name: name.to_string(),
+        detail,
+        kind,
+        tags: None,
+        deprecated: None,
+        range,
+        selection_range: range,
+        children,
+    }
+}
+
+fn push_matching(
+    decl: &Decl,
+    query_lc: &str,
+    source: &str,
+    idx: &LineIndex,
+    uri: &Url,
+    out: &mut Vec<SymbolInformation>,
+) {
+    let (name, kind, container): (&str, SymbolKind, Option<String>) = match &decl.kind {
+        DeclKind::Fn(f) => (&f.name, SymbolKind::FUNCTION, None),
+        DeclKind::Struct(s) => (&s.name, SymbolKind::STRUCT, None),
+        DeclKind::Enum(e) => (&e.name, SymbolKind::ENUM, None),
+        DeclKind::Trait(t) => (&t.name, SymbolKind::INTERFACE, None),
+        DeclKind::Const(c) => (&c.name, SymbolKind::CONSTANT, None),
+        DeclKind::Union(u) => (&u.name, SymbolKind::STRUCT, None),
+        DeclKind::Extern(e) => (&e.name, SymbolKind::FUNCTION, None),
+        DeclKind::TypeAlias(t) => (&t.name, SymbolKind::TYPE_PARAMETER, None),
+        DeclKind::Test(t) => (&t.name, SymbolKind::METHOD, Some("test".into())),
+        _ => return,
+    };
+    if !query_lc.is_empty() && !name.to_lowercase().contains(query_lc) {
+        return;
+    }
+    let range = idx.span_to_range(source, decl.span);
+    #[allow(deprecated)]
+    out.push(SymbolInformation {
+        name: name.to_string(),
+        kind,
+        tags: None,
+        deprecated: None,
+        location: Location { uri: uri.clone(), range },
+        container_name: container,
+    });
+    // Also include children (struct/enum/trait methods) for completeness.
+    match &decl.kind {
+        DeclKind::Struct(s) => push_methods(&s.methods, &s.name, query_lc, source, idx, uri, out),
+        DeclKind::Enum(e) => push_methods(&e.methods, &e.name, query_lc, source, idx, uri, out),
+        DeclKind::Trait(t) => push_methods(&t.methods, &t.name, query_lc, source, idx, uri, out),
+        DeclKind::Impl(i) => push_methods(&i.methods, &impl_name(i), query_lc, source, idx, uri, out),
+        _ => {}
+    }
+}
+
+fn push_methods(
+    methods: &[FnDecl],
+    container: &str,
+    query_lc: &str,
+    source: &str,
+    idx: &LineIndex,
+    uri: &Url,
+    out: &mut Vec<SymbolInformation>,
+) {
+    for m in methods {
+        if !query_lc.is_empty() && !m.name.to_lowercase().contains(query_lc) {
+            continue;
+        }
+        let range = idx.span_to_range(source, m.span);
+        #[allow(deprecated)]
+        out.push(SymbolInformation {
+            name: m.name.clone(),
+            kind: SymbolKind::METHOD,
+            tags: None,
+            deprecated: None,
+            location: Location { uri: uri.clone(), range },
+            container_name: Some(container.to_string()),
+        });
+    }
+}

--- a/compiler/crates/rask-lsp/src/util.rs
+++ b/compiler/crates/rask-lsp/src/util.rs
@@ -1,0 +1,62 @@
+// SPDX-License-Identifier: (MIT OR Apache-2.0)
+//! Shared helpers used by more than one feature module.
+
+use crate::backend::CompilationResult;
+
+/// Given a `.` position, figure out what type the receiver evaluates to so
+/// we can look up methods on it. Returns a stub-registry-ready type name.
+///
+/// Handles:
+///   - literal receivers (`Vec.new()`)
+///   - identifiers whose type was inferred
+///   - falls back to the identifier name itself (e.g., stdlib modules)
+pub fn resolve_receiver_type(
+    source: &str,
+    dot_pos: usize,
+    cached: &CompilationResult,
+) -> Option<String> {
+    let before = source.get(..dot_pos)?;
+    let ident_start = before
+        .rfind(|c: char| !c.is_alphanumeric() && c != '_')
+        .map(|i| i + 1)
+        .unwrap_or(0);
+    let receiver = &before[ident_start..];
+
+    if receiver.is_empty() {
+        return None;
+    }
+
+    // Direct stub type or module.
+    let reg = rask_stdlib::StubRegistry::load();
+    if reg.get_type(receiver).is_some() {
+        return Some(receiver.to_string());
+    }
+
+    // Look up through the typed program.
+    for (_span, node_id, name) in &cached.position_index.idents {
+        if name == receiver {
+            if let Some(ty) = cached.typed.node_types.get(node_id) {
+                return type_to_stub_name(ty, cached);
+            }
+        }
+    }
+
+    None
+}
+
+pub fn type_to_stub_name(
+    ty: &rask_types::Type,
+    cached: &CompilationResult,
+) -> Option<String> {
+    match ty {
+        rask_types::Type::String => Some("string".to_string()),
+        rask_types::Type::Named(id) => Some(cached.typed.types.type_name(*id)),
+        rask_types::Type::Generic { base, .. } => Some(cached.typed.types.type_name(*base)),
+        rask_types::Type::UnresolvedNamed(name) => Some(name.clone()),
+        rask_types::Type::UnresolvedGeneric { name, .. } => Some(name.clone()),
+        rask_types::Type::Option(_) => Some("Option".to_string()),
+        rask_types::Type::Result { .. } => Some("Result".to_string()),
+        rask_types::Type::Array { .. } | rask_types::Type::Slice(_) => Some("Vec".to_string()),
+        _ => None,
+    }
+}

--- a/editors/vscode/CHANGELOG.md
+++ b/editors/vscode/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## 0.2.0
+
+- Modern LSP client integration
+- Status bar indicator for server state
+- Better startup error reporting (output channel + quick actions)
+- Commands: `rask check`, `rask test`, `rask build`
+- Settings: `rask.cliPath`, `rask.inlayHints.enable`
+
 ## 0.1.0
 
 - Syntax highlighting for `.rk` files

--- a/editors/vscode/package-lock.json
+++ b/editors/vscode/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "rask",
-  "version": "0.1.0",
+  "version": "0.1.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "rask",
-      "version": "0.1.0",
+      "version": "0.1.3",
       "license": "MIT OR Apache-2.0",
       "dependencies": {
         "vscode-languageclient": "^9.0.1"

--- a/editors/vscode/package.json
+++ b/editors/vscode/package.json
@@ -2,7 +2,7 @@
   "name": "rask",
   "displayName": "Rask",
   "description": "Language support for Rask",
-  "version": "0.1.3",
+  "version": "0.2.0",
   "publisher": "rask-lang",
   "license": "MIT OR Apache-2.0",
   "icon": "icon.png",
@@ -55,8 +55,24 @@
         "icon": "$(play)"
       },
       {
+        "command": "rask.check",
+        "title": "Rask: Check File"
+      },
+      {
+        "command": "rask.test",
+        "title": "Rask: Run Tests"
+      },
+      {
+        "command": "rask.build",
+        "title": "Rask: Build Package"
+      },
+      {
         "command": "rask.restartServer",
         "title": "Rask: Restart Language Server"
+      },
+      {
+        "command": "rask.showOutput",
+        "title": "Rask: Show Language Server Output"
       }
     ],
     "snippets": [
@@ -82,6 +98,16 @@
           "type": "string",
           "default": "",
           "description": "Path to rask-lsp binary. If empty, searches PATH."
+        },
+        "rask.cliPath": {
+          "type": "string",
+          "default": "",
+          "description": "Path to the rask CLI binary (used by Run/Check/Test/Build). If empty, searches next to serverPath and PATH."
+        },
+        "rask.inlayHints.enable": {
+          "type": "boolean",
+          "default": true,
+          "description": "Show inferred types as inlay hints on `let`/`const` bindings."
         }
       }
     }

--- a/editors/vscode/src/extension.ts
+++ b/editors/vscode/src/extension.ts
@@ -1,40 +1,87 @@
 import {
     workspace, window, commands, languages,
     ExtensionContext, TextDocument, TextEdit, Range,
+    StatusBarAlignment, StatusBarItem, ThemeColor, Uri,
 } from 'vscode';
 import {
     LanguageClient,
     LanguageClientOptions,
     ServerOptions,
+    RevealOutputChannelOn,
+    State,
 } from 'vscode-languageclient/node';
 import { execFile, spawn } from 'child_process';
+import * as path from 'path';
+import * as fs from 'fs';
 
 let client: LanguageClient | undefined;
+let statusBar: StatusBarItem | undefined;
 
-function getRaskPath(): string {
-    const config = workspace.getConfiguration('rask');
-    const serverPath = config.get<string>('serverPath');
-    if (serverPath) {
-        // serverPath points to rask-lsp; assume rask is next to it
-        const dir = serverPath.substring(0, serverPath.lastIndexOf('/'));
-        if (dir) {
-            return dir + '/rask';
+function getConfig() {
+    return workspace.getConfiguration('rask');
+}
+
+function resolveServerPath(): string {
+    const configured = getConfig().get<string>('serverPath');
+    if (configured && configured.trim().length > 0) {
+        return configured;
+    }
+    return 'rask-lsp';
+}
+
+function resolveRaskPath(): string {
+    const configured = getConfig().get<string>('cliPath');
+    if (configured && configured.trim().length > 0) {
+        return configured;
+    }
+    // If serverPath is set, assume `rask` is a sibling.
+    const serverPath = getConfig().get<string>('serverPath');
+    if (serverPath && serverPath.trim().length > 0) {
+        const dir = path.dirname(serverPath);
+        const candidate = path.join(dir, 'rask');
+        if (fs.existsSync(candidate)) {
+            return candidate;
         }
     }
     return 'rask';
 }
 
-function startClient(): void {
-    const config = workspace.getConfiguration('rask');
-    let serverPath = config.get<string>('serverPath');
-
-    if (!serverPath) {
-        serverPath = 'rask-lsp';
+function setStatus(kind: 'starting' | 'ready' | 'error' | 'stopped', detail?: string) {
+    if (!statusBar) return;
+    switch (kind) {
+        case 'starting':
+            statusBar.text = '$(sync~spin) Rask: starting';
+            statusBar.backgroundColor = undefined;
+            break;
+        case 'ready':
+            statusBar.text = '$(check) Rask';
+            statusBar.backgroundColor = undefined;
+            break;
+        case 'error':
+            statusBar.text = '$(error) Rask';
+            statusBar.backgroundColor = new ThemeColor('statusBarItem.errorBackground');
+            break;
+        case 'stopped':
+            statusBar.text = '$(circle-slash) Rask';
+            statusBar.backgroundColor = new ThemeColor('statusBarItem.warningBackground');
+            break;
     }
+    statusBar.tooltip = detail ? `Rask LSP — ${kind}\n${detail}` : `Rask LSP — ${kind}\nClick to restart`;
+    statusBar.show();
+}
+
+async function startClient(context: ExtensionContext): Promise<void> {
+    const serverPath = resolveServerPath();
 
     const serverOptions: ServerOptions = {
         command: serverPath,
         args: [],
+        options: {
+            env: {
+                ...process.env,
+                RUST_BACKTRACE: '1',
+            },
+        },
     };
 
     const clientOptions: LanguageClientOptions = {
@@ -42,55 +89,123 @@ function startClient(): void {
         synchronize: {
             fileEvents: workspace.createFileSystemWatcher('**/*.rk'),
         },
+        // Send startup failures to the "Rask Language Server" output channel
+        // instead of a modal popup — the user can inspect the actual error.
+        revealOutputChannelOn: RevealOutputChannelOn.Error,
+        initializationOptions: {
+            // Advertise UTF-16 so positions align with the editor.
+            positionEncodings: ['utf-16'],
+        },
+        markdown: {
+            isTrusted: false,
+            supportHtml: false,
+        },
     };
 
     client = new LanguageClient(
         'rask',
         'Rask Language Server',
         serverOptions,
-        clientOptions
+        clientOptions,
     );
 
-    client.start().catch(() => {
-        window.showWarningMessage(
-            'Could not start rask-lsp. Install it or set rask.serverPath in settings. ' +
-            'Syntax highlighting still works without it.'
-        );
+    // Wire state transitions to the status bar so the user can see when
+    // the analyzer is alive.
+    client.onDidChangeState((ev) => {
+        if (ev.newState === State.Starting) setStatus('starting');
+        else if (ev.newState === State.Running) setStatus('ready');
+        else if (ev.newState === State.Stopped) setStatus('stopped');
     });
+
+    setStatus('starting');
+    try {
+        await client.start();
+    } catch (err: any) {
+        setStatus('error', String(err?.message ?? err));
+        // Surface the exact failure so the user knows whether it's "binary
+        // not found" vs. a protocol error vs. something else.
+        const detail = err?.message ?? String(err);
+        const action = await window.showErrorMessage(
+            `Rask LSP failed to start (${detail}). Syntax highlighting still works.`,
+            'Open Output',
+            'Configure Path',
+        );
+        if (action === 'Open Output') {
+            client?.outputChannel.show();
+        } else if (action === 'Configure Path') {
+            await commands.executeCommand(
+                'workbench.action.openSettings',
+                'rask.serverPath',
+            );
+        }
+    }
 }
 
-export function activate(context: ExtensionContext) {
-    startClient();
+async function stopClient(): Promise<void> {
+    if (!client) return;
+    try {
+        await client.stop();
+    } catch {
+        // Ignore — we're tearing down anyway.
+    }
+    client = undefined;
+}
+
+async function restartClient(context: ExtensionContext): Promise<void> {
+    await stopClient();
+    await startClient(context);
+}
+
+function runInTerminal(command: string, filePath?: string): void {
+    const editor = window.activeTextEditor;
+    if (!filePath && (!editor || editor.document.languageId !== 'rask')) {
+        window.showWarningMessage('Open a .rk file first.');
+        return;
+    }
+    const target = filePath ?? editor!.document.fileName;
+    const terminal = window.createTerminal('Rask');
+    terminal.show();
+    terminal.sendText(`${resolveRaskPath()} ${command} "${target}"`);
+}
+
+export async function activate(context: ExtensionContext): Promise<void> {
+    statusBar = window.createStatusBarItem(StatusBarAlignment.Left, 100);
+    statusBar.command = 'rask.restartServer';
+    context.subscriptions.push(statusBar);
+
+    await startClient(context);
 
     context.subscriptions.push(
-        commands.registerCommand('rask.run', () => {
-            const editor = window.activeTextEditor;
-            if (!editor || editor.document.languageId !== 'rask') {
-                window.showWarningMessage('Open a .rk file to run it.');
-                return;
-            }
-            const filePath = editor.document.fileName;
-            const terminal = window.createTerminal('Rask');
-            terminal.show();
-            terminal.sendText(`${getRaskPath()} run "${filePath}"`);
+        commands.registerCommand('rask.run', () => runInTerminal('run')),
+        commands.registerCommand('rask.check', () => runInTerminal('check')),
+        commands.registerCommand('rask.test', () => runInTerminal('test')),
+        commands.registerCommand('rask.build', () => runInTerminal('build')),
+
+        commands.registerCommand('rask.restartServer', () => restartClient(context)),
+
+        commands.registerCommand('rask.showOutput', () => {
+            client?.outputChannel.show();
         }),
 
-        commands.registerCommand('rask.restartServer', async () => {
-            if (client) {
-                await client.stop();
-                client = undefined;
-            }
-            startClient();
-        }),
-
+        // The LSP provides formatting, but keep this legacy path as a fallback
+        // for when the server isn't running.
         languages.registerDocumentFormattingEditProvider('rask', {
             provideDocumentFormattingEdits(document: TextDocument): Promise<TextEdit[]> {
+                // If the LSP is running, its formatter wins — VS Code applies
+                // the server's edits before calling this fallback.
+                if (client && client.state === State.Running) {
+                    return Promise.resolve([]);
+                }
                 return new Promise((resolve) => {
-                    const proc = spawn(getRaskPath(), ['fmt']);
+                    const proc = spawn(resolveRaskPath(), ['fmt']);
                     let stdout = '';
                     let stderr = '';
                     proc.stdout.on('data', (data: Buffer) => { stdout += data.toString(); });
                     proc.stderr.on('data', (data: Buffer) => { stderr += data.toString(); });
+                    proc.on('error', (err: Error) => {
+                        window.showWarningMessage(`rask fmt failed: ${err.message}`);
+                        resolve([]);
+                    });
                     proc.on('close', (code: number) => {
                         if (code !== 0) {
                             window.showWarningMessage(`rask fmt failed: ${stderr}`);
@@ -99,21 +214,27 @@ export function activate(context: ExtensionContext) {
                         }
                         const fullRange = new Range(
                             document.positionAt(0),
-                            document.positionAt(document.getText().length)
+                            document.positionAt(document.getText().length),
                         );
                         resolve([TextEdit.replace(fullRange, stdout)]);
                     });
                     proc.stdin.write(document.getText());
                     proc.stdin.end();
                 });
+            },
+        }),
+    );
+
+    // Auto-restart when the user changes the server path or similar.
+    context.subscriptions.push(
+        workspace.onDidChangeConfiguration(async (e) => {
+            if (e.affectsConfiguration('rask.serverPath')) {
+                await restartClient(context);
             }
-        })
+        }),
     );
 }
 
-export function deactivate(): Thenable<void> | undefined {
-    if (!client) {
-        return undefined;
-    }
-    return client.stop();
+export async function deactivate(): Promise<void> {
+    await stopClient();
 }


### PR DESCRIPTION
## Summary

This PR significantly refactors the Rask LSP server to improve architecture, add missing features, and fix critical bugs around text encoding and document synchronization. The server now uses incremental text sync instead of full document replacement, properly handles UTF-16 position encoding, and splits monolithic handler code into focused modules.

## Key Changes

### Core Architecture
- **Async-safe locking**: Replaced `std::sync::RwLock` with `tokio::sync::RwLock` throughout to avoid blocking the async executor
- **Panic safety**: Added `safe_handler` wrapper using `catch_unwind` to prevent compiler panics from crashing the server
- **Debounced analysis**: Implemented analysis scheduling with 120ms debounce to avoid redundant compilations during rapid typing
- **BackendHandle wrapper**: Introduced `BackendHandle` as the `LanguageServer` impl to enable `Arc<Backend>` cloning for async tasks

### Text Encoding & Position Handling
- **UTF-16 support**: Implemented `LineIndex` struct that properly converts between UTF-8 byte offsets (compiler) and UTF-16 code units (LSP)
  - Caches line starts and per-line ASCII flags for O(log n) position lookups
  - Fixes panics on emoji, accented letters, and CJK text
- **Incremental sync**: Changed from `TextDocumentSyncKind::FULL` to `INCREMENTAL` with proper `apply_change` implementation
- **Position encoding negotiation**: Server now advertises UTF-16 support and negotiates with client during initialization

### Feature Modules
Extracted handler logic into focused, testable modules:
- `hover.rs`: Type information, symbol docs, struct fields/enum variants
- `goto.rs`: Definition navigation with sibling file and stdlib support
- `completion.rs`: Dot-triggered (fields/methods) and identifier completion
- `signature_help.rs`: Parameter hints for function calls
- `references.rs`: Find references and rename operations
- `symbols.rs`: Document outline and workspace symbol search
- `semantic_tokens.rs`: Classifier-driven syntax highlighting
- `inlay_hints.rs`: Inline type hints for variable declarations
- `format.rs`: Document formatting via rask-fmt
- `incremental.rs`: Content change application with proper byte offset math
- `util.rs`: Shared helpers (receiver type resolution, etc.)

### Compilation Pipeline
- **Snapshot caching**: `CompilationResult` now holds the source snapshot it was analyzed against, preventing stale lookups
- **Current-file filtering**: Added `current_file_spans` to filter diagnostics from whole-package compilation down to editor buffer responsibility
- **Panic recovery**: Pipeline wrapped in `catch_unwind` with fallback diagnostic generation
- **Line index caching**: Each `CompilationResult` includes a `LineIndex` for consistent position conversions

### Server Capabilities
Expanded and corrected capability advertisement:
- Added signature help, document symbols, workspace symbols
- Added references, rename, inlay hints, semantic tokens
- Added formatting provider
- Fixed completion trigger characters: `[".", ":", "("]`
- Proper `position_encoding` negotiation in `InitializeResult`

### VS Code Extension
- Modern LSP client setup with proper error handling
- Status bar indicator showing server state (starting/ready/error/stopped)
- Output channel for server logs and startup diagnostics
- Commands: `rask check`, `rask test`, `rask build`
- Configurable `serverPath` and `cliPath` settings
- Version bump to 0.2.0

## Notable Implementation Details

- **Debounce mechanism**: Uses atomic generation counter to cancel outdated analyses when newer keystrokes arrive
- **Blocking worker pool**: CPU-heavy analysis runs via `tokio::task::spawn_blocking` to avoid stalling the async executor
- **Sibling file tracking**: Maintains cross-file symbol resolution for multi-file packages
- **Stub registry integration**: Falls back to stdlib docs and method signatures when user code isn't available
- **Span-to-range conversion**: Properly handles UTF-16 conversion for all diagnostic and navigation responses

## Testing Notes

The refactoring maintains backward compatibility with existing diagnostics while fixing

https://claude.ai/code/session_01PLmLVXbDzUvEf4JJDFo2mt