### PR TITLE
Document Box family, context clauses, and refine ownership model

### DIFF
--- a/specs/CORE_DESIGN.md
+++ b/specs/CORE_DESIGN.md
@@ -44,7 +44,9 @@ There is no distinction between "value types" and "reference types." Every type 
 
 There's no `Box<T>` because there's no need to distinguish "heap-allocated value" from "value." Some values happen to own heap memory internally — that's an implementation detail, not a type-system concept. The allocation is visible at creation (`Vec.new()`, `Cell.new()`), not in the type's behavior.
 
-**Why this matters:** When everything is a value, the ownership rules apply everywhere identically. Move a `Vec` and the buffer moves. Move a `Cell` and the inner value moves. Move an `any Widget` and the heap data moves. One model, no exceptions.
+**Why this matters:** When everything is a value, the ownership rules apply everywhere identically. Move a `Vec` and the buffer moves. Move a `Cell` and the inner value moves. Move an `any Widget` and the heap data moves. One model for owned data — the uniform rule.
+
+**Honest carve-out: a small fixed set of language primitives with shared semantics.** `string`, `Shared<T>`, `Mutex<T>`, and `Atomic*<T>` are values in the ownership sense (single owner, move on assignment), but their internal semantics are refcounted or shared. `string.clone()` is a refcount bump, not a deep copy; `Shared<T>.clone()` shares access with other holders; moving a `Shared<T>` moves one reference to data that may have other references. These are not types users can define — they're compiler-privileged. The [Box family](memory/boxes.md) collects them under named disciplines (`Pool`, `Cell`, `Shared`, `Mutex`, `Owned`, plus `Atomic*` as adjacent); consult it when you need cross-scope mutable access. The uniformity claim holds for user-defined types; the primitives are the exceptions you should know about.
 
 **Design space:** This approach is called *mutable value semantics* (MVS). The core idea: ban aliasing instead of banning mutation, then provide controlled mutation through parameter modes (`mutate`) and scoped access (`with`). [Hylo](https://www.hylo-lang.org/) (formerly Val, from Google Research) pioneered this as a formal model. [Rue](https://github.com/steveklabnik/rue) (by Steve Klabnik, author of *The Rust Programming Language*) explores the same tradeoff with `inout` parameters. Swift's value types are a partial version. Where Rask differs: `with` blocks for multi-statement collection access, `Pool`+`Handle` for graphs, disjoint field borrowing for partial borrows, and context clauses for implicit state threading — solutions to problems that pure MVS hits once you go beyond simple value passing.
 
@@ -88,12 +90,12 @@ All compiler analysis is function-local. No whole-program inference, no cross-fu
 - Private function signatures may omit types; the compiler infers them from the function body only — never from callers
 - Changing a public function's implementation cannot break external callers
 - Changing a private function's body may change its inferred signature, breaking internal callers (compiler reports this clearly with smart diagnostics showing what changed, which line caused it, and which callers break)
-- Incremental compilation is straightforward
+- Incremental compilation is *bounded propagation*, not whole-program: a private body change invalidates direct callers whose inferred signatures shift, and transitively only as long as each hop's signature keeps shifting. Most changes stop at the first caller; none walk the whole graph.
 - Compilation speed scales linearly with code size
 
 **Clarification:** Body-local inference for private functions IS local analysis. The compiler examines one function body at a time, solving constraints within that scope. It does not trace through call graphs or analyze callers. See [Gradual Constraints](types/gradual-constraints.md).
 
-**Why this matters:** Rust's borrow checker does global analysis. Change one function and the ripple effects are unpredictable. I want compilation to scale linearly—doubling your codebase should double compile time, not quadruple it. Local-only analysis makes this possible.
+**Why this matters:** Rust's borrow checker does global analysis. Change one function and the ripple effects are unpredictable. I want compilation to scale linearly—doubling your codebase should double compile time, not quadruple it. Local checking plus bounded invalidation makes this possible. The bound matters: "one function = one check" is true, but "one function = one invalidation" is not — we don't claim it.
 
 ### 6. Resource Types
 
@@ -140,13 +142,15 @@ See [Canonical Patterns](canonical-patterns.md) for conventions, naming patterns
 The compiler tracks information the language deliberately keeps out of the type system. That information surfaces through tooling — ghost text, lints, generated docs, warnings — but never becomes a constraint that splits the ecosystem or colors function signatures.
 
 **What this means:**
-- I/O, async, and mutation effects are tracked transitively (`comp.effects`) but don't appear in function signatures. No function coloring.
+- I/O, async, and mutation effects are tracked transitively (`comp.effects`) but don't appear in function signatures and don't color call syntax. A caller of a function that does I/O writes the call the same way as a caller of a pure one.
 - `@pure` is a lint annotation, not a type qualifier. A pure function can call an impure one; the lint warns.
 - IDE ghost annotations show parameter modes, closure captures, inferred types, and pause points — the compiler knows, the source doesn't say.
 
-**Why I chose this:** Effect systems and function coloring buy transparency at the cost of ecosystem fragmentation and annotation overhead. Rask keeps the information without the tax. You get `[io]` badges in the IDE and compiler warnings for I/O in tight loops — without `.await` on every line or effect polymorphism in every signature.
+**Honest carve-out: capabilities do color signatures.** `using` clauses (`using Multitasking`, `using ThreadPool`, `using Pool<T>`) are declared in signatures and propagate up the call graph via `mem.context/CC5`. A library that uses `spawn` internally forces `using Multitasking` on every direct caller, transitively up to the nearest `using Multitasking { ... }` scope. This is scope-level coloring, deliberately traded for uncolored call syntax. See [context-clauses.md](memory/context-clauses.md).
 
-This principle is what makes the async model (no `async`/`await`), the purity story (no effect types), and the IDE experience (ghost annotations everywhere) coherent rather than a list of compromises. They're all applications of the same rule: the compiler knows, tooling shows, syntax stays clean.
+**Why I chose this:** Effect systems and async/await color every call site. Rask keeps effects as metadata (no call-site color) and localizes capability coloring to signatures that actually need a runtime capability. You get `[io]` badges in the IDE and compiler warnings for I/O in tight loops — without `.await` on every line or effect polymorphism in every signature.
+
+This principle is what makes the async model (no `async`/`await` at call sites), the purity story (no effect types), and the IDE experience (ghost annotations everywhere) coherent rather than a list of compromises. The common rule: the compiler knows, tooling shows, call syntax stays clean. Capability requirements remain visible at the signature boundary where policy decisions belong.
 
 ---
 
@@ -210,7 +214,7 @@ Each mechanism has its own spec with full details. This section gives the shape 
 
 **Traits.** Structural matching by default — if a type has the right methods, it satisfies the trait. `explicit trait` requires an `extend` declaration. Runtime polymorphism via `any Trait` for heterogeneous collections. Structural matching and generic constraints are in [generics.md](types/generics.md); `any Trait` runtime dispatch is in [traits.md](types/traits.md).
 
-**Concurrency.** `spawn(|| {})` for green tasks (requires `using Multitasking`), `ThreadPool.spawn(|| {})` for CPU-bound work (requires `using ThreadPool`), `Thread.spawn(|| {})` for raw OS threads. No async/await, no function coloring — I/O pauses the task automatically. Task handles must be joined or detached (compile error if forgotten). Channels transfer ownership: no copies, no locks. Cooperative cancellation via cancel flag checked by I/O operations. See [concurrency/](concurrency/).
+**Concurrency.** `spawn(|| {})` for green tasks (requires `using Multitasking`), `ThreadPool.spawn(|| {})` for CPU-bound work (requires `using ThreadPool`), `Thread.spawn(|| {})` for raw OS threads. Call sites are uncolored — no `async`/`await` — and I/O pauses the task automatically. The cost of invisible suspension: a function reading from a socket may pause mid-call, including with locks held. Lint rules and IDE `[io]` annotations partially recover that visibility; the type system does not. Capability requirements (`using Multitasking` et al.) are declared in signatures and propagate via `mem.context/CC5`. Task handles must be joined or detached (compile error if forgotten). Channels transfer ownership: no copies, no locks. Cooperative cancellation via cancel flag checked by I/O operations. See [concurrency/](concurrency/).
 
 **Compile-time execution.** `comptime` runs a restricted subset of Rask in the compiler's interpreter — pure computation without I/O, pools, or concurrency. Build scripts (`build.rk`) handle full-language code generation. See [comptime.md](control/comptime.md).
 

--- a/specs/canonical-patterns.md
+++ b/specs/canonical-patterns.md
@@ -331,6 +331,46 @@ See [stdlib/strings.md](stdlib/strings.md), [stdlib/fmt.md](stdlib/fmt.md).
 
 ---
 
+## Choosing a Box
+
+When a value needs cross-scope access — shared ownership, identity-based references, cross-task mutation — pick a box from the family. The choice is not neutral: it sets the shape of the program. Pick by access discipline, not by habit from another language.
+
+| Need | Pick | Discipline |
+|------|------|------------|
+| One mutable value shared across closures in one task | `Cell<T>` | Exclusive, single-task |
+| Graph / ECS / entity table / anything identity-shaped | `Pool<T>` + `Handle<T>` | Generation-checked, sendable |
+| Read-heavy config / feature flags across tasks | `Shared<T>` | Many readers XOR one writer |
+| Queue / state machine / exclusive mutation across tasks | `Mutex<T>` | Exclusive lock |
+| Recursive types / single-owner heap value | `Owned<T>` | Linear, single consumer |
+| Single primitive read/written atomically | `Atomic*<T>` | Intrinsic ops (not a box) |
+
+**Rule of thumb:** scope grows from left to right. `Cell` stays in one task; `Owned` is linear and moves; `Pool` is identity-durable and sendable; `Shared`/`Mutex` cross task boundaries. Start with the smallest discipline that fits.
+
+**Graph-shaped data is Pool-shaped.** If your program has cycles, parent pointers, entity references, or any "node A knows about node B" relationship that isn't a tree, it routes through `Pool<T>` + `Handle<T>`. There is no storable-reference alternative. A Rask codebase with significant graph state looks structurally different from a Go or Rust equivalent — pool declarations at the root, handles flowing through call graphs, `using Pool<T>` clauses on functions that dereference. This is not a bug; it's the shape.
+
+**Multiple pools of the same element type need nominal separation.** If you have `Pool<Entity>` for live entities and `Pool<Entity>` for archived ones in the same scope, `using Pool<Entity>` is ambiguous at call sites (`mem.context/CC8`). Wrap one or both in a newtype:
+
+```rask
+struct Live(Pool<Entity>)
+struct Archive(Pool<Entity>)
+
+mut live = Live(Pool.new())
+mut archive = Archive(Pool.new())
+
+func damage(h: Handle<Entity>, amount: i32) using Pool<Entity> {
+    // auto-resolves against the pool that's currently in scope
+}
+```
+
+**Anti-patterns:**
+- Reaching for `Shared<T>` when `Cell<T>` or passing a `mutate` parameter would do — adds cross-task machinery for single-task code.
+- Using `Pool<T>` for simple containers where `Vec<T>` suffices — pools are for identity, not storage.
+- Using `Owned<T>` where a plain value works — `Owned` is for recursion or explicit heap placement, not a default.
+
+See [memory/boxes.md](memory/boxes.md), [memory/pools.md](memory/pools.md), [memory/cell.md](memory/cell.md), [concurrency/sync.md](concurrency/sync.md), [memory/owned.md](memory/owned.md).
+
+---
+
 ## Shared State
 
 Message passing for communication, `Shared<T>` for shared data.


### PR DESCRIPTION
## Summary
This PR adds comprehensive documentation for Rask's memory management primitives and refines the core design narrative around ownership, shared semantics, and capability coloring.

## Key Changes

**New "Choosing a Box" section in canonical-patterns.md:**
- Introduces decision table for selecting among `Cell<T>`, `Pool<T>`, `Shared<T>`, `Mutex<T>`, `Owned<T>`, and `Atomic*<T>` based on access discipline
- Establishes rule of thumb: scope grows left to right, start with smallest discipline that fits
- Documents graph-shaped data routing through `Pool<T>` + `Handle<T>` as the canonical pattern
- Explains nominal separation requirement for multiple pools of the same element type with code example
- Lists anti-patterns: premature `Shared<T>`, misusing `Pool<T>` for simple containers, unnecessary `Owned<T>`

**Refined CORE_DESIGN.md ownership narrative:**
- Clarifies "one model for owned data" applies to user-defined types; adds honest carve-out for language primitives (`string`, `Shared<T>`, `Mutex<T>`, `Atomic*<T>`) with shared/refcounted semantics
- Explains these primitives are compiler-privileged and collected under the Box family discipline
- Expands incremental compilation explanation: bounded propagation model where private function changes invalidate only direct callers whose signatures shift, not whole-program ripple
- Adds explicit carve-out for capability coloring: `using` clauses in signatures propagate via context, deliberately trading scope-level coloring for uncolored call syntax
- Clarifies async model: call sites are uncolored (no `async`/`await`), but documents the cost—functions may pause mid-call with locks held—and recovery mechanisms (lints, IDE annotations)
- Refines effect system rationale: compiler knows, tooling shows, call syntax stays clean, with capability requirements visible at signature boundary

## Notable Details

- Introduces `mem.context/CC5` and `mem.context/CC8` as reference points for context clause semantics and ambiguity resolution
- Distinguishes between "effects as metadata" (no call-site color) and "capabilities as scope-level coloring" (signature-visible)
- Emphasizes the structural difference between Rask graph code and Go/Rust equivalents as intentional, not a limitation

https://claude.ai/code/session_01Au4vNzHB6tv37ZHPzDQqRZ