### PR TITLE
Implement presence predicate operator (postfix ?) with type narrowing

### DIFF
--- a/compiler/crates/rask-ast/src/expr.rs
+++ b/compiler/crates/rask-ast/src/expr.rs
@@ -113,8 +113,11 @@ pub enum ExprKind {
     },
     /// Presence predicate (postfix `expr?`) — evaluates to bool.
     /// `true` if scrutinee is `Some`/`Ok`, `false` if `None`/`Err`.
+    /// `binding` (OPT20/ER20) is the optional `as v` that binds the inner
+    /// payload as a fresh const in the then-branch — `if x? as v { ... v ... }`.
     IsPresent {
         expr: Box<Expr>,
+        binding: Option<String>,
     },
     /// Unwrap expression (postfix !) - panics if None/Err
     Unwrap {

--- a/compiler/crates/rask-ast/src/expr.rs
+++ b/compiler/crates/rask-ast/src/expr.rs
@@ -106,10 +106,15 @@ pub enum ExprKind {
         scrutinee: Box<Expr>,
         arms: Vec<MatchArm>,
     },
-    /// Try expression (try prefix or postfix ?)
+    /// Try expression (prefix `try expr` for propagation; optional `else |e| handler`)
     Try {
         expr: Box<Expr>,
         else_clause: Option<TryElse>,
+    },
+    /// Presence predicate (postfix `expr?`) — evaluates to bool.
+    /// `true` if scrutinee is `Some`/`Ok`, `false` if `None`/`Err`.
+    IsPresent {
+        expr: Box<Expr>,
     },
     /// Unwrap expression (postfix !) - panics if None/Err
     Unwrap {

--- a/compiler/crates/rask-desugar/src/defaults.rs
+++ b/compiler/crates/rask-desugar/src/defaults.rs
@@ -450,6 +450,9 @@ impl DefaultDesugarer {
                     self.desugar_expr(&mut ec.body);
                 }
             }
+            ExprKind::IsPresent { expr: e } => {
+                self.desugar_expr(e);
+            }
             ExprKind::Unwrap { expr: e, .. } | ExprKind::Cast { expr: e, .. } => {
                 self.desugar_expr(e);
             }

--- a/compiler/crates/rask-desugar/src/defaults.rs
+++ b/compiler/crates/rask-desugar/src/defaults.rs
@@ -450,7 +450,7 @@ impl DefaultDesugarer {
                     self.desugar_expr(&mut ec.body);
                 }
             }
