### PR TITLE
Replace `let` with `mut` keyword for rebindable bindings

### DIFF
--- a/benchmarks/features/error_handling.rk
+++ b/benchmarks/features/error_handling.rk
@@ -8,8 +8,8 @@ func checked_div(a: i64, b: i64) -> i64 or string {
 }
 
 func sum_divs(n: i64) -> i64 or string {
-    let sum = 0
-    let i = 1
+    mut sum = 0
+    mut i = 1
     while i <= n {
         sum = sum + try checked_div(1000, i)
         i = i + 1
@@ -18,7 +18,7 @@ func sum_divs(n: i64) -> i64 or string {
 }
 
 benchmark "result propagation 10k" {
-    let i = 0
+    mut i = 0
     while i < 100 {
         sum_divs(100)
         i = i + 1

--- a/benchmarks/features/handle_overhead.rk
+++ b/benchmarks/features/handle_overhead.rk
@@ -6,18 +6,18 @@
 // Compares: Rask pool[h] → C with same pool.c → C raw array (unsafe)
 
 benchmark "handle sequential read 1k" {
-    let p = Pool.new()
-    let handles = Vec.new()
-    let i = 0
+    mut p = Pool.new()
+    mut handles = Vec.new()
+    mut i = 0
     while i < 1000 {
-        let result = p.insert(i)
+        mut result = p.insert(i)
         if result is Ok(h) {
             handles.push(h)
         }
         i = i + 1
     }
 
-    let sum = 0
+    mut sum = 0
     i = 0
     while i < 1000 {
         sum = sum + p[handles[i]]
@@ -26,11 +26,11 @@ benchmark "handle sequential read 1k" {
 }
 
 benchmark "handle random read 1k" {
-    let p = Pool.new()
-    let handles = Vec.new()
-    let i = 0
+    mut p = Pool.new()
+    mut handles = Vec.new()
+    mut i = 0
     while i < 1000 {
-        let result = p.insert(i)
+        mut result = p.insert(i)
         if result is Ok(h) {
             handles.push(h)
         }
@@ -38,8 +38,8 @@ benchmark "handle random read 1k" {
     }
 
     // Read in a pseudo-random order (stride 7, wraps around)
-    let sum = 0
-    let idx = 0
+    mut sum = 0
+    mut idx = 0
     i = 0
     while i < 1000 {
         sum = sum + p[handles[idx]]
@@ -49,11 +49,11 @@ benchmark "handle random read 1k" {
 }
 
 benchmark "handle churn remove 1k" {
-    let p = Pool.new()
-    let handles = Vec.new()
-    let i = 0
+    mut p = Pool.new()
+    mut handles = Vec.new()
+    mut i = 0
     while i < 1000 {
-        let result = p.insert(i)
+        mut result = p.insert(i)
         if result is Ok(h) {
             handles.push(h)
         }
@@ -64,7 +64,7 @@ benchmark "handle churn remove 1k" {
     i = 0
     while i < 1000 {
         if i % 5 == 0 {
-            let h = handles[i]
+            mut h = handles[i]
             p.remove(h)
         }
         i = i + 1
@@ -77,11 +77,11 @@ benchmark "handle churn remove 1k" {
 }
 
 benchmark "handle churn read 800" {
-    let p = Pool.new()
-    let handles = Vec.new()
-    let i = 0
+    mut p = Pool.new()
+    mut handles = Vec.new()
+    mut i = 0
     while i < 1000 {
-        let result = p.insert(i)
+        mut result = p.insert(i)
         if result is Ok(h) {
             handles.push(h)
         }
@@ -89,7 +89,7 @@ benchmark "handle churn read 800" {
     }
 
     // Read 800 surviving handles (skip every 5th)
-    let sum = 0
+    mut sum = 0
     i = 0
     while i < 1000 {
         if i % 5 != 0 {

--- a/benchmarks/features/pattern_match.rk
+++ b/benchmarks/features/pattern_match.rk
@@ -15,10 +15,10 @@ func area(s: Shape) -> i64 {
 }
 
 benchmark "match enum 10M" {
-    let sum = 0
-    let i = 0
+    mut sum = 0
+    mut i = 0
     while i < 10000000 {
-        let s = match i % 3 {
+        mut s = match i % 3 {
             0 => Shape.Circle(i),
             1 => Shape.Rect(i, i + 1),
             _ => Shape.Point,

--- a/benchmarks/features/pool_coalesce.rk
+++ b/benchmarks/features/pool_coalesce.rk
@@ -5,10 +5,10 @@
 // generation check per handle per iteration instead of N.
 
 benchmark "pool[h] x5 reads (coalesce target)" {
-    let p = Pool.new()
-    let h = p.insert(42)
-    let sum = 0
-    let i = 0
+    mut p = Pool.new()
+    mut h = p.insert(42)
+    mut sum = 0
+    mut i = 0
     while i < 100000 {
         sum = sum + p[h]
         sum = sum + p[h]
@@ -20,10 +20,10 @@ benchmark "pool[h] x5 reads (coalesce target)" {
 }
 
 benchmark "pool[h] x1 read baseline" {
-    let p = Pool.new()
-    let h = p.insert(42)
-    let sum = 0
-    let i = 0
+    mut p = Pool.new()
+    mut h = p.insert(42)
+    mut sum = 0
+    mut i = 0
     while i < 100000 {
         sum = sum + p[h]
         i = i + 1
@@ -31,12 +31,12 @@ benchmark "pool[h] x1 read baseline" {
 }
 
 benchmark "pool 3 handles x3 reads (coalesce target)" {
-    let p = Pool.new()
-    let h1 = p.insert(10)
-    let h2 = p.insert(20)
-    let h3 = p.insert(30)
-    let sum = 0
-    let i = 0
+    mut p = Pool.new()
+    mut h1 = p.insert(10)
+    mut h2 = p.insert(20)
+    mut h3 = p.insert(30)
+    mut sum = 0
+    mut i = 0
     while i < 100000 {
         sum = sum + p[h1]
         sum = sum + p[h1]

--- a/benchmarks/features/pool_ops.rk
+++ b/benchmarks/features/pool_ops.rk
@@ -1,9 +1,9 @@
 // SPDX-License-Identifier: (MIT OR Apache-2.0)
 
 benchmark "pool insert+get 10k" {
-    let p = Pool.new()
-    let last = 0
-    let i = 0
+    mut p = Pool.new()
+    mut last = 0
+    mut i = 0
     while i < 10000 {
         last = p.insert(i)
         i = i + 1
@@ -11,10 +11,10 @@ benchmark "pool insert+get 10k" {
 }
 
 benchmark "pool insert+remove 10k" {
-    let p = Pool.new()
-    let i = 0
+    mut p = Pool.new()
+    mut i = 0
     while i < 10000 {
-        let h = p.insert(i)
+        mut h = p.insert(i)
         p.remove(h)
         i = i + 1
     }

--- a/benchmarks/features/range_iter.rk
+++ b/benchmarks/features/range_iter.rk
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: (MIT OR Apache-2.0)
 
 benchmark "for-in range 10M" {
-    let sum = 0
+    mut sum = 0
     for i in 0..10000000 {
         sum = sum + i
     }

--- a/benchmarks/features/struct_ops.rk
+++ b/benchmarks/features/struct_ops.rk
@@ -6,27 +6,27 @@ struct Point {
 }
 
 func distance_sq(a: Point, b: Point) -> i64 {
-    let dx = a.x - b.x
-    let dy = a.y - b.y
+    mut dx = a.x - b.x
+    mut dy = a.y - b.y
     return dx * dx + dy * dy
 }
 
 benchmark "struct create+access 10k" {
-    let sum = 0
-    let i = 0
+    mut sum = 0
+    mut i = 0
     while i < 10000 {
-        let p = Point { x: i, y: i * 2 }
+        mut p = Point { x: i, y: i * 2 }
         sum = sum + p.x + p.y
         i = i + 1
     }
 }
 
 benchmark "struct fn pass 10k" {
-    let sum = 0
-    let i = 0
+    mut sum = 0
+    mut i = 0
     while i < 10000 {
-        let a = Point { x: i, y: i }
-        let b = Point { x: i + 1, y: i + 1 }
+        mut a = Point { x: i, y: i }
+        mut b = Point { x: i + 1, y: i + 1 }
         sum = sum + distance_sq(a, b)
         i = i + 1
     }

--- a/benchmarks/micro/func_call.rk
+++ b/benchmarks/micro/func_call.rk
@@ -5,8 +5,8 @@ func add(a: i64, b: i64) -> i64 {
 }
 
 benchmark "func call 10M" {
-    let sum = 0
-    let i = 0
+    mut sum = 0
+    mut i = 0
     while i < 10000000 {
         sum = add(sum, i)
         i = i + 1

--- a/benchmarks/micro/loop_arith.rk
+++ b/benchmarks/micro/loop_arith.rk
@@ -2,8 +2,8 @@
 // Benchmark: tight integer arithmetic loop — measures codegen quality.
 
 benchmark "loop arith 10M" {
-    let sum = 0
-    let i = 0
+    mut sum = 0
+    mut i = 0
     while i < 10000000 {
         sum = sum + i * 3 - i / 2
         i = i + 1

--- a/benchmarks/micro/map_insert.rk
+++ b/benchmarks/micro/map_insert.rk
@@ -1,8 +1,8 @@
 // SPDX-License-Identifier: (MIT OR Apache-2.0)
 
 benchmark "map insert 10k" {
-    let m = Map.new()
-    let i = 0
+    mut m = Map.new()
+    mut i = 0
     while i < 10000 {
         m.insert(i, i * 2)
         i = i + 1

--- a/benchmarks/micro/map_lookup.rk
+++ b/benchmarks/micro/map_lookup.rk
@@ -1,8 +1,8 @@
 // SPDX-License-Identifier: (MIT OR Apache-2.0)
 
 func fill_map() -> Map<i64, i64> {
-    let m = Map.new()
-    let i = 0
+    mut m = Map.new()
+    mut i = 0
     while i < 10000 {
         m.insert(i, i * 2)
         i = i + 1
@@ -11,9 +11,9 @@ func fill_map() -> Map<i64, i64> {
 }
 
 benchmark "map lookup 10k" {
-    let m = fill_map()
-    let sum = 0
-    let i = 0
+    mut m = fill_map()
+    mut sum = 0
+    mut i = 0
     while i < 10000 {
         sum = sum + m.get(i)
         i = i + 1

--- a/benchmarks/micro/string_concat.rk
+++ b/benchmarks/micro/string_concat.rk
@@ -1,8 +1,8 @@
 // SPDX-License-Identifier: (MIT OR Apache-2.0)
 
 benchmark "string concat 1k" {
-    let s = ""
-    let i = 0
+    mut s = ""
+    mut i = 0
     while i < 1000 {
         s = s.concat("x")
         i = i + 1

--- a/benchmarks/micro/vec_push.rk
+++ b/benchmarks/micro/vec_push.rk
@@ -2,8 +2,8 @@
 // Benchmark: Vec.push — measures runtime data structure overhead.
 
 benchmark "vec push 10k" {
-    let v = Vec.new()
-    let i = 0
+    mut v = Vec.new()
+    mut i = 0
     while i < 10000 {
         v.push(i)
         i = i + 1

--- a/compiler/crates/rask-ast/src/stmt.rs
+++ b/compiler/crates/rask-ast/src/stmt.rs
@@ -64,15 +64,15 @@ pub fn tuple_pats_flat_names(pats: &[TuplePat]) -> Vec<&str> {
 pub enum StmtKind {
     /// Expression statement
     Expr(Expr),
-    /// Let binding (mutable)
-    Let {
+    /// Mut binding (rebindable)
+    Mut {
         name: String,
         name_span: Span,
         ty: Option<String>,
         init: Expr,
     },
-    /// Let tuple destructuring
-    LetTuple {
+    /// Mut tuple destructuring
+    MutTuple {
         patterns: Vec<TuplePat>,
         init: Expr,
     },

--- a/compiler/crates/rask-ast/src/token.rs
+++ b/compiler/crates/rask-ast/src/token.rs
@@ -40,6 +40,7 @@ pub enum TokenKind {
     // Keywords
     Func,
     Let,
+    Mut,
     Const,
     Struct,
     Enum,
@@ -173,6 +174,7 @@ impl TokenKind {
             // Keywords
             TokenKind::Func => "'func'",
             TokenKind::Let => "'let'",
+            TokenKind::Mut => "'mut'",
             TokenKind::Const => "'const'",
             TokenKind::Struct => "'struct'",
             TokenKind::Enum => "'enum'",

--- a/compiler/crates/rask-cli/tests/fixtures/control_flow.rk
+++ b/compiler/crates/rask-cli/tests/fixtures/control_flow.rk
@@ -9,7 +9,7 @@ func fib(n: i32) -> i32 {
 func main() {
     println(fib(10).to_string())
 
-    let sum = 0
+    mut sum = 0
     for i in 0..5 {
         sum = sum + i
     }

--- a/compiler/crates/rask-cli/tests/fixtures/copy_rebind.rk
+++ b/compiler/crates/rask-cli/tests/fixtures/copy_rebind.rk
@@ -1,9 +1,9 @@
 // SPDX-License-Identifier: (MIT OR Apache-2.0)
-// Copy types survive let rebinding — source stays valid after copy.
+// Copy types survive mut rebinding — source stays valid after copy.
 
 func main() {
-    let x = 42
-    let y = x
+    mut x = 42
+    mut y = x
     print(x)
     print(" ")
     print(y)

--- a/compiler/crates/rask-cli/tests/fixtures/ensure_continuation.rk
+++ b/compiler/crates/rask-cli/tests/fixtures/ensure_continuation.rk
@@ -6,7 +6,7 @@
 // not found" when they targeted the post-cleanup continuation.
 
 func run(flag: bool) -> i64 {
-    let counter: i64 = 0
+    mut counter: i64 = 0
     ensure { counter = counter + 10 }
 
     if flag {

--- a/compiler/crates/rask-comptime/src/lib.rs
+++ b/compiler/crates/rask-comptime/src/lib.rs
@@ -163,8 +163,8 @@ fn eliminate_in_stmts(stmts: &mut Vec<Stmt>, cfg_values: &HashMap<String, String
 fn eliminate_in_stmt(stmt: &mut Stmt, cfg_values: &HashMap<String, String>) {
     match &mut stmt.kind {
         StmtKind::Expr(e) => eliminate_in_expr(e, cfg_values),
-        StmtKind::Let { init, .. } | StmtKind::Const { init, .. } => eliminate_in_expr(init, cfg_values),
-        StmtKind::LetTuple { init, .. } | StmtKind::ConstTuple { init, .. } => eliminate_in_expr(init, cfg_values),
+        StmtKind::Mut { init, .. } | StmtKind::Const { init, .. } => eliminate_in_expr(init, cfg_values),
+        StmtKind::MutTuple { init, .. } | StmtKind::ConstTuple { init, .. } => eliminate_in_expr(init, cfg_values),
         StmtKind::Assign { target, value } => {
             eliminate_in_expr(target, cfg_values);
             eliminate_in_expr(value, cfg_values);
@@ -1115,13 +1115,13 @@ impl ComptimeInterpreter {
         match &stmt.kind {
             StmtKind::Expr(e) => self.eval_expr_cf(e),
 
-            StmtKind::Let { name, init, .. } | StmtKind::Const { name, init, .. } => {
+            StmtKind::Mut { name, init, .. } | StmtKind::Const { name, init, .. } => {
                 let value = self.eval_expr(init)?;
                 self.env.define(name.clone(), value);
                 Ok(ControlFlow::Normal(ComptimeValue::Unit))
             }
 
-            StmtKind::LetTuple { patterns, init } | StmtKind::ConstTuple { patterns, init } => {
+            StmtKind::MutTuple { patterns, init } | StmtKind::ConstTuple { patterns, init } => {
                 let value = self.eval_expr(init)?;
                 if let ComptimeValue::Tuple(values) = value {
                     let names: Vec<&str> = rask_ast::stmt::tuple_pats_flat_names(patterns);

--- a/compiler/crates/rask-desugar/src/defaults.rs
+++ b/compiler/crates/rask-desugar/src/defaults.rs
@@ -353,8 +353,8 @@ impl DefaultDesugarer {
     fn desugar_stmt(&mut self, stmt: &mut Stmt) {
         match &mut stmt.kind {
             StmtKind::Expr(e) => self.desugar_expr(e),
-            StmtKind::Let { init, .. } | StmtKind::Const { init, .. } => self.desugar_expr(init),
-            StmtKind::LetTuple { init, .. } | StmtKind::ConstTuple { init, .. } => {
+            StmtKind::Mut { init, .. } | StmtKind::Const { init, .. } => self.desugar_expr(init),
+            StmtKind::MutTuple { init, .. } | StmtKind::ConstTuple { init, .. } => {
                 self.desugar_expr(init);
             }
             StmtKind::Assign { target, value } => {

--- a/compiler/crates/rask-desugar/src/lib.rs
+++ b/compiler/crates/rask-desugar/src/lib.rs
@@ -275,9 +275,9 @@ impl Desugarer {
     fn desugar_stmt(&mut self, stmt: &mut Stmt) {
         match &mut stmt.kind {
             StmtKind::Expr(e) => self.desugar_expr(e),
-            StmtKind::Let { init, .. } => self.desugar_expr(init),
+            StmtKind::Mut { init, .. } => self.desugar_expr(init),
             StmtKind::Const { init, .. } => self.desugar_expr(init),
-            StmtKind::LetTuple { init, .. } => self.desugar_expr(init),
+            StmtKind::MutTuple { init, .. } => self.desugar_expr(init),
             StmtKind::ConstTuple { init, .. } => self.desugar_expr(init),
             StmtKind::Assign { target, value } => {
                 self.desugar_expr(target);

--- a/compiler/crates/rask-effects/src/infer.rs
+++ b/compiler/crates/rask-effects/src/infer.rs
@@ -188,10 +188,10 @@ fn classify_body(stmts: &[Stmt], effects: &mut Effects, callees: &mut HashSet<St
 fn classify_stmt(stmt: &Stmt, effects: &mut Effects, callees: &mut HashSet<String>) {
     match &stmt.kind {
         StmtKind::Expr(e) => classify_expr(e, effects, callees),
-        StmtKind::Let { init, .. } | StmtKind::Const { init, .. } => {
+        StmtKind::Mut { init, .. } | StmtKind::Const { init, .. } => {
             classify_expr(init, effects, callees);
         }
-        StmtKind::LetTuple { init, .. } | StmtKind::ConstTuple { init, .. } => {
+        StmtKind::MutTuple { init, .. } | StmtKind::ConstTuple { init, .. } => {
             classify_expr(init, effects, callees);
         }
         StmtKind::Assign { target, value } => {

--- a/compiler/crates/rask-effects/src/warnings.rs
+++ b/compiler/crates/rask-effects/src/warnings.rs
@@ -72,10 +72,10 @@ impl<'a> WarnContext<'a> {
     fn check_stmt(&mut self, stmt: &Stmt, warnings: &mut Vec<EffectWarning>) {
         match &stmt.kind {
             StmtKind::Expr(e) => self.check_expr(e, warnings),
-            StmtKind::Let { init, .. } | StmtKind::Const { init, .. } => {
+            StmtKind::Mut { init, .. } | StmtKind::Const { init, .. } => {
                 self.check_expr(init, warnings);
             }
-            StmtKind::LetTuple { init, .. } | StmtKind::ConstTuple { init, .. } => {
+            StmtKind::MutTuple { init, .. } | StmtKind::ConstTuple { init, .. } => {
                 self.check_expr(init, warnings);
             }
             StmtKind::Assign { target, value } => {

--- a/compiler/crates/rask-fmt/src/printer.rs
+++ b/compiler/crates/rask-fmt/src/printer.rs
@@ -1139,8 +1139,8 @@ impl<'a> Printer<'a> {
             StmtKind::Expr(expr) => {
                 self.format_expr(expr);
             }
-            StmtKind::Let { name, name_span: _, ty, init } => {
-                self.emit("let ");
+            StmtKind::Mut { name, name_span: _, ty, init } => {
+                self.emit("mut ");
                 self.emit(name);
                 if let Some(ref ty) = ty {
                     self.emit(": ");
@@ -1150,8 +1150,8 @@ impl<'a> Printer<'a> {
                 self.emit(" = ");
                 self.format_expr(init);
             }
-            StmtKind::LetTuple { patterns, init } => {
-                self.emit("let ");
+            StmtKind::MutTuple { patterns, init } => {
+                self.emit("mut ");
                 self.format_tuple_pat_list(patterns);
                 self.emit(" = ");
                 self.format_expr(init);

--- a/compiler/crates/rask-hidden-params/src/callgraph.rs
+++ b/compiler/crates/rask-hidden-params/src/callgraph.rs
@@ -151,9 +151,9 @@ fn collect_callees_from_body(stmts: &[Stmt]) -> HashSet<String> {
 fn collect_callees_from_stmt(stmt: &Stmt, callees: &mut HashSet<String>) {
     match &stmt.kind {
         StmtKind::Expr(e) => collect_callees_from_expr(e, callees),
-        StmtKind::Let { init, .. }
+        StmtKind::Mut { init, .. }
         | StmtKind::Const { init, .. }
-        | StmtKind::LetTuple { init, .. }
+        | StmtKind::MutTuple { init, .. }
         | StmtKind::ConstTuple { init, .. } => {
             collect_callees_from_expr(init, callees);
         }

--- a/compiler/crates/rask-hidden-params/src/collect.rs
+++ b/compiler/crates/rask-hidden-params/src/collect.rs
@@ -108,7 +108,7 @@ fn collect_locals_from_stmt(
     locals: &mut Vec<(String, String)>,
 ) {
     match &stmt.kind {
-        StmtKind::Let { name, ty, init, .. } | StmtKind::Const { name, ty, init, .. } => {
+        StmtKind::Mut { name, ty, init, .. } | StmtKind::Const { name, ty, init, .. } => {
             // If explicit type annotation, use it
             if let Some(t) = ty {
                 locals.push((name.clone(), t.clone()));

--- a/compiler/crates/rask-hidden-params/src/resolve.rs
+++ b/compiler/crates/rask-hidden-params/src/resolve.rs
@@ -237,10 +237,10 @@ fn body_accesses_handle_fields(stmts: &[Stmt], handle_names: &[&str]) -> bool {
 fn stmt_accesses_handle_fields(stmt: &Stmt, handle_names: &[&str]) -> bool {
     match &stmt.kind {
         StmtKind::Expr(e) => expr_accesses_handle_fields(e, handle_names),
-        StmtKind::Let { init, .. } | StmtKind::Const { init, .. } => {
+        StmtKind::Mut { init, .. } | StmtKind::Const { init, .. } => {
             expr_accesses_handle_fields(init, handle_names)
         }
-        StmtKind::LetTuple { init, .. } | StmtKind::ConstTuple { init, .. } => {
+        StmtKind::MutTuple { init, .. } | StmtKind::ConstTuple { init, .. } => {
             expr_accesses_handle_fields(init, handle_names)
         }
         StmtKind::Assign { target, value } => {

--- a/compiler/crates/rask-hidden-params/src/rewrite.rs
+++ b/compiler/crates/rask-hidden-params/src/rewrite.rs
@@ -94,10 +94,10 @@ fn rewrite_stmts(pass: &mut HiddenParamPass, caller: &str, stmts: &mut [Stmt]) {
 fn rewrite_stmt(pass: &mut HiddenParamPass, caller: &str, stmt: &mut Stmt) {
     match &mut stmt.kind {
         StmtKind::Expr(e) => rewrite_expr(pass, caller, e),
-        StmtKind::Let { init, .. } | StmtKind::Const { init, .. } => {
+        StmtKind::Mut { init, .. } | StmtKind::Const { init, .. } => {
             rewrite_expr(pass, caller, init);
         }
-        StmtKind::LetTuple { init, .. } | StmtKind::ConstTuple { init, .. } => {
+        StmtKind::MutTuple { init, .. } | StmtKind::ConstTuple { init, .. } => {
             rewrite_expr(pass, caller, init);
         }
         StmtKind::Assign { target, value } => {

--- a/compiler/crates/rask-interp/src/interp/dispatch.rs
+++ b/compiler/crates/rask-interp/src/interp/dispatch.rs
@@ -643,6 +643,7 @@ impl Interpreter {
             Http => matches!(method, "listen_and_serve"),
             Env => matches!(method, "var" | "vars"),
             Cli => matches!(method, "args" | "parse"),
+            Reflect => false,
         }
     }
 }

--- a/compiler/crates/rask-interp/src/interp/exec_stmt.rs
+++ b/compiler/crates/rask-interp/src/interp/exec_stmt.rs
@@ -21,7 +21,7 @@ impl Interpreter {
                 Ok(Value::Unit)
             }
 
-            StmtKind::Let { name, name_span: _, ty, init } => {
+            StmtKind::Mut { name, name_span: _, ty, init } => {
                 let value = self.eval_expr(init)?;
                 // Coerce Vec to SimdF32x8 when type annotation says f32x8
                 let value = if ty.as_deref() == Some("f32x8") {
@@ -37,7 +37,7 @@ impl Interpreter {
                 Ok(Value::Unit)
             }
 
-            StmtKind::LetTuple { patterns, init } => {
+            StmtKind::MutTuple { patterns, init } => {
                 let value = self.eval_expr(init)?;
                 self.destructure_tuple_pats(patterns, value)
                     .map_err(|e| RuntimeDiagnostic::new(e, stmt.span))?;

--- a/compiler/crates/rask-lexer/src/lexer.rs
+++ b/compiler/crates/rask-lexer/src/lexer.rs
@@ -14,6 +14,8 @@ enum RawToken {
     Func,
     #[token("let")]
     Let,
+    #[token("mut")]
+    Mut,
     #[token("const")]
     Const,
     #[token("struct")]
@@ -446,6 +448,7 @@ impl<'a> Lexer<'a> {
             // Keywords
             RawToken::Func => TokenKind::Func,
             RawToken::Let => TokenKind::Let,
+            RawToken::Mut => TokenKind::Mut,
             RawToken::Const => TokenKind::Const,
             RawToken::Struct => TokenKind::Struct,
             RawToken::Enum => TokenKind::Enum,

--- a/compiler/crates/rask-lint/src/idiom.rs
+++ b/compiler/crates/rask-lint/src/idiom.rs
@@ -51,12 +51,12 @@ fn walk_stmts_for_unwrap(stmts: &[Stmt], source: &str, diags: &mut Vec<LintDiagn
 fn walk_stmt_for_unwrap(stmt: &Stmt, source: &str, diags: &mut Vec<LintDiagnostic>) {
     match &stmt.kind {
         StmtKind::Expr(e) => walk_expr_for_unwrap(e, source, diags),
-        StmtKind::Let { init, .. }
+        StmtKind::Mut { init, .. }
         | StmtKind::Const { init, .. }
         | StmtKind::Break { value: Some(init), .. } => {
             walk_expr_for_unwrap(init, source, diags);
         }
-        StmtKind::LetTuple { init, .. } | StmtKind::ConstTuple { init, .. } => {
+        StmtKind::MutTuple { init, .. } | StmtKind::ConstTuple { init, .. } => {
             walk_expr_for_unwrap(init, source, diags);
         }
         StmtKind::Return(Some(e)) => walk_expr_for_unwrap(e, source, diags),
@@ -260,7 +260,7 @@ fn check_stmt_for_resource(
     diags: &mut Vec<LintDiagnostic>,
 ) {
     match &stmt.kind {
-        StmtKind::Let { init, .. } | StmtKind::Const { init, .. } => {
+        StmtKind::Mut { init, .. } | StmtKind::Const { init, .. } => {
             check_expr_for_resource(init, resource_types, has_ensure, source, diags);
         }
         StmtKind::Expr(expr) => {
@@ -340,7 +340,7 @@ fn check_ensure_ordering_in_block(
 
     for stmt in stmts {
         match &stmt.kind {
-            StmtKind::Const { name, .. } | StmtKind::Let { name, .. } => {
+            StmtKind::Const { name, .. } | StmtKind::Mut { name, .. } => {
                 binding_order.push(name.clone());
             }
             StmtKind::Ensure { body, .. } => {
@@ -488,7 +488,7 @@ fn walk_for_large_unsafe(stmts: &[Stmt], source: &str, max: usize, diags: &mut V
     for stmt in stmts {
         match &stmt.kind {
             StmtKind::Expr(e) => check_expr_for_large_unsafe(e, source, max, diags),
-            StmtKind::Let { init, .. } | StmtKind::Const { init, .. } => {
+            StmtKind::Mut { init, .. } | StmtKind::Const { init, .. } => {
                 check_expr_for_large_unsafe(init, source, max, diags);
             }
             StmtKind::While { cond, body } => {

--- a/compiler/crates/rask-lsp/src/completion.rs
+++ b/compiler/crates/rask-lsp/src/completion.rs
@@ -97,7 +97,7 @@ fn identifier_completion(source: &str, offset: usize, cached: &CompilationResult
             rask_resolve::SymbolKind::Enum { .. } => (CompletionItemKind::ENUM, "enum".to_string()),
             rask_resolve::SymbolKind::Trait { .. } => (CompletionItemKind::INTERFACE, "trait".to_string()),
             rask_resolve::SymbolKind::Variable { mutable } => {
-                let kw = if *mutable { "let" } else { "const" };
+                let kw = if *mutable { "mut" } else { "const" };
                 (CompletionItemKind::VARIABLE, kw.to_string())
             }
             rask_resolve::SymbolKind::Parameter { .. } => (CompletionItemKind::VARIABLE, "param".to_string()),
@@ -121,7 +121,7 @@ fn identifier_completion(source: &str, offset: usize, cached: &CompilationResult
     }
 
     let keywords = [
-        "const", "let", "func", "struct", "enum", "trait", "extend",
+        "const", "mut", "func", "struct", "enum", "trait", "extend",
         "if", "else", "match", "for", "while", "loop", "return",
         "try", "ensure", "import", "public", "spawn", "with",
     ];

--- a/compiler/crates/rask-lsp/src/inlay_hints.rs
+++ b/compiler/crates/rask-lsp/src/inlay_hints.rs
@@ -60,7 +60,7 @@ fn visit_stmt(
     hi: usize,
 ) {
     match &stmt.kind {
-        StmtKind::Let { name_span, ty: None, .. } | StmtKind::Const { name_span, ty: None, .. } => {
+        StmtKind::Mut { name_span, ty: None, .. } | StmtKind::Const { name_span, ty: None, .. } => {
             if name_span.start < lo || name_span.end > hi {
                 return;
             }

--- a/compiler/crates/rask-lsp/src/position_index.rs
+++ b/compiler/crates/rask-lsp/src/position_index.rs
@@ -114,12 +114,12 @@ fn visit_stmt(stmt: &Stmt, index: &mut PositionIndex) {
         StmtKind::Break { value: Some(value), .. } => {
             visit_expr(value, index);
         }
-        StmtKind::Let { name, name_span, init, .. } | StmtKind::Const { name, name_span, init, .. } => {
+        StmtKind::Mut { name, name_span, init, .. } | StmtKind::Const { name, name_span, init, .. } => {
             // Track the declaration name as an identifier for hover support
             index.idents.push((*name_span, stmt.id, name.clone()));
             visit_expr(init, index);
         }
-        StmtKind::LetTuple { init, .. } | StmtKind::ConstTuple { init, .. } => {
+        StmtKind::MutTuple { init, .. } | StmtKind::ConstTuple { init, .. } => {
             visit_expr(init, index);
         }
         StmtKind::Assign { target, value } => {

--- a/compiler/crates/rask-mir/src/hidden_params/callgraph.rs
+++ b/compiler/crates/rask-mir/src/hidden_params/callgraph.rs
@@ -151,9 +151,9 @@ fn collect_callees_from_body(stmts: &[Stmt]) -> HashSet<String> {
 fn collect_callees_from_stmt(stmt: &Stmt, callees: &mut HashSet<String>) {
     match &stmt.kind {
         StmtKind::Expr(e) => collect_callees_from_expr(e, callees),
-        StmtKind::Let { init, .. }
+        StmtKind::Mut { init, .. }
         | StmtKind::Const { init, .. }
-        | StmtKind::LetTuple { init, .. }
+        | StmtKind::MutTuple { init, .. }
         | StmtKind::ConstTuple { init, .. } => {
             collect_callees_from_expr(init, callees);
         }

--- a/compiler/crates/rask-mir/src/hidden_params/collect.rs
+++ b/compiler/crates/rask-mir/src/hidden_params/collect.rs
@@ -108,7 +108,7 @@ fn collect_locals_from_stmt(
     locals: &mut Vec<(String, String)>,
 ) {
     match &stmt.kind {
-        StmtKind::Let { name, ty, init, .. } | StmtKind::Const { name, ty, init, .. } => {
+        StmtKind::Mut { name, ty, init, .. } | StmtKind::Const { name, ty, init, .. } => {
             // If explicit type annotation, use it
             if let Some(t) = ty {
                 locals.push((name.clone(), t.clone()));

--- a/compiler/crates/rask-mir/src/hidden_params/resolve.rs
+++ b/compiler/crates/rask-mir/src/hidden_params/resolve.rs
@@ -237,10 +237,10 @@ fn body_accesses_handle_fields(stmts: &[Stmt], handle_names: &[&str]) -> bool {
 fn stmt_accesses_handle_fields(stmt: &Stmt, handle_names: &[&str]) -> bool {
     match &stmt.kind {
         StmtKind::Expr(e) => expr_accesses_handle_fields(e, handle_names),
-        StmtKind::Let { init, .. } | StmtKind::Const { init, .. } => {
+        StmtKind::Mut { init, .. } | StmtKind::Const { init, .. } => {
             expr_accesses_handle_fields(init, handle_names)
         }
-        StmtKind::LetTuple { init, .. } | StmtKind::ConstTuple { init, .. } => {
+        StmtKind::MutTuple { init, .. } | StmtKind::ConstTuple { init, .. } => {
             expr_accesses_handle_fields(init, handle_names)
         }
         StmtKind::Assign { target, value } => {

--- a/compiler/crates/rask-mir/src/hidden_params/rewrite.rs
+++ b/compiler/crates/rask-mir/src/hidden_params/rewrite.rs
@@ -94,10 +94,10 @@ fn rewrite_stmts(pass: &mut HiddenParamPass, caller: &str, stmts: &mut [Stmt]) {
 fn rewrite_stmt(pass: &mut HiddenParamPass, caller: &str, stmt: &mut Stmt) {
     match &mut stmt.kind {
         StmtKind::Expr(e) => rewrite_expr(pass, caller, e),
-        StmtKind::Let { init, .. } | StmtKind::Const { init, .. } => {
+        StmtKind::Mut { init, .. } | StmtKind::Const { init, .. } => {
             rewrite_expr(pass, caller, init);
         }
-        StmtKind::LetTuple { init, .. } | StmtKind::ConstTuple { init, .. } => {
+        StmtKind::MutTuple { init, .. } | StmtKind::ConstTuple { init, .. } => {
             rewrite_expr(pass, caller, init);
         }
         StmtKind::Assign { target, value } => {

--- a/compiler/crates/rask-mir/src/lower/mod.rs
+++ b/compiler/crates/rask-mir/src/lower/mod.rs
@@ -1376,11 +1376,11 @@ impl<'a> MirLowerer<'a> {
         for stmt in stmts {
             self.walk_free_vars_stmt(stmt, &local_bound, seen, free);
             match &stmt.kind {
-                rask_ast::stmt::StmtKind::Let { name, .. }
+                rask_ast::stmt::StmtKind::Mut { name, .. }
                 | rask_ast::stmt::StmtKind::Const { name, .. } => {
                     local_bound.insert(name.clone());
                 }
-                rask_ast::stmt::StmtKind::LetTuple { patterns, .. }
+                rask_ast::stmt::StmtKind::MutTuple { patterns, .. }
                 | rask_ast::stmt::StmtKind::ConstTuple { patterns, .. } => {
                     for n in rask_ast::stmt::tuple_pats_flat_names(patterns) { local_bound.insert(n.to_string()); }
                 }
@@ -1399,10 +1399,10 @@ impl<'a> MirLowerer<'a> {
         use rask_ast::stmt::{ForBinding, StmtKind};
         match &stmt.kind {
             StmtKind::Expr(e) => self.walk_free_vars(e, bound, seen, free),
-            StmtKind::Let { init, .. } | StmtKind::Const { init, .. } => {
+            StmtKind::Mut { init, .. } | StmtKind::Const { init, .. } => {
                 self.walk_free_vars(init, bound, seen, free);
             }
-            StmtKind::LetTuple { init, .. } | StmtKind::ConstTuple { init, .. } => {
+            StmtKind::MutTuple { init, .. } | StmtKind::ConstTuple { init, .. } => {
                 self.walk_free_vars(init, bound, seen, free);
             }
             StmtKind::Return(Some(e)) => self.walk_free_vars(e, bound, seen, free),
@@ -1891,7 +1891,7 @@ mod tests {
     fn let_stmt(name: &str, ty: Option<&str>, init: Expr) -> Stmt {
         Stmt {
             id: NodeId(201),
-            kind: StmtKind::Let {
+            kind: StmtKind::Mut {
                 name: name.to_string(),
                 name_span: sp(),
                 ty: ty.map(|s| s.to_string()),

--- a/compiler/crates/rask-mir/src/lower/stmt.rs
+++ b/compiler/crates/rask-mir/src/lower/stmt.rs
@@ -26,7 +26,7 @@ impl<'a> MirLowerer<'a> {
                 Ok(())
             }
 
-            StmtKind::Let { name, ty, init, .. } => {
+            StmtKind::Mut { name, ty, init, .. } => {
                 self.lower_binding(name, ty.as_deref(), init)
             }
 
@@ -233,7 +233,7 @@ impl<'a> MirLowerer<'a> {
             StmtKind::Continue(label) => self.lower_continue(label.as_deref()),
 
             // Tuple destructuring
-            StmtKind::LetTuple { patterns, init }
+            StmtKind::MutTuple { patterns, init }
             | StmtKind::ConstTuple { patterns, init } => {
                 let names: Vec<String> = rask_ast::stmt::tuple_pats_flat_names(patterns)
                     .into_iter().map(|s| s.to_string()).collect();

--- a/compiler/crates/rask-mono/src/instantiate.rs
+++ b/compiler/crates/rask-mono/src/instantiate.rs
@@ -220,19 +220,19 @@ impl TypeSubstitutor {
             kind: match &stmt.kind {
                 StmtKind::Expr(e) => StmtKind::Expr(self.clone_expr(e)),
 
-                StmtKind::Let {
+                StmtKind::Mut {
                     name,
                     name_span,
                     ty,
                     init,
-                } => StmtKind::Let {
+                } => StmtKind::Mut {
                     name: name.clone(),
                     name_span: name_span.clone(),
                     ty: ty.as_ref().map(|t| self.substitute_type_string(t)),
                     init: self.clone_expr(init),
                 },
 
-                StmtKind::LetTuple { patterns, init } => StmtKind::LetTuple {
+                StmtKind::MutTuple { patterns, init } => StmtKind::MutTuple {
                     patterns: patterns.clone(),
                     init: self.clone_expr(init),
                 },

--- a/compiler/crates/rask-mono/src/reachability.rs
+++ b/compiler/crates/rask-mono/src/reachability.rs
@@ -236,7 +236,7 @@ impl<'a> Monomorphizer<'a> {
     fn visit_stmt(&mut self, stmt: &Stmt) {
         match &stmt.kind {
             StmtKind::Expr(e) => self.visit_expr(e),
-            StmtKind::Let { init, .. } | StmtKind::Const { init, .. } => {
+            StmtKind::Mut { init, .. } | StmtKind::Const { init, .. } => {
                 self.visit_expr(init);
             }
             StmtKind::Assign { target, value } => {
@@ -289,7 +289,7 @@ impl<'a> Monomorphizer<'a> {
                     self.visit_stmt(s);
                 }
             }
-            StmtKind::LetTuple { init, .. } | StmtKind::ConstTuple { init, .. } => {
+            StmtKind::MutTuple { init, .. } | StmtKind::ConstTuple { init, .. } => {
                 self.visit_expr(init);
             }
             StmtKind::Break { value: Some(e), .. } => self.visit_expr(e),

--- a/compiler/crates/rask-ownership/src/lib.rs
+++ b/compiler/crates/rask-ownership/src/lib.rs
@@ -299,7 +299,7 @@ impl<'a> OwnershipChecker<'a> {
 
     fn check_stmt(&mut self, stmt: &Stmt) {
         match &stmt.kind {
-            StmtKind::Let { name, name_span: _, ty, init } => {
+            StmtKind::Mut { name, name_span: _, ty, init } => {
                 self.check_expr(init);
                 // let: Copy types are copied (source stays valid),
                 // non-Copy types are moved (source invalidated)
@@ -322,7 +322,7 @@ impl<'a> OwnershipChecker<'a> {
                     self.resource_bindings.insert(name.clone());
                 }
             }
-            StmtKind::LetTuple { patterns, init } => {
+            StmtKind::MutTuple { patterns, init } => {
                 self.check_expr(init);
                 self.handle_assignment(init, stmt.span, true);
                 let names = rask_ast::stmt::tuple_pats_flat_names(patterns);
@@ -1794,10 +1794,10 @@ impl<'a> OwnershipChecker<'a> {
     ) {
         match &stmt.kind {
             StmtKind::Expr(e) => self.collect_free_vars_inner(e, locals, out, projections),
-            StmtKind::Let { init, .. } | StmtKind::Const { init, .. } => {
+            StmtKind::Mut { init, .. } | StmtKind::Const { init, .. } => {
                 self.collect_free_vars_inner(init, locals, out, projections);
             }
-            StmtKind::LetTuple { init, .. } | StmtKind::ConstTuple { init, .. } => {
+            StmtKind::MutTuple { init, .. } | StmtKind::ConstTuple { init, .. } => {
                 self.collect_free_vars_inner(init, locals, out, projections);
             }
             StmtKind::Assign { target, value } => {

--- a/compiler/crates/rask-parser/src/lib.rs
+++ b/compiler/crates/rask-parser/src/lib.rs
@@ -215,11 +215,18 @@ mod tests {
     }
 
     #[test]
+    fn rust_syntax_let() {
+        let result = parse("func main() { let counter = 0 }");
+        assert!(!result.is_ok());
+        assert_eq!(result.errors[0].message, "'let' is not a keyword in Rask");
+        assert_eq!(result.errors[0].hint.as_deref(), Some("use 'mut' for rebindable bindings or 'const' for permanent bindings"));
+    }
+
+    #[test]
     fn rust_syntax_let_mut() {
         let result = parse("func main() { let mut counter = 0 }");
         assert!(!result.is_ok());
-        assert_eq!(result.errors[0].message, "unexpected 'mut' keyword");
-        assert_eq!(result.errors[0].hint.as_deref(), Some("'let' is already mutable in Rask. Use 'const' for immutable bindings"));
+        assert_eq!(result.errors[0].message, "'let' is not a keyword in Rask");
     }
 
     #[test]

--- a/compiler/crates/rask-parser/src/parser.rs
+++ b/compiler/crates/rask-parser/src/parser.rs
@@ -238,6 +238,7 @@ impl Parser {
             // Declarations
             TokenKind::Func => "func".to_string(),
             TokenKind::Let => "let".to_string(),
+            TokenKind::Mut => "mut".to_string(),
             TokenKind::Const => "const".to_string(),
             TokenKind::Struct => "struct".to_string(),
             TokenKind::Enum => "enum".to_string(),
@@ -475,12 +476,21 @@ impl Parser {
                             self.advance();
                             self.synchronize();
                         }
-                    // Reject mutable bindings at top level
+                    // Reject rebindable bindings at top level
+                    } else if matches!(self.current_kind(), TokenKind::Mut) {
+                        let err = ParseError {
+                            span: self.current().span,
+                            message: "rebindable 'mut' bindings are not allowed at the top level".to_string(),
+                            hint: Some("use 'const' for permanent bindings, or move into a function".to_string()),
+                        };
+                        if !self.record_error(err) { break; }
+                        self.synchronize();
+                    // Reject Rust-style 'let' at top level with guidance
                     } else if matches!(self.current_kind(), TokenKind::Let) {
                         let err = ParseError {
                             span: self.current().span,
-                            message: "mutable 'let' bindings are not allowed at the top level".to_string(),
-                            hint: Some("use 'const' for immutable bindings, or move into a function".to_string()),
+                            message: "'let' is not a keyword in Rask".to_string(),
+                            hint: Some("use 'const' for permanent bindings at the top level, or 'mut' inside a function for rebindable".to_string()),
                         };
                         if !self.record_error(err) { break; }
                         self.synchronize();
@@ -2277,7 +2287,7 @@ impl Parser {
             }
             // Stop before statement-starting keywords
             match self.current_kind() {
-                TokenKind::Let | TokenKind::Const | TokenKind::Return |
+                TokenKind::Mut | TokenKind::Let | TokenKind::Const | TokenKind::Return |
                 TokenKind::If | TokenKind::While | TokenKind::For |
                 TokenKind::Loop | TokenKind::Match | TokenKind::Break |
                 TokenKind::Continue | TokenKind::Ensure |
@@ -2350,7 +2360,16 @@ impl Parser {
         };
 
         let kind = match self.current_kind() {
-            TokenKind::Let => self.parse_let_stmt()?,
+            TokenKind::Mut => self.parse_mut_stmt()?,
+            TokenKind::Let => {
+                let err = ParseError {
+                    span: self.current().span,
+                    message: "'let' is not a keyword in Rask".to_string(),
+                    hint: Some("use 'mut' for rebindable bindings or 'const' for permanent bindings".to_string()),
+                };
+                self.advance(); // consume 'let' so recovery doesn't loop
+                return Err(err);
+            }
             TokenKind::Const => self.parse_const_stmt()?,
             TokenKind::Return => self.parse_return_stmt()?,
             TokenKind::Break => self.parse_break_stmt()?,
@@ -2452,19 +2471,8 @@ impl Parser {
         }
     }
 
-    fn parse_let_stmt(&mut self) -> Result<StmtKind, ParseError> {
-        self.expect(&TokenKind::Let)?;
-
-        // Detect 'mut' keyword after 'let' (Rust syntax)
-        if let TokenKind::Ident(s) = self.current_kind() {
-            if s == "mut" {
-                return Err(ParseError {
-                    span: self.current().span,
-                    message: "unexpected 'mut' keyword".to_string(),
-                    hint: Some("'let' is already mutable in Rask. Use 'const' for immutable bindings".to_string()),
-                });
-            }
-        }
+    fn parse_mut_stmt(&mut self) -> Result<StmtKind, ParseError> {
+        self.expect(&TokenKind::Mut)?;
 
         if self.match_token(&TokenKind::LParen) {
             let mut patterns = Vec::new();
@@ -2476,7 +2484,7 @@ impl Parser {
             self.expect(&TokenKind::Eq)?;
             let init = self.parse_expr()?;
             self.expect_terminator()?;
-            return Ok(StmtKind::LetTuple { patterns, init });
+            return Ok(StmtKind::MutTuple { patterns, init });
         }
 
         let name_span = self.current().span;
@@ -2485,7 +2493,7 @@ impl Parser {
         self.expect(&TokenKind::Eq)?;
         let mut init = self.parse_expr()?;
 
-        // Check for guard pattern: let v = expr is Pattern else { ... }
+        // Check for guard pattern: mut v = expr is Pattern else { ... }
         if matches!(init.kind, ExprKind::IsPattern { .. }) && self.check(&TokenKind::Else) {
             let ExprKind::IsPattern { expr, pattern } = init.kind else { unreachable!() };
             let guard_start = expr.span.start;
@@ -2513,7 +2521,7 @@ impl Parser {
         }
 
         self.expect_terminator()?;
-        Ok(StmtKind::Let { name, name_span, ty, init })
+        Ok(StmtKind::Mut { name, name_span, ty, init })
     }
 
     fn parse_const_stmt(&mut self) -> Result<StmtKind, ParseError> {

--- a/compiler/crates/rask-resolve/src/capabilities.rs
+++ b/compiler/crates/rask-resolve/src/capabilities.rs
@@ -76,7 +76,7 @@ fn has_unsafe_in_stmts(stmts: &[Stmt]) -> bool {
 fn has_unsafe_in_stmt(stmt: &Stmt) -> bool {
     match &stmt.kind {
         StmtKind::Expr(expr) => has_unsafe_in_expr(expr),
-        StmtKind::Let { init, .. } | StmtKind::Const { init, .. } => {
+        StmtKind::Mut { init, .. } | StmtKind::Const { init, .. } => {
             has_unsafe_in_expr(init)
         }
         StmtKind::Assign { target, value } => {

--- a/compiler/crates/rask-resolve/src/resolver.rs
+++ b/compiler/crates/rask-resolve/src/resolver.rs
@@ -1522,7 +1522,7 @@ impl Resolver {
             StmtKind::Expr(expr) => {
                 self.resolve_expr(expr);
             }
-            StmtKind::Let { name, name_span, ty, init } => {
+            StmtKind::Mut { name, name_span, ty, init } => {
                 self.resolve_expr(init);
                 let sym_id = self.symbols.insert(
                     name.clone(),
@@ -1548,7 +1548,7 @@ impl Resolver {
                     self.errors.push(e);
                 }
             }
-            StmtKind::LetTuple { patterns, init } => {
+            StmtKind::MutTuple { patterns, init } => {
                 self.resolve_expr(init);
                 for name in rask_ast::stmt::tuple_pats_flat_names(patterns) {
                     let sym_id = self.symbols.insert(

--- a/compiler/crates/rask-semantic-hash/src/hasher.rs
+++ b/compiler/crates/rask-semantic-hash/src/hasher.rs
@@ -371,7 +371,7 @@ impl Hasher {
                 self.feed_tag(20);
                 self.hash_expr(e);
             }
-            StmtKind::Let { name, ty, init, .. } => {
+            StmtKind::Mut { name, ty, init, .. } => {
                 self.feed_tag(21);
                 self.feed_var(name);
                 if let Some(t) = ty {
@@ -382,7 +382,7 @@ impl Hasher {
                 }
                 self.hash_expr(init);
             }
-            StmtKind::LetTuple { patterns, init } => {
+            StmtKind::MutTuple { patterns, init } => {
                 self.feed_tag(22);
                 let names = rask_ast::stmt::tuple_pats_flat_names(patterns);
                 self.feed_u32(names.len() as u32);

--- a/compiler/crates/rask-types/src/checker/check_fn.rs
+++ b/compiler/crates/rask-types/src/checker/check_fn.rs
@@ -235,7 +235,7 @@ impl TypeChecker {
     pub(super) fn check_no_alloc_stmt(&mut self, fn_name: &str, stmt: &Stmt) {
         match &stmt.kind {
             StmtKind::Expr(e) => self.check_no_alloc_expr(fn_name, e),
-            StmtKind::Let { init, .. } | StmtKind::Const { init, .. } => {
+            StmtKind::Mut { init, .. } | StmtKind::Const { init, .. } => {
                 self.check_no_alloc_expr(fn_name, init);
             }
             StmtKind::Assign { value, .. } => self.check_no_alloc_expr(fn_name, value),

--- a/compiler/crates/rask-types/src/checker/check_stmt.rs
+++ b/compiler/crates/rask-types/src/checker/check_stmt.rs
@@ -28,7 +28,7 @@ impl TypeChecker {
                 // ESAD Phase 1: Clear borrows at statement end (semicolon)
                 self.clear_expression_borrows();
             }
-            StmtKind::Let { name, name_span, ty, init } => {
+            StmtKind::Mut { name, name_span, ty, init } => {
                 let (init_ty, declared_ty) = if let Some(ty_str) = ty {
                     if let Ok(declared) = parse_type_string(ty_str, &self.types) {
                         let init_ty = self.infer_expr_expecting(init, &declared);
@@ -228,7 +228,7 @@ impl TypeChecker {
                 }
                 self.pop_scope();
             }
-            StmtKind::LetTuple { patterns, init } | StmtKind::ConstTuple { patterns, init } => {
+            StmtKind::MutTuple { patterns, init } | StmtKind::ConstTuple { patterns, init } => {
                 let is_const = matches!(&stmt.kind, StmtKind::ConstTuple { .. });
                 let init_ty = self.infer_expr(init);
                 self.bind_tuple_patterns(patterns, &init_ty, is_const, stmt.span);

--- a/editors/vscode/syntaxes/rask.tmLanguage.json
+++ b/editors/vscode/syntaxes/rask.tmLanguage.json
@@ -123,7 +123,7 @@
       "patterns": [
         {
           "name": "entity.name.function.method.rk",
-          "match": "(?<=\\.)\\s*(if|else|match|for|in|while|loop|break|continue|return|deliver|is|check|assert|try|func|let|const|struct|enum|trait|extend|import|type|test|public|take|own|mutate|unsafe|comptime|native|export|extern|using|lazy|with|using|ensure|catch|select|step|or|as|where|none|null|benchmark|asm)(?=\\s*\\()"
+          "match": "(?<=\\.)\\s*(if|else|match|for|in|while|loop|break|continue|return|deliver|is|check|assert|try|func|mut|const|struct|enum|trait|extend|import|type|test|public|take|own|mutate|unsafe|comptime|native|export|extern|using|lazy|with|using|ensure|catch|select|step|or|as|where|none|null|benchmark|asm)(?=\\s*\\()"
         },
         {
           "name": "entity.name.function.method.rk",
@@ -139,7 +139,7 @@
         },
         {
           "name": "keyword.declaration.rk",
-          "match": "\\b(func|let|const|struct|enum|trait|extend|import|type|test)\\b"
+          "match": "\\b(func|mut|const|struct|enum|trait|extend|import|type|test)\\b"
         },
         {
           "name": "keyword.modifier.rk",

--- a/examples/01_variables.rk
+++ b/examples/01_variables.rk
@@ -14,8 +14,8 @@ func main() {
     print(age)
     print("\n")
 
-    // let - binding can be reassigned
-    let counter = 0
+    // mut - binding can be reassigned
+    mut counter = 0
     counter = counter + 1
     counter = counter + 1
 

--- a/examples/05_loops.rk
+++ b/examples/05_loops.rk
@@ -20,7 +20,7 @@ func main() {
     }
 
     // While loop
-    let count = 0
+    mut count = 0
     print("\nWhile counting:\n")
     while count < 3 {
         print(count)

--- a/examples/15_memory_management.rk
+++ b/examples/15_memory_management.rk
@@ -53,7 +53,7 @@ func main() {
 
     // Traverse the list using handles
     print("List values: ")
-    let current = Some(first)
+    mut current = Some(first)
 
     loop {
         if current is Some(handle) {

--- a/examples/16_concurrency_basics.rk
+++ b/examples/16_concurrency_basics.rk
@@ -8,7 +8,7 @@ func worker(id: i32, iterations: i32) -> i32 {
     print(id)
     print(" starting\n")
 
-    let sum = 0
+    mut sum = 0
     for i in 1..iterations + 1 {
         sum = sum + i
     }

--- a/examples/17_comptime.rk
+++ b/examples/17_comptime.rk
@@ -28,7 +28,7 @@ const FIBONACCI = comptime {
 // Powers of two
 const POWERS_OF_TWO = comptime {
     const powers = Vec.new()
-    let power = 1
+    mut power = 1
     for i in 0..16 {
         powers.push(power)
         power = power * 2
@@ -41,7 +41,7 @@ const PRIMES = comptime {
     const primes = Vec.new()
 
     for n in 2..50 {
-        let is_prime = true
+        mut is_prime = true
 
         for i in 2..n {
             if i * i > n {

--- a/examples/cli_calculator.rk
+++ b/examples/cli_calculator.rk
@@ -112,7 +112,7 @@ extend Lexer {
 
     func read_number(self) -> Token or CalcError {
         const num_str = string.new()
-        let has_dot = false
+        mut has_dot = false
 
         while self.peek_char() is Some(c) {
             if c.is_digit() {
@@ -176,7 +176,7 @@ extend Parser {
 
     // expression = term (('+' | '-') term)*
     func parse_expression(self) -> Expr or CalcError {
-        let left = try self.parse_term()
+        mut left = try self.parse_term()
 
         loop {
             const op = match self.current {
@@ -194,7 +194,7 @@ extend Parser {
 
     // term = power (('*' | '/' | '%') power)*
     func parse_term(self) -> Expr or CalcError {
-        let left = try self.parse_power()
+        mut left = try self.parse_power()
 
         loop {
             const op = match self.current {

--- a/examples/file_copy.rk
+++ b/examples/file_copy.rk
@@ -35,16 +35,16 @@ struct CopyOptions {
 }
 
 func parse_args(take args: Vec<string>) -> CopyOptions or string {
-    let opts = CopyOptions {
+    mut opts = CopyOptions {
         source: "",
         dest: "",
         force: false,
         verbose: false,
     }
 
-    let positional = Vec.new()
+    mut positional = Vec.new()
 
-    let i: usize = 1
+    mut i: usize = 1
     while i < args.len() {
         const arg = args[i]
         match arg {

--- a/examples/game_loop.rk
+++ b/examples/game_loop.rk
@@ -64,7 +64,7 @@ struct GameState {
 
 extend GameState {
     func new() -> GameState or Error {
-        let entities = Pool.new()
+        mut entities = Pool.new()
 
         // Spawn player at center
         const player_handle = entities.insert(Entity {
@@ -120,7 +120,7 @@ func movement_system(mutate entities: Pool<Entity>, dt: f32) {
 
 // System: Check collisions between entities
 func collision_system(mutate state: GameState) {
-    let to_check = state.entities.handles()
+    mut to_check = state.entities.handles()
 
     for i in 0..to_check.len() {
         for j in (i + 1)..to_check.len() {
@@ -181,7 +181,7 @@ func handle_collision(mutate state: GameState, h1: Handle<Entity>, h2: Handle<En
 
 // System: Remove inactive entities
 func cleanup_system(mutate state: GameState) {
-    let to_remove = Vec.new()
+    mut to_remove = Vec.new()
 
     for h in state.entities {
         if !state.entities[h].active {
@@ -213,14 +213,14 @@ func spawn_system(mutate state: GameState, time_since_last_spawn: f32) -> f32 {
 func parallel_movement_system(mutate entities: Pool<Entity>, dt: f32, num_threads: usize)
     using ThreadPool
 {
-    let handles = entities.handles()
-    let chunk_size = (handles.len() + num_threads - 1) / num_threads
+    mut handles = entities.handles()
+    mut chunk_size = (handles.len() + num_threads - 1) / num_threads
 
     // Split work across thread pool
-    let thread_handles = Vec.new()
+    mut thread_handles = Vec.new()
     for chunk in handles.chunks(chunk_size) {
-        let chunk = chunk.to_vec()
-        let task = ThreadPool.spawn(|| {
+        mut chunk = chunk.to_vec()
+        mut task = ThreadPool.spawn(|| {
             for h in chunk {
                 if !entities[h].active: continue
                 entities[h].position.x += entities[h].velocity.dx * dt
@@ -238,16 +238,16 @@ func parallel_movement_system(mutate entities: Pool<Entity>, dt: f32, num_thread
 
 // Main game loop with fixed timestep and threading
 func main() -> () or Error {
-    let state = try GameState.new()
+    mut state = try GameState.new()
 
     const target_fps = 60.0f32
     const dt = 1.0f32 / target_fps
     const NUM_PHYSICS_THREADS: usize = 4u64
 
-    let last_time = 0.0f32  // Simplified: track elapsed time
-    let accumulator = 0.0f32
-    let spawn_timer = 0.0f32
-    let frame_count = 0
+    mut last_time = 0.0f32  // Simplified: track elapsed time
+    mut accumulator = 0.0f32
+    mut spawn_timer = 0.0f32
+    mut frame_count = 0
 
     println("Game started! Score: 0")
 
@@ -291,7 +291,7 @@ func main() -> () or Error {
         // Render (simulated - just print status occasionally)
         if frame_count % 60 == 0 {
             const entity_count = state.entities.len()
-            let player_health = 0
+            mut player_health = 0
             if state.player is Some(h) {
                 player_health = state.entities[h].health.current
             }

--- a/examples/grep_clone.rk
+++ b/examples/grep_clone.rk
@@ -32,7 +32,7 @@ extend GrepError {
 }
 
 func parse_args(take args: Vec<string>) -> GrepOptions or GrepError {
-    let opts = GrepOptions {
+    mut opts = GrepOptions {
         pattern: "",
         files: Vec.new(),
         ignore_case: false,
@@ -41,9 +41,9 @@ func parse_args(take args: Vec<string>) -> GrepOptions or GrepError {
         invert_match: false,
     }
 
-    let positional = Vec.new()
+    mut positional = Vec.new()
 
-    let i: usize = 1
+    mut i: usize = 1
     while i < args.len() {
         const arg = args[i]
         match arg {
@@ -96,8 +96,8 @@ func grep_file(path: string, opts: GrepOptions) -> i64 or GrepError {
         else |e| GrepError.FileError(e)
 
     const lines = content.lines()
-    let match_count: i64 = 0
-    let line_num = 0
+    mut match_count: i64 = 0
+    mut line_num = 0
 
     for line in lines {
         line_num = line_num + 1
@@ -126,7 +126,7 @@ func grep_file(path: string, opts: GrepOptions) -> i64 or GrepError {
 
 func main() {
     const args = cli.args()
-    let opts = match parse_args(own args) {
+    mut opts = match parse_args(own args) {
         Ok(o) => o,
         Err(e) => {
             const msg = e.message()
@@ -136,10 +136,10 @@ func main() {
         }
     }
 
-    let total_matches = 0
-    let had_errors = false
+    mut total_matches = 0
+    mut had_errors = false
 
-    let fi: usize = 0
+    mut fi: usize = 0
     while fi < opts.files.len() {
         const file_path = opts.files[fi]
         match grep_file(file_path, opts) {

--- a/examples/litmus_edge_cases.rk
+++ b/examples/litmus_edge_cases.rk
@@ -30,7 +30,7 @@ extend TextBuffer {
 }
 
 test "string is Copy — read then write same container" {
-    let buf = TextBuffer.new()
+    mut buf = TextBuffer.new()
     buf.add("hello")
     buf.add("world")
     const old = buf.replace(0, "changed")

--- a/examples/lsm_database/bloom.rk
+++ b/examples/lsm_database/bloom.rk
@@ -14,7 +14,7 @@ struct BloomFilter {
 
 extend BloomFilter {
     func new() -> BloomFilter {
-        let bits = Vec.new()
+        mut bits = Vec.new()
         for _ in 0..BLOOM_BITS {
             bits.push(false)
         }
@@ -38,7 +38,7 @@ extend BloomFilter {
     }
 
     func false_positive_rate(self) -> f64 {
-        let set_bits = 0
+        mut set_bits = 0
         for b in self.bits {
             if b { set_bits += 1 }
         }
@@ -48,7 +48,7 @@ extend BloomFilter {
 }
 
 func bloom_hash(key: string, seed: i32) -> usize {
-    let hash: i64 = 2166136261 + (seed as i64) * 16777619
+    mut hash: i64 = 2166136261 + (seed as i64) * 16777619
     for ch in key.chars() {
         hash = hash ^ (ch.to_int() as i64)
         hash = (hash * 16777619) % 4294967296
@@ -57,8 +57,8 @@ func bloom_hash(key: string, seed: i32) -> usize {
 }
 
 func encode_bloom(filter: BloomFilter) -> string {
-    let out = ""
-    let first = true
+    mut out = ""
+    mut first = true
     for b in filter.bits {
         if !first { out.push_str(",") }
         first = false
@@ -74,8 +74,8 @@ func decode_bloom(data: string) -> BloomFilter or SstError {
             "expected {BLOOM_BITS} bits, got {parts.len()}"
         ))
     }
-    let bits = Vec.new()
-    let count = 0
+    mut bits = Vec.new()
+    mut count = 0
     for p in parts {
         const val = p.trim() == "1"
         bits.push(val)
@@ -87,7 +87,7 @@ func decode_bloom(data: string) -> BloomFilter or SstError {
 // ─── Tests ──────────────────────────────────────────────────────────
 
 test "bloom filter basic" {
-    let bloom = BloomFilter.new()
+    mut bloom = BloomFilter.new()
     bloom.insert("hello")
     bloom.insert("world")
 
@@ -96,7 +96,7 @@ test "bloom filter basic" {
 }
 
 test "bloom filter encode/decode roundtrip" {
-    let bloom = BloomFilter.new()
+    mut bloom = BloomFilter.new()
     bloom.insert("key1")
     bloom.insert("key2")
     bloom.insert("key3")

--- a/examples/lsm_database/cache.rk
+++ b/examples/lsm_database/cache.rk
@@ -64,8 +64,8 @@ extend BlockCache {
     }
 
     func evict_one(mutate self) {
-        let min_access: i64 = i64.MAX
-        let victim: Handle<CacheBlock>? = None
+        mut min_access: i64 = i64.MAX
+        mut victim: Handle<CacheBlock>? = None
 
         for handle in self.blocks {
             if self.blocks[handle].access_count < min_access {
@@ -84,7 +84,7 @@ extend BlockCache {
     }
 
     func invalidate(mutate self, sst_id: i32) {
-        let to_remove = Vec.new()
+        mut to_remove = Vec.new()
         for handle in self.blocks {
             if self.blocks[handle].sst_id == sst_id {
                 const key = BlockCache.cache_key(
@@ -158,7 +158,7 @@ func sst_point_lookup(
 // ─── Tests ──────────────────────────────────────────────────────────
 
 test "block cache put and get" {
-    let cache = BlockCache.new()
+    mut cache = BlockCache.new()
     const entries = Vec.from([
         KeyValue.new("k1", "v1", 1),
         KeyValue.new("k2", "v2", 2),
@@ -175,11 +175,11 @@ test "block cache put and get" {
 }
 
 test "block cache eviction" {
-    let cache = BlockCache.new()
+    mut cache = BlockCache.new()
 
-    let i = 0
+    mut i = 0
     while i < MAX_CACHE_ENTRIES + 10 {
-        let entries = Vec.new()
+        mut entries = Vec.new()
         entries.push(KeyValue.new("k", "v", i as i64))
         cache.put(i as i32, 0, entries)
         i += 1
@@ -189,10 +189,10 @@ test "block cache eviction" {
 }
 
 test "block cache invalidate" {
-    let cache = BlockCache.new()
-    let e1 = Vec.new(); e1.push(KeyValue.new("a", "1", 1))
-    let e2 = Vec.new(); e2.push(KeyValue.new("b", "2", 2))
-    let e3 = Vec.new(); e3.push(KeyValue.new("c", "3", 3))
+    mut cache = BlockCache.new()
+    mut e1 = Vec.new(); e1.push(KeyValue.new("a", "1", 1))
+    mut e2 = Vec.new(); e2.push(KeyValue.new("b", "2", 2))
+    mut e3 = Vec.new(); e3.push(KeyValue.new("c", "3", 3))
     cache.put(1, 0, e1)
     cache.put(1, 1, e2)
     cache.put(2, 0, e3)

--- a/examples/lsm_database/compaction.rk
+++ b/examples/lsm_database/compaction.rk
@@ -12,9 +12,9 @@ const MAX_LEVELS: i32 = 4
 const LEVEL_SIZE_MULTIPLIER: i32 = 10
 
 func merge_entries(a: Vec<KeyValue>, b: Vec<KeyValue>) -> Vec<KeyValue> {
-    let result = Vec.new()
-    let i: usize = 0
-    let j: usize = 0
+    mut result = Vec.new()
+    mut i: usize = 0
+    mut j: usize = 0
 
     while i < a.len() && j < b.len() {
         if a[i].key < b[j].key {
@@ -60,7 +60,7 @@ func compact_sstables(
         return Err(CompactionError.MergeConflict("cannot read SSTable {b.id}"))
     }
 
-    let merged = merge_entries(entries_a, entries_b)
+    mut merged = merge_entries(entries_a, entries_b)
 
     // Strip tombstones at bottom level
     if target_level == MAX_LEVELS - 1 {
@@ -131,8 +131,8 @@ test "merge entries deduplicates by seq" {
 }
 
 test "merge preserves tombstones" {
-    let a = Vec.new(); a.push(KeyValue.new("x", "alive", 1))
-    let b = Vec.new(); b.push(KeyValue.tombstone("x", 5))
+    mut a = Vec.new(); a.push(KeyValue.new("x", "alive", 1))
+    mut b = Vec.new(); b.push(KeyValue.tombstone("x", 5))
 
     const merged = merge_entries(a, b)
     assert merged.len() == 1

--- a/examples/lsm_database/db.rk
+++ b/examples/lsm_database/db.rk
@@ -41,13 +41,13 @@ extend Db {
         try fs.create_dir_all(config.dir)
             else |e| DbError.Io("cannot create directory: {config.dir}: {e}")
 
-        let wal = try Wal.open(config.wal_path)
+        mut wal = try Wal.open(config.wal_path)
             else |e| DbError.Wal(e)
         ensure wal.close() else |_| {}
 
         // Recover memtable from WAL
-        let memtable = Memtable.new()
-        let max_seq: i64 = 0
+        mut memtable = Memtable.new()
+        mut max_seq: i64 = 0
         const recovered = try recover_wal(config.wal_path)
             else |e| DbError.Wal(e)
 
@@ -57,11 +57,11 @@ extend Db {
         }
 
         // Discover existing SSTables
-        let levels = Vec.new()
+        mut levels = Vec.new()
         for _ in 0..MAX_LEVELS {
             levels.push(Vec.new())
         }
-        let next_sst_id = 0
+        mut next_sst_id = 0
 
         const discovered = discover_sstables(config.dir)
         for meta in discovered {
@@ -113,10 +113,10 @@ extend Db {
         }
 
         // Search levels from newest to oldest
-        let level_idx: usize = 0
+        mut level_idx: usize = 0
         while level_idx < self.levels.len() {
             const level = self.levels[level_idx].clone()
-            let sst_idx = level.len()
+            mut sst_idx = level.len()
             while sst_idx > 0 {
                 sst_idx -= 1
                 const meta = level[sst_idx].clone()
@@ -158,9 +158,9 @@ extend Db {
     }
 
     func scan(mutate self, start: string, end: string) -> Vec<KeyValue> or DbError {
-        let all_entries = self.memtable.scan(start, end)
+        mut all_entries = self.memtable.scan(start, end)
 
-        let level_idx: usize = 0
+        mut level_idx: usize = 0
         while level_idx < self.levels.len() {
             const level = self.levels[level_idx].clone()
             for meta in level {
@@ -186,8 +186,8 @@ extend Db {
             return b.seq.compare(a.seq)
         })
 
-        let deduped = Vec.new()
-        let last_key = ""
+        mut deduped = Vec.new()
+        mut last_key = ""
         for entry in all_entries {
             if entry.key == last_key { continue }
             last_key = entry.key
@@ -257,8 +257,8 @@ extend Db {
     }
 
     func stats(self) -> DbStats {
-        let total_sst = 0
-        let level_counts = Vec.new()
+        mut total_sst = 0
+        mut level_counts = Vec.new()
         for level in self.levels {
             level_counts.push(level.len() as i32)
             total_sst += level.len()
@@ -277,7 +277,7 @@ extend Db {
 
     func compact_all(mutate self) -> () or DbError {
         try self.flush()
-        let level = 0
+        mut level = 0
         while level < MAX_LEVELS - 1 {
             try self.compact_level(level)
             level += 1
@@ -317,7 +317,7 @@ func print_stats(stats: DbStats) {
     println("  Memtable:  {stats.memtable_entries} entries, {stats.memtable_bytes} bytes")
     println("  SSTables:  {stats.sst_count} total")
 
-    let level = 0
+    mut level = 0
     for count in stats.level_counts {
         if count > 0 {
             println("    L{level}: {count} files")
@@ -338,7 +338,7 @@ struct BatchEntry {
 }
 
 func execute_batch(mutate db: Db, entries: Vec<BatchEntry>) -> i32 or DbError {
-    let success_count = 0
+    mut success_count = 0
     for entry in entries {
         if entry.is_delete {
             try db.delete(entry.key)

--- a/examples/lsm_database/main.rk
+++ b/examples/lsm_database/main.rk
@@ -15,7 +15,7 @@ struct CliArgs {
 }
 
 func parse_cli_args(args: Vec<string>) -> CliArgs or DbError {
-    let result = CliArgs {
+    mut result = CliArgs {
         command: "",
         db_dir: "./rask-db",
         key: "",
@@ -25,8 +25,8 @@ func parse_cli_args(args: Vec<string>) -> CliArgs or DbError {
         prefix: "key",
     }
 
-    let positional = Vec.new()
-    let i = 1
+    mut positional = Vec.new()
+    mut i = 1
 
     while i < args.len() {
         const arg = args[i]
@@ -102,7 +102,7 @@ func run_benchmark(mutate db: Db, count: i32, prefix: string) -> () or DbError {
 
     // Sequential writes
     println("Writing {count} keys...")
-    let i = 0
+    mut i = 0
     while i < count {
         const key = "{prefix}_{i:06}"
         const padding = "x".repeat(64)
@@ -114,8 +114,8 @@ func run_benchmark(mutate db: Db, count: i32, prefix: string) -> () or DbError {
 
     // Point reads
     println("Reading {count} keys...")
-    let found = 0
-    let missing = 0
+    mut found = 0
+    mut missing = 0
     i = 0
     while i < count {
         const key = "{prefix}_{i:06}"
@@ -136,7 +136,7 @@ func run_benchmark(mutate db: Db, count: i32, prefix: string) -> () or DbError {
 
     // Delete every other key
     println("Deleting {count / 2} keys...")
-    let deleted = 0
+    mut deleted = 0
     i = 0
     while i < count {
         if i % 2 == 0 {
@@ -149,8 +149,8 @@ func run_benchmark(mutate db: Db, count: i32, prefix: string) -> () or DbError {
 
     // Verify deletes
     println("Verifying deletes...")
-    let still_found = 0
-    let correctly_deleted = 0
+    mut still_found = 0
+    mut correctly_deleted = 0
     i = 0
     while i < count {
         const key = "{prefix}_{i:06}"
@@ -176,7 +176,7 @@ func run_benchmark(mutate db: Db, count: i32, prefix: string) -> () or DbError {
 
 func run(args: CliArgs) -> () or DbError {
     const config = DbConfig.default_for(args.db_dir)
-    let db = try Db.open(config)
+    mut db = try Db.open(config)
     ensure db.close() else |_| {}
 
     match args.command {

--- a/examples/lsm_database/memtable.rk
+++ b/examples/lsm_database/memtable.rk
@@ -29,7 +29,7 @@ extend Memtable {
         } else {
             // Manual insert at position: append then bubble into place
             self.entries.push(kv)
-            let i = self.entries.len() - 1
+            mut i = self.entries.len() - 1
             while i > pos {
                 const tmp = self.entries[i].clone()
                 self.entries[i] = self.entries[i - 1].clone()
@@ -60,8 +60,8 @@ extend Memtable {
     }
 
     func find_pos(self, key: string) -> usize {
-        let lo: usize = 0
-        let hi: usize = self.entries.len()
+        mut lo: usize = 0
+        mut hi: usize = self.entries.len()
         while lo < hi {
             const mid = lo + (hi - lo) / 2
             if self.entries[mid].key < key {
@@ -74,9 +74,9 @@ extend Memtable {
     }
 
     func scan(self, start: string, end: string) -> Vec<KeyValue> {
-        let result = Vec.new()
+        mut result = Vec.new()
         const start_pos = self.find_pos(start)
-        let i = start_pos
+        mut i = start_pos
         while i < self.entries.len() {
             if self.entries[i].key > end { break }
             result.push(self.entries[i].clone())
@@ -89,7 +89,7 @@ extend Memtable {
 // ─── Tests ──────────────────────────────────────────────────────────
 
 test "memtable put and get" {
-    let mt = Memtable.new()
+    mut mt = Memtable.new()
     mt.put(KeyValue.new("b", "2", 1))
     mt.put(KeyValue.new("a", "1", 2))
     mt.put(KeyValue.new("c", "3", 3))
@@ -104,7 +104,7 @@ test "memtable put and get" {
 }
 
 test "memtable overwrites by key" {
-    let mt = Memtable.new()
+    mut mt = Memtable.new()
     mt.put(KeyValue.new("k", "old", 1))
     mt.put(KeyValue.new("k", "new", 2))
 
@@ -115,7 +115,7 @@ test "memtable overwrites by key" {
 }
 
 test "memtable maintains sort order" {
-    let mt = Memtable.new()
+    mut mt = Memtable.new()
     mt.put(KeyValue.new("delta", "4", 1))
     mt.put(KeyValue.new("alpha", "1", 2))
     mt.put(KeyValue.new("charlie", "3", 3))
@@ -128,7 +128,7 @@ test "memtable maintains sort order" {
 }
 
 test "memtable range scan" {
-    let mt = Memtable.new()
+    mut mt = Memtable.new()
     mt.put(KeyValue.new("a", "1", 1))
     mt.put(KeyValue.new("b", "2", 2))
     mt.put(KeyValue.new("c", "3", 3))

--- a/examples/lsm_database/sstable.rk
+++ b/examples/lsm_database/sstable.rk
@@ -44,15 +44,15 @@ func write_sstable(
 
     const path = "{dir}/L{level}_{id}.sst"
 
-    let bloom = BloomFilter.new()
+    mut bloom = BloomFilter.new()
     for entry in entries {
         bloom.insert(entry.key)
     }
 
-    let index = Vec.new()
-    let blocks = Vec.new()
-    let block_entries = Vec.new()
-    let block_id = 0
+    mut index = Vec.new()
+    mut blocks = Vec.new()
+    mut block_entries = Vec.new()
+    mut block_id = 0
 
     for entry in entries {
         if block_entries.len() >= BLOCK_SIZE {
@@ -77,7 +77,7 @@ func write_sstable(
         blocks.push(block_entries)
     }
 
-    let out = "BLOOM:{encode_bloom(bloom)}\n"
+    mut out = "BLOOM:{encode_bloom(bloom)}\n"
 
     for idx_entry in index {
         out.push_str("INDEX:{idx_entry.first_key}\t{idx_entry.offset}\t{idx_entry.count}\n")
@@ -120,8 +120,8 @@ func read_sstable_block(path: string, block_offset: i32) -> Vec<KeyValue> or Sst
     }
     const data = content[sep_pos + 4..].to_string()
 
-    let current_block = 0
-    let block_lines = Vec.new()
+    mut current_block = 0
+    mut block_lines = Vec.new()
 
     for line in data.lines() {
         const trimmed = line.trim()
@@ -145,7 +145,7 @@ func read_sstable_block(path: string, block_offset: i32) -> Vec<KeyValue> or Sst
 }
 
 func parse_block_lines(lines: Vec<string>, block_id: i32) -> Vec<KeyValue> or SstError {
-    let entries = Vec.new()
+    mut entries = Vec.new()
     for line in lines {
         const kv = decode_kv(line) is Ok(entry) else {
             return Err(SstError.BlockCorrupt(block_id, "corrupt entry"))
@@ -159,7 +159,7 @@ func read_sstable_index(path: string) -> Vec<BlockIndex> or SstError {
     const content = try fs.read_file(path)
         else |e| SstError.ReadFailure("cannot read index: {path}: {e}")
 
-    let index = Vec.new()
+    mut index = Vec.new()
     for line in content.lines() {
         const trimmed = line.trim()
         if trimmed == "---" { break }
@@ -205,7 +205,7 @@ func read_all_sstable_entries(path: string) -> Vec<KeyValue> or SstError {
     }
     const data = content[sep_pos + 4..].to_string()
 
-    let entries = Vec.new()
+    mut entries = Vec.new()
     for line in data.lines() {
         const trimmed = line.trim()
         if trimmed.is_empty() { continue }
@@ -219,9 +219,9 @@ func read_all_sstable_entries(path: string) -> Vec<KeyValue> or SstError {
 // ─── Index Lookup ───────────────────────────────────────────────────
 
 func find_block_for_key(index: Vec<BlockIndex>, key: string) -> i32? {
-    let lo: usize = 0
-    let hi: usize = index.len()
-    let result: i32? = None
+    mut lo: usize = 0
+    mut hi: usize = index.len()
+    mut result: i32? = None
 
     while lo < hi {
         const mid = lo + (hi - lo) / 2
@@ -238,7 +238,7 @@ func find_block_for_key(index: Vec<BlockIndex>, key: string) -> i32? {
 // ─── Discovery ──────────────────────────────────────────────────────
 
 func discover_sstables(dir: string) -> Vec<SstMeta> {
-    let metas = Vec.new()
+    mut metas = Vec.new()
 
     const files = fs.list_dir(dir) is Ok(f) else { return metas }
 
@@ -267,7 +267,7 @@ func discover_sstables(dir: string) -> Vec<SstMeta> {
         if last_entries.is_empty() { continue }
         const max_key = last_entries[last_entries.len() - 1].key
 
-        let entry_count = 0
+        mut entry_count = 0
         for idx_entry in index {
             entry_count += idx_entry.count
         }

--- a/examples/lsm_database/wal.rk
+++ b/examples/lsm_database/wal.rk
@@ -55,7 +55,7 @@ func recover_wal(path: string) -> Vec<KeyValue> or WalError {
         return Err(WalError.RecoveryFailure("cannot read WAL: {path}"))
     }
 
-    let entries = Vec.new()
+    mut entries = Vec.new()
     for line in content.lines() {
         const trimmed = line.trim()
         if trimmed.is_empty() { continue }

--- a/examples/markdown_renderer.rk
+++ b/examples/markdown_renderer.rk
@@ -85,7 +85,7 @@ enum Block {
 // ─── HTML Utilities ─────────────────────────────────────────────────
 
 func html_escape(input: string) -> string {
-    let builder = string.new()
+    mut builder = string.new()
     for ch in input.chars() {
         match ch {
             '&' => builder.push_str("&amp;")
@@ -103,7 +103,7 @@ func html_escape(input: string) -> string {
 }
 
 func count_leading(line: string, ch: char) -> i32 {
-    let count = 0
+    mut count = 0
     for c in line.chars() {
         if c != ch {
             break
@@ -129,7 +129,7 @@ func is_hr_line(line: string) -> bool {
         return false
     }
 
-    let count = 0
+    mut count = 0
     for ch in trimmed.chars() {
         if ch == first {
             count = count + 1
@@ -270,7 +270,7 @@ extend Scanner {
 // These are removed from the document and stored for later resolution.
 
 func parse_references(input: string) -> Map<string, string> {
-    let refs = Map.new()
+    mut refs = Map.new()
 
     for line in input.lines() {
         const trimmed = line.trim()
@@ -316,7 +316,7 @@ func is_reference_def(line: string) -> bool {
 // via recursive descent. This is the most string-intensive part.
 
 func parse_inline(text: string) -> Vec<Inline> or MarkdownError {
-    let scanner = Scanner.new(text)
+    mut scanner = Scanner.new(text)
     return parse_inline_until(mutate scanner, "")
 }
 
@@ -328,8 +328,8 @@ func flush_text(mutate result: Vec<Inline>, mutate text_buf: string) {
 }
 
 func parse_inline_until(mutate scanner: Scanner, stop: string) -> Vec<Inline> or MarkdownError {
-    let result = Vec.new()
-    let text_buf = string.new()
+    mut result = Vec.new()
+    mut text_buf = string.new()
 
     while !scanner.is_done() {
         // Check for stop sequence
@@ -454,8 +454,8 @@ func parse_inline_until(mutate scanner: Scanner, stop: string) -> Vec<Inline> or
 
 func parse_blocks(input: string) -> Vec<Block> or MarkdownError {
     const lines = input.lines().collect()
-    let blocks = Vec.new()
-    let i = 0
+    mut blocks = Vec.new()
+    mut i = 0
     const line_count = lines.len()
 
     while i < line_count {
@@ -499,8 +499,8 @@ func parse_blocks(input: string) -> Vec<Block> or MarkdownError {
         // Fenced code block: ```
         if trimmed.starts_with("```") {
             const lang = trimmed[3..].trim().to_string()
-            let code = string.new()
-            let first_code_line = true
+            mut code = string.new()
+            mut first_code_line = true
             i = i + 1
             while i < line_count {
                 if lines[i].trim() == "```" {
@@ -520,7 +520,7 @@ func parse_blocks(input: string) -> Vec<Block> or MarkdownError {
 
         // Blockquote: > text
         if trimmed.starts_with(">") {
-            let quote_lines = Vec.new()
+            mut quote_lines = Vec.new()
             while i < line_count {
                 const ql = lines[i].trim()
                 if !ql.starts_with(">") && !is_blank_line(lines[i]) {
@@ -546,7 +546,7 @@ func parse_blocks(input: string) -> Vec<Block> or MarkdownError {
 
         // Unordered list: - item or * item
         if trimmed.starts_with("- ") || trimmed.starts_with("* ") {
-            let items = Vec.new()
+            mut items = Vec.new()
             while i < line_count {
                 const il = lines[i]
                 const it = il.trim()
@@ -586,7 +586,7 @@ func parse_blocks(input: string) -> Vec<Block> or MarkdownError {
 
         // Ordered list: 1. item
         if ordered_list_start(trimmed) is Some(start_num) {
-            let items = Vec.new()
+            mut items = Vec.new()
             while i < line_count {
                 const il = lines[i]
                 const it = il.trim()
@@ -625,7 +625,7 @@ func parse_blocks(input: string) -> Vec<Block> or MarkdownError {
         }
 
         // Paragraph: collect consecutive non-blank, non-special lines
-        let para_lines = Vec.new()
+        mut para_lines = Vec.new()
         while i < line_count {
             const pl = lines[i]
             const pt = pl.trim()
@@ -806,7 +806,7 @@ func render_markdown(input: string) -> string or RenderError {
     const refs = parse_references(input)
     const blocks = try parse_blocks(input) else |e| RenderError.Parse(e)
 
-    let out = string.new()
+    mut out = string.new()
     render_children(blocks, mutate out, refs)
     return Ok(out)
 }
@@ -814,7 +814,7 @@ func render_markdown(input: string) -> string or RenderError {
 func render_full_page(input: string) -> string or RenderError {
     const body = try render_markdown(input)
 
-    let out = string.new()
+    mut out = string.new()
     out.push_str("""
 <!DOCTYPE html>
 <html>
@@ -846,11 +846,11 @@ func print_usage() {
 
 func main() {
     const args = cli.args()
-    let input_path = ""
-    let output_path = ""
-    let use_stdout = false
-    let fragment = false
-    let i = 1
+    mut input_path = ""
+    mut output_path = ""
+    mut use_stdout = false
+    mut fragment = false
+    mut i = 1
 
     while i < args.len() {
         const arg = args[i]

--- a/examples/package_manager.rk
+++ b/examples/package_manager.rk
@@ -274,11 +274,11 @@ func load_manifest(path: string) -> Manifest or FetchError {
 
 func parse_manifest(content: string) -> Manifest or ManifestError {
     const lines = content.lines()
-    let name = ""
-    let version_str = ""
-    let deps = Vec.new()
-    let in_block = false
-    let line_num = 0
+    mut name = ""
+    mut version_str = ""
+    mut deps = Vec.new()
+    mut in_block = false
+    mut line_num = 0
 
     for line in lines {
         line_num += 1
@@ -327,8 +327,8 @@ func parse_manifest(content: string) -> Manifest or ManifestError {
 
 // Extract the nth quoted string from a line, or error.
 func extract_nth_quoted(line: string, n: i32, line_num: i32, label: string) -> string or ManifestError {
-    let pos = 0
-    let found = 0
+    mut pos = 0
+    mut found = 0
     while found <= n {
         const open = line[pos..].find("\"") is Some(idx) else {
             return Err(ManifestError.ParseError(line_num, "expected quoted {label}"))
@@ -407,7 +407,7 @@ func local_available(root: string, name: string) -> Vec<PackageMeta> or Registry
         return Err(RegistryError.IoError("expected array in {index_path}"))
     }
 
-    let versions = Vec.new()
+    mut versions = Vec.new()
     for entry in version_list {
         const ver_str = entry.as_string() is Some(s) else { continue }
         const meta_path = "{root}/{name}/{ver_str}/meta.json"
@@ -460,7 +460,7 @@ func parse_meta_from_json(obj: JsonValue, source: string) -> PackageMeta or Regi
         return Err(RegistryError.IoError("bad version in {source}: {ver_str}"))
     }
 
-    let deps = Vec.new()
+    mut deps = Vec.new()
     if m.get("deps")?.as_array() is Some(dep_arr) {
         for d_val in dep_arr {
             const d_obj = d_val.as_object() is Some(dm) else { continue }
@@ -516,7 +516,7 @@ func http_available(base_url: string, name: string) -> Vec<PackageMeta> or Regis
         return Err(RegistryError.NetworkError("expected array from registry for {name}"))
     }
 
-    let versions = Vec.new()
+    mut versions = Vec.new()
     for entry in arr {
         const meta = parse_meta_from_json(entry, name) is Ok(m) else { continue }
         versions.push(meta)
@@ -560,7 +560,7 @@ struct ResolveState {
 }
 
 func resolve(manifest: Manifest, registry: any Registry) -> DepGraph or FetchError {
-    let state = ResolveState {
+    mut state = ResolveState {
         packages: Pool.new(),
         by_name: Map.new(),
         visiting: Vec.new(),
@@ -633,7 +633,7 @@ func resolve_one(
         else |e| FetchError.Registry(e)
 
     // Filter to satisfying versions, pick newest via sort_by
-    let candidates = versions.filter(|m| constraint.satisfies(m.version))
+    mut candidates = versions.filter(|m| constraint.satisfies(m.version))
     candidates.sort_by(|a, b| b.version.compare(a.version))
 
     const meta = candidates.first() is Some else {
@@ -667,7 +667,7 @@ func resolve_one(
 }
 
 func format_cycle(chain: Vec<string>, name: string) -> string {
-    let parts = chain.clone()
+    mut parts = chain.clone()
     parts.push(name)
     return parts.join(" -> ")
 }
@@ -685,7 +685,7 @@ struct FetchItem {
 }
 
 func collect_fetch_items(graph: DepGraph, cache_dir: string) -> Vec<FetchItem> {
-    let items = Vec.new()
+    mut items = Vec.new()
     const handles = graph.packages.handles()
     for handle in handles {
         with graph.packages[handle] as pkg {
@@ -713,7 +713,7 @@ func collect_fetch_items(graph: DepGraph, cache_dir: string) -> Vec<FetchItem> {
 func verify_checksum(data: string, expected: string, pkg_name: string) -> () or RegistryError {
     if expected.is_empty() { return Ok(()) }
     // Simple hash: sum all bytes mod 2^32 (real impl would SHA-256)
-    let hash: i64 = 0
+    mut hash: i64 = 0
     for ch in data.chars() {
         hash = (hash * 31 + ch.to_int()) % 4294967296
     }
@@ -742,7 +742,7 @@ func fetch_packages(
     // Concurrent fetch: spawn a task per package, collect results via channel.
     // Mutex<i32> tracks fetch count across tasks (conc.sync/MX1).
     using Multitasking {
-        let (tx, rx) = Channel.buffered(items.len())
+        mut (tx, rx) = Channel.buffered(items.len())
         const counter = Mutex.new(0)
 
         for item in items {
@@ -761,8 +761,8 @@ func fetch_packages(
         }
 
         // Collect results — first error is fatal
-        let first_error: FetchError? = None
-        let received = 0
+        mut first_error: FetchError? = None
+        mut received = 0
         while received < items.len() {
             if rx.recv() is Ok(result) {
                 match result {
@@ -822,7 +822,7 @@ func write_lockfile(graph: DepGraph, path: string) -> () or FetchError {
         else |e| FetchError.Io("cannot create temp lock file: {e}")
     ensure fs.remove(tmp_path) else |_| {}
 
-    let out = string.new()
+    mut out = string.new()
     out.push_str("lockfile-version = 1\n\n")
 
     const order = topo_sort(graph)
@@ -838,7 +838,7 @@ func write_lockfile(graph: DepGraph, path: string) -> () or FetchError {
             out.push_str("checksum = \"{pkg.meta.checksum}\"\n")
 
             if !pkg.deps.is_empty() {
-                let dep_names = Vec.new()
+                mut dep_names = Vec.new()
                 for dep_handle in pkg.deps {
                     with graph.packages[dep_handle] as dep_pkg {
                         dep_names.push("\"{dep_pkg.meta.name}\"")
@@ -866,16 +866,16 @@ func write_lockfile(graph: DepGraph, path: string) -> () or FetchError {
 }
 
 func read_lockfile(path: string) -> Map<string, LockedPackage> or FetchError {
-    let packages = Map.new()
+    mut packages = Map.new()
 
     const content = fs.read_file(path) is Ok(c) else {
         // No lock file yet — that's fine
         return Ok(packages)
     }
 
-    let current_name = ""
-    let current_version = ""
-    let current_checksum = ""
+    mut current_name = ""
+    mut current_version = ""
+    mut current_checksum = ""
 
     for line in content.lines() {
         const trimmed = line.trim()
@@ -935,8 +935,8 @@ func extract_quoted_value(line: string) -> string {
 // unique in the dependency graph.
 
 func topo_sort(graph: DepGraph) -> Vec<Handle<ResolvedPkg>> {
-    let visited = Map.new()
-    let order = Vec.new()
+    mut visited = Map.new()
+    mut order = Vec.new()
 
     topo_visit(graph, graph.root, mutate visited, mutate order)
 
@@ -988,9 +988,9 @@ func print_node(graph: DepGraph, handle: Handle<ResolvedPkg>, depth: i32) {
 
 func print_lock_diff(old_lock: Map<string, LockedPackage>, graph: DepGraph) {
     const handles = graph.packages.handles()
-    let added = 0
-    let updated = 0
-    let unchanged = 0
+    mut added = 0
+    mut updated = 0
+    mut unchanged = 0
 
     for handle in handles {
         with graph.packages[handle] as pkg {
@@ -1037,7 +1037,7 @@ struct CliArgs {
 }
 
 func parse_cli_args(args: Vec<string>) -> CliArgs or FetchError {
-    let result = CliArgs {
+    mut result = CliArgs {
         command: "",
         manifest_path: "build.rk",
         registry_type: RegistryType.Local,
@@ -1047,8 +1047,8 @@ func parse_cli_args(args: Vec<string>) -> CliArgs or FetchError {
         lock_path: "rask.lock",
     }
 
-    let positional = Vec.new()
-    let i = 1  // skip program name
+    mut positional = Vec.new()
+    mut i = 1  // skip program name
 
     while i < args.len() {
         const arg = args[i]
@@ -1188,7 +1188,7 @@ func run(args: CliArgs) -> () or FetchError {
             println("Resolving dependencies...")
             const graph = try resolve(manifest, registry)
 
-            let drift = false
+            mut drift = false
             const handles = graph.packages.handles()
             for handle in handles {
                 with graph.packages[handle] as pkg {

--- a/examples/sensor_processor.rk
+++ b/examples/sensor_processor.rk
@@ -12,7 +12,7 @@ import time
 func build_crc8_table() -> Vec<i64> {
     const table = Vec.new()
     for i in 0..256 {
-        let crc = i
+        mut crc = i
         for j in 0..8 {
             if crc & 128 != 0 {
                 crc = ((crc * 2) & 255) ^ 7
@@ -26,7 +26,7 @@ func build_crc8_table() -> Vec<i64> {
 }
 
 func crc8(data: Vec<i64>, table: Vec<i64>) -> i64 {
-    let crc: i64 = 0
+    mut crc: i64 = 0
     const n = data.len()
     for i in 0..n {
         const byte = data.get(i).unwrap()
@@ -96,8 +96,8 @@ func isqrt(n: i64) -> i64 {
     if n == 0 {
         return 0
     }
-    let x = n
-    let y = (x + 1) / 2
+    mut x = n
+    mut y = (x + 1) / 2
     while y < x {
         x = y
         y = (x + n / x) / 2
@@ -117,7 +117,7 @@ func interrupt_handler(
     sample_rate_hz: i64
 ) {
     const period_ns = 1000000000 / sample_rate_hz
-    let sequence: i64 = 0
+    mut sequence: i64 = 0
 
     while sequence < sample_rate_hz * 2 {
         const now_ns = time.Instant.now().duration_since(start_time).as_nanos() as i64
@@ -175,9 +175,9 @@ extend ProcessorState {
             return
         }
 
-        let temp_sum = 0.0
-        let pres_sum = 0.0
-        let hum_sum = 0.0
+        mut temp_sum = 0.0
+        mut pres_sum = 0.0
+        mut hum_sum = 0.0
         for i in 0..self.history_count {
             temp_sum += self.temp_history.get(i).unwrap()
             pres_sum += self.pressure_history.get(i).unwrap()
@@ -224,7 +224,7 @@ func main() {
         pres_hist.push(0.0)
         hum_hist.push(0.0)
     }
-    let state = ProcessorState {
+    mut state = ProcessorState {
         temp_history: temp_hist,
         pressure_history: pres_hist,
         humidity_history: hum_hist,
@@ -240,7 +240,7 @@ func main() {
     for i in 0..256 {
         timing_samples.push(0)
     }
-    let timing = TimingStats {
+    mut timing = TimingStats {
         samples: timing_samples,
         sample_idx: 0,
         sample_count: 0,
@@ -255,15 +255,15 @@ func main() {
     const deadline_ns = HARD_DEADLINE_US * 1000
 
     // Start interrupt handler on separate thread
-    let isr_handle = Thread.spawn(|| {
+    mut isr_handle = Thread.spawn(|| {
         interrupt_handler(readings, start_time, SAMPLE_RATE_HZ)
     })
 
     println("Started. Processing for {DURATION_SECS} seconds...")
     println("")
 
-    let cycle: i64 = 0
-    let read_idx: i64 = 0
+    mut cycle: i64 = 0
+    mut read_idx: i64 = 0
 
     while (time.Instant.now().duration_since(start_time).as_secs() as i64) < DURATION_SECS {
         const cycle_start = time.Instant.now()

--- a/examples/simple_grep.rk
+++ b/examples/simple_grep.rk
@@ -17,8 +17,8 @@ func grep_file(pattern: string, path: string) -> GrepResult {
 
     match lines_result {
         Ok(lines) => {
-            let match_count = 0
-            let line_num = 0
+            mut match_count = 0
+            mut line_num = 0
 
             for line in lines {
                 line_num = line_num + 1

--- a/examples/test_example.rk
+++ b/examples/test_example.rk
@@ -59,7 +59,7 @@ func add_is_commutative() {
 // === Benchmark ===
 
 benchmark "add 1000 times" {
-    let sum = 0
+    mut sum = 0
     for i in 0..1000 {
         sum = add(sum, i)
     }

--- a/examples/text_editor.rk
+++ b/examples/text_editor.rk
@@ -52,7 +52,7 @@ extend Document {
         const file = try fs.open(path)
         ensure file.close()
 
-        let doc = Document.new()
+        mut doc = Document.new()
         for line in file.lines() {
             const text = try line
             const h = doc.lines.insert(Line { text: text })
@@ -237,7 +237,7 @@ func print_help() {
 }
 
 func main() -> () or Error {
-    let doc = Document.new()
+    mut doc = Document.new()
 
     println("Simple Text Editor - type 'help' for commands")
 

--- a/projects/raido/language/types.md
+++ b/projects/raido/language/types.md
@@ -231,21 +231,21 @@ extern func noise(quality: number, id: int, index: int) -> number
 
 See [vm/interop.md](../vm/interop.md) for host-side binding.
 
-## Const and Let
+## Const and Mut
 
-`const` and `let` control mutability of the binding **and the data it reaches**:
+`const` and `mut` control mutability of the binding **and the data it reaches**:
 
 - `const x = ...` -- cannot reassign `x`, cannot mutate fields through `x`
-- `let x = ...` -- can reassign `x`, can mutate fields through `x`
+- `mut x = ...` -- can reassign `x`, can mutate fields through `x`
 
 ```raido
 const ship = Ship { id: 1, health: 100, x: 0.0, y: 0.0, shield: None }
 ship.health -= 10  // ERROR: ship is const
 ship = other_ship  // ERROR: ship is const
 
-let ship = Ship { id: 1, health: 100, x: 0.0, y: 0.0, shield: None }
-ship.health -= 10  // OK: ship is let
-ship = other_ship  // OK: ship is let
+mut ship = Ship { id: 1, health: 100, x: 0.0, y: 0.0, shield: None }
+ship.health -= 10  // OK: ship is mut
+ship = other_ship  // OK: ship is mut
 ```
 
 **Function parameters are const.** A function cannot mutate a struct passed to it. Return a modified copy instead:

--- a/projects/raido/src/arena.rk
+++ b/projects/raido/src/arena.rk
@@ -91,7 +91,7 @@ extend Arena {
     func read_string(self, offset: i64) -> string {
         const body = offset + HEADER_SIZE
         const len = read_u32le(self.buf, body)
-        let result = Vec.new()
+        mut result = Vec.new()
         for i in 0..len {
             result.push(read_u8(self.buf, body + 4 + i) as u8)
         }
@@ -208,7 +208,7 @@ extend Arena {
         if cap == 0 { return none }
         const idx_start = body + 8
         const entries_start = idx_start + cap * 4
-        let slot = hash % cap
+        mut slot = hash % cap
         for _ in 0..cap {
             const entry_idx = read_u32le(self.buf, idx_start + slot * 4)
             if entry_idx == EMPTY_SLOT {
@@ -238,7 +238,7 @@ extend Arena {
 
         const idx_start = body + 8
         const entries_start = idx_start + cap * 4
-        let slot = hash % cap
+        mut slot = hash % cap
         for _ in 0..cap {
             const entry_idx = read_u32le(self.buf, idx_start + slot * 4)
             if entry_idx == EMPTY_SLOT {
@@ -281,7 +281,7 @@ extend Arena {
             const v = read_i64le(self.buf, src + 8)
             const h = read_u32le(self.buf, src + 16)
 
-            let slot = h % new_cap
+            mut slot = h % new_cap
             while read_u32le(self.buf, new_idx_start + slot * 4) != EMPTY_SLOT {
                 slot = (slot + 1) % new_cap
             }

--- a/projects/raido/src/chunk.rk
+++ b/projects/raido/src/chunk.rk
@@ -67,8 +67,8 @@ extend Prototype {
 
     // Disassemble the whole prototype to a string
     func disassemble(self) -> string {
-        let out = "== {self.name} (regs={self.num_registers}, args={self.arity}) ==\n"
-        let i = 0
+        mut out = "== {self.name} (regs={self.num_registers}, args={self.arity}) ==\n"
+        mut i = 0
         while i < self.code.len() {
             const instr = self.code.get(i)
             out = out + disassemble_instr(instr, i) + "\n"

--- a/projects/raido/src/compiler.rk
+++ b/projects/raido/src/compiler.rk
@@ -36,7 +36,7 @@
 //    ← parameters →       ← locals →            ← temporaries →
 //
 // - Parameters get the first registers (r0, r1, ...).
-// - Local variables (const/let) get the next ones.
+// - Local variables (const/mut) get the next ones.
 // - Temporaries are used during expression evaluation and freed afterward.
 //
 // The compiler tracks `next_reg` — the next free register. To allocate:
@@ -234,7 +234,7 @@ extend Compiler {
     // Look up a variable by name. Returns the register, or -1 if not found.
     func resolve_local(self, name: string) -> i64 {
         // Search backwards (innermost scope first)
-        let i = self.scope.locals.len() - 1
+        mut i = self.scope.locals.len() - 1
         while i >= 0 {
             const local = self.scope.locals.get(i)
             if local.name == name {
@@ -286,7 +286,7 @@ extend Compiler {
     // --- Statements ---
     // A statement is one "line" of code:
     //   const x = 42
-    //   let y = x + 1
+    //   mut y = x + 1
     //   return x
     //   if x > 0 { ... }
     //   func foo() { ... }
@@ -328,6 +328,6 @@ extend Compiler {
 // --- Public API ---
 
 func compile(source: string) -> Chunk or CompileError {
-    let compiler = Compiler.new(source)
+    mut compiler = Compiler.new(source)
     return compiler.compile()
 }

--- a/projects/raido/src/lexer.rk
+++ b/projects/raido/src/lexer.rk
@@ -24,7 +24,7 @@ enum Token {
 
     // Keywords
     Const
-    Let
+    Mut
     Func
     Return
     If
@@ -185,7 +185,7 @@ extend Lexer {
     func keyword_or_ident(self, word: string) -> Token {
         match word {
             "const" => return Token.Const,
-            "let" => return Token.Let,
+            "mut" => return Token.Mut,
             "func" => return Token.Func,
             "return" => return Token.Return,
             "if" => return Token.If,
@@ -289,7 +289,7 @@ extend Lexer {
     func read_number(self) -> Token or LexError {
         const isNumLit = false
         const start = self.pos
-        let frac_start = self.pos
+        mut frac_start = self.pos
 
         while self.peek() is Some(c) {
             match c {

--- a/projects/raido/src/main.rk
+++ b/projects/raido/src/main.rk
@@ -24,14 +24,14 @@ func code_get(code: Vec<i64>, idx: i64) -> i64 {
 // Minimal VM loop for testing — uses opcodes and Value from the package
 func vm_run(code: Vec<i64>, fuel: i64) -> Value {
     const regs = Vec.new()
-    let i: i64 = 0
+    mut i: i64 = 0
     while i < 256 {
         regs.push(Value.None)
         i = i + 1
     }
 
-    let pc: i64 = 0
-    let remaining = fuel
+    mut pc: i64 = 0
+    mut remaining = fuel
     const code_len = code.len() as i64
 
     while pc < code_len {

--- a/projects/raido/src/vm.rk
+++ b/projects/raido/src/vm.rk
@@ -75,7 +75,7 @@ struct Vm {
 extend Vm {
     func new(chunk: Chunk, fuel: i64) -> Vm {
         const regs = Vec.new()
-        let i = 0
+        mut i = 0
         while i < 256 {
             regs.push(Value.None)
             i = i + 1
@@ -120,7 +120,7 @@ extend Vm {
     //   7. Everything else
     //
     func execute(self) -> Value or VmError {
-        let pc = 0
+        mut pc = 0
         const code = self.chunk.main.code
 
         loop {

--- a/projects/tiwaz/backend.rk
+++ b/projects/tiwaz/backend.rk
@@ -11,7 +11,7 @@ extend BackendPool {
     func next_healthy(self) -> Backend or ProxyError {
         with self.index.lock() as idx {
             const count = self.backends.len()
-            let checked = 0
+            mut checked = 0
             loop {
                 if checked >= count {
                     return Err(ProxyError.UpstreamUnreachable)

--- a/specs/SYNTAX.md
+++ b/specs/SYNTAX.md
@@ -68,7 +68,7 @@ Try to use readable keywords, not symbols or abbreviations.
 
 | Concept | Rask | Rust | Go |
 |---------|------|------|-----|
-| Variable binding | `let` | `let` | `:=` or `var` |
+| Variable binding | `const` / `mut` | `let` / `let mut` | `:=` or `var` |
 | Function | `func` | `fn` | `func` |
 | Return | `return` | `return` | `return` |
 | Match | `match` | `match` | `switch` |
@@ -141,21 +141,21 @@ false
 ```rask
 const x = 42                  // Permanent binding — x always refers to this value
 const name = "Alice"
-let counter = 0               // Rebindable — can reassign counter later
+mut counter = 0               // Rebindable — can reassign counter later
 counter = 1                   // Reassignment
 
-let x = "shadow"              // Shadowing allowed (IDE shows ghost annotation)
+mut x = "shadow"              // Shadowing allowed (IDE shows ghost annotation)
 ```
 
 | Syntax | Meaning |
 |--------|---------|
 | `const x = v` | Permanent binding — `x` cannot be reassigned |
-| `let x = v` | Rebindable — `x` can be reassigned |
+| `mut x = v` | Rebindable — `x` can be reassigned |
 | `x = v` | Reassignment (variable must exist) |
 
 **`const` controls the binding, not the value.** `const v = Vec.new()` means `v` always refers to this Vec — you can't write `v = other_vec`. But `v.push(1)` works fine because the Vec itself is mutable. This is the JavaScript/Go model, not C++/Rust `const`. The name is fixed; the contents aren't.
 
-**Why `const`/`let`:** `const` means "this name is permanently bound." `let` means "let it vary." Opposite of Rust but matches the most common meaning of `const` across languages.
+**Why `const`/`mut`:** `const` for permanent bindings, `mut` for rebindable. No `let`. Rust users writing `let x = 5` get a clear parse error pointing to `mut` or `const` — better than silent semantic inversion.
 
 ---
 
@@ -700,17 +700,17 @@ if state is Connected(sock) && sock.is_ready() {
 
 `is` is non-exhaustive — unmatched patterns skip the block. Use `match` when you need to handle all cases.
 
-**Guard pattern with `let ... is ... else`:**
+**Guard pattern with `const ... is ... else` (or `mut` for rebindable):**
 
 Early exits where bindings need to escape to outer scope:
 
 ```rask
-let value = result is Ok else { return Err(e) }
+const value = result is Ok else { return Err(e) }
 // value available here
 
-let sock = state is Connected else { panic("not connected") }
-let item = queue.pop() is Some else { break }
-let (a, b) = pair is Some else { return None }
+const sock = state is Connected else { panic("not connected") }
+const item = queue.pop() is Some else { break }
+const (a, b) = pair is Some else { return None }
 ```
 
 The `else` block must diverge (`return`, `break`, `panic`).
@@ -1093,7 +1093,7 @@ const v = Vec.new()
 v.push(1)
 v.push(2)
 v.push(3)
-let sum = 0
+mut sum = 0
 for i in 0..v.len() {
     sum += v[i]
 }
@@ -1112,7 +1112,7 @@ println("{sum}")
 | Types | `: Type` | Inference reduces annotations |
 | Functions | `func name(params) -> Type` | Familiar |
 | Permanent binding | `const x = ...` | Cannot reassign (value still mutable) |
-| Rebindable | `let x = ...` | Can reassign |
+| Rebindable | `mut x = ...` | Can reassign |
 | Mutable | `mutate param` | Explicit mutable borrow |
 | Ownership | `take param` | Explicit when consuming |
 | Optional | `T?` | Type and chaining |
@@ -1120,7 +1120,7 @@ println("{sum}")
 | Error prop | `try expr` | Prefix keyword |
 | Match | `match x { ... }` | Expression with `=>` arms |
 | Pattern condition | `if x is Pattern` | Non-exhaustive, binds `v` |
-| Guard extraction | `let v = x is P else { }` | Binds to outer scope |
+| Guard extraction | `const v = x is P else { }` | Binds to outer scope |
 | Loops | `for x in xs: ...` | Inline or braced |
 | Loop value | `break expr` | Exit loop with value |
 | Attributes | `@name` | Familiar from Python/Java |

--- a/specs/analysis/complexity-stress-test.md
+++ b/specs/analysis/complexity-stress-test.md
@@ -106,7 +106,7 @@ func sync_physics(mutate world: GameWorld) {
 <!-- test: skip -->
 ```rask
 func update_entities(mutate world: GameWorld) -> () or Error {
-    let doomed: Vec<Handle<Entity>> = Vec.new()
+    mut doomed: Vec<Handle<Entity>> = Vec.new()
 
     for h in world.entities.cursor() {
         world.entities[h].health -= 1

--- a/specs/canonical-patterns.md
+++ b/specs/canonical-patterns.md
@@ -156,7 +156,7 @@ match fs.read_file(path) {
 
 // Guard pattern — early return on error
 func get_user(id: i64) -> User or NotFound {
-    let user = db.find(id) is Ok else { return Err(NotFound {}) }
+    mut user = db.find(id) is Ok else { return Err(NotFound {}) }
     return user
 }
 ```
@@ -237,7 +237,7 @@ if opt is Some(v) {
 const name = opt ?? "anonymous"
 
 // Guard — early return if absent
-let v = opt is Some else { return None }
+mut v = opt is Some else { return None }
 
 // Full handling — both branches matter
 match opt {
@@ -303,7 +303,7 @@ Strings are UTF-8. Use `format()` for building, methods for inspecting.
 const msg = format("hello, {name}! you have {count} messages")
 
 // StringBuilder — for loops or many concatenations
-let sb = StringBuilder.new()
+mut sb = StringBuilder.new()
 for item in items {
     sb.append("{item}\n")
 }
@@ -465,7 +465,7 @@ if point is Point { x, y } {
 }
 
 // Guard pattern
-let conn = try_connect() is Ok else { return Err(ConnectFailed {}) }
+mut conn = try_connect() is Ok else { return Err(ConnectFailed {}) }
 ```
 
 **Anti-patterns:**

--- a/specs/compiler/incremental.md
+++ b/specs/compiler/incremental.md
@@ -25,7 +25,7 @@ Rask compiles at function granularity. Each monomorphized function is independen
 func sort<T: Comparable>(items: Vec<T>) {
     for i in 1..items.len() {
         const key = items[i]
-        let j = i
+        mut j = i
         while j > 0 and items[j - 1] > key {
             items[j] = items[j - 1]
             j -= 1

--- a/specs/compiler/semantic-hash-caching.md
+++ b/specs/compiler/semantic-hash-caching.md
@@ -42,13 +42,13 @@ The compiler creates a fingerprint (hash) of each function's simplified code tre
 ```rask
 // These two functions have IDENTICAL semantic hashes:
 func compute(data: Vec<i32>) -> i32 {
-    let total = 0
+    mut total = 0
     for item in data { total += item }
     return total
 }
 
 func compute(items: Vec<i32>) -> i32 {
-    let sum = 0
+    mut sum = 0
     for element in items { sum += element }
     return sum
 }

--- a/specs/concurrency/README.md
+++ b/specs/concurrency/README.md
@@ -71,7 +71,7 @@ const result = try h.join()
 spawn(|| { background_work() }).detach()
 
 // Multiple tasks
-let (a, b) = join_all(
+mut (a, b) = join_all(
     spawn(|| { work1() }),
     spawn(|| { work2() })
 )

--- a/specs/concurrency/async.md
+++ b/specs/concurrency/async.md
@@ -95,7 +95,7 @@ enum JoinError {
 
 <!-- test: skip -->
 ```rask
-let (a, b) = join_all(
+mut (a, b) = join_all(
     spawn(|| { work1() }),
     spawn(|| { work2() })
 )
@@ -201,7 +201,7 @@ try h.cancel()
 
 <!-- test: skip -->
 ```rask
-let (tx, rx) = Channel<Message>.buffered(100)
+mut (tx, rx) = Channel<Message>.buffered(100)
 
 const producer = spawn(|| {
     for msg in generate_messages() {

--- a/specs/concurrency/io-context.md
+++ b/specs/concurrency/io-context.md
@@ -179,7 +179,7 @@ extend File with Reader {
 func io.copy(reader: any Reader, writer: any Writer) -> usize or IoError {
     // Compiler desugars to: io.copy(reader, writer, __ctx?)
     const buf = [0u8; 8192]
-    let total = 0
+    mut total = 0
     loop {
         const n = try reader.read(buf)   // __ctx forwarded
         if n == 0 { break }

--- a/specs/concurrency/sync.md
+++ b/specs/concurrency/sync.md
@@ -36,7 +36,7 @@ Cross-task shared state when channels aren't enough.
 
 <!-- test: skip -->
 ```rask
-let config = Shared.new(AppConfig {
+mut config = Shared.new(AppConfig {
     timeout: 30.seconds,
     max_retries: 3,
 })
@@ -135,7 +135,7 @@ with mutex as data {
 }
 
 // Guard-based (Rust) — reference can escape scope
-// let guard = mutex.lock()  // NOT in Rask
+// mut guard = mutex.lock()  // NOT in Rask
 ```
 
 ## Deadlock Prevention

--- a/specs/control/comptime.md
+++ b/specs/control/comptime.md
@@ -227,7 +227,7 @@ const BAD = comptime {
 <!-- test: skip -->
 ```rask
 comptime func slow() {
-    let i = 0
+    mut i = 0
     while i < 5000 {  // Exceeds default 1,000 backwards branches
         i += 1
     }
@@ -409,7 +409,7 @@ FIX: Call .freeze() to convert to const data:
 comptime func crc8_table() -> [u8; 256] {
     const table = [0u8; 256]
     for i in 0..256 {
-        let crc = i as u8
+        mut crc = i as u8
         for _ in 0..8 {
             if crc & 0x80 != 0 {
                 crc = (crc << 1) ^ 0x07
@@ -425,7 +425,7 @@ comptime func crc8_table() -> [u8; 256] {
 const CRC8_TABLE: [u8; 256] = comptime crc8_table()
 
 func crc8(data: []u8) -> u8 {
-    let crc = 0u8
+    mut crc = 0u8
     for byte in data {
         crc = CRC8_TABLE[(crc ^ byte) as usize]
     }

--- a/specs/control/control-flow.md
+++ b/specs/control/control-flow.md
@@ -235,7 +235,7 @@ const result = {
 | **CF32: Never coercion** | `Never` coerces to any type |
 
 ```rask
-let x: i32 = if cond { 42 } else { panic("nope") }
+mut x: i32 = if cond { 42 } else { panic("nope") }
 // else branch is Never, coerces to i32
 ```
 
@@ -372,8 +372,8 @@ const point = (10, 20)
 const (x, y) = point
 
 func use_destructuring() {
-    // Mutable destructuring (let requires function scope)
-    let (a, b) = get_pair()
+    // Mutable destructuring (mut requires function scope)
+    mut (a, b) = get_pair()
     a = a + 1
 
     // For loop destructuring
@@ -521,7 +521,7 @@ Some expressions never complete normally:
 `Never` coerces to any type, allowing branches with different control flow:
 
 ```rask
-let x: i32 = if cond { 42 } else { return }
+mut x: i32 = if cond { 42 } else { return }
 // else branch is Never, coerces to i32
 ```
 
@@ -564,7 +564,7 @@ const input = loop {
 <!-- test: skip -->
 ```rask
 func find_first<T: Equal>(items: Vec<T>, target: T) -> Option<usize> {
-    let i = 0
+    mut i = 0
     loop {
         if i >= items.len() {
             break None

--- a/specs/control/ensure.md
+++ b/specs/control/ensure.md
@@ -277,7 +277,7 @@ Cleaning up pools of linear resources:
 <!-- test: parse -->
 ```rask
 func process_many_files(paths: Vec<string>) -> () or Error {
-    let files: Pool<File> = Pool.new()
+    mut files: Pool<File> = Pool.new()
     ensure files.take_all_with(|f| { f.close(); })
 
     for path in paths {
@@ -297,7 +297,7 @@ Errors during cleanup (e.g., `close()` fails) are ignored by default (ER1). If c
 <!-- test: parse -->
 ```rask
 func process_many_files_careful(paths: Vec<string>) -> () or Error {
-    let files: Pool<File> = Pool.new()
+    mut files: Pool<File> = Pool.new()
 
     for path in paths {
         const file = try File.open(path)
@@ -459,7 +459,7 @@ func modify_database(db: Database) -> () or Error {
 <!-- test: skip -->
 ```rask
 func process_many(paths: Vec<string>) -> () or Error {
-    let resources: Pool<Resource> = Pool.new()
+    mut resources: Pool<Resource> = Pool.new()
     ensure resources.take_all_with(|r| { r.cleanup(); })
 
     for path in paths {

--- a/specs/control/loops.md
+++ b/specs/control/loops.md
@@ -175,7 +175,7 @@ for item in vec { body }
 // Equivalent to:
 {
     const _len = vec.len()
-    let _pos = 0
+    mut _pos = 0
     while _pos < _len {
         // `item` is a read-only alias for vec[_pos]  (LP17)
         // item.field  → vec[_pos].field  (inline access, E1)
@@ -194,7 +194,7 @@ for mutate item in vec { body }
 // Equivalent to:
 {
     const _len = vec.len()
-    let _pos = 0
+    mut _pos = 0
     while _pos < _len {
         // `item` is a mutable alias for vec[_pos]
         // item.field  → vec[_pos].field  (inline access)
@@ -214,7 +214,7 @@ for mutate item in pool { body }
 // Equivalent to:
 {
     const _handles = pool._snapshot_handles()  // Handle snapshot
-    let _idx = 0
+    mut _idx = 0
     while _idx < _handles.len() {
         const _h = _handles[_idx]
         // `item` is a mutable alias for pool[_h]
@@ -248,7 +248,7 @@ for i in 0..vec.len() { body }
 // Equivalent to:
 {
     const _len = vec.len()
-    let _pos = 0
+    mut _pos = 0
     while _pos < _len {
         const i = _pos
         body

--- a/specs/control/ranges.md
+++ b/specs/control/ranges.md
@@ -82,7 +82,7 @@ for x in (0.0..1.0).step(0.1) { }  // Floats: 0.0, 0.1, ..., 0.9
 
 <!-- test: skip -->
 ```rask
-let vec: Vec<u16> = Vec.new()
+mut vec: Vec<u16> = Vec.new()
 for i in 0..vec.len() { }  // i inferred as usize
 for i in 0..10 { }          // i inferred as i32 (default)
 for i in 0u8..10 { }        // i explicitly u8

--- a/specs/memory/allocators.md
+++ b/specs/memory/allocators.md
@@ -208,7 +208,7 @@ using arena {
 // all memory freed at once
 
 // FixedBuffer — no malloc, embedded-safe
-let buf: [u8; 4096] = [0; 4096]
+mut buf: [u8; 4096] = [0; 4096]
 const alloc = FixedBuffer.new(buf)
 using alloc {
     const data = Vec.new()
@@ -317,7 +317,7 @@ func typecheck(ast: Ast) -> TypedAst {
 <!-- test: skip -->
 ```rask
 func sensor_loop() {
-    let buf: [u8; 2048] = [0; 2048]
+    mut buf: [u8; 2048] = [0; 2048]
     const alloc = FixedBuffer.new(buf)
 
     using alloc {

--- a/specs/memory/atomics.md
+++ b/specs/memory/atomics.md
@@ -213,7 +213,7 @@ func read_latest(pool: Pool<Reading>) -> Reading? {
 
 <!-- test: skip -->
 ```rask
-let counter = AtomicU64.new(0)
+mut counter = AtomicU64.new(0)
 const final_value = counter.into_value()
 ```
 

--- a/specs/memory/borrowing.md
+++ b/specs/memory/borrowing.md
@@ -528,7 +528,7 @@ func parse_header(line: string) -> Option<(string, string)> {
 <!-- test: parse -->
 ```rask
 func update_combat(pool: Pool<Entity>) {
-    let targets: Vec<Handle<Entity>> = find_targets(pool)
+    mut targets: Vec<Handle<Entity>> = find_targets(pool)
 
     for h in targets {
         pool[h].health -= 10             // Inline access (E1)
@@ -610,8 +610,8 @@ struct Token {
 }
 
 func tokenize(input: string) -> Vec<Token> {
-    let tokens = Vec.new()
-    let pos = 0
+    mut tokens = Vec.new()
+    mut pos = 0
     // scan() returns positions — no allocations per token
     for (start, end, kind) in scan(input) {
         tokens.push(Token { kind, span: Span(start, end) })

--- a/specs/memory/closures.md
+++ b/specs/memory/closures.md
@@ -82,14 +82,14 @@ Closures can borrow mutable locals with explicit `mutate` in the capture:
 
 <!-- test: skip -->
 ```rask
-let count = 0
+mut count = 0
 const inc = |mutate count| { count += 1 }
 inc()
 inc()
 // count == 2
 
 // Iterator example
-let total = 0
+mut total = 0
 items.for_each(|item, mutate total| { total += item.value })
 print(total)  // sees accumulated value
 ```
@@ -98,7 +98,7 @@ Without `mutate`, captured values are copies. The mutation stays inside the clos
 
 <!-- test: skip -->
 ```rask
-let count = 0
+mut count = 0
 const inc = || { count += 1 }  // Captures count by COPY
 inc()
 // count is still 0 — the closure mutated its own copy
@@ -110,7 +110,7 @@ The `mutate` keyword makes the intent visible — you see exactly which variable
 
 <!-- test: skip -->
 ```rask
-let x = 0
+mut x = 0
 const a = |mutate x| { x += 1 }
 const b = |mutate x| { x += 2 }  // ERROR: x already mutably captured by a
 ```
@@ -136,7 +136,7 @@ items.filter(|i| vec[*i].active)
      .collect()
 
 // Mutation in inline context
-let count = 0
+mut count = 0
 items.for_each(|item| { count += 1 })  // inline: direct access, no capture needed
 ```
 
@@ -177,7 +177,7 @@ Note: Copy fields like `string` don't create scope-limited closures — `const n
 
 <!-- test: compile-fail -->
 ```rask
-let outer_closure
+mut outer_closure
 {
     const entity = get_entity()
     const tags = entity.tags

--- a/specs/memory/pools.md
+++ b/specs/memory/pools.md
@@ -295,7 +295,7 @@ func cleanup(h: Handle<Entity>) using entities: Pool<Entity> {
 
 <!-- test: skip -->
 ```rask
-let (snapshot, mut pool) = entities.snapshot()
+mut (snapshot, mut pool) = entities.snapshot()
 
 // Readers see frozen state
 spawn(|| { render_frame(snapshot) })
@@ -594,8 +594,8 @@ Pool cannot be split by predicate because accessing entities requires borrowing 
 
 ```rask
 func process_by_type(mut entities: Pool<Entity>) {
-    let player_handles = Vec.new()
-    let enemy_handles = Vec.new()
+    mut player_handles = Vec.new()
+    mut enemy_handles = Vec.new()
 
     for h in entities.handles() {
         match entities[h].kind {

--- a/specs/memory/unsafe.md
+++ b/specs/memory/unsafe.md
@@ -20,7 +20,7 @@ Explicit `unsafe` blocks quarantine operations that bypass safety checks. Debug 
 <!-- test: skip -->
 ```rask
 const x = 42
-let ptr: *i32 = &x as *i32
+mut ptr: *i32 = &x as *i32
 
 const value = unsafe { *ptr }
 ```
@@ -66,8 +66,8 @@ const value = unsafe { *ptr }
 ```rask
 // Creating raw pointers (safe)
 const x = 42
-let ptr: *i32 = &x as *i32
-let null_ptr: *i32 = null
+mut ptr: *i32 = &x as *i32
+mut null_ptr: *i32 = null
 
 // Using raw pointers (unsafe)
 unsafe {
@@ -116,7 +116,7 @@ unsafe func read_ptr<T>(ptr: *T) -> T {
 }
 
 func caller() {
-    let x = 0
+    mut x = 0
     unsafe {
         dangerous_operation(&x)
     }
@@ -180,8 +180,8 @@ Reinterprets the bits of one type as another. Requires unsafe.
 <!-- test: parse -->
 ```rask
 unsafe {
-    let x: u32 = 0x41424344
-    let bytes: [u8; 4] = transmute(x)
+    mut x: u32 = 0x41424344
+    mut bytes: [u8; 4] = transmute(x)
 }
 ```
 
@@ -525,7 +525,7 @@ extend CString {
 ```rask
 func rdtsc() -> u64 {
     unsafe {
-        let result: u64
+        mut result: u64
         asm {
             "rdtsc; shl rdx, 32; or rax, rdx"
             out("rax") result

--- a/specs/rejected-features.md
+++ b/specs/rejected-features.md
@@ -83,7 +83,7 @@ Erlang's supervision trees are great—processes automatically restart when they
 
 ```rask
 // Explicit restart loop
-let restart_count = 0
+mut restart_count = 0
 loop {
     const h = spawn(|| { worker_task() }
     match h.join() {

--- a/specs/stdlib/bits.md
+++ b/specs/stdlib/bits.md
@@ -92,7 +92,7 @@ const data = BinaryBuilder.new()
 
 // Zero-alloc buffer write
 const buffer: [u8; 64] = [0; 64]
-let cursor = 0
+mut cursor = 0
 cursor += buffer[cursor..].write_u32be(0xCAFEBABE)
 cursor += buffer[cursor..].write_u8(1)
 ```

--- a/specs/stdlib/collections.md
+++ b/specs/stdlib/collections.md
@@ -198,11 +198,11 @@ for item in vec.take_all() { }   // item: T (consuming iteration)
 
 <!-- test: skip -->
 ```rask
-let scores = [3, 1, 4, 1, 5]
+mut scores = [3, 1, 4, 1, 5]
 scores.sort()
 // [1, 1, 3, 4, 5]
 
-let users = get_users()
+mut users = get_users()
 users.sort_by_key(|u| u.name)
 users.sort_by(|a, b| b.score.compare(a.score))  // descending
 ```
@@ -219,7 +219,7 @@ users.sort_by(|a, b| b.score.compare(a.score))  // descending
 
 <!-- test: skip -->
 ```rask
-let items = [3, 1, 4, 1, 5]
+mut items = [3, 1, 4, 1, 5]
 items.contains(4)             // true
 items.first()                 // Some(3)
 items.last()                  // Some(5)

--- a/specs/stdlib/encoding.md
+++ b/specs/stdlib/encoding.md
@@ -267,7 +267,7 @@ func encode_value<T: Encode>(value: T, w: mutate JsonWriter) -> () or JsonError 
 
 // Top-level entry point
 public func encode<T: Encode>(value: T) -> string or JsonError {
-    let w = JsonWriter.new()
+    mut w = JsonWriter.new()
     try encode_value(value, mutate w)
     return w.finish()
 }
@@ -292,7 +292,7 @@ func decode_value<T: Decode>(parser: mutate JsonParser) -> T or JsonError {
         }
         return Some(try decode_value(parser))
     } else if reflect.is_vec<T>() {
-        let result = Vec.new()
+        mut result = Vec.new()
         try parser.begin_array()
         while !parser.end_array() {
             result.push(try decode_value(parser))
@@ -305,7 +305,7 @@ func decode_value<T: Decode>(parser: mutate JsonParser) -> T or JsonError {
 
 func decode_struct<T: Decode>(parser: mutate JsonParser) -> T or JsonError {
     try parser.begin_object()
-    let fields = Map<string, JsonValue>.new()
+    mut fields = Map<string, JsonValue>.new()
     while !parser.end_object() {
         const key = try parser.read_key()
         fields.insert(key, try parser.read_value())

--- a/specs/stdlib/fmt.md
+++ b/specs/stdlib/fmt.md
@@ -226,7 +226,7 @@ extend Color with Displayable {
 
 <!-- test: skip -->
 ```rask
-let b = StringBuilder.with_capacity(1024)
+mut b = StringBuilder.with_capacity(1024)
 for item in items {
     b.append("{item.name}: {item.value}\n")
 }

--- a/specs/stdlib/net.md
+++ b/specs/stdlib/net.md
@@ -112,7 +112,7 @@ import net
 const socket = try net.udp_bind("0.0.0.0:9000")
 ensure socket.close()
 
-let buf = [0u8; 1024]
+mut buf = [0u8; 1024]
 const (n, sender) = try socket.recv_from(buf)
 try socket.send_to(buf[0..n], sender)
 ```

--- a/specs/stdlib/random.md
+++ b/specs/stdlib/random.md
@@ -96,7 +96,7 @@ test "shuffle is deterministic with seed" {
 <!-- test: parse -->
 ```rask
 func weighted_choice(weights: Vec<f64>) -> i64 {
-    let r = random.f64() * weights.sum()
+    mut r = random.f64() * weights.sum()
     for i in 0..weights.len() {
         r -= weights[i]
         if r <= 0.0 { return i }

--- a/specs/stdlib/strings.md
+++ b/specs/stdlib/strings.md
@@ -396,7 +396,7 @@ For cheap sharing of arbitrary data, use `Shared<T>` — explicit, visible, corr
 
 <!-- test: skip -->
 ```rask
-let b = StringBuilder.new()
+mut b = StringBuilder.new()
 b.append("User: ")
 b.append(name)
 b.append_char('\n')
@@ -408,9 +408,9 @@ const msg = b.build()
 <!-- test: skip -->
 ```rask
 func flush_lines(lines: Vec<string>) -> Vec<string> {
-    let results = Vec.new()
+    mut results = Vec.new()
     for line in lines {
-        let b = StringBuilder.new()
+        mut b = StringBuilder.new()
         b.append(line)
         b.append_char('\n')
         results.push(b.build())

--- a/specs/structure/c-interop.md
+++ b/specs/structure/c-interop.md
@@ -192,9 +192,9 @@ import c "sqlite3.h" as sql
 public struct Database { handle: *sql.sqlite3 }
 
 public func open(path: string) -> Database or Error {
-    let db: *sql.sqlite3 = null
+    mut db: *sql.sqlite3 = null
     unsafe {
-        let rc = sql.sqlite3_open(path.as_c_str(), &db)
+        mut rc = sql.sqlite3_open(path.as_c_str(), &db)
         if rc != sql.SQLITE_OK {
             return Err(Error.new("sqlite open failed"))
         }
@@ -208,7 +208,7 @@ public func open(path: string) -> Database or Error {
 ```rask
 public extern "C" func rask_process(data: *u8, len: c_size) -> c_int {
     unsafe {
-        let slice = slice_from_raw(data, len)
+        mut slice = slice_from_raw(data, len)
         match process(slice) {
             Ok(_) => 0,
             Err(_) => -1,

--- a/specs/types/binary.md
+++ b/specs/types/binary.md
@@ -104,7 +104,7 @@ For one-off parsing without a struct, use `unpack`:
 
 <!-- test: skip -->
 ```rask
-let (magic, version, length, rest) = try data.unpack(u32be, u8, u16be)
+mut (magic, version, length, rest) = try data.unpack(u32be, u8, u16be)
 ```
 
 See [stdlib/bits.md](../stdlib/bits.md) for `unpack`, `pack`, and related functions.

--- a/specs/types/generics.md
+++ b/specs/types/generics.md
@@ -354,7 +354,7 @@ func increment<T: Numeric>(val: T) -> T {
 ```rask
 public func sort<T: Comparable>(items: []T) {
     for i in 1..items.len() {
-        let j = i
+        mut j = i
         while j > 0 && items[j] < items[j - 1] {
             swap(mut items[j], mut items[j - 1])
             j = j - 1

--- a/specs/types/gradual-constraints.md
+++ b/specs/types/gradual-constraints.md
@@ -32,7 +32,7 @@ Non-public functions may omit parameter types, return types, and bounds. Compile
 <!-- test: skip -->
 ```rask
 func find_best(items, score_fn) {
-    let best = items[0]
+    mut best = items[0]
     for i in 1..items.len() {
         if score_fn(items[i]) > score_fn(best) {
             best = items[i]
@@ -48,7 +48,7 @@ func find_best(items, score_fn) {
 <!-- test: skip -->
 ```rask
 func find_best(items: Vec<Record>, score_fn) -> Record {
-    let best = items[0]
+    mut best = items[0]
     for i in 1..items.len() {
         if score_fn(items[i]) > score_fn(best) {
             best = items[i]
@@ -63,7 +63,7 @@ func find_best(items: Vec<Record>, score_fn) -> Record {
 <!-- test: parse -->
 ```rask
 public func find_best<T: Copy, U: Comparable>(items: Vec<T>, score_fn: |T| -> U) -> T {
-    let best = items[0]
+    mut best = items[0]
     for i in 1..items.len() {
         if score_fn(items[i]) > score_fn(best) {
             best = items[i]
@@ -99,7 +99,7 @@ public func find_best<T: Copy, U: Comparable>(items: Vec<T>, score_fn: |T| -> U)
 // PascalCase: explicitly name the type parameter
 func identity(x: T) -> T { return x }
 
-// Gradual: omit type, let compiler decide
+// Gradual: omit type, mut compiler decide
 func identity(x) { return x }
 // Inferred: func identity<T>(x: T) -> T
 ```

--- a/specs/types/integer-overflow.md
+++ b/specs/types/integer-overflow.md
@@ -27,7 +27,7 @@ Default: panic on overflow, consistent in debug and release. Use `Wrapping<T>` o
 
 <!-- test: skip -->
 ```rask
-let x: u8 = 255
+mut x: u8 = 255
 const y = x + 1   // Panic: "integer overflow: 255 + 1 exceeds u8 range"
 ```
 

--- a/specs/types/iterator-protocol.md
+++ b/specs/types/iterator-protocol.md
@@ -144,7 +144,7 @@ if items.any(|i| i.is_expired()) { alert() }
 
 <!-- test: skip -->
 ```rask
-let total = 0
+mut total = 0
 items.for_each(|item, mutate total| { total += item.value })
 ```
 

--- a/specs/types/optionals.md
+++ b/specs/types/optionals.md
@@ -40,13 +40,13 @@ enum Option<T> {
 | **OPT9: No reverse coercion** | `Option<T>` does NOT coerce to `T` — must unwrap explicitly |
 
 ```rask
-let user: User? = load_user()    // wraps to Some(user)
+mut user: User? = load_user()    // wraps to Some(user)
 ```
 
 ## The `none` Literal
 
 ```rask
-let x: User? = none
+mut x: User? = none
 func find(id: i64) -> User? { none }
 ```
 
@@ -137,7 +137,7 @@ const user = get_user(id) is Some else { return None }
 | **OPT11: Linear propagation** | If `T` is linear, `T?` is linear — must handle both paths |
 
 ```rask
-let file: File? = open("data.txt")
+mut file: File? = open("data.txt")
 if file is Some(f) {
     f.close()
 }

--- a/specs/types/primitives.md
+++ b/specs/types/primitives.md
@@ -153,7 +153,7 @@ struct NetworkHeader {
 }
 
 const header = try NetworkHeader.parse(bytes)
-let port: u16 = header.port   // Native u16
+mut port: u16 = header.port   // Native u16
 ```
 
 ## Numeric Traits

--- a/specs/types/simd.md
+++ b/specs/types/simd.md
@@ -212,14 +212,14 @@ func process(data: []f32, scale: f32) {
 ```rask
 func sum_array(data: []f32) -> f32 {
     const N = Vec[f32, native].lanes
-    let acc: Vec[f32, native] = [0.0; N]
+    mut acc: Vec[f32, native] = [0.0; N]
     const main_end = (data.len() / N) * N
 
     for i in (0..main_end).step_by(N) {
         acc = acc + Vec[f32, native].load(data[i..])
     }
 
-    let total = acc.sum()
+    mut total = acc.sum()
     for i in main_end..data.len() {
         total += data[i]
     }

--- a/specs/types/structs.md
+++ b/specs/types/structs.md
@@ -261,7 +261,7 @@ match point {
 **Partial patterns:**
 <!-- test: skip -->
 ```rask
-let Point { x, .. } = point    // Bind visible fields, ignore rest
+mut Point { x, .. } = point    // Bind visible fields, ignore rest
 ```
 
 Visibility in patterns: `extend` blocks see all fields; same package sees package-visible + `public` fields; external sees only `public` fields. `private` fields require `..`.

--- a/specs/types/traits.md
+++ b/specs/types/traits.md
@@ -269,7 +269,7 @@ match shape {
 }
 
 // any: open set, methods only
-let shapes: []any Drawable = [circle, rect, custom_shape]
+mut shapes: []any Drawable = [circle, rect, custom_shape]
 for s in shapes { s.draw() }  // Only trait methods
 ```
 

--- a/specs/types/union-types.md
+++ b/specs/types/union-types.md
@@ -23,7 +23,7 @@ func load() -> Config or (IoError | ParseError)
 func process() -> Output or (IoError | ParseError | ValidationError)
 
 // Invalid: general unions not allowed
-let x: int | string = ...              // Compile error
+mut x: int | string = ...              // Compile error
 func foo(input: A | B) -> C           // Compile error
 ```
 
@@ -172,9 +172,9 @@ func load_app() -> App or (IoError | ParseError | ValidationError) {
 
 <!-- test: skip -->
 ```rask
-// Instead of: let value: int | string = ...
+// Instead of: mut value: int | string = ...
 enum IntOrString { Int(i32), String(string) }
-let value: IntOrString = IntOrString.Int(42)
+mut value: IntOrString = IntOrString.Int(42)
 ```
 
 Explicit enums are self-documenting (meaningful variant names), extensible (add methods), and clear at call sites.

--- a/stdlib/fs.rk
+++ b/stdlib/fs.rk
@@ -66,11 +66,11 @@ extend fs {
         unsafe fseek(f, 0, 2)
         const size = unsafe ftell(f)
         unsafe fseek(f, 0, 0)
-        let bytes: Vec<u8> = Vec.new()
+        mut bytes: Vec<u8> = Vec.new()
         if size > 0 {
             const buf = unsafe rask_alloc(size)
             const n = unsafe fread(buf, 1, size as u64, f)
-            let i: u64 = 0
+            mut i: u64 = 0
             loop {
                 if i >= n { break }
                 const b = unsafe buf.add(i as usize).read()
@@ -109,7 +109,7 @@ extend fs {
     /// Read a file and split into lines.
     public func read_lines(path: string) -> Vec<string> or IoError {
         const content = try fs.read_file(path)
-        let lines: Vec<string> = Vec.new()
+        mut lines: Vec<string> = Vec.new()
         for line in content.lines() {
             lines.push(line)
         }
@@ -142,7 +142,7 @@ extend fs {
             return Err("could not open destination file")
         }
         const buf = unsafe rask_alloc(8192)
-        let total: u64 = 0
+        mut total: u64 = 0
         loop {
             const n = unsafe fread(buf, 1, 8192, src)
             if n == 0 { break }
@@ -205,7 +205,7 @@ extend fs {
         if unsafe dir.is_null() {
             return Err("could not open directory")
         }
-        let entries: Vec<string> = Vec.new()
+        mut entries: Vec<string> = Vec.new()
         loop {
             const entry = unsafe readdir(dir)
             if unsafe entry.is_null() { break }

--- a/stdlib/http.rk
+++ b/stdlib/http.rk
@@ -151,7 +151,7 @@ extend Request {
 
     // All query parameters as a map.
     public func query_params(self) -> Map<string, string> {
-        let result = Map<string, string>.new()
+        mut result = Map<string, string>.new()
         const qpos = self.url.find("?")
         if qpos is None { return result }
 
@@ -192,7 +192,7 @@ extend Response {
     }
 
     public func json(body: string) -> Response {
-        let resp = Response.new(200, body)
+        mut resp = Response.new(200, body)
         resp.headers.set("Content-Type", "application/json")
         return resp
     }
@@ -218,7 +218,7 @@ extend Response {
     }
 
     public func redirect(url: string) -> Response {
-        let resp = Response.new(302, "")
+        mut resp = Response.new(302, "")
         resp.headers.set("Location", url)
         return resp
     }
@@ -284,7 +284,7 @@ func parse_http_request(raw: string) -> Request or HttpError {
     }
 
     // Find end of request line (first \r\n)
-    let line_end: usize = 0
+    mut line_end: usize = 0
     while line_end + 1 < len {
         if raw.byte_at(line_end) == 13 && raw.byte_at(line_end + 1) == 10 {
             break
@@ -294,11 +294,11 @@ func parse_http_request(raw: string) -> Request or HttpError {
     const request_line = raw[0..line_end]
 
     // Parse request line: "METHOD PATH HTTP/1.1"
-    let first_sp: usize = 0
+    mut first_sp: usize = 0
     while first_sp < line_end && raw.byte_at(first_sp) != 32 {
         first_sp += 1
     }
-    let second_sp = first_sp + 1
+    mut second_sp = first_sp + 1
     while second_sp < line_end && raw.byte_at(second_sp) != 32 {
         second_sp += 1
     }
@@ -311,9 +311,9 @@ func parse_http_request(raw: string) -> Request or HttpError {
     }
 
     // Parse headers: starts after first \r\n, ends at \r\n\r\n
-    let headers = Headers.new()
-    let pos = line_end + 2  // skip past \r\n
-    let header_end = pos
+    mut headers = Headers.new()
+    mut pos = line_end + 2  // skip past \r\n
+    mut header_end = pos
 
     while pos + 1 < len {
         if raw.byte_at(pos) == 13 && raw.byte_at(pos + 1) == 10 {
@@ -322,7 +322,7 @@ func parse_http_request(raw: string) -> Request or HttpError {
             break
         }
 
-        let hline_end = pos
+        mut hline_end = pos
         while hline_end + 1 < len {
             if raw.byte_at(hline_end) == 13 && raw.byte_at(hline_end + 1) == 10 {
                 break
@@ -330,7 +330,7 @@ func parse_http_request(raw: string) -> Request or HttpError {
             hline_end += 1
         }
 
-        let colon = pos
+        mut colon = pos
         while colon < hline_end {
             if raw.byte_at(colon) == 58 && colon + 1 < hline_end && raw.byte_at(colon + 1) == 32 {
                 break
@@ -391,7 +391,7 @@ func reason_phrase(status: u16) -> string {
 
 // Format an HTTP/1.1 response into a raw byte string for the wire.
 func format_http_response(resp: Response) -> string {
-    let out = string.new()
+    mut out = string.new()
 
     // Status line
     out.push_str("HTTP/1.1 ")
@@ -436,7 +436,7 @@ func write_raw(conn_fd: i64, data: string) {
 
 // Parse "http://host:port/path" into (host, port, path).
 func parse_url(url: string) -> (string, string, string) or HttpError {
-    let rest = url
+    mut rest = url
 
     // Strip scheme
     if rest.starts_with("http://") {
@@ -446,8 +446,8 @@ func parse_url(url: string) -> (string, string, string) or HttpError {
     }
 
     // Split host+port from path at first /
-    let host_port = rest
-    let path = "/"
+    mut host_port = rest
+    mut path = "/"
     const slash = rest.find("/")
     if slash is Some(pos) {
         host_port = rest[0..pos].to_string()
@@ -455,8 +455,8 @@ func parse_url(url: string) -> (string, string, string) or HttpError {
     }
 
     // Split host from port at last :
-    let host = host_port
-    let port = "80"
+    mut host = host_port
+    mut port = "80"
     const colon = host_port.find(":")
     if colon is Some(cpos) {
         host = host_port[0..cpos].to_string()
@@ -472,7 +472,7 @@ func parse_url(url: string) -> (string, string, string) or HttpError {
 
 // Format an HTTP/1.1 request for the wire.
 func format_http_request(req: Request, host: string) -> string {
-    let out = string.new()
+    mut out = string.new()
 
     // Request line
     out.push_str(req.method.to_string())
@@ -517,7 +517,7 @@ func parse_http_response(raw: string) -> Response or HttpError {
     }
 
     // Find end of status line
-    let line_end: usize = 0
+    mut line_end: usize = 0
     while line_end + 1 < len {
         if raw.byte_at(line_end) == 13 && raw.byte_at(line_end + 1) == 10 {
             break
@@ -527,11 +527,11 @@ func parse_http_response(raw: string) -> Response or HttpError {
 
     // Parse status line: "HTTP/1.1 200 OK"
     const status_line = raw[0..line_end]
-    let first_sp: usize = 0
+    mut first_sp: usize = 0
     while first_sp < line_end && raw.byte_at(first_sp) != 32 {
         first_sp += 1
     }
-    let second_sp = first_sp + 1
+    mut second_sp = first_sp + 1
     while second_sp < line_end && raw.byte_at(second_sp) != 32 {
         second_sp += 1
     }
@@ -543,15 +543,15 @@ func parse_http_response(raw: string) -> Response or HttpError {
     const status = status_val as u16
 
     // Parse headers
-    let headers = Headers.new()
-    let pos = line_end + 2
+    mut headers = Headers.new()
+    mut pos = line_end + 2
     while pos + 1 < len {
         if raw.byte_at(pos) == 13 && raw.byte_at(pos + 1) == 10 {
             pos += 2
             break
         }
 
-        let hline_end = pos
+        mut hline_end = pos
         while hline_end + 1 < len {
             if raw.byte_at(hline_end) == 13 && raw.byte_at(hline_end + 1) == 10 {
                 break
@@ -559,7 +559,7 @@ func parse_http_response(raw: string) -> Response or HttpError {
             hline_end += 1
         }
 
-        let colon = pos
+        mut colon = pos
         while colon < hline_end {
             if raw.byte_at(colon) == 58 && colon + 1 < hline_end && raw.byte_at(colon + 1) == 32 {
                 break
@@ -603,7 +603,7 @@ func _send_request_impl(method: Method, url: string, body: string, extra_headers
     }
 
     // Build and send request
-    let req = Request.new(method, path)
+    mut req = Request.new(method, path)
     for (name, value) in extra_headers.entries.iter() {
         req = req.with_header(name, value)
     }

--- a/stdlib/json.rk
+++ b/stdlib/json.rk
@@ -158,7 +158,7 @@ extend JsonParser {
         self.pos = self.pos + 1
         self.skip_ws()
 
-        let map = Map<string, JsonValue>.new()
+        mut map = Map<string, JsonValue>.new()
 
         if self.peek() == 125 {
             self.pos = self.pos + 1
@@ -196,7 +196,7 @@ extend JsonParser {
         self.pos = self.pos + 1
         self.skip_ws()
 
-        let arr = Vec<JsonValue>.new()
+        mut arr = Vec<JsonValue>.new()
 
         if self.peek() == 93 {
             self.pos = self.pos + 1
@@ -225,7 +225,7 @@ extend JsonParser {
             return Err(JsonError.ParseError("expected '\"'"))
         }
 
-        let b = StringBuilder.new()
+        mut b = StringBuilder.new()
 
         while self.pos < self.len {
             const byte = self.advance()
@@ -271,8 +271,8 @@ extend JsonParser {
         if self.pos + 4 > self.len {
             return Err(JsonError.ParseError("incomplete unicode escape"))
         }
-        let cp: u32 = 0
-        let i = 0
+        mut cp: u32 = 0
+        mut i = 0
         while i < 4 {
             const b = self.advance()
             const digit = hex_digit(b)
@@ -395,7 +395,7 @@ struct json {  }
 extend json {
     /// Parse a JSON string into a JsonValue tree. RFC 8259 compliant.
     public func parse(input: string) -> JsonValue or JsonError {
-        let parser = JsonParser.new(input)
+        mut parser = JsonParser.new(input)
         const value = try parser.parse_value()
         parser.skip_ws()
         if parser.pos < parser.len {
@@ -411,7 +411,7 @@ extend json {
 
     /// Serialize a JsonValue to a pretty-printed JSON string.
     public func stringify_pretty(value: JsonValue) -> string {
-        let b = StringBuilder.new()
+        mut b = StringBuilder.new()
         stringify_pretty_inner(value, mutate b, 0)
         return b.build()
     }
@@ -450,9 +450,9 @@ func stringify_value(value: JsonValue) -> string {
 }
 
 func stringify_array(arr: Vec<JsonValue>) -> string {
-    let b = StringBuilder.new()
+    mut b = StringBuilder.new()
     b.append("[")
-    let first = true
+    mut first = true
     for item in arr {
         if !first {
             b.append(",")
@@ -465,9 +465,9 @@ func stringify_array(arr: Vec<JsonValue>) -> string {
 }
 
 func stringify_object(map: Map<string, JsonValue>) -> string {
-    let b = StringBuilder.new()
+    mut b = StringBuilder.new()
     b.append("{")
-    let first = true
+    mut first = true
     for (key, value) in map {
         if !first {
             b.append(",")
@@ -482,9 +482,9 @@ func stringify_object(map: Map<string, JsonValue>) -> string {
 }
 
 func escape_string(s: string) -> string {
-    let b = StringBuilder.new()
+    mut b = StringBuilder.new()
     b.append_char('"')
-    let i: usize = 0
+    mut i: usize = 0
     while i < s.len() {
         const byte = s.byte_at(i)
         if byte == 34 {
@@ -547,7 +547,7 @@ func stringify_pretty_inner(value: JsonValue, mutate out: StringBuilder, indent:
                 return
             }
             out.append("[\n")
-            let first = true
+            mut first = true
             for item in arr {
                 if !first {
                     out.append(",\n")
@@ -566,7 +566,7 @@ func stringify_pretty_inner(value: JsonValue, mutate out: StringBuilder, indent:
                 return
             }
             out.append("{\n")
-            let first = true
+            mut first = true
             for (key, val) in map {
                 if !first {
                     out.append(",\n")
@@ -585,7 +585,7 @@ func stringify_pretty_inner(value: JsonValue, mutate out: StringBuilder, indent:
 }
 
 func write_indent(mutate out: StringBuilder, level: usize) {
-    let i: usize = 0
+    mut i: usize = 0
     while i < level {
         out.append("  ")
         i = i + 1

--- a/tests/compile_errors/borrow_errors.rk
+++ b/tests/compile_errors/borrow_errors.rk
@@ -42,7 +42,7 @@ struct Holder { data: Vec<i32> }
 
 func test_borrow_escape() {
     const h = Holder { data: Vec.new() }
-    let escaped = h.data     // ERROR: h.data is a block-scoped borrow (non-Copy)
+    mut escaped = h.data     // ERROR: h.data is a block-scoped borrow (non-Copy)
     // escaped would outlive h
 }
 
@@ -78,7 +78,7 @@ func boost(mutate health: i32) { health += 10 }
 func read_player(p: Player) -> i32 { return p.score }
 
 func test_overlapping_borrow() {
-    let p = Player { health: 50, score: 10 }
+    mut p = Player { health: 50, score: 10 }
     // Passing p.health as mutate, then p as borrow — whole-object
     // conflicts with field-level borrow (F3)
     boost(p.health)

--- a/tests/compile_errors/closure_errors.rk
+++ b/tests/compile_errors/closure_errors.rk
@@ -6,7 +6,7 @@
 // --- mutable capture conflict (MC2) ---
 // ERROR: variable 'x' already mutably captured
 func test_double_mutable_capture() {
-    let x = 0
+    mut x = 0
     const a = |mutate x| { x += 1 }
     const b = |mutate x| { x += 2 }   // ERROR: x already captured by a
 }

--- a/tests/compile_errors/comptime_loop.rk
+++ b/tests/compile_errors/comptime_loop.rk
@@ -7,7 +7,7 @@
 
 // Infinite loop at comptime - compiler catches this
 comptime func infinite() -> i32 {
-    let x = 0
+    mut x = 0
     loop {
         x += 1
         // COMPILE ERROR: exceeded 1000 backwards branches
@@ -32,7 +32,7 @@ comptime func infinite() -> i32 {
 
 // This is fine - bounded loop
 comptime func build_table() -> [u8; 256] {
-    let table = [0u8; 256]
+    mut table = [0u8; 256]
     for i in 0..256 {  // 256 iterations, well under limit
         table[i] = (i * i) as u8
     }
@@ -49,7 +49,7 @@ const FACT_10 = comptime factorial(10)  // OK: 10 recursive calls
 
 // This would fail - too many iterations
 comptime func too_many_iterations() -> i32 {
-    let sum = 0
+    mut sum = 0
     for i in 0..1_000_000 {  // COMPILE ERROR: exceeds iteration limit
         sum += i
     }

--- a/tests/compile_errors/for_mutate_errors.rk
+++ b/tests/compile_errors/for_mutate_errors.rk
@@ -2,7 +2,7 @@
 // ERROR: cannot push during mutable iteration
 
 func test_structural_mutation() {
-    let items = Vec.new<string>()
+    mut items = Vec.new<string>()
     items.push("hello")
 
     for mutate item in items {
@@ -19,7 +19,7 @@ func consume(take s: string) {
 }
 
 func test_take_item() {
-    let items = Vec.new<string>()
+    mut items = Vec.new<string>()
     items.push("hello")
 
     for mutate item in items {

--- a/tests/compile_errors/match_errors.rk
+++ b/tests/compile_errors/match_errors.rk
@@ -33,7 +33,7 @@ func test_wildcard_linear() {
 // ERROR: else block must diverge
 func test_guard_no_diverge() {
     const opt: i32? = Some(42)
-    let value = opt is Some else { 0 }   // ERROR: 0 doesn't diverge
+    mut value = opt is Some else { 0 }   // ERROR: 0 doesn't diverge
     // else must use return, break, panic, etc.
 }
 

--- a/tests/compile_errors/ownership_errors.rk
+++ b/tests/compile_errors/ownership_errors.rk
@@ -48,8 +48,8 @@ func test_double_move() {
 struct Token { id: i32 }
 
 func test_unique_no_copy() {
-    let t = Token { id: 1 }
-    let t2 = t           // moves, not copies (despite being small)
+    mut t = Token { id: 1 }
+    mut t2 = t           // moves, not copies (despite being small)
     println("{t.id}")    // ERROR: t was moved
 }
 
@@ -58,8 +58,8 @@ func test_unique_no_copy() {
 struct Wrapper { tok: Token, label: string }
 
 func test_unique_transitive() {
-    let w = Wrapper { tok: Token { id: 1 }, label: "test" }
-    let w2 = w           // moves (Wrapper contains @unique Token)
+    mut w = Wrapper { tok: Token { id: 1 }, label: "test" }
+    mut w2 = w           // moves (Wrapper contains @unique Token)
     println("{w.label}")  // ERROR: w was moved
 }
 

--- a/tests/compile_errors/rust_syntax_rejected.rk
+++ b/tests/compile_errors/rust_syntax_rejected.rk
@@ -15,7 +15,12 @@ func test_path() {
     const x = Result::Ok(42)
 }
 
-// ERROR: `let mut` — use `let` (rebindable by default)
+// ERROR: `let` is not a keyword — use `mut` (rebindable) or `const` (permanent)
+func test_let() {
+    let counter = 0
+}
+
+// ERROR: `let mut` — use `mut` directly
 func test_let_mut() {
     let mut counter = 0
 }

--- a/tests/compile_errors/syntax_rejected.rk
+++ b/tests/compile_errors/syntax_rejected.rk
@@ -18,8 +18,14 @@ func test_double_colon() {
     const x = Result::Ok(42)
 }
 
+// --- Rust-ism: `let` ---
+// ERROR: 'let' is not a keyword — use 'mut' or 'const'
+func test_let() {
+    let x = 0
+}
+
 // --- Rust-ism: `let mut` ---
-// ERROR: 'mut' is not a keyword, 'let' is already rebindable
+// ERROR: 'let' is not a keyword — use 'mut' directly
 func test_let_mut() {
     let mut x = 0
 }

--- a/tests/suite/t04_enums.rk
+++ b/tests/suite/t04_enums.rk
@@ -29,7 +29,7 @@ func area(s: Shape) -> i32 {
 
 test "simple enum match" {
     const c = Color.Red
-    let name = ""
+    mut name = ""
     match c {
         Color.Red => name = "red"
         Color.Green => name = "green"
@@ -70,7 +70,7 @@ test "enum with number payload" {
 
 test "enum wildcard match" {
     const c = Color.Blue
-    let matched_wildcard = false
+    mut matched_wildcard = false
     match c {
         Color.Red => assert false, "wrong"
         _ => matched_wildcard = true

--- a/tests/suite/t05_control_flow.rk
+++ b/tests/suite/t05_control_flow.rk
@@ -17,7 +17,7 @@ func abs(n: i32) -> i32 {
 }
 
 func sum_range(start: i32, end: i32) -> i32 {
-    let total = 0
+    mut total = 0
     for i in start..end {
         total += i
     }
@@ -32,7 +32,7 @@ test "if-else" {
 
 test "nested if" {
     const x = 42
-    let result = ""
+    mut result = ""
     if x > 0 {
         if x > 100 {
             result = "big"
@@ -53,8 +53,8 @@ test "for range loop" {
 }
 
 test "while loop" {
-    let n = 0
-    let sum = 0
+    mut n = 0
+    mut sum = 0
     while n < 10 {
         sum += n
         n += 1
@@ -64,7 +64,7 @@ test "while loop" {
 }
 
 test "break in while" {
-    let i = 0
+    mut i = 0
     while true {
         if i == 5 { break }
         i += 1
@@ -73,7 +73,7 @@ test "break in while" {
 }
 
 test "continue in for" {
-    let sum = 0
+    mut sum = 0
     for i in 0..10 {
         if i % 2 == 0 { continue }
         sum += i
@@ -89,7 +89,7 @@ test "early return" {
 }
 
 test "multiple return paths" {
-    let x = 10
+    mut x = 10
     if x > 5 {
         assert true
     } else {

--- a/tests/suite/t09_vec.rk
+++ b/tests/suite/t09_vec.rk
@@ -53,7 +53,7 @@ test "vec sum via loop" {
     v.push(3)
     v.push(4)
     v.push(5)
-    let sum = 0
+    mut sum = 0
     for i in 0..v.len() {
         sum += v[i]
     }

--- a/tests/suite/t14_ownership.rk
+++ b/tests/suite/t14_ownership.rk
@@ -86,7 +86,7 @@ test "vec clone is independent" {
 
 test "copy survives if/else branches" {
     const x = 42
-    let result = 0
+    mut result = 0
     if true {
         result = x
     }
@@ -96,7 +96,7 @@ test "copy survives if/else branches" {
 
 test "copy in loop iterations" {
     const base = 10
-    let sum = 0
+    mut sum = 0
     for i in 0..5 {
         sum = sum + base
     }

--- a/tests/suite/t15_borrowing.rk
+++ b/tests/suite/t15_borrowing.rk
@@ -42,7 +42,7 @@ func boost_health(mutate health: i32) {
 }
 
 test "disjoint field mutation" {
-    let p = Player { name: "Eve", score: 42, health: 99 }
+    mut p = Player { name: "Eve", score: 42, health: 99 }
     // These borrow disjoint fields — both should be allowed
     boost_score(mutate p.score)
     boost_health(mutate p.health)

--- a/tests/suite/t16_iterators.rk
+++ b/tests/suite/t16_iterators.rk
@@ -5,7 +5,7 @@
 // --- Range iteration (always works) ---
 
 test "for range basic" {
-    let sum = 0
+    mut sum = 0
     for i in 0..5 {
         sum = sum + i
     }
@@ -15,7 +15,7 @@ test "for range basic" {
 test "for range with variable bounds" {
     const start = 2
     const end = 6
-    let sum = 0
+    mut sum = 0
     for i in start..end {
         sum = sum + i
     }
@@ -23,7 +23,7 @@ test "for range with variable bounds" {
 }
 
 test "for range empty when start >= end" {
-    let count = 0
+    mut count = 0
     for i in 5..5 {
         count = count + 1
     }
@@ -31,7 +31,7 @@ test "for range empty when start >= end" {
 }
 
 test "for range single element" {
-    let count = 0
+    mut count = 0
     for i in 3..4 {
         count = count + 1
         assert i == 3
@@ -48,7 +48,7 @@ test "for-in vec sums elements" {
     v.push(1)
     v.push(2)
     v.push(3)
-    let sum = 0
+    mut sum = 0
     for item in v {
         sum = sum + item
     }
@@ -59,7 +59,7 @@ test "for-in vec counts elements" {
     const v = Vec<i32>.new()
     v.push(10)
     v.push(20)
-    let count = 0
+    mut count = 0
     for item in v {
         count = count + 1
     }
@@ -68,7 +68,7 @@ test "for-in vec counts elements" {
 
 test "for-in empty vec" {
     const v = Vec<i32>.new()
-    let count = 0
+    mut count = 0
     for item in v {
         count = count + 1
     }
@@ -82,7 +82,7 @@ test "range-based vec iteration" {
     v.push(10)
     v.push(20)
     v.push(30)
-    let sum = 0
+    mut sum = 0
     for i in 0..v.len() {
         sum = sum + v[i]
     }
@@ -92,7 +92,7 @@ test "range-based vec iteration" {
 // --- Nested loops ---
 
 test "nested range loops" {
-    let sum = 0
+    mut sum = 0
     for i in 0..3 {
         for j in 0..3 {
             sum = sum + 1

--- a/tests/suite/t17_option.rk
+++ b/tests/suite/t17_option.rk
@@ -12,7 +12,7 @@ func find_positive(n: i32) -> i32? {
 
 test "option some match" {
     const result = find_positive(5)
-    let value = 0
+    mut value = 0
     match result {
         Some(v) => value = v
         None => value = -1
@@ -22,7 +22,7 @@ test "option some match" {
 
 test "option none match" {
     const result = find_positive(-3)
-    let value = 0
+    mut value = 0
     match result {
         Some(v) => value = v
         None => value = -1

--- a/tests/suite/t17b_result.rk
+++ b/tests/suite/t17b_result.rk
@@ -12,7 +12,7 @@ func divide(a: i32, b: i32) -> i32 or string {
 
 test "result ok match" {
     const r = divide(10, 2)
-    let value = 0
+    mut value = 0
     match r {
         Ok(v) => value = v
         Err(e) => value = -1
@@ -22,7 +22,7 @@ test "result ok match" {
 
 test "result err match" {
     const r = divide(10, 0)
-    let is_err = false
+    mut is_err = false
     match r {
         Ok(v) => is_err = false
         Err(e) => is_err = true
@@ -38,7 +38,7 @@ func compute() -> i32 or string {
 
 test "try propagates error" {
     const r = compute()
-    let got_err = false
+    mut got_err = false
     match r {
         Ok(v) => got_err = false
         Err(e) => got_err = true
@@ -54,7 +54,7 @@ func compute_ok() -> i32 or string {
 
 test "try passes through ok" {
     const r = compute_ok()
-    let value = 0
+    mut value = 0
     match r {
         Ok(v) => value = v
         Err(e) => value = -1
@@ -68,7 +68,7 @@ func always_ok(n: i32) -> i32 or string {
 
 test "auto-ok wrapping" {
     const r = always_ok(21)
-    let value = 0
+    mut value = 0
     match r {
         Ok(v) => value = v
         Err(e) => value = -1

--- a/tests/suite/t20_control_expressions.rk
+++ b/tests/suite/t20_control_expressions.rk
@@ -57,7 +57,7 @@ test "match expression in binding" {
 // BUG: parser doesn't support loop-as-expression yet
 
 test "loop with break value" {
-    let i = 0
+    mut i = 0
     const found = loop {
         if i == 5: break i * 10
         i += 1
@@ -66,7 +66,7 @@ test "loop with break value" {
 }
 
 test "loop break value type" {
-    let n = 1
+    mut n = 1
     const result = loop {
         if n > 100: break n
         n = n * 2
@@ -77,7 +77,7 @@ test "loop break value type" {
 // --- labeled loop with break value (CF22-CF25) ---
 
 test "labeled loop break" {
-    let found = -1
+    mut found = -1
     outer: for i in 0..10 {
         for j in 0..10 {
             if i * 10 + j == 42 {
@@ -102,7 +102,7 @@ test "labeled loop break value" {
 // --- continue with label (CF25) ---
 
 test "continue label" {
-    let count = 0
+    mut count = 0
     outer: for i in 0..5 {
         for j in 0..5 {
             if j == 2: continue outer
@@ -132,7 +132,7 @@ test "is pattern with binding" {
 
 test "is pattern non-match skips" {
     const s = Shape.Point
-    let matched = false
+    mut matched = false
     if s is Circle(r) {
         matched = true
     }
@@ -173,8 +173,8 @@ test "while is pattern" {
     items.push(Some(2))
     items.push(Some(3))
 
-    let sum = 0
-    let idx = 0
+    mut sum = 0
+    mut idx = 0
     while idx < items.len() {
         if items[idx] is Some(v) {
             sum += v
@@ -184,10 +184,10 @@ test "while is pattern" {
     assert sum == 6
 }
 
-// --- guard pattern: let...is...else (CF13-CF15) ---
+// --- guard pattern: mut...is...else (CF13-CF15) ---
 
 func extract_or_zero(opt: i32?) -> i32 {
-    let value = opt is Some else { return 0 }
+    mut value = opt is Some else { return 0 }
     return value * 2
 }
 
@@ -200,7 +200,7 @@ test "guard pattern None diverges" {
 }
 
 func extract_ok(result: i32 or string) -> i32 {
-    let value = result is Ok else { return -1 }
+    mut value = result is Ok else { return -1 }
     return value
 }
 
@@ -284,7 +284,7 @@ test "pattern guards" {
 // This is tested implicitly by if expressions where one branch diverges.
 
 test "never coercion in if expression" {
-    let x = 5
+    mut x = 5
     const y = if x > 0: x else { panic("negative") }
     // The else branch has type Never, which coerces to i32
     assert y == 5

--- a/tests/suite/t21_let_bindings.rk
+++ b/tests/suite/t21_let_bindings.rk
@@ -1,11 +1,9 @@
 // SPDX-License-Identifier: (MIT OR Apache-2.0)
-// let rebinding, const vs let, shadowing.
+// mut rebinding, const vs mut, shadowing.
 //
 // Spec: SYNTAX.md (bindings section)
 //
-// SPEC ISSUE: Every existing test uses only `const`. Zero coverage of `let`
-// with reassignment, which is a core language feature. `let` is the mutable
-// binding keyword (rebindable), `const` is permanent.
+// `mut` is the rebindable binding keyword, `const` is permanent.
 //
 // Note: `const` controls the binding, not the value. `const v = Vec.new()`
 // allows `v.push(1)` but not `v = other_vec`. This is like JS `const`.
@@ -18,10 +16,10 @@ test "const binding is permanent" {
     assert x == 42
 }
 
-// --- let can be reassigned ---
+// --- mut can be reassigned ---
 
-test "let binding reassignment" {
-    let x = 1
+test "mut binding reassignment" {
+    mut x = 1
     assert x == 1
     x = 2
     assert x == 2
@@ -29,16 +27,16 @@ test "let binding reassignment" {
     assert x == 12
 }
 
-test "let in loop" {
-    let sum = 0
+test "mut in loop" {
+    mut sum = 0
     for i in 0..5 {
         sum += i
     }
     assert sum == 10
 }
 
-test "let multiple reassignments" {
-    let s = "hello"
+test "mut multiple reassignments" {
+    mut s = "hello"
     assert s == "hello"
     s = "world"
     assert s == "world"
@@ -54,8 +52,8 @@ test "const shadows const" {
     assert x == 2
 }
 
-test "const shadows let" {
-    let x = 1
+test "const shadows mut" {
+    mut x = 1
     x = 5
     const x = x * 2
     assert x == 10
@@ -92,14 +90,14 @@ test "const map allows insert" {
     assert m["a"] == 1
 }
 
-// --- let with struct field mutation ---
+// --- mut with struct field mutation ---
 
 struct Counter {
     value: i32
 }
 
-test "let struct reassignment" {
-    let c = Counter { value: 0 }
+test "mut struct reassignment" {
+    mut c = Counter { value: 0 }
     assert c.value == 0
     c = Counter { value: 10 }
     assert c.value == 10

--- a/tests/suite/t22_parameter_modes.rk
+++ b/tests/suite/t22_parameter_modes.rk
@@ -36,7 +36,7 @@ func increment(mutate p: Point) {
 }
 
 test "mutate mode modifies caller value" {
-    let p = Point { x: 1, y: 2 }
+    mut p = Point { x: 1, y: 2 }
     increment(p)
     assert p.x == 2
     assert p.y == 3
@@ -66,7 +66,7 @@ func reset(mutate p: Point) {
 }
 
 test "mutate allows reassignment" {
-    let p = Point { x: 99, y: 99 }
+    mut p = Point { x: 99, y: 99 }
     reset(p)
     assert p.x == 0
     assert p.y == 0
@@ -119,7 +119,7 @@ test "self borrow" {
 }
 
 test "mutate self" {
-    let p = Point { x: 1, y: 2 }
+    mut p = Point { x: 1, y: 2 }
     p.translate(10, 20)
     assert p.x == 11
     assert p.y == 22
@@ -143,7 +143,7 @@ func modify_int(mutate x: i32) {
 }
 
 test "mutate on copy type only affects local copy" {
-    let x = 42
+    mut x = 42
     modify_int(x)
     assert x == 42
 }
@@ -157,7 +157,7 @@ func swap_fields(mutate x: i32, mutate y: i32) {
 }
 
 test "disjoint field mutate" {
-    let p = Point { x: 1, y: 2 }
+    mut p = Point { x: 1, y: 2 }
     swap_fields(p.x, p.y)
     assert p.x == 2
     assert p.y == 1

--- a/tests/suite/t23_with_blocks.rk
+++ b/tests/suite/t23_with_blocks.rk
@@ -75,7 +75,7 @@ test "break inside with" {
     v.push(2)
     v.push(3)
 
-    let found = -1
+    mut found = -1
     for i in 0..v.len() {
         with v[i] as item {
             if item == 2 {

--- a/tests/suite/t24_bitwise_ops.rk
+++ b/tests/suite/t24_bitwise_ops.rk
@@ -86,21 +86,21 @@ test "shift near limit" {
 // --- compound assignment (CA1) ---
 
 test "compound bitwise assignment" {
-    let x = 0xFF
+    mut x = 0xFF
     x &= 0x0F
     assert x == 0x0F
 
-    let y = 0xF0
+    mut y = 0xF0
     y |= 0x0F
     assert y == 0xFF
 
-    let z = 0xFF
+    mut z = 0xFF
     z ^= 0xF0
     assert z == 0x0F
 }
 
 test "compound shift assignment" {
-    let x = 1
+    mut x = 1
     x <<= 4
     assert x == 16
     x >>= 2

--- a/tests/suite/t25_iterator_adapters.rk
+++ b/tests/suite/t25_iterator_adapters.rk
@@ -214,7 +214,7 @@ test "skip first n" {
 // --- for-in on range (basic, already tested elsewhere, included for completeness) ---
 
 test "range iteration" {
-    let sum = 0
+    mut sum = 0
     for i in 0..5 {
         sum += i
     }
@@ -228,7 +228,7 @@ test "map iteration with destructuring" {
     m.insert("a", 1)
     m.insert("b", 2)
 
-    let total = 0
+    mut total = 0
     for (key, value) in m {
         total += value
     }
@@ -261,7 +261,7 @@ test "take_all consumes vec" {
     v.push(20)
     v.push(30)
 
-    let sum = 0
+    mut sum = 0
     for item in v.take_all() {
         sum += item
     }

--- a/tutorials/learn-rask/02_variables.rk
+++ b/tutorials/learn-rask/02_variables.rk
@@ -5,10 +5,10 @@
 //
 // Two kinds of variables:
 //   const x = 42      // can never change (default — use this most of the time)
-//   let x = 42        // can be reassigned: x = 43
+//   mut x = 42        // can be reassigned: x = 43
 //
-// Think of `const` as the normal case and `let` as the exception.
-// In Python everything is `let`. In Rask you opt *in* to mutability.
+// Think of `const` as the normal case and `mut` as the exception.
+// In Python everything is mutable. In Rask you opt *in* to mutability.
 //
 // Types you'll use:
 //   i32       — integer (whole number). The default. Handles up to ~2 billion.
@@ -32,8 +32,8 @@ func example_variables() {
     println("pi = {pi}")
     println("name = {name}")
 
-    // Mutable variable — use `let`
-    let counter = 0
+    // Mutable variable — use `mut`
+    mut counter = 0
     counter = counter + 1
     counter = counter + 1
     println("counter = {counter}")    // 2
@@ -85,7 +85,7 @@ func celsius_to_kelvin(c: f64) -> f64 {
 }
 
 // --- Puzzle 4: Mutable accumulator ---
-// Sum the integers from 1 to n (inclusive) using a `let` variable and a loop.
+// Sum the integers from 1 to n (inclusive) using a `mut` variable and a loop.
 // Example: sum_to(5) = 1 + 2 + 3 + 4 + 5 = 15
 //
 // Hint: for i in 1..n+1 { ... }  gives you 1, 2, ..., n

--- a/tutorials/learn-rask/05_control_flow.rk
+++ b/tutorials/learn-rask/05_control_flow.rk
@@ -27,7 +27,7 @@
 // --- Example ---
 
 func countdown(n: i32) {
-    let i = n
+    mut i = n
     while i > 0 {
         println("{i}...")
         i = i - 1

--- a/tutorials/learn-rask/07_structs.rk
+++ b/tutorials/learn-rask/07_structs.rk
@@ -36,7 +36,7 @@
 
 func sqrt(x: f64) -> f64 {
     if x <= 0.0 { return 0.0 }
-    let g = x / 2.0
+    mut g = x / 2.0
     for i in 0..30 { g = (g + x / g) / 2.0 }
     return g
 }
@@ -130,7 +130,7 @@ extend Projectile {
 
     // Advance one time step under gravity (0, 0, -9.81) m/s²
     // Return a new Projectile with updated position and velocity.
-    // Don't let z go below 0.
+    // Don't mut z go below 0.
     func step(self, dt: f64) -> Projectile {
         todo()
     }
@@ -213,7 +213,7 @@ test "projectile step" {
 
 test "projectile hits ground" {
     // Launch at 45° with speed 10
-    let p = Projectile.launch(Vec3 { x: 7.07, y: 0.0, z: 7.07 })
+    mut p = Projectile.launch(Vec3 { x: 7.07, y: 0.0, z: 7.07 })
     // Simulate for a while
     for i in 0..200 {
         p = p.step(0.01)
@@ -224,9 +224,9 @@ test "projectile hits ground" {
 
 func main() {
     // Mini simulation you can watch
-    let p = Projectile.launch(Vec3 { x: 50.0, y: 0.0, z: 30.0 })
+    mut p = Projectile.launch(Vec3 { x: 50.0, y: 0.0, z: 30.0 })
     println("=== Projectile Simulation ===")
-    let t = 0.0
+    mut t = 0.0
     while p.is_airborne() {
         println("t={t}s  x={p.position.x}  z={p.position.z}")
         p = p.step(0.5)

--- a/tutorials/learn-rask/08_error_handling.rk
+++ b/tutorials/learn-rask/08_error_handling.rk
@@ -99,7 +99,7 @@ func calc() -> f64 or string {
 
 func sqrt(x: f64) -> f64 {
     if x <= 0.0 { return 0.0 }
-    let g = x / 2.0
+    mut g = x / 2.0
     for i in 0..30 { g = (g + x / g) / 2.0 }
     return g
 }

--- a/tutorials/learn-rask/09_ownership.rk
+++ b/tutorials/learn-rask/09_ownership.rk
@@ -36,7 +36,7 @@
 //   }
 //   print_length(my_vec)    // my_vec is still yours after the call
 //
-// To let a function modify your value, use `mutate`:
+// To mut a function modify your value, use `mutate`:
 //   func add_item(mutate list: Vec<i32>, item: i32) {
 //       list.push(item)
 //   }
@@ -135,7 +135,7 @@ func sqrt(x: f64) -> f64 {
     if x <= 0.0 {
         return 0.0
     }
-    let g = x / 2.0
+    mut g = x / 2.0
     for i in 0..30 {
         g = (g + x / g) / 2.0
     }
@@ -169,7 +169,7 @@ test "flight altitudes" {
 }
 
 test "record altitude" {
-    let log = Vec.from([0, 5000])
+    mut log = Vec.from([0, 5000])
     record_altitude(mutate log, 10000)
     assert log.len() == 3
     assert log[2] == 10000

--- a/tutorials/learn-rask/15_concurrency.rk
+++ b/tutorials/learn-rask/15_concurrency.rk
@@ -74,7 +74,7 @@ func parallel_max(readings: Vec<f64>) -> f64 {
 
 // Helper — finds the largest value in a Vec
 func vec_max(v: Vec<f64>) -> f64 {
-    let m = v[0]
+    mut m = v[0]
     for i in 1..v.len() {
         if v[i] > m { m = v[i] }
     }

--- a/tutorials/learn-rask/17_resource_types.rk
+++ b/tutorials/learn-rask/17_resource_types.rk
@@ -54,7 +54,7 @@ func example_resource() -> () or string {
 //   2. Reserve seat, charge payment
 //   3. Commit if everything worked, rollback if not
 //
-// The compiler won't let you forget step 3. If a Booking goes
+// The compiler won't mut you forget step 3. If a Booking goes
 // out of scope without being committed or rolled back → compile error.
 //
 // Fun fact: this is how databases work internally. PostgreSQL's
@@ -150,7 +150,7 @@ test "booking failure" {
 }
 
 test "booking pattern" {
-    let b = Booking.new(42)
+    mut b = Booking.new(42)
     assert b.is_committed() == false
     b.commit()
     assert b.is_committed() == true

--- a/tutorials/learn-rask/19_final_project.rk
+++ b/tutorials/learn-rask/19_final_project.rk
@@ -50,7 +50,7 @@ extend Vec3 {
 // You wrote this in lesson 03
 func sqrt(x: f64) -> f64 {
     if x <= 0.0 { return 0.0 }
-    let g = x / 2.0
+    mut g = x / 2.0
     for i in 0..30 { g = (g + x / g) / 2.0 }
     return g
 }
@@ -287,7 +287,7 @@ test "simulation runs" {
 func main() {
     // Simulate a light aircraft takeoff
     // 2 tons, ~136 knots initial speed, moderate thrust
-    let ac = Aircraft {
+    mut ac = Aircraft {
         position: Vec3.zero(),
         velocity: Vec3.new(0.0, 70.0, 0.0),
         mass: 2000.0,

--- a/tutorials/learn-rask/solutions/02_variables.rk
+++ b/tutorials/learn-rask/solutions/02_variables.rk
@@ -15,7 +15,7 @@ func celsius_to_kelvin(c: f64) -> f64 {
 }
 
 func sum_to(n: i32) -> i32 {
-    let total = 0
+    mut total = 0
     for i in 1..n+1 {
         total = total + i
     }

--- a/tutorials/learn-rask/solutions/03_functions.rk
+++ b/tutorials/learn-rask/solutions/03_functions.rk
@@ -11,7 +11,7 @@ func gravitational_force(m1: f64, m2: f64, r: f64) -> f64 {
 
 func sqrt(x: f64) -> f64 {
     if x <= 0.0 { return 0.0 }
-    let g = x / 2.0
+    mut g = x / 2.0
     for i in 0..20 {
         g = (g + x / g) / 2.0
     }

--- a/tutorials/learn-rask/solutions/04_collections.rk
+++ b/tutorials/learn-rask/solutions/04_collections.rk
@@ -5,7 +5,7 @@ func particle_masses() -> Vec<f64> {
 }
 
 func sum_vec(numbers: Vec<f64>) -> f64 {
-    let total = 0.0
+    mut total = 0.0
     for n in numbers {
         total = total + n
     }
@@ -26,7 +26,7 @@ func periodic_table() -> Map<string, i32> {
 }
 
 func dot_product(a: Vec<f64>, b: Vec<f64>) -> f64 {
-    let sum = 0.0
+    mut sum = 0.0
     for i in 0..a.len() {
         sum = sum + a[i] * b[i]
     }

--- a/tutorials/learn-rask/solutions/05_control_flow.rk
+++ b/tutorials/learn-rask/solutions/05_control_flow.rk
@@ -9,7 +9,7 @@ func next_departure(arrival_minute: i32) -> i32 {
 
 func collatz(start: i32) -> Vec<i32> {
     const seq = Vec.new()
-    let n = start
+    mut n = start
     seq.push(n)
     while n != 1 {
         if n % 2 == 0 {
@@ -23,17 +23,17 @@ func collatz(start: i32) -> Vec<i32> {
 }
 
 func manhattan_walk(directions: Vec<string>) -> i32 {
-    let x = 0
-    let y = 0
+    mut x = 0
+    mut y = 0
     for dir in directions {
         if dir == "N" { y = y + 1 }
         if dir == "S" { y = y - 1 }
         if dir == "E" { x = x + 1 }
         if dir == "W" { x = x - 1 }
     }
-    let abs_x = x
+    mut abs_x = x
     if abs_x < 0 { abs_x = 0 - abs_x }
-    let abs_y = y
+    mut abs_y = y
     if abs_y < 0 { abs_y = 0 - abs_y }
     return abs_x + abs_y
 }

--- a/tutorials/learn-rask/solutions/07_structs.rk
+++ b/tutorials/learn-rask/solutions/07_structs.rk
@@ -2,7 +2,7 @@
 
 func sqrt(x: f64) -> f64 {
     if x <= 0.0 { return 0.0 }
-    let g = x / 2.0
+    mut g = x / 2.0
     for i in 0..30 { g = (g + x / g) / 2.0 }
     return g
 }
@@ -51,7 +51,7 @@ extend Projectile {
     func step(self, dt: f64) -> Projectile {
         const gravity = Vec3 { x: 0.0, y: 0.0, z: -9.81 }
         const new_vel = self.velocity.add(gravity.scale(dt))
-        let new_pos = self.position.add(new_vel.scale(dt))
+        mut new_pos = self.position.add(new_vel.scale(dt))
         if new_pos.z < 0.0 {
             new_pos = Vec3 { x: new_pos.x, y: new_pos.y, z: 0.0 }
         }
@@ -127,7 +127,7 @@ test "projectile step" {
 }
 
 test "projectile hits ground" {
-    let p = Projectile.launch(Vec3 { x: 7.07, y: 0.0, z: 7.07 })
+    mut p = Projectile.launch(Vec3 { x: 7.07, y: 0.0, z: 7.07 })
     for i in 0..200 {
         p = p.step(0.01)
     }

--- a/tutorials/learn-rask/solutions/08_error_handling.rk
+++ b/tutorials/learn-rask/solutions/08_error_handling.rk
@@ -2,7 +2,7 @@
 
 func sqrt(x: f64) -> f64 {
     if x <= 0.0 { return 0.0 }
-    let g = x / 2.0
+    mut g = x / 2.0
     for i in 0..30 { g = (g + x / g) / 2.0 }
     return g
 }

--- a/tutorials/learn-rask/solutions/09_ownership.rk
+++ b/tutorials/learn-rask/solutions/09_ownership.rk
@@ -2,7 +2,7 @@
 
 func sqrt(x: f64) -> f64 {
     if x <= 0.0 { return 0.0 }
-    let g = x / 2.0
+    mut g = x / 2.0
     for i in 0..30 { g = (g + x / g) / 2.0 }
     return g
 }
@@ -22,7 +22,7 @@ func record_altitude(mutate log: Vec<i32>, altitude: i32) {
 }
 
 func max_altitude(log: Vec<i32>) -> i32 {
-    let max_val = log[0]
+    mut max_val = log[0]
     for alt in log {
         if alt > max_val {
             max_val = alt
@@ -32,7 +32,7 @@ func max_altitude(log: Vec<i32>) -> i32 {
 }
 
 func mean(data: Vec<f64>) -> f64 {
-    let total = 0.0
+    mut total = 0.0
     for v in data {
         total = total + v
     }
@@ -41,7 +41,7 @@ func mean(data: Vec<f64>) -> f64 {
 
 func std_dev(data: Vec<f64>) -> f64 {
     const m = mean(data)
-    let sum_sq = 0.0
+    mut sum_sq = 0.0
     for v in data {
         const diff = v - m
         sum_sq = sum_sq + diff * diff
@@ -67,7 +67,7 @@ test "flight altitudes" {
 }
 
 test "record altitude" {
-    let log = Vec.from([0, 5000])
+    mut log = Vec.from([0, 5000])
     record_altitude(mutate log, 10000)
     assert log.len() == 3
     assert log[2] == 10000

--- a/tutorials/learn-rask/solutions/10_closures.rk
+++ b/tutorials/learn-rask/solutions/10_closures.rk
@@ -2,7 +2,7 @@
 
 func integrate(f: |f64| -> f64, a: f64, b: f64, n: i32) -> f64 {
     const h = (b - a) / n as f64
-    let sum = f(a) / 2.0 + f(b) / 2.0
+    mut sum = f(a) / 2.0 + f(b) / 2.0
     for i in 1..n {
         sum = sum + f(a + i as f64 * h)
     }
@@ -16,7 +16,7 @@ func cruising_altitudes_meters(readings_feet: Vec<f64>) -> Vec<f64> {
 }
 
 func apply_n(f: |f64| -> f64, x: f64, n: i32) -> f64 {
-    let result = x
+    mut result = x
     for i in 0..n {
         result = f(result)
     }

--- a/tutorials/learn-rask/solutions/11_generics.rk
+++ b/tutorials/learn-rask/solutions/11_generics.rk
@@ -19,8 +19,8 @@ func clamp_value<T: Comparable>(value: T, low: T, high: T) -> T {
 }
 
 func min_max<T: Comparable>(items: Vec<T>) -> Pair<T, T> {
-    let lo = items[0]
-    let hi = items[0]
+    mut lo = items[0]
+    mut hi = items[0]
     for i in 1..items.len() {
         if items[i] < lo { lo = items[i] }
         if items[i] > hi { hi = items[i] }

--- a/tutorials/learn-rask/solutions/12_traits.rk
+++ b/tutorials/learn-rask/solutions/12_traits.rk
@@ -37,7 +37,7 @@ extend Measurement {
 }
 
 func total<T: Summable>(items: Vec<T>) -> f64 {
-    let sum = 0.0
+    mut sum = 0.0
     for item in items {
         sum = sum + item.value()
     }

--- a/tutorials/learn-rask/solutions/13_enums_advanced.rk
+++ b/tutorials/learn-rask/solutions/13_enums_advanced.rk
@@ -25,8 +25,8 @@ func entry_time(entry: LogEntry) -> i32 {
 }
 
 func flight_time(log: Vec<LogEntry>) -> i32 {
-    let takeoff_time = -1
-    let landing_time = -1
+    mut takeoff_time = -1
+    mut landing_time = -1
     for entry in log {
         match entry {
             Takeoff(t, _) => { takeoff_time = t }

--- a/tutorials/learn-rask/solutions/14_strings.rk
+++ b/tutorials/learn-rask/solutions/14_strings.rk
@@ -12,7 +12,7 @@ func parse_wind(metar: string) -> Wind {
 }
 
 func format_flight_plan(departure: string, arrival: string, waypoints: Vec<string>) -> string {
-    let result = departure
+    mut result = departure
     for wp in waypoints {
         result = "{result} → {wp}"
     }
@@ -27,7 +27,7 @@ func word_count(text: string) -> i32 {
 }
 
 func callsign_prefix(callsign: string) -> string {
-    let end = 0
+    mut end = 0
     for c in callsign.chars() {
         if c >= 'A' && c <= 'Z' {
             end = end + 1

--- a/tutorials/learn-rask/solutions/15_concurrency.rk
+++ b/tutorials/learn-rask/solutions/15_concurrency.rk
@@ -2,7 +2,7 @@
 import async.spawn
 
 func vec_max(v: Vec<f64>) -> f64 {
-    let m = v[0]
+    mut m = v[0]
     for i in 1..v.len() {
         if v[i] > m { m = v[i] }
     }
@@ -32,7 +32,7 @@ func parallel_max(readings: Vec<f64>) -> f64 or Error {
 
 func channel_sum(n: i32) -> i32 or Error {
     using Multitasking {
-        let (tx, rx) = Channel<i32>.buffered(n)
+        mut (tx, rx) = Channel<i32>.buffered(n)
 
         const producer = spawn(|| {
             for i in 1..(n + 1) {
@@ -41,7 +41,7 @@ func channel_sum(n: i32) -> i32 or Error {
             tx.close()
         })
 
-        let sum = 0
+        mut sum = 0
         for value in rx {
             sum = sum + value
         }
@@ -54,14 +54,14 @@ func channel_sum(n: i32) -> i32 or Error {
 func estimate_pi(total: i32, num_tasks: i32) -> f64 {
     using Multitasking {
         const per_task = total / num_tasks
-        let (tx, rx) = Channel<i32>.buffered(num_tasks)
+        mut (tx, rx) = Channel<i32>.buffered(num_tasks)
 
         for task_id in 0..num_tasks {
             const seed = task_id * 1000 + 42
             const iters = per_task
             spawn(|| {
-                let state = seed
-                let inside = 0
+                mut state = seed
+                mut inside = 0
                 const a = 1103515245
                 const c = 12345
                 const m = 2147483648
@@ -79,7 +79,7 @@ func estimate_pi(total: i32, num_tasks: i32) -> f64 {
             }).detach()
         }
 
-        let total_inside = 0
+        mut total_inside = 0
         for i in 0..num_tasks {
             total_inside = total_inside + rx.recv()
         }

--- a/tutorials/learn-rask/solutions/16_shared_state.rk
+++ b/tutorials/learn-rask/solutions/16_shared_state.rk
@@ -63,7 +63,7 @@ func atomic_counter(num_tasks: i32, count_per_task: i32) -> i64 {
 func shared_config_update() -> i32 {
     using Multitasking {
         const config = Shared.new(35000)
-        let (tx, rx) = Channel<bool>.buffered(1)
+        mut (tx, rx) = Channel<bool>.buffered(1)
 
         const atc = spawn(|| {
             config.write(|c| {

--- a/tutorials/learn-rask/solutions/17_resource_types.rk
+++ b/tutorials/learn-rask/solutions/17_resource_types.rk
@@ -20,7 +20,7 @@ extend Booking {
 }
 
 func book_flight(id: i32, passenger: string) -> i32 or string {
-    let booking = Booking.new(id)
+    mut booking = Booking.new(id)
 
     if passenger == "FAIL" {
         return Err("payment failed")
@@ -36,10 +36,10 @@ struct BookingStatus {
 }
 
 func two_bookings() -> BookingStatus {
-    let b1 = Booking.new(1)
+    mut b1 = Booking.new(1)
     b1.commit()
 
-    let b2 = Booking.new(2)
+    mut b2 = Booking.new(2)
 
     return BookingStatus {
         first_committed: b1.is_committed(),
@@ -62,7 +62,7 @@ test "booking failure" {
 }
 
 test "booking pattern" {
-    let b = Booking.new(42)
+    mut b = Booking.new(42)
     assert b.is_committed() == false
     b.commit()
     assert b.is_committed() == true

--- a/tutorials/learn-rask/solutions/18_comptime.rk
+++ b/tutorials/learn-rask/solutions/18_comptime.rk
@@ -10,7 +10,7 @@ const SQUARES = comptime {
 
 const FACTORIALS = comptime {
     const v = Vec.new()
-    let f: i64 = 1
+    mut f: i64 = 1
     v.push(f)
     for i in 1..13 {
         f = f * i as i64

--- a/tutorials/learn-rask/solutions/19_final_project.rk
+++ b/tutorials/learn-rask/solutions/19_final_project.rk
@@ -24,7 +24,7 @@ extend Vec3 {
 
 func sqrt(x: f64) -> f64 {
     if x <= 0.0 { return 0.0 }
-    let g = x / 2.0
+    mut g = x / 2.0
     for i in 0..30 { g = (g + x / g) / 2.0 }
     return g
 }
@@ -79,7 +79,7 @@ func step(ac: Aircraft, dt: f64) -> Aircraft {
     const f = total_force(ac)
     const accel = f.scale(1.0 / ac.mass)
     const new_vel = ac.velocity.add(accel.scale(dt))
-    let new_pos = ac.position.add(new_vel.scale(dt))
+    mut new_pos = ac.position.add(new_vel.scale(dt))
     if new_pos.z < 0.0 {
         new_pos = Vec3 { x: new_pos.x, y: new_pos.y, z: 0.0 }
     }
@@ -118,7 +118,7 @@ func phase_name(p: Phase) -> string {
 }
 
 func simulate(take ac: Aircraft, dt: f64, n_steps: i32) -> f64 {
-    let current = ac
+    mut current = ac
     for i in 0..n_steps {
         current = step(current, dt)
     }
@@ -214,7 +214,7 @@ test "flight phase" {
 }
 
 test "simulation runs" {
-    let ac = Aircraft {
+    mut ac = Aircraft {
         position: Vec3.zero(),
         velocity: Vec3.new(0.0, 50.0, 0.0),
         mass: 1000.0, thrust_n: 30000.0, wing_area: 20.0,
@@ -225,7 +225,7 @@ test "simulation runs" {
 }
 
 func main() {
-    let ac = Aircraft {
+    mut ac = Aircraft {
         position: Vec3.zero(),
         velocity: Vec3.new(0.0, 70.0, 0.0),
         mass: 2000.0,


### PR DESCRIPTION
This PR replaces the `let` keyword with `mut` for rebindable variable bindings throughout the codebase, aligning with a language design decision to make mutability explicit and more intuitive.

## Summary
The Rask language previously used `let` for rebindable bindings and `const` for permanent bindings. This change introduces a new `mut` keyword for rebindable bindings, making the mutability semantics clearer and more consistent with user expectations. The `let` keyword is now rejected as a Rust-ism.

## Key Changes

- **Lexer & Parser**: Added `mut` as a new keyword token (`TokenKind::Mut`) in the lexer and parser
- **Syntax**: Updated all variable declarations from `let x = ...` to `mut x = ...` across:
  - Examples (package_manager, markdown_renderer, game_loop, grep_clone, etc.)
  - Benchmarks (all micro and feature benchmarks)
  - Tests (control flow, iterators, ownership, etc.)
  - Tutorials and solutions
  - Standard library (http, json, fs)
  - Compiler codebase (test fixtures)

- **Parser Error Handling**: Added validation to reject `mut` bindings at the top level with a helpful error message directing users to use `const` or move code into a function

- **Documentation**: Updated specs and comments to reflect the new `mut` keyword:
  - SYNTAX.md: Updated binding comparison table
  - Memory/unsafe.md, closures.md, control-flow.md, loops.md, and other specs
  - Tutorial comments explaining `mut` vs `const`

- **Compiler Support**: Updated all compiler passes to handle `StmtKind::Mut` instead of `StmtKind::Let`:
  - Type checker, ownership checker, MIR lowering
  - Desugarer, effects analysis, hidden parameters
  - LSP support (completion, inlay hints, position indexing)

## Implementation Details

- The change maintains backward compatibility at the semantic level—`mut` bindings behave identically to the previous `let` bindings
- Top-level `mut` bindings are rejected with a clear error message
- All existing tests pass with the new keyword
- The `let` keyword is now treated as a Rust-ism and rejected with a helpful error message

https://claude.ai/code/session_01NDzo1kJgnGq1YtNHFjGT8R