-            ExprKind::IsPresent { expr: e } => {
+            ExprKind::IsPresent { expr: e, .. } => {
                 self.desugar_expr(e);
             }
             ExprKind::Unwrap { expr: e, .. } | ExprKind::Cast { expr: e, .. } => {

--- a/compiler/crates/rask-desugar/src/lib.rs
+++ b/compiler/crates/rask-desugar/src/lib.rs
@@ -408,7 +408,7 @@ impl Desugarer {
                     self.desugar_expr(&mut ec.body);
                 }
             }
-            ExprKind::IsPresent { expr: e } => self.desugar_expr(e),
+            ExprKind::IsPresent { expr: e, .. } => self.desugar_expr(e),
             ExprKind::Unwrap { expr: e, message: _ } => self.desugar_expr(e),
             ExprKind::GuardPattern {
                 expr,
@@ -820,7 +820,7 @@ fn offset_expr_spans(expr: &mut Expr, offset: usize) {
             offset_expr_spans(expr, offset);
             if let Some(tc) = else_clause { offset_expr_spans(&mut tc.body, offset); }
         }
-        ExprKind::IsPresent { expr } => offset_expr_spans(expr, offset),
+        ExprKind::IsPresent { expr, .. } => offset_expr_spans(expr, offset),
         ExprKind::Unwrap { expr, .. } => offset_expr_spans(expr, offset),
         ExprKind::Cast { expr, .. } => offset_expr_spans(expr, offset),
         ExprKind::NullCoalesce { value, default } => {

--- a/compiler/crates/rask-desugar/src/lib.rs
+++ b/compiler/crates/rask-desugar/src/lib.rs
@@ -408,6 +408,7 @@ impl Desugarer {
                     self.desugar_expr(&mut ec.body);
                 }
             }
+            ExprKind::IsPresent { expr: e } => self.desugar_expr(e),
             ExprKind::Unwrap { expr: e, message: _ } => self.desugar_expr(e),
             ExprKind::GuardPattern {
                 expr,
@@ -819,6 +820,7 @@ fn offset_expr_spans(expr: &mut Expr, offset: usize) {
             offset_expr_spans(expr, offset);
             if let Some(tc) = else_clause { offset_expr_spans(&mut tc.body, offset); }
         }
+        ExprKind::IsPresent { expr } => offset_expr_spans(expr, offset),
         ExprKind::Unwrap { expr, .. } => offset_expr_spans(expr, offset),
         ExprKind::Cast { expr, .. } => offset_expr_spans(expr, offset),
         ExprKind::NullCoalesce { value, default } => {

--- a/compiler/crates/rask-effects/src/infer.rs
+++ b/compiler/crates/rask-effects/src/infer.rs
@@ -328,7 +328,7 @@ fn classify_expr(expr: &Expr, effects: &mut Effects, callees: &mut HashSet<Strin
                 classify_expr(&ec.body, effects, callees);
             }
         }
-        ExprKind::IsPresent { expr: e } => {
+        ExprKind::IsPresent { expr: e, .. } => {
             classify_expr(e, effects, callees);
         }
         ExprKind::Unwrap { expr: e, .. } | ExprKind::Cast { expr: e, .. } => {

--- a/compiler/crates/rask-effects/src/infer.rs
+++ b/compiler/crates/rask-effects/src/infer.rs
@@ -328,6 +328,9 @@ fn classify_expr(expr: &Expr, effects: &mut Effects, callees: &mut HashSet<Strin
                 classify_expr(&ec.body, effects, callees);
             }
         }
+        ExprKind::IsPresent { expr: e } => {
+            classify_expr(e, effects, callees);
+        }
         ExprKind::Unwrap { expr: e, .. } | ExprKind::Cast { expr: e, .. } => {
             classify_expr(e, effects, callees);
         }

--- a/compiler/crates/rask-effects/src/warnings.rs
+++ b/compiler/crates/rask-effects/src/warnings.rs
@@ -239,7 +239,7 @@ impl<'a> WarnContext<'a> {
                     self.check_expr(&ec.body, warnings);
                 }
             }
-            ExprKind::IsPresent { expr: e } => {
+            ExprKind::IsPresent { expr: e, .. } => {
                 self.check_expr(e, warnings);
             }
             ExprKind::Unwrap { expr: e, .. } | ExprKind::Cast { expr: e, .. } => {

--- a/compiler/crates/rask-effects/src/warnings.rs
+++ b/compiler/crates/rask-effects/src/warnings.rs
@@ -239,6 +239,9 @@ impl<'a> WarnContext<'a> {
                     self.check_expr(&ec.body, warnings);
                 }
             }
+            ExprKind::IsPresent { expr: e } => {
+                self.check_expr(e, warnings);
+            }
             ExprKind::Unwrap { expr: e, .. } | ExprKind::Cast { expr: e, .. } => {
                 self.check_expr(e, warnings);
             }

--- a/compiler/crates/rask-fmt/src/printer.rs
+++ b/compiler/crates/rask-fmt/src/printer.rs
@@ -1574,7 +1574,7 @@ impl<'a> Printer<'a> {
                     self.format_expr(&ec.body);
                 }
             }
-            ExprKind::IsPresent { expr: inner } => {
+            ExprKind::IsPresent { expr: inner, .. } => {
                 self.format_expr(inner);
                 self.emit("?");
             }

--- a/compiler/crates/rask-fmt/src/printer.rs
+++ b/compiler/crates/rask-fmt/src/printer.rs
@@ -1574,6 +1574,10 @@ impl<'a> Printer<'a> {
                     self.format_expr(&ec.body);
                 }
             }
+            ExprKind::IsPresent { expr: inner } => {
+                self.format_expr(inner);
+                self.emit("?");
+            }
             ExprKind::Unwrap { expr: inner, message } => {
                 self.format_expr(inner);
                 self.emit("!");

--- a/compiler/crates/rask-hidden-params/src/callgraph.rs
+++ b/compiler/crates/rask-hidden-params/src/callgraph.rs
@@ -296,7 +296,7 @@ fn collect_callees_from_expr(expr: &Expr, callees: &mut HashSet<String>) {
                 collect_callees_from_expr(&ec.body, callees);
             }
         }
-        ExprKind::IsPresent { expr: e } => {
+        ExprKind::IsPresent { expr: e, .. } => {
             collect_callees_from_expr(e, callees);
         }
         ExprKind::Unwrap { expr: e, .. } | ExprKind::Cast { expr: e, .. } => {

--- a/compiler/crates/rask-hidden-params/src/callgraph.rs
+++ b/compiler/crates/rask-hidden-params/src/callgraph.rs
@@ -296,6 +296,9 @@ fn collect_callees_from_expr(expr: &Expr, callees: &mut HashSet<String>) {
                 collect_callees_from_expr(&ec.body, callees);
             }
         }
+        ExprKind::IsPresent { expr: e } => {
+            collect_callees_from_expr(e, callees);
+        }
         ExprKind::Unwrap { expr: e, .. } | ExprKind::Cast { expr: e, .. } => {
             collect_callees_from_expr(e, callees);
         }

--- a/compiler/crates/rask-hidden-params/src/rewrite.rs
+++ b/compiler/crates/rask-hidden-params/src/rewrite.rs
@@ -276,7 +276,7 @@ fn rewrite_expr(pass: &mut HiddenParamPass, caller: &str, expr: &mut Expr) {
                 rewrite_expr(pass, caller, &mut ec.body);
             }
         }
-        ExprKind::IsPresent { expr: e } => {
+        ExprKind::IsPresent { expr: e, .. } => {
             rewrite_expr(pass, caller, e);
         }
         ExprKind::Unwrap { expr: e, .. } | ExprKind::Cast { expr: e, .. } => {

--- a/compiler/crates/rask-hidden-params/src/rewrite.rs
+++ b/compiler/crates/rask-hidden-params/src/rewrite.rs
@@ -276,6 +276,9 @@ fn rewrite_expr(pass: &mut HiddenParamPass, caller: &str, expr: &mut Expr) {
                 rewrite_expr(pass, caller, &mut ec.body);
             }
         }
+        ExprKind::IsPresent { expr: e } => {
+            rewrite_expr(pass, caller, e);
+        }
         ExprKind::Unwrap { expr: e, .. } | ExprKind::Cast { expr: e, .. } => {
             rewrite_expr(pass, caller, e);
         }

--- a/compiler/crates/rask-interp/src/interp/dispatch.rs
+++ b/compiler/crates/rask-interp/src/interp/dispatch.rs
@@ -490,6 +490,29 @@ impl Interpreter {
         }
     }
 
+    /// Extract the inner payload of an Option/Result bound to `name`.
+    /// `present=true` returns the Some/Ok payload; `false` returns the Err
+    /// payload (or None for Option since there is no payload).
+    /// Used by `if x?` narrowing to rebind the variable in the branch scope.
+    pub(crate) fn extract_presence_payload(&self, name: &str, present: bool) -> Option<Value> {
+        let val = self.env.get(name)?;
+        match &val {
+            Value::Enum { variant, fields, .. } => {
+                let match_present = matches!(variant.as_str(), "Some" | "Ok");
+                let match_absent = matches!(variant.as_str(), "None" | "Err");
+                if present && match_present {
+                    fields.first().cloned()
+                } else if !present && match_absent {
+                    // None has no payload; Err has a payload.
+                    fields.first().cloned()
+                } else {
+                    None
+                }
+            }
+            _ => None,
+        }
+    }
+
     /// Handle ctx.step(name, inputs, body) — incremental build step.
     /// Hashes input files, skips if unchanged since last run.
     fn call_build_step(&mut self, args: Vec<Value>) -> Result<Value, RuntimeError> {

--- a/compiler/crates/rask-interp/src/interp/dispatch.rs
+++ b/compiler/crates/rask-interp/src/interp/dispatch.rs
@@ -490,28 +490,6 @@ impl Interpreter {
         }
     }
 
-    /// Extract the inner payload of an Option/Result bound to `name`.
-    /// `present=true` returns the Some/Ok payload; `false` returns the Err
-    /// payload (or None for Option since there is no payload).
-    /// Used by `if x?` narrowing to rebind the variable in the branch scope.
-    pub(crate) fn extract_presence_payload(&self, name: &str, present: bool) -> Option<Value> {
-        let val = self.env.get(name)?;
-        match &val {
-            Value::Enum { variant, fields, .. } => {
-                let match_present = matches!(variant.as_str(), "Some" | "Ok");
-                let match_absent = matches!(variant.as_str(), "None" | "Err");
-                if present && match_present {
-                    fields.first().cloned()
-                } else if !present && match_absent {
-                    // None has no payload; Err has a payload.
-                    fields.first().cloned()
-                } else {
-                    None
-                }
-            }
-            _ => None,
-        }
-    }
 
     /// Handle ctx.step(name, inputs, body) — incremental build step.
     /// Hashes input files, skips if unchanged since last run.

--- a/compiler/crates/rask-interp/src/interp/eval_expr.rs
+++ b/compiler/crates/rask-interp/src/interp/eval_expr.rs
@@ -1199,6 +1199,31 @@ impl Interpreter {
                 }
             }
 
+            // Postfix `?` — presence predicate. OPT10/ER12.
+            ExprKind::IsPresent { expr: inner } => {
+                let val = self.eval_expr(inner)?;
+                match &val {
+                    Value::Enum { variant, .. } => match variant.as_str() {
+                        "Some" | "Ok" => Ok(Value::Bool(true)),
+                        "None" | "Err" => Ok(Value::Bool(false)),
+                        _ => Err(RuntimeDiagnostic::new(
+                            RuntimeError::TypeError(format!(
+                                "? presence predicate requires Option or Result, got variant {}",
+                                variant
+                            )),
+                            expr.span,
+                        )),
+                    },
+                    _ => Err(RuntimeDiagnostic::new(
+                        RuntimeError::TypeError(format!(
+                            "? presence predicate requires Option or Result, got {}",
+                            val.type_name()
+                        )),
+                        expr.span,
+                    )),
+                }
+            }
+
             ExprKind::Unwrap { expr: inner, message } => {
                 let val = self.eval_expr(inner)?;
                 match &val {

--- a/compiler/crates/rask-interp/src/interp/eval_expr.rs
+++ b/compiler/crates/rask-interp/src/interp/eval_expr.rs
@@ -590,10 +590,41 @@ impl Interpreter {
                 then_branch,
                 else_branch,
             } => {
+                // OPT19/ER19: `if x?` narrows x to its inner value in the block.
+                // ER21: else branch narrows to E for Result.
+                let presence_narrow = match &cond.kind {
+                    ExprKind::IsPresent { expr: inner } => match &inner.kind {
+                        ExprKind::Ident(name) => Some(name.clone()),
+                        _ => None,
+                    },
+                    _ => None,
+                };
+
                 let cond_val = self.eval_expr(cond)?;
                 if self.is_truthy(&cond_val) {
+                    if let Some(name) = presence_narrow.as_ref() {
+                        // Rebind to the inner (Some/Ok) payload in the then-scope.
+                        if let Some(inner_val) = self.extract_presence_payload(name, true) {
+                            self.env.push_scope();
+                            self.env.define(name.clone(), inner_val);
+                            let result = self.eval_expr(then_branch);
+                            self.env.pop_scope();
+                            return result;
+                        }
+                    }
                     self.eval_expr(then_branch)
                 } else if let Some(else_br) = else_branch {
+                    if let Some(name) = presence_narrow.as_ref() {
+                        // For Result, rebind to the Err payload in the else-scope.
+                        // For Option, no payload — fall through to normal eval.
+                        if let Some(err_val) = self.extract_presence_payload(name, false) {
+                            self.env.push_scope();
+                            self.env.define(name.clone(), err_val);
+                            let result = self.eval_expr(else_br);
+                            self.env.pop_scope();
+                            return result;
+                        }
+                    }
                     self.eval_expr(else_br)
                 } else {
                     Ok(Value::Unit)

--- a/compiler/crates/rask-interp/src/interp/eval_expr.rs
+++ b/compiler/crates/rask-interp/src/interp/eval_expr.rs
@@ -590,41 +590,55 @@ impl Interpreter {
                 then_branch,
                 else_branch,
             } => {
-                // OPT19/ER19: `if x?` narrows x to its inner value in the block.
-                // ER21: else branch narrows to E for Result.
-                let presence_narrow = match &cond.kind {
-                    ExprKind::IsPresent { expr: inner } => match &inner.kind {
-                        ExprKind::Ident(name) => Some(name.clone()),
+                // OPT19/OPT20 + ER19/ER20/ER21: `if x?` or `if expr? as v`
+                // evaluates the scrutinee once and rebinds the payload as the
+                // narrow name (scrutinee ident for plain, `v` for `as v`).
+                if let ExprKind::IsPresent { expr: inner, binding } = &cond.kind {
+                    let narrow_name = match (binding, &inner.kind) {
+                        (Some(v), _) => Some(v.clone()),
+                        (None, ExprKind::Ident(n)) => Some(n.clone()),
                         _ => None,
-                    },
-                    _ => None,
-                };
-
-                let cond_val = self.eval_expr(cond)?;
-                if self.is_truthy(&cond_val) {
-                    if let Some(name) = presence_narrow.as_ref() {
-                        // Rebind to the inner (Some/Ok) payload in the then-scope.
-                        if let Some(inner_val) = self.extract_presence_payload(name, true) {
+                    };
+                    if let Some(name) = narrow_name {
+                        let scrutinee_val = self.eval_expr(inner)?;
+                        let present = matches!(
+                            &scrutinee_val,
+                            Value::Enum { variant, .. } if matches!(variant.as_str(), "Some" | "Ok")
+                        );
+                        if present {
+                            let payload = match &scrutinee_val {
+                                Value::Enum { fields, .. } => fields.first().cloned().unwrap_or(Value::Unit),
+                                _ => Value::Unit,
+                            };
                             self.env.push_scope();
-                            self.env.define(name.clone(), inner_val);
+                            self.env.define(name, payload);
                             let result = self.eval_expr(then_branch);
                             self.env.pop_scope();
                             return result;
+                        } else if let Some(else_br) = else_branch {
+                            let payload = match &scrutinee_val {
+                                Value::Enum { fields, .. } => fields.first().cloned(),
+                                _ => None,
+                            };
+                            if let Some(p) = payload {
+                                // Result Err branch binds E; Option None has no payload.
+                                self.env.push_scope();
+                                self.env.define(name, p);
+                                let result = self.eval_expr(else_br);
+                                self.env.pop_scope();
+                                return result;
+                            }
+                            return self.eval_expr(else_br);
+                        } else {
+                            return Ok(Value::Unit);
                         }
                     }
+                }
+
+                let cond_val = self.eval_expr(cond)?;
+                if self.is_truthy(&cond_val) {
                     self.eval_expr(then_branch)
                 } else if let Some(else_br) = else_branch {
-                    if let Some(name) = presence_narrow.as_ref() {
-                        // For Result, rebind to the Err payload in the else-scope.
-                        // For Option, no payload — fall through to normal eval.
-                        if let Some(err_val) = self.extract_presence_payload(name, false) {
-                            self.env.push_scope();
-                            self.env.define(name.clone(), err_val);
-                            let result = self.eval_expr(else_br);
-                            self.env.pop_scope();
-                            return result;
-                        }
-                    }
                     self.eval_expr(else_br)
                 } else {
                     Ok(Value::Unit)
@@ -1231,7 +1245,10 @@ impl Interpreter {
             }
 
             // Postfix `?` — presence predicate. OPT10/ER12.
-            ExprKind::IsPresent { expr: inner } => {
+            // When in a condition with narrowing, the outer If handler evaluates
+            // the scrutinee directly; this path only fires for bare `x?` uses
+            // outside a condition.
+            ExprKind::IsPresent { expr: inner, .. } => {
                 let val = self.eval_expr(inner)?;
                 match &val {
                     Value::Enum { variant, .. } => match variant.as_str() {

--- a/compiler/crates/rask-lint/src/idiom.rs
+++ b/compiler/crates/rask-lint/src/idiom.rs
@@ -190,7 +190,7 @@ fn walk_expr_for_unwrap(expr: &Expr, source: &str, diags: &mut Vec<LintDiagnosti
                 walk_expr_for_unwrap(&ec.body, source, diags);
             }
         }
-        ExprKind::IsPresent { expr: inner } => {
+        ExprKind::IsPresent { expr: inner, .. } => {
             walk_expr_for_unwrap(inner, source, diags);
         }
         ExprKind::Unwrap { expr: inner, .. } | ExprKind::Cast { expr: inner, .. } => {

--- a/compiler/crates/rask-lint/src/idiom.rs
+++ b/compiler/crates/rask-lint/src/idiom.rs
@@ -190,6 +190,9 @@ fn walk_expr_for_unwrap(expr: &Expr, source: &str, diags: &mut Vec<LintDiagnosti
                 walk_expr_for_unwrap(&ec.body, source, diags);
             }
         }
+        ExprKind::IsPresent { expr: inner } => {
+            walk_expr_for_unwrap(inner, source, diags);
+        }
         ExprKind::Unwrap { expr: inner, .. } | ExprKind::Cast { expr: inner, .. } => {
             walk_expr_for_unwrap(inner, source, diags);
         }

--- a/compiler/crates/rask-lsp/src/position_index.rs
+++ b/compiler/crates/rask-lsp/src/position_index.rs
@@ -242,6 +242,9 @@ fn visit_expr(expr: &Expr, index: &mut PositionIndex) {
                 visit_expr(&ec.body, index);
             }
         }
+        ExprKind::IsPresent { expr: e } => {
+            visit_expr(e, index);
+        }
         ExprKind::Unwrap { expr: e, .. } => {
             visit_expr(e, index);
         }

--- a/compiler/crates/rask-lsp/src/position_index.rs
+++ b/compiler/crates/rask-lsp/src/position_index.rs
@@ -242,7 +242,7 @@ fn visit_expr(expr: &Expr, index: &mut PositionIndex) {
                 visit_expr(&ec.body, index);
             }
         }
-        ExprKind::IsPresent { expr: e } => {
+        ExprKind::IsPresent { expr: e, .. } => {
             visit_expr(e, index);
         }
         ExprKind::Unwrap { expr: e, .. } => {

--- a/compiler/crates/rask-mir/src/hidden_params/callgraph.rs
+++ b/compiler/crates/rask-mir/src/hidden_params/callgraph.rs
@@ -296,7 +296,7 @@ fn collect_callees_from_expr(expr: &Expr, callees: &mut HashSet<String>) {
                 collect_callees_from_expr(&ec.body, callees);
             }
         }
-        ExprKind::IsPresent { expr: e } => {
+        ExprKind::IsPresent { expr: e, .. } => {
             collect_callees_from_expr(e, callees);
         }
         ExprKind::Unwrap { expr: e, .. } | ExprKind::Cast { expr: e, .. } => {

--- a/compiler/crates/rask-mir/src/hidden_params/callgraph.rs
+++ b/compiler/crates/rask-mir/src/hidden_params/callgraph.rs
@@ -296,6 +296,9 @@ fn collect_callees_from_expr(expr: &Expr, callees: &mut HashSet<String>) {
                 collect_callees_from_expr(&ec.body, callees);
             }
         }
+        ExprKind::IsPresent { expr: e } => {
+            collect_callees_from_expr(e, callees);
+        }
         ExprKind::Unwrap { expr: e, .. } | ExprKind::Cast { expr: e, .. } => {
             collect_callees_from_expr(e, callees);
         }

--- a/compiler/crates/rask-mir/src/hidden_params/rewrite.rs
+++ b/compiler/crates/rask-mir/src/hidden_params/rewrite.rs
@@ -276,7 +276,7 @@ fn rewrite_expr(pass: &mut HiddenParamPass, caller: &str, expr: &mut Expr) {
                 rewrite_expr(pass, caller, &mut ec.body);
             }
         }
-        ExprKind::IsPresent { expr: e } => {
+        ExprKind::IsPresent { expr: e, .. } => {
             rewrite_expr(pass, caller, e);
         }
         ExprKind::Unwrap { expr: e, .. } | ExprKind::Cast { expr: e, .. } => {

--- a/compiler/crates/rask-mir/src/hidden_params/rewrite.rs
+++ b/compiler/crates/rask-mir/src/hidden_params/rewrite.rs
@@ -276,6 +276,9 @@ fn rewrite_expr(pass: &mut HiddenParamPass, caller: &str, expr: &mut Expr) {
                 rewrite_expr(pass, caller, &mut ec.body);
             }
         }
+        ExprKind::IsPresent { expr: e } => {
+            rewrite_expr(pass, caller, e);
+        }
         ExprKind::Unwrap { expr: e, .. } | ExprKind::Cast { expr: e, .. } => {
             rewrite_expr(pass, caller, e);
         }

--- a/compiler/crates/rask-mir/src/lower/expr.rs
+++ b/compiler/crates/rask-mir/src/lower/expr.rs
@@ -2361,6 +2361,24 @@ impl<'a> MirLowerer<'a> {
                 }
             }
 
+            // Presence predicate (postfix ?) — evaluates to bool.
+            // Some/Ok tag is 0 (present/ok); None/Err tag is 1.
+            ExprKind::IsPresent { expr: inner } => {
+                let is_niche = self.is_niche_option_expr(inner);
+                let (val, _ty) = self.lower_expr(inner)?;
+                let tag = self.emit_option_tag(&val, is_niche);
+                let result = self.builder.alloc_temp(MirType::Bool);
+                self.builder.push_stmt(MirStmt::dummy(MirStmtKind::Assign {
+                    dst: result,
+                    rvalue: MirRValue::BinaryOp {
+                        op: crate::operand::BinOp::Eq,
+                        left: MirOperand::Local(tag),
+                        right: MirOperand::Constant(MirConst::Int(0)),
+                    },
+                }));
+                Ok((MirOperand::Local(result), MirType::Bool))
+            }
+
             // Unwrap (postfix !) - panic on None/Err
             ExprKind::Unwrap { expr: inner, message: _ } => {
                 let is_niche = self.is_niche_option_expr(inner);

--- a/compiler/crates/rask-mir/src/lower/expr.rs
+++ b/compiler/crates/rask-mir/src/lower/expr.rs
@@ -2363,7 +2363,7 @@ impl<'a> MirLowerer<'a> {
 
             // Presence predicate (postfix ?) — evaluates to bool.
             // Some/Ok tag is 0 (present/ok); None/Err tag is 1.
-            ExprKind::IsPresent { expr: inner } => {
+            ExprKind::IsPresent { expr: inner, .. } => {
                 let is_niche = self.is_niche_option_expr(inner);
                 let (val, _ty) = self.lower_expr(inner)?;
                 let tag = self.emit_option_tag(&val, is_niche);

--- a/compiler/crates/rask-mir/src/lower/mod.rs
+++ b/compiler/crates/rask-mir/src/lower/mod.rs
@@ -1285,7 +1285,7 @@ impl<'a> MirLowerer<'a> {
                     self.walk_free_vars(&ec.body, &inner_bound, seen, free);
                 }
             }
-            ExprKind::IsPresent { expr: inner } => {
+            ExprKind::IsPresent { expr: inner, .. } => {
                 self.walk_free_vars(inner, bound, seen, free);
             }
             ExprKind::Unwrap { expr: inner, .. } => {

--- a/compiler/crates/rask-mir/src/lower/mod.rs
+++ b/compiler/crates/rask-mir/src/lower/mod.rs
@@ -1285,6 +1285,9 @@ impl<'a> MirLowerer<'a> {
                     self.walk_free_vars(&ec.body, &inner_bound, seen, free);
                 }
             }
+            ExprKind::IsPresent { expr: inner } => {
+                self.walk_free_vars(inner, bound, seen, free);
+            }
             ExprKind::Unwrap { expr: inner, .. } => {
                 self.walk_free_vars(inner, bound, seen, free);
             }

--- a/compiler/crates/rask-mono/src/instantiate.rs
+++ b/compiler/crates/rask-mono/src/instantiate.rs
@@ -458,6 +458,9 @@ impl TypeSubstitutor {
                         body: Box::new(self.clone_expr(&ec.body)),
                     }),
                 },
+                ExprKind::IsPresent { expr: inner } => ExprKind::IsPresent {
+                    expr: Box::new(self.clone_expr(inner)),
+                },
                 ExprKind::Unwrap { expr: inner, message } => ExprKind::Unwrap {
                     expr: Box::new(self.clone_expr(inner)),
                     message: message.clone(),

--- a/compiler/crates/rask-mono/src/instantiate.rs
+++ b/compiler/crates/rask-mono/src/instantiate.rs
@@ -458,8 +458,9 @@ impl TypeSubstitutor {
                         body: Box::new(self.clone_expr(&ec.body)),
                     }),
                 },
-                ExprKind::IsPresent { expr: inner } => ExprKind::IsPresent {
+                ExprKind::IsPresent { expr: inner, binding } => ExprKind::IsPresent {
                     expr: Box::new(self.clone_expr(inner)),
+                    binding: binding.clone(),
                 },
                 ExprKind::Unwrap { expr: inner, message } => ExprKind::Unwrap {
                     expr: Box::new(self.clone_expr(inner)),

--- a/compiler/crates/rask-mono/src/reachability.rs
+++ b/compiler/crates/rask-mono/src/reachability.rs
@@ -407,7 +407,7 @@ impl<'a> Monomorphizer<'a> {
                     self.visit_expr(&ec.body);
                 }
             }
-            ExprKind::IsPresent { expr: e } => self.visit_expr(e),
+            ExprKind::IsPresent { expr: e, .. } => self.visit_expr(e),
             ExprKind::Unwrap { expr: e, .. } => self.visit_expr(e),
             ExprKind::NullCoalesce { value, default } => {
                 self.visit_expr(value);

--- a/compiler/crates/rask-mono/src/reachability.rs
+++ b/compiler/crates/rask-mono/src/reachability.rs
@@ -407,6 +407,7 @@ impl<'a> Monomorphizer<'a> {
                     self.visit_expr(&ec.body);
                 }
             }
+            ExprKind::IsPresent { expr: e } => self.visit_expr(e),
             ExprKind::Unwrap { expr: e, .. } => self.visit_expr(e),
             ExprKind::NullCoalesce { value, default } => {
                 self.visit_expr(value);

--- a/compiler/crates/rask-ownership/src/lib.rs
+++ b/compiler/crates/rask-ownership/src/lib.rs
@@ -925,6 +925,9 @@ impl<'a> OwnershipChecker<'a> {
                     self.bindings = pre_else;
                 }
             }
+            ExprKind::IsPresent { expr: inner } => {
+                self.check_expr(inner);
+            }
             ExprKind::Unwrap { expr: inner, .. } => {
                 self.check_expr(inner);
             }
@@ -1729,6 +1732,9 @@ impl<'a> OwnershipChecker<'a> {
                 if let Some(tc) = else_clause {
                     self.collect_free_vars_inner(&tc.body, locals, out, projections);
                 }
+            }
+            ExprKind::IsPresent { expr: inner } => {
+                self.collect_free_vars_inner(inner, locals, out, projections);
             }
             ExprKind::Unwrap { expr: inner, .. } | ExprKind::Cast { expr: inner, .. } => {
                 self.collect_free_vars_inner(inner, locals, out, projections);

--- a/compiler/crates/rask-ownership/src/lib.rs
+++ b/compiler/crates/rask-ownership/src/lib.rs
@@ -925,7 +925,7 @@ impl<'a> OwnershipChecker<'a> {
                     self.bindings = pre_else;
                 }
             }
-            ExprKind::IsPresent { expr: inner } => {
+            ExprKind::IsPresent { expr: inner, .. } => {
                 self.check_expr(inner);
             }
             ExprKind::Unwrap { expr: inner, .. } => {
@@ -1733,7 +1733,7 @@ impl<'a> OwnershipChecker<'a> {
                     self.collect_free_vars_inner(&tc.body, locals, out, projections);
                 }
             }
-            ExprKind::IsPresent { expr: inner } => {
+            ExprKind::IsPresent { expr: inner, .. } => {
                 self.collect_free_vars_inner(inner, locals, out, projections);
             }
             ExprKind::Unwrap { expr: inner, .. } | ExprKind::Cast { expr: inner, .. } => {

--- a/compiler/crates/rask-parser/src/parser.rs
+++ b/compiler/crates/rask-parser/src/parser.rs
@@ -3074,6 +3074,16 @@ impl Parser {
                 self.advance();
                 let operand = self.parse_expr_bp(Self::PREFIX_BP)?;
                 let end = operand.span.end;
+                // OPT17/ER26: `!x?` is forbidden — prefix `!` with suffix `?`
+                // fights the parse. Suggest `x == none` (Option) or `x is E`
+                // (Result) instead. `!` on a plain bool is still fine.
+                if matches!(operand.kind, ExprKind::IsPresent { .. }) {
+                    return Err(ParseError {
+                        span: self.span(start, end),
+                        message: "cannot negate `?` with prefix `!`".to_string(),
+                        hint: Some("use `x == none` for Option or `r is E` for Result".to_string()),
+                    });
+                }
                 Ok(Expr { id: self.next_id(), kind: ExprKind::Unary { op: UnaryOp::Not, operand: Box::new(operand) }, span: self.span(start, end) })
             }
             TokenKind::Tilde => {

--- a/compiler/crates/rask-parser/src/parser.rs
+++ b/compiler/crates/rask-parser/src/parser.rs
@@ -3577,10 +3577,24 @@ impl Parser {
             }
 
             // Presence predicate (postfix ?) — evaluates to bool (OPT10/ER12).
+            // OPT20/ER20: `expr? as v` binds the payload as a fresh const in
+            // the then-branch. Consuming `as <ident>` here avoids the `as` cast
+            // infix operator swallowing `v` as a type name. To cast a bool from
+            // `?`, wrap in parens: `(x?) as i32`.
             TokenKind::Question => {
                 self.advance();
-                let end = self.tokens[self.pos - 1].span.end;
-                Ok(Expr { id: self.next_id(), kind: ExprKind::IsPresent { expr: Box::new(lhs) }, span: self.span(start, end) })
+                let mut end = self.tokens[self.pos - 1].span.end;
+                let binding = if self.check(&TokenKind::As)
+                    && matches!(self.peek(1), TokenKind::Ident(_))
+                {
+                    self.advance();
+                    let name = self.expect_ident()?;
+                    end = self.tokens[self.pos - 1].span.end;
+                    Some(name)
+                } else {
+                    None
+                };
+                Ok(Expr { id: self.next_id(), kind: ExprKind::IsPresent { expr: Box::new(lhs), binding }, span: self.span(start, end) })
             }
 
             // Unwrap operator (!) - panics if None/Err

--- a/compiler/crates/rask-parser/src/parser.rs
+++ b/compiler/crates/rask-parser/src/parser.rs
@@ -3576,13 +3576,11 @@ impl Parser {
                 Ok(Expr { id: self.next_id(), kind: ExprKind::Index { object: Box::new(lhs), index: Box::new(index) }, span: self.span(start, end) })
             }
 
-            // Try operator (?)
-            // Note: Postfix ? is for optional chaining (T?).
-            // For Result error propagation, use prefix 'try expr' instead.
+            // Presence predicate (postfix ?) — evaluates to bool (OPT10/ER12).
             TokenKind::Question => {
                 self.advance();
                 let end = self.tokens[self.pos - 1].span.end;
-                Ok(Expr { id: self.next_id(), kind: ExprKind::Try { expr: Box::new(lhs), else_clause: None }, span: self.span(start, end) })
+                Ok(Expr { id: self.next_id(), kind: ExprKind::IsPresent { expr: Box::new(lhs) }, span: self.span(start, end) })
             }
 
             // Unwrap operator (!) - panics if None/Err

--- a/compiler/crates/rask-resolve/src/resolver.rs
+++ b/compiler/crates/rask-resolve/src/resolver.rs
@@ -2025,6 +2025,9 @@ impl Resolver {
                     self.scopes.pop();
                 }
             }
+            ExprKind::IsPresent { expr: inner } => {
+                self.resolve_expr(inner);
+            }
             ExprKind::Unwrap { expr: inner, message: _ } => {
                 self.resolve_expr(inner);
             }

--- a/compiler/crates/rask-resolve/src/resolver.rs
+++ b/compiler/crates/rask-resolve/src/resolver.rs
@@ -1980,9 +1980,47 @@ impl Resolver {
             }
             ExprKind::If { cond, then_branch, else_branch } => {
                 self.resolve_expr(cond);
-                self.resolve_expr(then_branch);
+                // OPT20/ER20: `if expr? as v` binds v in the then-branch.
+                // ER21: else-branch also binds v (to the error) for Result.
+                let presence_binding = match &cond.kind {
+                    ExprKind::IsPresent { binding: Some(name), .. } => Some(name.clone()),
+                    _ => None,
+                };
+                if let Some(ref name) = presence_binding {
+                    self.scopes.push(ScopeKind::Block);
+                    let sym_id = self.symbols.insert(
+                        name.clone(),
+                        SymbolKind::Variable { mutable: false },
+                        None,
+                        Span::new(0, 0),
+                        false,
+                    );
+                    if let Err(e) = self.scopes.define(name.clone(), sym_id, Span::new(0, 0)) {
+                        self.errors.push(e);
+                    }
+                    self.resolve_expr(then_branch);
+                    self.scopes.pop();
+                } else {
+                    self.resolve_expr(then_branch);
+                }
                 if let Some(else_br) = else_branch {
-                    self.resolve_expr(else_br);
+                    if let Some(ref name) = presence_binding {
+                        self.scopes.push(ScopeKind::Block);
+                        let sym_id = self.symbols.insert(
+                            name.clone(),
+                            SymbolKind::Variable { mutable: false },
+                            None,
+                            Span::new(0, 0),
+                            false,
+                        );
+                        if let Err(e) = self.scopes.define(name.clone(), sym_id, Span::new(0, 0)) {
+                            self.errors.push(e);
+                        }
+                        self.resolve_expr(else_br);
+                        self.scopes.pop();
+                    } else {
+                        self.resolve_expr(else_br);
+                    }
                 }
             }
             ExprKind::IfLet { expr, pattern, then_branch, else_branch } => {
@@ -2025,7 +2063,7 @@ impl Resolver {
                     self.scopes.pop();
                 }
             }
-            ExprKind::IsPresent { expr: inner } => {
+            ExprKind::IsPresent { expr: inner, .. } => {
                 self.resolve_expr(inner);
             }
             ExprKind::Unwrap { expr: inner, message: _ } => {

--- a/compiler/crates/rask-semantic-hash/src/hasher.rs
+++ b/compiler/crates/rask-semantic-hash/src/hasher.rs
@@ -685,9 +685,15 @@ impl Hasher {
                     self.feed_bool(false);
                 }
             }
-            ExprKind::IsPresent { expr } => {
+            ExprKind::IsPresent { expr, binding } => {
                 self.feed_tag(100);
                 self.hash_expr(expr);
+                if let Some(b) = binding {
+                    self.feed_bool(true);
+                    self.feed_str(b);
+                } else {
+                    self.feed_bool(false);
+                }
             }
             ExprKind::Unwrap { expr, message } => {
                 self.feed_tag(61);

--- a/compiler/crates/rask-semantic-hash/src/hasher.rs
+++ b/compiler/crates/rask-semantic-hash/src/hasher.rs
@@ -685,6 +685,10 @@ impl Hasher {
                     self.feed_bool(false);
                 }
             }
+            ExprKind::IsPresent { expr } => {
+                self.feed_tag(100);
+                self.hash_expr(expr);
+            }
             ExprKind::Unwrap { expr, message } => {
                 self.feed_tag(61);
                 self.hash_expr(expr);

--- a/compiler/crates/rask-types/src/checker/check_expr.rs
+++ b/compiler/crates/rask-types/src/checker/check_expr.rs
@@ -715,6 +715,26 @@ impl TypeChecker {
                 }
             }
 
+            // Postfix `?` — presence predicate. OPT10/ER12.
+            ExprKind::IsPresent { expr: inner } => {
+                let inner_ty = self.infer_expr(inner);
+                let resolved = self.ctx.apply(&inner_ty);
+                match &resolved {
+                    Type::Option(_) | Type::Result { .. } => Type::Bool,
+                    Type::Var(_) => {
+                        // Unresolved scrutinee — leave as bool, let later context constrain.
+                        Type::Bool
+                    }
+                    _ => {
+                        self.errors.push(TypeError::TryOnNonResult {
+                            found: resolved,
+                            span: expr.span,
+                        });
+                        Type::Error
+                    }
+                }
+            }
+
             ExprKind::Unwrap { expr: inner, message: _ } => {
                 let inner_ty = self.infer_expr(inner);
                 let resolved = self.ctx.apply(&inner_ty);

--- a/compiler/crates/rask-types/src/checker/check_expr.rs
+++ b/compiler/crates/rask-types/src/checker/check_expr.rs
@@ -736,7 +736,7 @@ impl TypeChecker {
             }
 
             // Postfix `?` — presence predicate. OPT10/ER12.
-            ExprKind::IsPresent { expr: inner } => {
+            ExprKind::IsPresent { expr: inner, .. } => {
                 let inner_ty = self.infer_expr(inner);
                 let resolved = self.ctx.apply(&inner_ty);
                 match &resolved {
@@ -2048,38 +2048,38 @@ impl TypeChecker {
         }
     }
 
-    /// Detect `if x?` on an Option or Result bound locally. Returns the
-    /// variable name, the then-branch type, and (for Result) the else-branch
-    /// type. OPT19/OPT21 for Option; ER19/ER21 for Result.
+    /// Detect a presence check (`x?` or `x? as v`) in an if-condition and
+    /// return the narrow name, the then-branch type, and (for Result) the
+    /// else-branch type.
     ///
-    /// Narrowing only applies when the scrutinee is a plain const-bound ident —
-    /// mutability and compound expressions are rejected to keep the rule
-    /// structural (no flow analysis).
+    /// OPT19/ER19 — plain `if x?`: narrows the scrutinee when it's a
+    /// const-bound ident; mut is rejected (user needs `as v`).
+    /// OPT20/ER20 — `if expr? as v`: binds a fresh const `v: T` regardless
+    /// of the scrutinee's shape or mutability.
+    ///
+    /// Must run after the cond has been inferred so the scrutinee's type is
+    /// available in `node_types`.
     pub(super) fn extract_is_present_narrowing(
         &self,
         cond: &Expr,
     ) -> Option<(String, Type, Option<Type>)> {
-        let ExprKind::IsPresent { expr: inner } = &cond.kind else {
+        let ExprKind::IsPresent { expr: inner, binding } = &cond.kind else {
             return None;
         };
-        let ExprKind::Ident(var_name) = &inner.kind else {
-            return None;
+
+        // Use the already-inferred scrutinee type; no re-inference.
+        let scrutinee_ty = self.node_types.get(&inner.id).cloned()?;
+        let resolved = self.ctx.apply(&scrutinee_ty);
+
+        let narrow_name = match (binding, &inner.kind) {
+            (Some(v), _) => v.clone(),
+            (None, ExprKind::Ident(n)) if self.is_local_read_only(n) => n.clone(),
+            _ => return None,
         };
-        // OPT19/ER19: const scrutinee only. Mut requires `as v` bind (OPT20/ER20).
-        if !self.is_local_read_only(var_name) {
-            return None;
-        }
-        let var_ty = self.lookup_local(var_name)?;
-        let resolved = self.ctx.apply(&var_ty);
+
         match resolved {
-            Type::Option(inner_ty) => {
-                // Option: then = T, else = no narrowing (information-only).
-                Some((var_name.clone(), *inner_ty, None))
-            }
-            Type::Result { ok, err } => {
-                // Result: then = T, else = E.
-                Some((var_name.clone(), *ok, Some(*err)))
-            }
+            Type::Option(inner_ty) => Some((narrow_name, *inner_ty, None)),
+            Type::Result { ok, err } => Some((narrow_name, *ok, Some(*err))),
             _ => None,
         }
     }

--- a/compiler/crates/rask-types/src/checker/check_expr.rs
+++ b/compiler/crates/rask-types/src/checker/check_expr.rs
@@ -247,21 +247,41 @@ impl TypeChecker {
                 self.ctx
                     .add_constraint(TypeConstraint::Equal(Type::Bool, cond_ty, expr.span));
 
-                // Type narrowing: if the condition is `opt is Some` (OPT10),
+                // Type narrowing: if the condition is `opt is Some` (legacy OPT10),
                 // rebind `opt` to the inner type inside the then-branch.
                 let narrowing = self.extract_is_some_narrowing(cond);
+
+                // OPT19/ER19: `if x?` on a const Option/Result narrows.
+                // ER21: for Result, the else-branch narrows to E.
+                let presence_narrowing = self.extract_is_present_narrowing(cond);
 
                 if let Some((ref var_name, ref inner_ty)) = narrowing {
                     self.push_scope();
                     self.define_local(var_name.clone(), inner_ty.clone());
+                } else if let Some((ref var_name, ref then_ty, _)) = presence_narrowing {
+                    self.push_scope();
+                    self.define_local(var_name.clone(), then_ty.clone());
                 }
                 let then_ty = self.infer_expr(then_branch);
-                if narrowing.is_some() {
+                if narrowing.is_some() || presence_narrowing.is_some() {
                     self.pop_scope();
                 }
 
                 if let Some(else_branch) = else_branch {
+                    // ER21: narrow the else branch to E for Result scrutinees.
+                    let else_narrowed = matches!(
+                        &presence_narrowing,
+                        Some((_, _, Some(_)))
+                    );
+                    if else_narrowed {
+                        let (var_name, _, else_ty) = presence_narrowing.as_ref().unwrap();
+                        self.push_scope();
+                        self.define_local(var_name.clone(), else_ty.clone().unwrap());
+                    }
                     let else_ty = self.infer_expr(else_branch);
+                    if else_narrowed {
+                        self.pop_scope();
+                    }
                     let resolved_then = self.ctx.apply(&then_ty);
                     let resolved_else = self.ctx.apply(&else_ty);
                     // Never coerces to any type (CF32) — don't constrain
@@ -2023,6 +2043,42 @@ impl TypeChecker {
             // Handle `opt is Some && ...` — narrow on the left side
             ExprKind::Binary { op: rask_ast::expr::BinOp::And, left, .. } => {
                 self.extract_is_some_narrowing(left)
+            }
+            _ => None,
+        }
+    }
+
+    /// Detect `if x?` on an Option or Result bound locally. Returns the
+    /// variable name, the then-branch type, and (for Result) the else-branch
+    /// type. OPT19/OPT21 for Option; ER19/ER21 for Result.
+    ///
+    /// Narrowing only applies when the scrutinee is a plain const-bound ident —
+    /// mutability and compound expressions are rejected to keep the rule
+    /// structural (no flow analysis).
+    pub(super) fn extract_is_present_narrowing(
+        &self,
+        cond: &Expr,
+    ) -> Option<(String, Type, Option<Type>)> {
+        let ExprKind::IsPresent { expr: inner } = &cond.kind else {
+            return None;
+        };
+        let ExprKind::Ident(var_name) = &inner.kind else {
+            return None;
+        };
+        // OPT19/ER19: const scrutinee only. Mut requires `as v` bind (OPT20/ER20).
+        if !self.is_local_read_only(var_name) {
+            return None;
+        }
+        let var_ty = self.lookup_local(var_name)?;
+        let resolved = self.ctx.apply(&var_ty);
+        match resolved {
+            Type::Option(inner_ty) => {
+                // Option: then = T, else = no narrowing (information-only).
+                Some((var_name.clone(), *inner_ty, None))
+            }
+            Type::Result { ok, err } => {
+                // Result: then = T, else = E.
+                Some((var_name.clone(), *ok, Some(*err)))
             }
             _ => None,
         }


### PR DESCRIPTION
## Summary
This PR implements the postfix `?` operator as a presence predicate for `Option` and `Result` types, with support for type narrowing in `if` conditions and optional binding via `as v` syntax.

## Key Changes

### Parser (`rask-parser`)
- Changed postfix `?` from `Try` expression to new `IsPresent` expression kind
- Added support for `expr? as v` syntax to bind the inner payload as a fresh const variable
- Added validation to reject `!x?` (prefix `!` with suffix `?`), suggesting alternatives like `x == none` or `r is E`

### AST (`rask-ast`)
- Added new `IsPresent` variant to `ExprKind` with optional `binding` field for the `as v` clause
- Kept existing `Try` expression for prefix `try expr` error propagation

### Type Checker (`rask-types`)
- Implemented `extract_is_present_narrowing()` to detect presence checks in if-conditions
- Added type narrowing for `if x?` (OPT19/ER19) when scrutinee is a const-bound identifier
- Added type narrowing for `if expr? as v` (OPT20/ER20) with fresh const binding
- For `Result`, the else-branch narrows to the error type (ER21)
- `IsPresent` expressions evaluate to `Bool` type

### Resolver (`rask-resolve`)
- Added scope management for `if expr? as v` bindings in both then and else branches
- Binds the optional variable as a read-only const in the appropriate branch scope

### Interpreter (`rask-interp`)
- Implemented evaluation of `IsPresent` expressions, checking for `Some`/`Ok` variants
- Added special handling in `if` statement evaluation to bind narrowed variables and evaluate the correct branch
- For `Result` else-branches, binds the error payload to the narrowed variable name

### MIR Lowering (`rask-mir`)
- Implemented lowering of `IsPresent` to tag comparison (tag 0 = present/ok, tag 1 = absent/err)
- Uses niche optimization detection for efficient representation

### Supporting Passes
- Updated all compiler passes to handle the new `IsPresent` expression kind:
  - Semantic hashing, ownership checking, formatting, monomorphization, desugaring, effects analysis, linting, LSP indexing, and hidden parameter rewriting

## Notable Implementation Details
- The presence predicate is distinct from error propagation (`try expr`), which uses prefix syntax
- Type narrowing works seamlessly with const-bound identifiers without requiring explicit binding
- The `as v` binding syntax avoids conflicts with the `as` cast operator by consuming it at the postfix level
- Niche optimization is leveraged in MIR lowering for efficient tag representation

https://claude.ai/code/session_01RjUt43xVwS7bkScnZQYGC8