### PR TITLE
Implement Result type validation and auto-wrapping (ER3, ER4, ER9, OPT3)

### DIFF
--- a/compiler/crates/rask-ast/src/expr.rs
+++ b/compiler/crates/rask-ast/src/expr.rs
@@ -77,11 +77,14 @@ pub enum ExprKind {
     },
     /// Block expression
     Block(Vec<super::stmt::Stmt>),
-    /// If expression
+    /// If expression. `else_binding` (ER22) is the optional `as e` on the else
+    /// clause that binds the error value from a `IsPresent` cond on a Result.
+    /// `if r? { … } else as e { use(e) }`.
     If {
         cond: Box<Expr>,
         then_branch: Box<Expr>,
         else_branch: Option<Box<Expr>>,
+        else_binding: Option<String>,
     },
     /// If-is pattern matching expression (if expr is Pattern { })
     IfLet {
@@ -368,5 +371,12 @@ pub enum Pattern {
     Range {
         start: Box<Expr>,
         end: Box<Expr>,
+    },
+    /// ER23: type pattern `Type as name` — narrows the scrutinee to `Type`
+    /// and binds the value as `name`. Currently supported for `T or E` Result
+    /// errors in `if r is E as e { ... }`.
+    TypePat {
+        ty_name: String,
+        binding: Option<String>,
     },
 }

--- a/compiler/crates/rask-ast/src/expr.rs
+++ b/compiler/crates/rask-ast/src/expr.rs
@@ -30,6 +30,9 @@ pub enum ExprKind {
     Bool(bool),
     /// Null pointer literal
     Null,
+    /// OPT3: absent sentinel for `T?`. Dedicated literal — not tied to the
+    /// `None` enum variant. Context infers the inner type `T`.
+    None,
     /// Identifier
     Ident(String),
     /// Binary operation

--- a/compiler/crates/rask-compiler/src/derive.rs
+++ b/compiler/crates/rask-compiler/src/derive.rs
@@ -118,6 +118,7 @@ fn gen_struct_compare(
                 })))),
             ]))),
             else_branch: None,
+            else_binding: None,
         }))));
 
         // if self.field > other.field { return 1 }
@@ -131,6 +132,7 @@ fn gen_struct_compare(
                 stmt(StmtKind::Return(Some(expr(ExprKind::Int(1, None))))),
             ]))),
             else_branch: None,
+            else_binding: None,
         }))));
     }
 

--- a/compiler/crates/rask-comptime/src/lib.rs
+++ b/compiler/crates/rask-comptime/src/lib.rs
@@ -219,7 +219,7 @@ fn eliminate_in_expr(expr: &mut Expr, cfg_values: &HashMap<String, String>) {
             eliminate_in_expr(index, cfg_values);
         }
         ExprKind::Block(stmts) => eliminate_in_stmts(stmts, cfg_values),
-        ExprKind::If { cond, then_branch, else_branch } => {
+        ExprKind::If { cond, then_branch, else_branch, .. } => {
             eliminate_in_expr(cond, cfg_values);
             eliminate_in_expr(then_branch, cfg_values);
             if let Some(e) = else_branch { eliminate_in_expr(e, cfg_values); }
@@ -261,7 +261,7 @@ fn try_eval_comptime_if_stmts(stmts: &[Stmt], cfg_values: &HashMap<String, Strin
         _ => return None,
     };
     let (cond, then_branch, else_branch) = match &inner.kind {
-        ExprKind::If { cond, then_branch, else_branch } => (cond, then_branch, else_branch),
+        ExprKind::If { cond, then_branch, else_branch, .. } => (cond, then_branch, else_branch),
         _ => return None,
     };
 
@@ -895,6 +895,7 @@ impl ComptimeInterpreter {
                 cond,
                 then_branch,
                 else_branch,
+                ..
             } => {
                 let cond_val = self.eval_expr(cond)?;
                 let cond_bool = cond_val.as_bool().ok_or_else(|| ComptimeError::TypeMismatch {
@@ -2013,6 +2014,10 @@ impl ComptimeInterpreter {
                     _ => false,
                 })
             }
+            Pattern::TypePat { ty_name, .. } => {
+                // Match when the value's enum tag matches the named type.
+                Ok(matches!(value, ComptimeValue::Enum { variant, .. } if variant == ty_name))
+            }
         }
     }
 
@@ -2071,6 +2076,12 @@ impl ComptimeInterpreter {
                 Ok(())
             }
             Pattern::Range { .. } => Ok(()),
+            Pattern::TypePat { binding, .. } => {
+                if let Some(name) = binding {
+                    self.env.define(name.clone(), value.clone());
+                }
+                Ok(())
+            }
         }
     }
 }

--- a/compiler/crates/rask-desugar/src/defaults.rs
+++ b/compiler/crates/rask-desugar/src/defaults.rs
@@ -427,7 +427,7 @@ impl DefaultDesugarer {
             ExprKind::Block(stmts) => {
                 for s in stmts { self.desugar_stmt(s); }
             }
-            ExprKind::If { cond, then_branch, else_branch } => {
+            ExprKind::If { cond, then_branch, else_branch, .. } => {
                 self.desugar_expr(cond);
                 self.desugar_expr(then_branch);
                 if let Some(e) = else_branch { self.desugar_expr(e); }

--- a/compiler/crates/rask-desugar/src/defaults.rs
+++ b/compiler/crates/rask-desugar/src/defaults.rs
@@ -40,7 +40,8 @@ pub fn is_valid_default_expr(expr: &Expr) -> bool {
         | ExprKind::StringInterp(_)
         | ExprKind::Char(_)
         | ExprKind::Bool(_)
-        | ExprKind::Null => true,
+        | ExprKind::Null
+        | ExprKind::None => true,
 
         // Negated literal: -1, -3.14
         ExprKind::Unary { op: rask_ast::expr::UnaryOp::Neg, operand } => {
@@ -287,6 +288,7 @@ fn clone_expr_kind(
         ExprKind::Char(c) => ExprKind::Char(*c),
         ExprKind::Bool(b) => ExprKind::Bool(*b),
         ExprKind::Null => ExprKind::Null,
+        ExprKind::None => ExprKind::None,
         ExprKind::Ident(n) => ExprKind::Ident(n.clone()),
         ExprKind::Field { object, field } => ExprKind::Field {
             object: Box::new(clone_expr_with_fresh_ids(object, fresh_id)),
@@ -514,7 +516,7 @@ impl DefaultDesugarer {
             // Terminals
             ExprKind::Int(_, _) | ExprKind::Float(_, _) | ExprKind::String(_)
             | ExprKind::StringInterp(_) | ExprKind::Char(_) | ExprKind::Bool(_)
-            | ExprKind::Ident(_) | ExprKind::Null => {}
+            | ExprKind::Ident(_) | ExprKind::Null | ExprKind::None => {}
         }
 
         // After recursing, try to resolve defaults at this call site

--- a/compiler/crates/rask-desugar/src/lib.rs
+++ b/compiler/crates/rask-desugar/src/lib.rs
@@ -377,6 +377,7 @@ impl Desugarer {
                 cond,
                 then_branch,
                 else_branch,
+                ..
             } => {
                 self.desugar_expr(cond);
                 self.desugar_expr(then_branch);

--- a/compiler/crates/rask-desugar/src/lib.rs
+++ b/compiler/crates/rask-desugar/src/lib.rs
@@ -512,6 +512,7 @@ impl Desugarer {
             | ExprKind::Bool(_)
             | ExprKind::Ident(_)
             | ExprKind::Null
+            | ExprKind::None
             => {}
             ExprKind::String(_) | ExprKind::StringInterp(_) => {
                 // String interpolation desugaring handled below

--- a/compiler/crates/rask-diagnostics/src/convert.rs
+++ b/compiler/crates/rask-diagnostics/src/convert.rs
@@ -688,6 +688,20 @@ impl ToDiagnostic for rask_types::TypeError {
                     .with_help(format!("add `extend {ty} {{ func message(self) -> string {{ ... }} }}`"))
                     .with_why("every error type must provide `func message(self) -> string`; primitives don't qualify — newtype them [type.errors/ER4]")
             }
+            ElseBindingNotResult { name, span } => {
+                Diagnostic::error(format!("`else as {}` requires a Result condition", name))
+                    .with_code("E0345")
+                    .with_primary(*span, "the `if` condition has no error to bind")
+                    .with_help("use `else as e` only when the condition is `if r?` on a `T or E`")
+                    .with_why("`else as e` binds the error branch of a Result — Option absence has no payload [type.errors/ER22]")
+            }
+            TypePatternNotResult { ty_name, found, span } => {
+                Diagnostic::error(format!("type pattern `{}` needs a Result scrutinee", ty_name))
+                    .with_code("E0346")
+                    .with_primary(*span, format!("found `{}`", found))
+                    .with_help("type patterns narrow the error side of `T or E`; the scrutinee must be a Result")
+                    .with_why("`is Type as name` dispatches on the error branch — not applicable to other types [type.errors/ER23]")
+            }
         }
     }
 }

--- a/compiler/crates/rask-diagnostics/src/convert.rs
+++ b/compiler/crates/rask-diagnostics/src/convert.rs
@@ -674,6 +674,20 @@ impl ToDiagnostic for rask_types::TypeError {
                     .with_primary(*span, format!("both `{}` and `{}` have value {}", first, second, value))
                     .with_why("each variant must have a unique discriminant value [type.enums/E15]")
             }
+            ResultNotDisjoint { ty, span } => {
+                Diagnostic::error(format!("`T or E` needs distinct types — both sides are `{}`", ty))
+                    .with_code("E0343")
+                    .with_primary(*span, "T and E must differ")
+                    .with_help("newtype one side (e.g. `type MyError = ...`) or pick a different error type")
+                    .with_why("type-based branch disambiguation only works when T and E are distinct [type.errors/ER3]")
+            }
+            ErrorMessageMissing { ty, span } => {
+                Diagnostic::error(format!("error type `{}` does not implement `ErrorMessage`", ty))
+                    .with_code("E0344")
+                    .with_primary(*span, format!("`{}` needs a `message` method", ty))
+                    .with_help(format!("add `extend {ty} {{ func message(self) -> string {{ ... }} }}`"))
+                    .with_why("every error type must provide `func message(self) -> string`; primitives don't qualify — newtype them [type.errors/ER4]")
+            }
         }
     }
 }

--- a/compiler/crates/rask-diagnostics/src/convert.rs
+++ b/compiler/crates/rask-diagnostics/src/convert.rs
@@ -702,6 +702,13 @@ impl ToDiagnostic for rask_types::TypeError {
                     .with_help("type patterns narrow the error side of `T or E`; the scrutinee must be a Result")
                     .with_why("`is Type as name` dispatches on the error branch — not applicable to other types [type.errors/ER23]")
             }
+            TypePatternNotInUnion { ty_name, union, span } => {
+                Diagnostic::error(format!("`{}` is not a component of `{}`", ty_name, union))
+                    .with_code("E0347")
+                    .with_primary(*span, format!("not in `{}`", union))
+                    .with_help("the type in a type pattern must appear in the Result's error union")
+                    .with_why("type dispatch can only match types that the Result is declared to contain [type.errors/ER23]")
+            }
         }
     }
 }

--- a/compiler/crates/rask-diagnostics/src/convert.rs
+++ b/compiler/crates/rask-diagnostics/src/convert.rs
@@ -709,6 +709,35 @@ impl ToDiagnostic for rask_types::TypeError {
                     .with_help("the type in a type pattern must appear in the Result's error union")
                     .with_why("type dispatch can only match types that the Result is declared to contain [type.errors/ER23]")
             }
+            LegacyWrapperConstructor { name, span } => {
+                let (what, fix) = match name.as_str() {
+                    "Some" => (
+                        "Option has no `Some` constructor — bare values auto-wrap at return/assignment",
+                        "drop the wrapper: `return value` instead of `return Some(value)`",
+                    ),
+                    "Ok" => (
+                        "Result has no `Ok` constructor — bare T values auto-wrap at return",
+                        "drop the wrapper: `return value` instead of `return Ok(value)`",
+                    ),
+                    "Err" => (
+                        "Result has no `Err` constructor — return the error value directly",
+                        "drop the wrapper: `return MyError.Variant` instead of `return Err(MyError.Variant)`",
+                    ),
+                    _ => ("legacy wrapper constructor", "remove the wrapper"),
+                };
+                Diagnostic::error(format!("`{}(...)` is no longer a valid constructor", name))
+                    .with_code("E0348")
+                    .with_primary(*span, format!("`{}` is not callable", name))
+                    .with_help(fix)
+                    .with_why(format!("{} [type.optionals/OPT2, type.errors/ER2]", what))
+            }
+            MatchOnOption { span } => {
+                Diagnostic::error("match on an Option is not supported")
+                    .with_code("E0349")
+                    .with_primary(*span, "Option is not a user enum")
+                    .with_help("use the ?-operator family: `if x? { ... } else { ... }`, `x?.field ?? default`, or `if x == none { return }`")
+                    .with_why("Option has two states — the operator family covers both more concisely [type.optionals/NO_MATCH]")
+            }
         }
     }
 }

--- a/compiler/crates/rask-effects/src/infer.rs
+++ b/compiler/crates/rask-effects/src/infer.rs
@@ -294,7 +294,7 @@ fn classify_expr(expr: &Expr, effects: &mut Effects, callees: &mut HashSet<Strin
             classify_expr(index, effects, callees);
         }
         ExprKind::Block(stmts) => classify_body(stmts, effects, callees),
-        ExprKind::If { cond, then_branch, else_branch } => {
+        ExprKind::If { cond, then_branch, else_branch, .. } => {
             classify_expr(cond, effects, callees);
             classify_expr(then_branch, effects, callees);
             if let Some(e) = else_branch {

--- a/compiler/crates/rask-effects/src/infer.rs
+++ b/compiler/crates/rask-effects/src/infer.rs
@@ -405,6 +405,7 @@ fn classify_expr(expr: &Expr, effects: &mut Effects, callees: &mut HashSet<Strin
         | ExprKind::Char(_)
         | ExprKind::Bool(_)
         | ExprKind::Null
+        | ExprKind::None
         | ExprKind::Ident(_) => {}
     }
 }

--- a/compiler/crates/rask-effects/src/warnings.rs
+++ b/compiler/crates/rask-effects/src/warnings.rs
@@ -295,7 +295,7 @@ impl<'a> WarnContext<'a> {
             // Leaves
             ExprKind::Int(_, _) | ExprKind::Float(_, _) | ExprKind::String(_)
             | ExprKind::StringInterp(_)
-            | ExprKind::Char(_) | ExprKind::Bool(_) | ExprKind::Null
+            | ExprKind::Char(_) | ExprKind::Bool(_) | ExprKind::Null | ExprKind::None
             | ExprKind::Ident(_) => {}
         }
     }

--- a/compiler/crates/rask-effects/src/warnings.rs
+++ b/compiler/crates/rask-effects/src/warnings.rs
@@ -211,7 +211,7 @@ impl<'a> WarnContext<'a> {
                 self.check_expr(index, warnings);
             }
             ExprKind::Block(stmts) => self.check_stmts(stmts, warnings),
-            ExprKind::If { cond, then_branch, else_branch } => {
+            ExprKind::If { cond, then_branch, else_branch, .. } => {
                 self.check_expr(cond, warnings);
                 self.check_expr(then_branch, warnings);
                 if let Some(e) = else_branch { self.check_expr(e, warnings); }

--- a/compiler/crates/rask-fmt/src/printer.rs
+++ b/compiler/crates/rask-fmt/src/printer.rs
@@ -1386,6 +1386,7 @@ impl<'a> Printer<'a> {
                 let text = self.source_text(expr.span).to_string();
                 self.emit(&text);
             }
+            ExprKind::None => self.emit("none"),
             ExprKind::StringInterp(_) => {
                 let text = self.source_text(expr.span).to_string();
                 self.emit(&text);

--- a/compiler/crates/rask-fmt/src/printer.rs
+++ b/compiler/crates/rask-fmt/src/printer.rs
@@ -1485,8 +1485,8 @@ impl<'a> Printer<'a> {
                     self.emit("}");
                 }
             }
-            ExprKind::If { cond, then_branch, else_branch } => {
-                self.format_if_expr(cond, then_branch, else_branch);
+            ExprKind::If { cond, then_branch, else_branch, else_binding } => {
+                self.format_if_expr(cond, then_branch, else_branch, else_binding.as_deref());
             }
             ExprKind::IfLet { expr: scrutinee, pattern, then_branch, else_branch } => {
                 self.emit("if ");
@@ -1847,7 +1847,13 @@ impl<'a> Printer<'a> {
         }
     }
 
-    fn format_if_expr(&mut self, cond: &Expr, then_branch: &Expr, else_branch: &Option<Box<Expr>>) {
+    fn format_if_expr(
+        &mut self,
+        cond: &Expr,
+        then_branch: &Expr,
+        else_branch: &Option<Box<Expr>>,
+        else_binding: Option<&str>,
+    ) {
         self.emit("if ");
         self.format_expr(cond);
 
@@ -1855,7 +1861,12 @@ impl<'a> Printer<'a> {
             self.emit(": ");
             self.format_expr(then_branch);
             if let Some(ref else_br) = else_branch {
-                self.emit(" else: ");
+                self.emit(" else");
+                if let Some(name) = else_binding {
+                    self.emit(" as ");
+                    self.emit(name);
+                }
+                self.emit(": ");
                 self.format_expr(else_br);
             }
             return;
@@ -1869,6 +1880,10 @@ impl<'a> Printer<'a> {
                 self.format_expr(else_br);
             } else {
                 self.emit(" else");
+                if let Some(name) = else_binding {
+                    self.emit(" as ");
+                    self.emit(name);
+                }
                 self.format_branch(else_br);
             }
         }
@@ -1978,6 +1993,13 @@ impl<'a> Printer<'a> {
                 self.format_expr(start);
                 self.emit("..=");
                 self.format_expr(end);
+            }
+            Pattern::TypePat { ty_name, binding } => {
+                self.emit(ty_name);
+                if let Some(name) = binding {
+                    self.emit(" as ");
+                    self.emit(name);
+                }
             }
         }
     }

--- a/compiler/crates/rask-hidden-params/src/resolve.rs
+++ b/compiler/crates/rask-hidden-params/src/resolve.rs
@@ -296,7 +296,7 @@ fn expr_accesses_handle_fields(expr: &Expr, handle_names: &[&str]) -> bool {
             expr_accesses_handle_fields(object, handle_names)
                 || expr_accesses_handle_fields(index, handle_names)
         }
-        ExprKind::If { cond, then_branch, else_branch } => {
+        ExprKind::If { cond, then_branch, else_branch, .. } => {
             expr_accesses_handle_fields(cond, handle_names)
                 || expr_accesses_handle_fields(then_branch, handle_names)
                 || else_branch.as_ref().map_or(false, |e| expr_accesses_handle_fields(e, handle_names))

--- a/compiler/crates/rask-interp/src/builtins/enums.rs
+++ b/compiler/crates/rask-interp/src/builtins/enums.rs
@@ -171,6 +171,15 @@ impl Interpreter {
                 }),
                 _ => Err(RuntimeError::TypeError("expected Option.Some or Option.None variant".to_string())),
             },
+            // `x == none` desugars to `x.eq(none)` — compare by variant
+            "eq" if args.len() == 1 => {
+                let is_none = variant == "None";
+                let arg_is_none = matches!(
+                    &args[0],
+                    Value::Enum { name, variant: v, .. } if name == "Option" && v == "None"
+                );
+                Ok(Value::Bool(is_none == arg_is_none))
+            }
             _ => Err(RuntimeError::NoSuchMethod {
                 ty: "Option".to_string(),
                 method: method.to_string(),

--- a/compiler/crates/rask-interp/src/interp/call.rs
+++ b/compiler/crates/rask-interp/src/interp/call.rs
@@ -99,15 +99,31 @@ impl Interpreter {
             .map(|t| t.ends_with('?'))
             .unwrap_or(false);
         if returns_result {
-            match &value {
-                Value::Enum { name, .. } if name == "Result" => Ok(value),
-                _ => Ok(Value::Enum {
-                    name: "Result".to_string(),
-                    variant: "Ok".to_string(),
-                    fields: vec![value],
-                    variant_index: 0, origin: None,
-                }),
+            // Already a Result: pass through.
+            if matches!(&value, Value::Enum { name, .. } if name == "Result") {
+                return Ok(value);
             }
+            // ER9: pick the branch by the value's runtime type. If the value
+            // matches E (or a variant of a union E), wrap as Err; else Ok.
+            // Disjointness (ER3) makes this unambiguous.
+            let err_names = func.ret_ty.as_ref()
+                .map(|t| extract_result_err_names(t))
+                .unwrap_or_default();
+            let is_err_branch = value_matches_any_type(&value, &err_names);
+            if is_err_branch {
+                return Ok(Value::Enum {
+                    name: "Result".to_string(),
+                    variant: "Err".to_string(),
+                    fields: vec![value],
+                    variant_index: 1, origin: None,
+                });
+            }
+            return Ok(Value::Enum {
+                name: "Result".to_string(),
+                variant: "Ok".to_string(),
+                fields: vec![value],
+                variant_index: 0, origin: None,
+            });
         } else if returns_option {
             match &value {
                 Value::Enum { name, .. } if name == "Option" => Ok(value),
@@ -242,6 +258,74 @@ impl Interpreter {
             let _ = self.exec_ensure_body(handler);
             self.env.pop_scope();
         }
+    }
+}
+
+/// Extract the E type names from a `Result<T, E>` string. Handles union
+/// errors `Result<T, A | B | C>` by returning each component.
+fn extract_result_err_names(ret_ty: &str) -> Vec<String> {
+    let Some(rest) = ret_ty.strip_prefix("Result<").and_then(|s| s.strip_suffix('>')) else {
+        return Vec::new();
+    };
+    // Split at the top-level comma separating T from E.
+    let mut depth: i32 = 0;
+    let mut split_at: Option<usize> = None;
+    for (i, c) in rest.char_indices() {
+        match c {
+            '<' | '(' => depth += 1,
+            '>' | ')' => depth -= 1,
+            ',' if depth == 0 => { split_at = Some(i); break; }
+            _ => {}
+        }
+    }
+    let Some(idx) = split_at else { return Vec::new() };
+    let err_str = rest[idx + 1..].trim();
+    // Strip outer parens if present.
+    let err_str = err_str
+        .strip_prefix('(').and_then(|s| s.strip_suffix(')'))
+        .map(str::trim)
+        .unwrap_or(err_str);
+    // Split by `|` at depth 0 (for union errors).
+    let mut out = Vec::new();
+    let mut depth = 0;
+    let mut start = 0;
+    for (i, c) in err_str.char_indices() {
+        match c {
+            '<' | '(' => depth += 1,
+            '>' | ')' => depth -= 1,
+            '|' if depth == 0 => {
+                out.push(err_str[start..i].trim().to_string());
+                start = i + 1;
+            }
+            _ => {}
+        }
+    }
+    if start < err_str.len() {
+        out.push(err_str[start..].trim().to_string());
+    }
+    out
+}
+
+/// Does the runtime value match any of the named types?
+fn value_matches_any_type(value: &Value, names: &[String]) -> bool {
+    if names.is_empty() {
+        return false;
+    }
+    let value_type_name: Option<&str> = match value {
+        Value::Enum { name, .. } => Some(name.as_str()),
+        Value::Struct(s) => {
+            let guard = s.lock().unwrap();
+            if names.iter().any(|n| n == &guard.name) {
+                return true;
+            }
+            None
+        }
+        _ => None,
+    };
+    if let Some(vn) = value_type_name {
+        names.iter().any(|n| n == vn)
+    } else {
+        false
     }
 }
 

--- a/compiler/crates/rask-interp/src/interp/eval_expr.rs
+++ b/compiler/crates/rask-interp/src/interp/eval_expr.rs
@@ -162,6 +162,14 @@ impl Interpreter {
             }
             ExprKind::Char(c) => Ok(Value::Char(*c)),
             ExprKind::Bool(b) => Ok(Value::Bool(*b)),
+            // OPT3: `none` is Option::None — a stateless sentinel, cheaply cloned.
+            ExprKind::None => Ok(Value::Enum {
+                name: "Option".to_string(),
+                variant: "None".to_string(),
+                fields: vec![],
+                variant_index: 1,
+                origin: None,
+            }),
 
             ExprKind::Ident(name) => {
                 if let Some(val) = self.env.get(name) {

--- a/compiler/crates/rask-interp/src/interp/eval_expr.rs
+++ b/compiler/crates/rask-interp/src/interp/eval_expr.rs
@@ -589,17 +589,20 @@ impl Interpreter {
                 cond,
                 then_branch,
                 else_branch,
+                else_binding,
             } => {
-                // OPT19/OPT20 + ER19/ER20/ER21: `if x?` or `if expr? as v`
+                // OPT19/OPT20 + ER19/ER20/ER21/ER22: `if x?` or `if expr? as v`
                 // evaluates the scrutinee once and rebinds the payload as the
-                // narrow name (scrutinee ident for plain, `v` for `as v`).
+                // narrow name (scrutinee ident for plain, `v` for `as v`,
+                // `else as e` for the else branch).
                 if let ExprKind::IsPresent { expr: inner, binding } = &cond.kind {
-                    let narrow_name = match (binding, &inner.kind) {
+                    let then_name = match (binding, &inner.kind) {
                         (Some(v), _) => Some(v.clone()),
                         (None, ExprKind::Ident(n)) => Some(n.clone()),
                         _ => None,
                     };
-                    if let Some(name) = narrow_name {
+                    let else_name = else_binding.clone().or_else(|| then_name.clone());
+                    if then_name.is_some() || else_name.is_some() {
                         let scrutinee_val = self.eval_expr(inner)?;
                         let present = matches!(
                             &scrutinee_val,
@@ -611,7 +614,9 @@ impl Interpreter {
                                 _ => Value::Unit,
                             };
                             self.env.push_scope();
-                            self.env.define(name, payload);
+                            if let Some(name) = then_name {
+                                self.env.define(name, payload);
+                            }
                             let result = self.eval_expr(then_branch);
                             self.env.pop_scope();
                             return result;
@@ -620,7 +625,7 @@ impl Interpreter {
                                 Value::Enum { fields, .. } => fields.first().cloned(),
                                 _ => None,
                             };
-                            if let Some(p) = payload {
+                            if let (Some(name), Some(p)) = (else_name, payload) {
                                 // Result Err branch binds E; Option None has no payload.
                                 self.env.push_scope();
                                 self.env.define(name, p);

--- a/compiler/crates/rask-interp/src/interp/eval_expr.rs
+++ b/compiler/crates/rask-interp/src/interp/eval_expr.rs
@@ -1211,6 +1211,39 @@ impl Interpreter {
             }
 
             ExprKind::Try { expr: inner, ref else_clause } => {
+                // ER17/ER18: `try { … }` block form. Catches TryError raised
+                // by inner `try` propagations and routes to the else handler.
+                // Without an else, behaves like a normal block (errors continue
+                // propagating to the enclosing function).
+                if matches!(&inner.kind, ExprKind::Block(_)) {
+                    let block_result = self.eval_expr(inner);
+                    return match block_result {
+                        Ok(v) => Ok(v),
+                        Err(diag) => match diag.error {
+                            RuntimeError::TryError(err_val) => {
+                                if let Some(ec) = else_clause {
+                                    let inner_err = match &err_val {
+                                        Value::Enum { fields, .. } => {
+                                            fields.first().cloned().unwrap_or(Value::Unit)
+                                        }
+                                        _ => err_val,
+                                    };
+                                    self.env.push_scope();
+                                    self.env.define(ec.error_binding.clone(), inner_err);
+                                    let transformed = self.eval_expr(&ec.body);
+                                    self.env.pop_scope();
+                                    transformed
+                                } else {
+                                    Err(RuntimeDiagnostic::new(
+                                        RuntimeError::TryError(err_val),
+                                        diag.span,
+                                    ))
+                                }
+                            }
+                            other => Err(RuntimeDiagnostic::new(other, diag.span)),
+                        },
+                    };
+                }
                 let val = self.eval_expr(inner)?;
                 match &val {
                     Value::Enum {

--- a/compiler/crates/rask-interp/src/interp/exec_stmt.rs
+++ b/compiler/crates/rask-interp/src/interp/exec_stmt.rs
@@ -12,8 +12,11 @@ impl Interpreter {
         match &stmt.kind {
             StmtKind::Expr(expr) => self.eval_expr(expr),
 
-            StmtKind::Const { name, init, .. } => {
-                let value = self.eval_expr(init)?;
+            StmtKind::Const { name, init, ty, .. } => {
+                let mut value = self.eval_expr(init)?;
+                if let Some(ty_str) = ty {
+                    value = auto_wrap_for_annotation(value, ty_str);
+                }
                 if let Some(id) = self.get_resource_id(&value) {
                     self.resource_tracker.set_var_name(id, name.clone());
                 }
@@ -27,6 +30,12 @@ impl Interpreter {
                 let value = if ty.as_deref() == Some("f32x8") {
                     Self::coerce_to_simd_f32x8(value)
                         .map_err(|e| RuntimeDiagnostic::new(e, stmt.span))?
+                } else {
+                    value
+                };
+                // OPT6: auto-wrap bare T into T? / T or E when annotated.
+                let value = if let Some(ty_str) = ty {
+                    auto_wrap_for_annotation(value, ty_str)
                 } else {
                     value
                 };
@@ -620,5 +629,88 @@ impl Interpreter {
             }
         }
     }
+}
+
+/// OPT6: wrap `value` to match the declared `T?` or `Result<T, E>` annotation.
+/// No-op for non-Option/non-Result annotations, or when the value is already
+/// shaped like the annotation. For Result, picks Ok vs Err by the value's type.
+fn auto_wrap_for_annotation(value: Value, ty: &str) -> Value {
+    let ty = ty.trim();
+    if ty.ends_with('?') && !ty.starts_with('(') {
+        // T? annotation
+        if matches!(&value, Value::Enum { name, .. } if name == "Option") {
+            return value;
+        }
+        return Value::Enum {
+            name: "Option".to_string(),
+            variant: "Some".to_string(),
+            fields: vec![value],
+            variant_index: 0,
+            origin: None,
+        };
+    }
+    if ty.starts_with("Result<") && ty.ends_with('>') {
+        if matches!(&value, Value::Enum { name, .. } if name == "Result") {
+            return value;
+        }
+        let err_names = extract_err_names(ty);
+        let is_err = match &value {
+            Value::Enum { name, .. } => err_names.iter().any(|n| n == name),
+            Value::Struct(s) => {
+                let guard = s.lock().unwrap();
+                err_names.iter().any(|n| n == &guard.name)
+            }
+            _ => false,
+        };
+        return Value::Enum {
+            name: "Result".to_string(),
+            variant: if is_err { "Err".to_string() } else { "Ok".to_string() },
+            fields: vec![value],
+            variant_index: if is_err { 1 } else { 0 },
+            origin: None,
+        };
+    }
+    value
+}
+
+/// Parse `Result<T, E>` and return the error type component names.
+fn extract_err_names(ty: &str) -> Vec<String> {
+    let Some(rest) = ty.strip_prefix("Result<").and_then(|s| s.strip_suffix('>')) else {
+        return Vec::new();
+    };
+    let mut depth: i32 = 0;
+    let mut split_at: Option<usize> = None;
+    for (i, c) in rest.char_indices() {
+        match c {
+            '<' | '(' => depth += 1,
+            '>' | ')' => depth -= 1,
+            ',' if depth == 0 => { split_at = Some(i); break; }
+            _ => {}
+        }
+    }
+    let Some(idx) = split_at else { return Vec::new() };
+    let err_str = rest[idx + 1..].trim();
+    let err_str = err_str
+        .strip_prefix('(').and_then(|s| s.strip_suffix(')'))
+        .map(str::trim)
+        .unwrap_or(err_str);
+    let mut out = Vec::new();
+    let mut depth = 0;
+    let mut start = 0;
+    for (i, c) in err_str.char_indices() {
+        match c {
+            '<' | '(' => depth += 1,
+            '>' | ')' => depth -= 1,
+            '|' if depth == 0 => {
+                out.push(err_str[start..i].trim().to_string());
+                start = i + 1;
+            }
+            _ => {}
+        }
+    }
+    if start < err_str.len() {
+        out.push(err_str[start..].trim().to_string());
+    }
+    out
 }
 

--- a/compiler/crates/rask-interp/src/interp/pattern.rs
+++ b/compiler/crates/rask-interp/src/interp/pattern.rs
@@ -24,6 +24,17 @@ impl Interpreter {
                         {
                             Some(HashMap::new())
                         }
+                        // ER28: for a Result scrutinee, descend into Ok/Err
+                        // and retry against the payload (so arms like
+                        // `IoError.NotFound` work against `r: T or IoError`).
+                        Value::Enum { name: en, variant, fields, .. }
+                            if en == "Result" && matches!(variant.as_str(), "Ok" | "Err") =>
+                        {
+                            if let Some(inner) = fields.first() {
+                                return self.match_pattern(pattern, inner);
+                            }
+                            None
+                        }
                         // Unit struct variant with no fields
                         Value::Struct(ref s) => {
                             let guard = s.lock().unwrap();
@@ -46,6 +57,19 @@ impl Interpreter {
                             return Some(HashMap::new());
                         } else {
                             return None;
+                        }
+                    }
+                }
+                // ER27: bare type name as match arm on a Result scrutinee —
+                // match by payload type. Primitives (`i32`, `f64`, ...) and
+                // user type names (`DivError`) match if the Ok/Err payload
+                // has that runtime type.
+                if let Value::Enum { name: sc_name, fields, .. } = value {
+                    if sc_name == "Result" {
+                        if let Some(inner) = fields.first() {
+                            if runtime_type_matches(inner, name) {
+                                return Some(HashMap::new());
+                            }
                         }
                     }
                 }
@@ -88,6 +112,14 @@ impl Interpreter {
                             }
                         }
                         return Some(bindings);
+                    }
+                    // ER28: for a Result scrutinee, descend into Ok/Err and
+                    // match against the inner value. Lets `match r { IoError.NotFound(p) => ... }`
+                    // work when r: T or IoError.
+                    if enum_name == "Result" && matches!(variant.as_str(), "Ok" | "Err") {
+                        if let Some(inner) = enum_fields.first() {
+                            return self.match_pattern(pattern, inner);
+                        }
                     }
                 }
                 None
@@ -158,40 +190,28 @@ impl Interpreter {
                 if in_range { Some(HashMap::new()) } else { None }
             }
 
-            // ER23: `r is TypeName as e` — match the Err branch of a Result,
-            // narrowing to the named error type and binding the payload.
+            // ER23/ER27: `TypeName [as name]` type pattern.
+            // For Result scrutinees, match either the Ok branch (T side) or
+            // Err branch (E side) by inspecting the payload's runtime type.
             Pattern::TypePat { ty_name, binding } => {
-                let Value::Enum { variant, fields, .. } = value else {
+                let Value::Enum { name: sc_name, variant, fields, .. } = value else {
                     return None;
                 };
-                if variant != "Err" {
+                // Only Result (and Option, but TypePat is Result-scoped) match here.
+                if sc_name != "Result" {
                     return None;
                 }
                 let inner = fields.first()?;
-                let inner_name = match inner {
-                    Value::Enum { name, .. } => name.as_str(),
-                    Value::Struct(s) => {
-                        let guard = s.lock().unwrap();
-                        if &guard.name == ty_name {
-                            let mut bindings = HashMap::new();
-                            if let Some(n) = binding {
-                                bindings.insert(n.clone(), inner.clone());
-                            }
-                            return Some(bindings);
-                        }
-                        return None;
-                    }
-                    _ => return None,
-                };
-                if inner_name == ty_name {
-                    let mut bindings = HashMap::new();
-                    if let Some(n) = binding {
-                        bindings.insert(n.clone(), inner.clone());
-                    }
-                    Some(bindings)
-                } else {
-                    None
+                if !runtime_type_matches(inner, ty_name) {
+                    return None;
                 }
+                // Found a match. Must be Ok or Err — both bind the inner.
+                let _ = variant;
+                let mut bindings = HashMap::new();
+                if let Some(n) = binding {
+                    bindings.insert(n.clone(), inner.clone());
+                }
+                Some(bindings)
             }
         }
     }
@@ -307,6 +327,29 @@ impl Interpreter {
             }
             _ => None,
         }
+    }
+}
+
+/// Does the runtime `value` have type `ty_name`?
+/// Handles primitives (`i32`, `f64`, `string`, `bool`, `char`) and named
+/// enum/struct types. Used by ER27 match type patterns.
+fn runtime_type_matches(value: &Value, ty_name: &str) -> bool {
+    match value {
+        Value::Bool(_) => ty_name == "bool",
+        Value::Char(_) => ty_name == "char",
+        Value::String(_) => ty_name == "string",
+        Value::Int(_) => matches!(
+            ty_name,
+            "i8" | "i16" | "i32" | "i64" | "u8" | "u16" | "u32" | "u64"
+                | "int" | "uint" | "isize" | "usize"
+        ),
+        Value::Float(_) => matches!(ty_name, "f32" | "f64"),
+        Value::Enum { name, .. } => name == ty_name,
+        Value::Struct(s) => {
+            let guard = s.lock().unwrap();
+            guard.name == ty_name
+        }
+        _ => false,
     }
 }
 

--- a/compiler/crates/rask-interp/src/interp/pattern.rs
+++ b/compiler/crates/rask-interp/src/interp/pattern.rs
@@ -157,6 +157,42 @@ impl Interpreter {
                 };
                 if in_range { Some(HashMap::new()) } else { None }
             }
+
+            // ER23: `r is TypeName as e` — match the Err branch of a Result,
+            // narrowing to the named error type and binding the payload.
+            Pattern::TypePat { ty_name, binding } => {
+                let Value::Enum { variant, fields, .. } = value else {
+                    return None;
+                };
+                if variant != "Err" {
+                    return None;
+                }
+                let inner = fields.first()?;
+                let inner_name = match inner {
+                    Value::Enum { name, .. } => name.as_str(),
+                    Value::Struct(s) => {
+                        let guard = s.lock().unwrap();
+                        if &guard.name == ty_name {
+                            let mut bindings = HashMap::new();
+                            if let Some(n) = binding {
+                                bindings.insert(n.clone(), inner.clone());
+                            }
+                            return Some(bindings);
+                        }
+                        return None;
+                    }
+                    _ => return None,
+                };
+                if inner_name == ty_name {
+                    let mut bindings = HashMap::new();
+                    if let Some(n) = binding {
+                        bindings.insert(n.clone(), inner.clone());
+                    }
+                    Some(bindings)
+                } else {
+                    None
+                }
+            }
         }
     }
 

--- a/compiler/crates/rask-lint/src/idiom.rs
+++ b/compiler/crates/rask-lint/src/idiom.rs
@@ -136,6 +136,7 @@ fn walk_expr_for_unwrap(expr: &Expr, source: &str, diags: &mut Vec<LintDiagnosti
             cond,
             then_branch,
             else_branch,
+            ..
         } => {
             walk_expr_for_unwrap(cond, source, diags);
             walk_expr_for_unwrap(then_branch, source, diags);
@@ -540,7 +541,7 @@ fn check_expr_for_large_unsafe(expr: &Expr, source: &str, max: usize, diags: &mu
         | ExprKind::Loop { body: stmts, .. } => {
             walk_for_large_unsafe(stmts, source, max, diags);
         }
-        ExprKind::If { cond, then_branch, else_branch } => {
+        ExprKind::If { cond, then_branch, else_branch, .. } => {
             check_expr_for_large_unsafe(cond, source, max, diags);
             check_expr_for_large_unsafe(then_branch, source, max, diags);
             if let Some(e) = else_branch {

--- a/compiler/crates/rask-lsp/src/position_index.rs
+++ b/compiler/crates/rask-lsp/src/position_index.rs
@@ -210,7 +210,7 @@ fn visit_expr(expr: &Expr, index: &mut PositionIndex) {
                 visit_stmt(stmt, index);
             }
         }
-        ExprKind::If { cond, then_branch, else_branch } => {
+        ExprKind::If { cond, then_branch, else_branch, .. } => {
             visit_expr(cond, index);
             visit_expr(then_branch, index);
             if let Some(else_br) = else_branch {

--- a/compiler/crates/rask-mir/src/hidden_params/callgraph.rs
+++ b/compiler/crates/rask-mir/src/hidden_params/callgraph.rs
@@ -394,6 +394,7 @@ fn collect_callees_from_expr(expr: &Expr, callees: &mut HashSet<String>) {
         | ExprKind::Char(_)
         | ExprKind::Bool(_)
         | ExprKind::Null
+        | ExprKind::None
         | ExprKind::Ident(_) => {}
     }
 }

--- a/compiler/crates/rask-mir/src/hidden_params/callgraph.rs
+++ b/compiler/crates/rask-mir/src/hidden_params/callgraph.rs
@@ -262,6 +262,7 @@ fn collect_callees_from_expr(expr: &Expr, callees: &mut HashSet<String>) {
             cond,
             then_branch,
             else_branch,
+            ..
         } => {
             collect_callees_from_expr(cond, callees);
             collect_callees_from_expr(then_branch, callees);

--- a/compiler/crates/rask-mir/src/hidden_params/resolve.rs
+++ b/compiler/crates/rask-mir/src/hidden_params/resolve.rs
@@ -296,7 +296,7 @@ fn expr_accesses_handle_fields(expr: &Expr, handle_names: &[&str]) -> bool {
             expr_accesses_handle_fields(object, handle_names)
                 || expr_accesses_handle_fields(index, handle_names)
         }
-        ExprKind::If { cond, then_branch, else_branch } => {
+        ExprKind::If { cond, then_branch, else_branch, .. } => {
             expr_accesses_handle_fields(cond, handle_names)
                 || expr_accesses_handle_fields(then_branch, handle_names)
                 || else_branch.as_ref().map_or(false, |e| expr_accesses_handle_fields(e, handle_names))

--- a/compiler/crates/rask-mir/src/hidden_params/rewrite.rs
+++ b/compiler/crates/rask-mir/src/hidden_params/rewrite.rs
@@ -367,6 +367,7 @@ fn rewrite_expr(pass: &mut HiddenParamPass, caller: &str, expr: &mut Expr) {
         | ExprKind::Char(_)
         | ExprKind::Bool(_)
         | ExprKind::Null
+        | ExprKind::None
         | ExprKind::Ident(_) => {}
     }
 }

--- a/compiler/crates/rask-mir/src/hidden_params/rewrite.rs
+++ b/compiler/crates/rask-mir/src/hidden_params/rewrite.rs
@@ -242,6 +242,7 @@ fn rewrite_expr(pass: &mut HiddenParamPass, caller: &str, expr: &mut Expr) {
             cond,
             then_branch,
             else_branch,
+            ..
         } => {
             rewrite_expr(pass, caller, cond);
             rewrite_expr(pass, caller, then_branch);

--- a/compiler/crates/rask-mir/src/lower/expr.rs
+++ b/compiler/crates/rask-mir/src/lower/expr.rs
@@ -589,6 +589,7 @@ impl<'a> MirLowerer<'a> {
                 cond,
                 then_branch,
                 else_branch,
+                ..
             } => self.lower_if(cond, then_branch, else_branch.as_deref()),
 
             // Match expression (spec L2)

--- a/compiler/crates/rask-mir/src/lower/expr.rs
+++ b/compiler/crates/rask-mir/src/lower/expr.rs
@@ -219,6 +219,25 @@ impl<'a> MirLowerer<'a> {
                 // Null pointer literal — zero value
                 Ok((MirOperand::Constant(MirConst::Int(0)), MirType::Ptr))
             }
+            ExprKind::None => {
+                // OPT3: `none` — identical lowering to bare `None`.
+                // Niche Option<Handle<T>> uses a sentinel; otherwise tag = 1.
+                if self.is_niche_option_expr(expr) {
+                    Ok((MirOperand::Constant(MirConst::Int(HANDLE_NONE_SENTINEL)), MirType::Handle))
+                } else {
+                    let option_ty = self.lookup_expr_type(expr)
+                        .filter(|t| matches!(t, MirType::Option(_)))
+                        .unwrap_or_else(|| MirType::Option(Box::new(MirType::I64)));
+                    let result_local = self.builder.alloc_temp(option_ty.clone());
+                    self.builder.push_stmt(MirStmt::dummy(MirStmtKind::Store {
+                        addr: result_local,
+                        offset: 0,
+                        value: MirOperand::Constant(MirConst::Int(1)), // tag = None
+                        store_size: None,
+                    }));
+                    Ok((MirOperand::Local(result_local), option_ty))
+                }
+            }
 
             // Variable reference (or bare enum variant like None)
             ExprKind::Ident(name) => {

--- a/compiler/crates/rask-mir/src/lower/expr.rs
+++ b/compiler/crates/rask-mir/src/lower/expr.rs
@@ -1125,6 +1125,36 @@ impl<'a> MirLowerer<'a> {
                     }
                 }
 
+                // `x == none` / `x != none`: desugared to x.eq(none) / !(x.eq(none)).
+                // Lower as a tag comparison — emit the option tag and compare to 1 (None).
+                let is_option_none_cmp = (method == "eq" || method == "ne")
+                    && args.len() == 1
+                    && matches!(args[0].expr.kind, ExprKind::None)
+                    && self.ctx.lookup_raw_type(object.id)
+                        .map_or(false, |ty| matches!(ty, rask_types::Type::Option(_)));
+                if is_option_none_cmp {
+                    let is_niche = self.is_niche_option_expr(object);
+                    let tag_local = self.emit_option_tag(&obj_op, is_niche);
+                    let result = self.builder.alloc_temp(MirType::Bool);
+                    // tag == 1 means None; tag == 0 means Some.
+                    // eq(none) → true when None (tag == 1)
+                    // ne(none) → true when Some (tag == 0), i.e. tag != 1
+                    let cmp_op = if method == "eq" {
+                        crate::operand::BinOp::Eq
+                    } else {
+                        crate::operand::BinOp::Ne
+                    };
+                    self.builder.push_stmt(MirStmt::dummy(MirStmtKind::Assign {
+                        dst: result,
+                        rvalue: MirRValue::BinaryOp {
+                            op: cmp_op,
+                            left: MirOperand::Local(tag_local),
+                            right: MirOperand::Constant(MirConst::Int(1)),
+                        },
+                    }));
+                    return Ok((MirOperand::Local(result), MirType::Bool));
+                }
+
                 // Skip native binop for types that need C runtime calls (strings,
                 // SIMD vectors) or special method dispatch (raw pointers:
                 // ptr.add != arithmetic add).

--- a/compiler/crates/rask-mir/src/lower/mod.rs
+++ b/compiler/crates/rask-mir/src/lower/mod.rs
@@ -1236,7 +1236,7 @@ impl<'a> MirLowerer<'a> {
                     self.walk_free_vars(&arg.expr, bound, seen, free);
                 }
             }
-            ExprKind::If { cond, then_branch, else_branch } => {
+            ExprKind::If { cond, then_branch, else_branch, .. } => {
                 self.walk_free_vars(cond, bound, seen, free);
                 self.walk_free_vars(then_branch, bound, seen, free);
                 if let Some(e) = else_branch {
@@ -1484,6 +1484,11 @@ fn collect_pattern_names(
             if let Some(first) = alts.first() { collect_pattern_names(first, names); }
         }
         Pattern::Wildcard | Pattern::Literal(_) | Pattern::Range { .. } => {}
+        Pattern::TypePat { binding, .. } => {
+            if let Some(name) = binding {
+                names.insert(name.clone());
+            }
+        }
     }
 }
 
@@ -1863,6 +1868,7 @@ mod tests {
                 cond: Box::new(cond),
                 then_branch: Box::new(then_br),
                 else_branch: else_br.map(Box::new),
+                else_binding: None,
             },
             span: sp(),
         }

--- a/compiler/crates/rask-mir/src/lower/mod.rs
+++ b/compiler/crates/rask-mir/src/lower/mod.rs
@@ -1364,7 +1364,7 @@ impl<'a> MirLowerer<'a> {
             // Literals — no free variables
             ExprKind::Int(..) | ExprKind::Float(..) | ExprKind::String(..)
             | ExprKind::StringInterp(..)
-            | ExprKind::Char(..) | ExprKind::Bool(..) | ExprKind::Null => {}
+            | ExprKind::Char(..) | ExprKind::Bool(..) | ExprKind::Null | ExprKind::None => {}
         }
     }
 

--- a/compiler/crates/rask-mir/src/lower/stmt.rs
+++ b/compiler/crates/rask-mir/src/lower/stmt.rs
@@ -485,7 +485,7 @@ impl<'a> MirLowerer<'a> {
             _ => return Ok(None),
         };
         let (cond, then_branch, else_branch) = match &inner.kind {
-            ExprKind::If { cond, then_branch, else_branch } => (cond, then_branch, else_branch),
+            ExprKind::If { cond, then_branch, else_branch, .. } => (cond, then_branch, else_branch),
             _ => return Ok(None),
         };
 

--- a/compiler/crates/rask-mono/src/instantiate.rs
+++ b/compiler/crates/rask-mono/src/instantiate.rs
@@ -416,10 +416,12 @@ impl TypeSubstitutor {
                     cond,
                     then_branch,
                     else_branch,
+                    else_binding,
                 } => ExprKind::If {
                     cond: Box::new(self.clone_expr(cond)),
                     then_branch: Box::new(self.clone_expr(then_branch)),
                     else_branch: else_branch.as_ref().map(|e| Box::new(self.clone_expr(e))),
+                    else_binding: else_binding.clone(),
                 },
                 ExprKind::IfLet {
                     expr,
@@ -622,6 +624,10 @@ impl TypeSubstitutor {
             Pattern::Range { start, end } => Pattern::Range {
                 start: start.clone(),
                 end: end.clone(),
+            },
+            Pattern::TypePat { ty_name, binding } => Pattern::TypePat {
+                ty_name: ty_name.clone(),
+                binding: binding.clone(),
             },
         }
     }

--- a/compiler/crates/rask-mono/src/instantiate.rs
+++ b/compiler/crates/rask-mono/src/instantiate.rs
@@ -352,6 +352,7 @@ impl TypeSubstitutor {
                 ExprKind::Char(c) => ExprKind::Char(*c),
                 ExprKind::Bool(b) => ExprKind::Bool(*b),
                 ExprKind::Null => ExprKind::Null,
+                ExprKind::None => ExprKind::None,
 
                 // Variables
                 ExprKind::Ident(name) => ExprKind::Ident(name.clone()),

--- a/compiler/crates/rask-mono/src/lib.rs
+++ b/compiler/crates/rask-mono/src/lib.rs
@@ -780,6 +780,7 @@ mod tests {
                         }),
                         then_branch: Box::new(call_expr("a", vec![])),
                         else_branch: Some(Box::new(call_expr("b", vec![]))),
+                        else_binding: None,
                     },
                     span: sp(),
                 })],

--- a/compiler/crates/rask-mono/src/reachability.rs
+++ b/compiler/crates/rask-mono/src/reachability.rs
@@ -364,6 +364,7 @@ impl<'a> Monomorphizer<'a> {
                 cond,
                 then_branch,
                 else_branch,
+                ..
             } => {
                 self.visit_expr(cond);
                 self.visit_expr(then_branch);

--- a/compiler/crates/rask-mono/src/reachability.rs
+++ b/compiler/crates/rask-mono/src/reachability.rs
@@ -505,6 +505,7 @@ impl<'a> Monomorphizer<'a> {
             | ExprKind::Char(_)
             | ExprKind::Bool(_)
             | ExprKind::Null
+            | ExprKind::None
             | ExprKind::Ident(_) => {}
         }
     }

--- a/compiler/crates/rask-ownership/src/lib.rs
+++ b/compiler/crates/rask-ownership/src/lib.rs
@@ -859,7 +859,7 @@ impl<'a> OwnershipChecker<'a> {
                 // SL1: Record scope limit for the next binding to pick up
                 self.last_closure_scope_limit = scope_limit;
             }
-            ExprKind::If { cond, then_branch, else_branch } => {
+            ExprKind::If { cond, then_branch, else_branch, .. } => {
                 self.check_expr(cond);
                 let pre_branch = self.bindings.clone();
                 self.check_expr(then_branch);
@@ -1592,6 +1592,11 @@ impl<'a> OwnershipChecker<'a> {
                 }
             }
             Pattern::Wildcard | Pattern::Literal(_) | Pattern::Range { .. } => {}
+            Pattern::TypePat { binding, .. } => {
+                if let Some(name) = binding {
+                    self.bindings.insert(name.clone(), BindingState::Owned);
+                }
+            }
         }
     }
 
@@ -1695,7 +1700,7 @@ impl<'a> OwnershipChecker<'a> {
                 self.collect_free_vars_inner(object, locals, out, projections);
                 self.collect_free_vars_inner(index, locals, out, projections);
             }
-            ExprKind::If { cond, then_branch, else_branch } => {
+            ExprKind::If { cond, then_branch, else_branch, .. } => {
                 self.collect_free_vars_inner(cond, locals, out, projections);
                 self.collect_free_vars_inner(then_branch, locals, out, projections);
                 if let Some(e) = else_branch { self.collect_free_vars_inner(e, locals, out, projections); }

--- a/compiler/crates/rask-ownership/src/lib.rs
+++ b/compiler/crates/rask-ownership/src/lib.rs
@@ -563,7 +563,7 @@ impl<'a> OwnershipChecker<'a> {
             }
             ExprKind::Int(_, _) | ExprKind::Float(_, _) | ExprKind::String(_)
             | ExprKind::StringInterp(_)
-            | ExprKind::Char(_) | ExprKind::Bool(_) | ExprKind::Null => {}
+            | ExprKind::Char(_) | ExprKind::Bool(_) | ExprKind::Null | ExprKind::None => {}
 
             ExprKind::Binary { left, op: _, right } => {
                 self.check_expr(left);

--- a/compiler/crates/rask-parser/src/parser.rs
+++ b/compiler/crates/rask-parser/src/parser.rs
@@ -197,6 +197,12 @@ impl Parser {
                 self.advance();
                 Ok(name)
             }
+            // `read` is reserved by the lexer but has no structural role in the grammar.
+            // Allow it anywhere a plain identifier is expected.
+            TokenKind::ReadKw => {
+                self.advance();
+                Ok("read".to_string())
+            }
             _ => Err(ParseError::expected(
                 "a name",
                 self.current_kind(),
@@ -2679,7 +2685,7 @@ impl Parser {
                 | TokenKind::Select | TokenKind::SelectPriority
                 | TokenKind::Minus | TokenKind::Bang | TokenKind::Pipe | TokenKind::Try
                 | TokenKind::Amp | TokenKind::Star | TokenKind::Tilde
-                | TokenKind::None | TokenKind::Null
+                | TokenKind::None | TokenKind::Null | TokenKind::ReadKw
         )
     }
 
@@ -3112,6 +3118,16 @@ impl Parser {
             TokenKind::Own => {
                 self.advance();
                 self.parse_expr_bp(Self::PREFIX_BP)
+            }
+
+            // `read` is reserved as a parameter mode keyword but has no syntactic
+            // role in expressions. Allow it as a plain identifier so user-defined
+            // functions and variables named `read` work correctly.
+            TokenKind::ReadKw => {
+                self.advance();
+                let name = "read".to_string();
+                let end = self.tokens[self.pos - 1].span.end;
+                Ok(Expr { id: self.next_id(), kind: ExprKind::Ident(name), span: self.span(start, end) })
             }
 
             TokenKind::LParen => self.parse_paren_or_tuple(),

--- a/compiler/crates/rask-parser/src/parser.rs
+++ b/compiler/crates/rask-parser/src/parser.rs
@@ -2967,7 +2967,8 @@ impl Parser {
             TokenKind::None => {
                 self.advance();
                 let end = self.tokens[self.pos - 1].span.end;
-                Ok(Expr { id: self.next_id(), kind: ExprKind::Ident("None".to_string()), span: self.span(start, end) })
+                // OPT3: dedicated absent literal, not the `None` enum variant.
+                Ok(Expr { id: self.next_id(), kind: ExprKind::None, span: self.span(start, end) })
             }
             TokenKind::Null => {
                 self.advance();

--- a/compiler/crates/rask-parser/src/parser.rs
+++ b/compiler/crates/rask-parser/src/parser.rs
@@ -3740,30 +3740,40 @@ impl Parser {
             Expr { id: self.next_id(), kind: ExprKind::Block(stmts), span: self.span(start, end) }
         };
 
-        let else_branch = if self.check(&TokenKind::Else) ||
+        let (else_branch, else_binding) = if self.check(&TokenKind::Else) ||
             (self.check(&TokenKind::Newline) && self.peek_past_newlines_is_else()) {
             if self.check(&TokenKind::Newline) {
                 self.skip_newlines();
             }
             self.expect(&TokenKind::Else)?;
-            if self.check(&TokenKind::If) {
-                Some(Box::new(self.parse_if_expr()?))
+            // ER22: `else as e { … }` binds the error from a Result cond.
+            let binding = if self.check(&TokenKind::As)
+                && matches!(self.peek(1), TokenKind::Ident(_))
+            {
+                self.advance();
+                Some(self.expect_ident()?)
+            } else {
+                None
+            };
+            let body = if self.check(&TokenKind::If) {
+                Box::new(self.parse_if_expr()?)
             } else if self.match_token(&TokenKind::Colon) {
-                Some(Box::new(self.parse_inline_block(start)?))
+                Box::new(self.parse_inline_block(start)?)
             } else {
                 self.skip_newlines();
                 let stmts = self.parse_block_body()?;
                 let end = self.tokens[self.pos - 1].span.end;
-                Some(Box::new(Expr { id: self.next_id(), kind: ExprKind::Block(stmts), span: self.span(start, end) }))
-            }
+                Box::new(Expr { id: self.next_id(), kind: ExprKind::Block(stmts), span: self.span(start, end) })
+            };
+            (Some(body), binding)
         } else {
-            None
+            (None, None)
         };
 
         let end = self.tokens[self.pos - 1].span.end;
         Ok(Expr {
             id: self.next_id(),
-            kind: ExprKind::If { cond: Box::new(cond), then_branch: Box::new(then_branch), else_branch },
+            kind: ExprKind::If { cond: Box::new(cond), then_branch: Box::new(then_branch), else_branch, else_binding },
             span: self.span(start, end),
         })
     }
@@ -4353,6 +4363,14 @@ impl Parser {
                     }
                     self.expect(&TokenKind::RParen)?;
                     Ok(Pattern::Constructor { name, fields })
+                } else if self.check(&TokenKind::As)
+                    && matches!(self.peek(1), TokenKind::Ident(_))
+                {
+                    // ER23: type pattern `Type as binding`. Unqualified name
+                    // without a constructor — interpret as a type match.
+                    self.advance();
+                    let binding = self.expect_ident()?;
+                    Ok(Pattern::TypePat { ty_name: name, binding: Some(binding) })
                 } else if self.check(&TokenKind::LBrace) && name.contains('.') {
                     // Struct variant pattern: Enum.Variant { field1, field2 }
                     // Only for qualified names to avoid ambiguity with blocks

--- a/compiler/crates/rask-resolve/src/resolver.rs
+++ b/compiler/crates/rask-resolve/src/resolver.rs
@@ -1849,7 +1849,7 @@ impl Resolver {
     fn resolve_expr(&mut self, expr: &Expr) {
         match &expr.kind {
             ExprKind::Int(_, _) | ExprKind::Float(_, _) | ExprKind::String(_) |
-            ExprKind::StringInterp(_) | ExprKind::Char(_) | ExprKind::Bool(_) | ExprKind::Null => {}
+            ExprKind::StringInterp(_) | ExprKind::Char(_) | ExprKind::Bool(_) | ExprKind::Null | ExprKind::None => {}
             ExprKind::Ident(name) => {
                 match self.scopes.lookup(name) {
                     Some(sym_id) => {

--- a/compiler/crates/rask-resolve/src/resolver.rs
+++ b/compiler/crates/rask-resolve/src/resolver.rs
@@ -1745,7 +1745,7 @@ impl Resolver {
             _ => return None,
         };
         let (cond, then_branch, else_branch) = match &inner.kind {
-            ExprKind::If { cond, then_branch, else_branch } => (cond, then_branch, else_branch),
+            ExprKind::If { cond, then_branch, else_branch, .. } => (cond, then_branch, else_branch),
             _ => return None,
         };
 
@@ -1978,7 +1978,7 @@ impl Resolver {
                 }
                 self.scopes.pop();
             }
-            ExprKind::If { cond, then_branch, else_branch } => {
+            ExprKind::If { cond, then_branch, else_branch, else_binding } => {
                 self.resolve_expr(cond);
                 // OPT20/ER20: `if expr? as v` binds v in the then-branch.
                 // ER21: else-branch also binds v (to the error) for Result.
@@ -2004,7 +2004,10 @@ impl Resolver {
                     self.resolve_expr(then_branch);
                 }
                 if let Some(else_br) = else_branch {
-                    if let Some(ref name) = presence_binding {
+                    // ER22: explicit `else as e` takes precedence over the cond's
+                    // `as v` for the else-branch name.
+                    let else_name = else_binding.clone().or_else(|| presence_binding.clone());
+                    if let Some(ref name) = else_name {
                         self.scopes.push(ScopeKind::Block);
                         let sym_id = self.symbols.insert(
                             name.clone(),
@@ -2344,6 +2347,20 @@ impl Resolver {
                 }
             }
             Pattern::Range { .. } => {}
+            Pattern::TypePat { binding, .. } => {
+                if let Some(name) = binding {
+                    let sym_id = self.symbols.insert(
+                        name.clone(),
+                        SymbolKind::Variable { mutable: false },
+                        None,
+                        Span::new(0, 0),
+                        false,
+                    );
+                    if let Err(e) = self.scopes.define(name.clone(), sym_id, Span::new(0, 0)) {
+                        self.errors.push(e);
+                    }
+                }
+            }
         }
     }
 }

--- a/compiler/crates/rask-semantic-hash/src/hasher.rs
+++ b/compiler/crates/rask-semantic-hash/src/hasher.rs
@@ -633,13 +633,19 @@ impl Hasher {
                 self.feed_tag(54);
                 self.hash_stmts(stmts);
             }
-            ExprKind::If { cond, then_branch, else_branch } => {
+            ExprKind::If { cond, then_branch, else_branch, else_binding } => {
                 self.feed_tag(55);
                 self.hash_expr(cond);
                 self.hash_expr(then_branch);
                 if let Some(eb) = else_branch {
                     self.feed_bool(true);
                     self.hash_expr(eb);
+                } else {
+                    self.feed_bool(false);
+                }
+                if let Some(name) = else_binding {
+                    self.feed_bool(true);
+                    self.feed_str(name);
                 } else {
                     self.feed_bool(false);
                 }
@@ -928,6 +934,16 @@ impl Hasher {
                 self.feed_tag(87);
                 self.hash_expr(start);
                 self.hash_expr(end);
+            }
+            Pattern::TypePat { ty_name, binding } => {
+                self.feed_tag(88);
+                self.feed_str(ty_name);
+                if let Some(name) = binding {
+                    self.feed_bool(true);
+                    self.feed_var(name);
+                } else {
+                    self.feed_bool(false);
+                }
             }
         }
     }

--- a/compiler/crates/rask-semantic-hash/src/hasher.rs
+++ b/compiler/crates/rask-semantic-hash/src/hasher.rs
@@ -573,6 +573,9 @@ impl Hasher {
             ExprKind::Null => {
                 self.feed_tag(45);
             }
+            ExprKind::None => {
+                self.feed_tag(89);
+            }
             ExprKind::Ident(name) => {
                 self.feed_tag(46);
                 // H4: Normalize local variable references

--- a/compiler/crates/rask-types/src/checker/check_expr.rs
+++ b/compiler/crates/rask-types/src/checker/check_expr.rs
@@ -237,6 +237,7 @@ impl TypeChecker {
                 cond,
                 then_branch,
                 else_branch,
+                else_binding,
             } => {
                 // Capture and clear the statement-position flag so it doesn't
                 // leak into nested expressions (e.g. const x = if ... { ... }).
@@ -267,19 +268,36 @@ impl TypeChecker {
                     self.pop_scope();
                 }
 
+                // ER22: `else as e` requires a Result cond. Reject otherwise.
+                if let Some(name) = else_binding {
+                    let has_err = matches!(presence_narrowing, Some((_, _, Some(_))));
+                    if !has_err {
+                        self.errors.push(TypeError::ElseBindingNotResult {
+                            name: name.clone(),
+                            span: expr.span,
+                        });
+                    }
+                }
+
                 if let Some(else_branch) = else_branch {
-                    // ER21: narrow the else branch to E for Result scrutinees.
-                    let else_narrowed = matches!(
-                        &presence_narrowing,
-                        Some((_, _, Some(_)))
-                    );
-                    if else_narrowed {
-                        let (var_name, _, else_ty) = presence_narrowing.as_ref().unwrap();
+                    // ER21/ER22: narrow the else branch to E for Result scrutinees.
+                    // `else as e` picks a separate name; otherwise reuse the
+                    // cond's `as v` / scrutinee name.
+                    let else_narrow = match (else_binding, &presence_narrowing) {
+                        (Some(e_name), Some((_, _, Some(err_ty)))) => {
+                            Some((e_name.clone(), err_ty.clone()))
+                        }
+                        (None, Some((var_name, _, Some(err_ty)))) => {
+                            Some((var_name.clone(), err_ty.clone()))
+                        }
+                        _ => None,
+                    };
+                    if let Some((ref name, ref err_ty)) = else_narrow {
                         self.push_scope();
-                        self.define_local(var_name.clone(), else_ty.clone().unwrap());
+                        self.define_local(name.clone(), err_ty.clone());
                     }
                     let else_ty = self.infer_expr(else_branch);
-                    if else_narrowed {
+                    if else_narrow.is_some() {
                         self.pop_scope();
                     }
                     let resolved_then = self.ctx.apply(&then_ty);

--- a/compiler/crates/rask-types/src/checker/check_expr.rs
+++ b/compiler/crates/rask-types/src/checker/check_expr.rs
@@ -593,6 +593,37 @@ impl TypeChecker {
             }
 
             ExprKind::Try { expr: inner, ref else_clause } => {
+                // ER17/ER18: `try { ... } [else |e| handler]` block form.
+                // Inner `try` expressions inside the block propagate E.
+                // The else clause catches and transforms; without else, this
+                // is just the block's value (errors keep propagating).
+                if matches!(&inner.kind, ExprKind::Block(_)) {
+                    let block_ty = self.infer_expr(inner);
+                    if let Some(ec) = else_clause {
+                        let err_ty = self
+                            .current_return_type
+                            .as_ref()
+                            .map(|t| self.ctx.apply(t))
+                            .and_then(|t| match t {
+                                Type::Result { err, .. } => Some(*err),
+                                _ => None,
+                            })
+                            .unwrap_or_else(|| self.ctx.fresh_var());
+                        self.push_scope();
+                        if let Some(scope) = self.local_types.last_mut() {
+                            scope.insert(ec.error_binding.clone(), (err_ty, true));
+                        }
+                        let handler_ty = self.infer_expr(&ec.body);
+                        self.pop_scope();
+                        // Block and handler must produce the same type.
+                        self.ctx.add_constraint(TypeConstraint::Equal(
+                            block_ty.clone(),
+                            handler_ty,
+                            expr.span,
+                        ));
+                    }
+                    return block_ty;
+                }
                 let inner_ty = self.infer_expr(inner);
                 let resolved = self.ctx.apply(&inner_ty);
                 match &resolved {

--- a/compiler/crates/rask-types/src/checker/check_expr.rs
+++ b/compiler/crates/rask-types/src/checker/check_expr.rs
@@ -121,6 +121,8 @@ impl TypeChecker {
             ExprKind::Char(_) => Type::Char,
             ExprKind::Bool(_) => Type::Bool,
             ExprKind::Null => Type::RawPtr(Box::new(self.ctx.fresh_var())),
+            // OPT3: `none` is `T?` with inner type inferred from context.
+            ExprKind::None => Type::Option(Box::new(self.ctx.fresh_var())),
 
             ExprKind::Ident(name) => {
                 // D1: use after discard is a compile error
@@ -407,6 +409,11 @@ impl TypeChecker {
                 self.in_stmt_expr = false;
 
                 let scrutinee_ty = self.infer_expr(scrutinee);
+                // OPT NO_MATCH: reject `match x?` on an Option — migration error.
+                let resolved_sc = self.ctx.apply(&scrutinee_ty);
+                if matches!(resolved_sc, Type::Option(_)) {
+                    self.errors.push(TypeError::MatchOnOption { span: expr.span });
+                }
                 let result_ty = self.ctx.fresh_var();
                 for arm in arms {
                     self.push_scope();
@@ -1156,6 +1163,18 @@ impl TypeChecker {
 
     pub(super) fn check_call(&mut self, call_id: NodeId, func: &Expr, args: &[CallArg], span: Span) -> Type {
         if let ExprKind::Ident(name) = &func.kind {
+            // OPT2/ER2: reject legacy `Some(x)`, `Ok(x)`, `Err(x)` constructors.
+            // The new model auto-wraps bare values at return/assignment, and
+            // error values use their own constructor (e.g., `DivError.ByZero`).
+            if matches!(name.as_str(), "Some" | "Ok" | "Err") {
+                self.errors.push(TypeError::LegacyWrapperConstructor {
+                    name: name.clone(),
+                    span,
+                });
+                for arg in args { self.infer_expr(&arg.expr); }
+                return Type::Error;
+            }
+
             // transmute(val) — reinterpret bits, requires unsafe
             if name == "transmute" {
                 self.unsafe_ops.push((span, super::UnsafeCategory::Transmute));

--- a/compiler/crates/rask-types/src/checker/check_fn.rs
+++ b/compiler/crates/rask-types/src/checker/check_fn.rs
@@ -64,6 +64,8 @@ impl TypeChecker {
         } else {
             Type::Unit
         };
+        // ER3/ER4: validate every `T or E` that appears in the return type.
+        self.validate_result_types_in(&ret_ty, f.span);
         self.current_return_type = Some(ret_ty);
 
         // ER20: Save outer accumulation state and detect if we should accumulate
@@ -134,6 +136,8 @@ impl TypeChecker {
             } else {
                 continue;
             };
+            // ER3/ER4: validate nested `T or E` in parameter types.
+            self.validate_result_types_in(&ty, param.name_span);
             if param.is_mutate || param.is_take {
                 self.define_local(param.name.clone(), ty.clone());
             } else {

--- a/compiler/crates/rask-types/src/checker/check_fn.rs
+++ b/compiler/crates/rask-types/src/checker/check_fn.rs
@@ -303,7 +303,7 @@ impl TypeChecker {
                 self.check_no_alloc_expr(fn_name, object);
                 self.check_no_alloc_expr(fn_name, index);
             }
-            ExprKind::If { cond, then_branch, else_branch } => {
+            ExprKind::If { cond, then_branch, else_branch, .. } => {
                 self.check_no_alloc_expr(fn_name, cond);
                 self.check_no_alloc_expr(fn_name, then_branch);
                 if let Some(e) = else_branch { self.check_no_alloc_expr(fn_name, e); }

--- a/compiler/crates/rask-types/src/checker/check_pattern.rs
+++ b/compiler/crates/rask-types/src/checker/check_pattern.rs
@@ -6,10 +6,18 @@ use rask_ast::Span;
 
 use super::errors::TypeError;
 use super::inference::TypeConstraint;
+use super::parse_type::parse_type_string;
 use super::type_defs::TypeDef;
+use super::type_table::TypeTable;
 use super::TypeChecker;
 
 use crate::types::Type;
+
+/// Resolve a bare type name to a Type.
+/// Returns UnresolvedNamed when the name isn't a known primitive or user type.
+fn resolve_type_name(name: &str, types: &TypeTable) -> Type {
+    parse_type_string(name, types).unwrap_or_else(|_| Type::UnresolvedNamed(name.to_string()))
+}
 
 impl TypeChecker {
     // ------------------------------------------------------------------------
@@ -28,6 +36,25 @@ impl TypeChecker {
                 // Bare constructors (Ok, Err, Some, None) without parens — match, don't bind
                 if matches!(name.as_str(), "Ok" | "Err" | "Some" | "None") {
                     return self.check_constructor_pattern(name, &[], scrutinee_ty, span);
+                }
+                // ER27: bare `Type` in a Result match is a type pattern.
+                // Recognize when `name` resolves to a type matching the ok or
+                // err branch of the scrutinee.
+                let resolved = self.ctx.apply(scrutinee_ty);
+                if let Type::Result { ok, err } = &resolved {
+                    let candidate = resolve_type_name(name, &self.types);
+                    if !matches!(candidate, Type::UnresolvedNamed(_)) {
+                        let ok_applied = self.ctx.apply(ok);
+                        let err_applied = self.ctx.apply(err);
+                        let matches_ok = ok_applied == candidate;
+                        let matches_err = match &err_applied {
+                            Type::Union(variants) => variants.contains(&candidate),
+                            other => other == &candidate,
+                        };
+                        if matches_ok || matches_err {
+                            return vec![];
+                        }
+                    }
                 }
                 vec![(name.clone(), scrutinee_ty.clone())]
             }
@@ -124,34 +151,37 @@ impl TypeChecker {
                 vec![]
             }
 
-            // ER23: `is TypeName as binding` — narrows the scrutinee to TypeName.
-            // Two-branch `T or E`: constrain E == TypeName.
+            // ER23/ER27: `TypeName [as binding]` type pattern.
+            // In match arms, matches either the T (ok) or E (err) branch of a
+            // Result by type. In `if r is E as e`, typically the err side.
             // Union `E = A | B | ...`: accept if TypeName is a union component.
             Pattern::TypePat { ty_name, binding } => {
-                let narrow_ty = match self.types.get_type_id(ty_name) {
-                    Some(id) => Type::Named(id),
-                    None => Type::UnresolvedNamed(ty_name.clone()),
-                };
+                let narrow_ty = resolve_type_name(ty_name, &self.types);
                 let resolved = self.ctx.apply(scrutinee_ty);
                 match &resolved {
-                    Type::Result { err, .. } => {
+                    Type::Result { ok, err } => {
+                        let ok_applied = self.ctx.apply(ok);
                         let err_applied = self.ctx.apply(err);
-                        match &err_applied {
-                            Type::Union(variants) => {
-                                if !variants.contains(&narrow_ty) {
-                                    self.errors.push(TypeError::TypePatternNotInUnion {
-                                        ty_name: ty_name.clone(),
-                                        union: err_applied.clone(),
-                                        span,
-                                    });
-                                }
-                            }
-                            _ => {
-                                self.ctx.add_constraint(TypeConstraint::Equal(
-                                    err_applied,
-                                    narrow_ty.clone(),
+                        let matches_ok = ok_applied == narrow_ty;
+                        let matches_err = match &err_applied {
+                            Type::Union(variants) => variants.contains(&narrow_ty),
+                            other => other == &narrow_ty,
+                        };
+                        if !matches_ok && !matches_err {
+                            // If err was a single type (not union), emit the
+                            // "not in union" error for clearer messaging.
+                            if matches!(&err_applied, Type::Union(_)) {
+                                self.errors.push(TypeError::TypePatternNotInUnion {
+                                    ty_name: ty_name.clone(),
+                                    union: err_applied,
                                     span,
-                                ));
+                                });
+                            } else {
+                                self.errors.push(TypeError::TypePatternNotResult {
+                                    ty_name: ty_name.clone(),
+                                    found: resolved,
+                                    span,
+                                });
                             }
                         }
                     }

--- a/compiler/crates/rask-types/src/checker/check_pattern.rs
+++ b/compiler/crates/rask-types/src/checker/check_pattern.rs
@@ -125,9 +125,8 @@ impl TypeChecker {
             }
 
             // ER23: `is TypeName as binding` — narrows the scrutinee to TypeName.
-            // Scope: two-branch `T or E` where the error side matches TypeName.
-            // Union errors are not supported here yet (ER23 mentions them but
-            // runtime type dispatch for union components lands separately).
+            // Two-branch `T or E`: constrain E == TypeName.
+            // Union `E = A | B | ...`: accept if TypeName is a union component.
             Pattern::TypePat { ty_name, binding } => {
                 let narrow_ty = match self.types.get_type_id(ty_name) {
                     Some(id) => Type::Named(id),
@@ -137,11 +136,24 @@ impl TypeChecker {
                 match &resolved {
                     Type::Result { err, .. } => {
                         let err_applied = self.ctx.apply(err);
-                        self.ctx.add_constraint(TypeConstraint::Equal(
-                            err_applied,
-                            narrow_ty.clone(),
-                            span,
-                        ));
+                        match &err_applied {
+                            Type::Union(variants) => {
+                                if !variants.contains(&narrow_ty) {
+                                    self.errors.push(TypeError::TypePatternNotInUnion {
+                                        ty_name: ty_name.clone(),
+                                        union: err_applied.clone(),
+                                        span,
+                                    });
+                                }
+                            }
+                            _ => {
+                                self.ctx.add_constraint(TypeConstraint::Equal(
+                                    err_applied,
+                                    narrow_ty.clone(),
+                                    span,
+                                ));
+                            }
+                        }
                     }
                     Type::Var(_) => {
                         let ok_ty = self.ctx.fresh_var();

--- a/compiler/crates/rask-types/src/checker/check_pattern.rs
+++ b/compiler/crates/rask-types/src/checker/check_pattern.rs
@@ -124,6 +124,51 @@ impl TypeChecker {
                 vec![]
             }
 
+            // ER23: `is TypeName as binding` — narrows the scrutinee to TypeName.
+            // Scope: two-branch `T or E` where the error side matches TypeName.
+            // Union errors are not supported here yet (ER23 mentions them but
+            // runtime type dispatch for union components lands separately).
+            Pattern::TypePat { ty_name, binding } => {
+                let narrow_ty = match self.types.get_type_id(ty_name) {
+                    Some(id) => Type::Named(id),
+                    None => Type::UnresolvedNamed(ty_name.clone()),
+                };
+                let resolved = self.ctx.apply(scrutinee_ty);
+                match &resolved {
+                    Type::Result { err, .. } => {
+                        let err_applied = self.ctx.apply(err);
+                        self.ctx.add_constraint(TypeConstraint::Equal(
+                            err_applied,
+                            narrow_ty.clone(),
+                            span,
+                        ));
+                    }
+                    Type::Var(_) => {
+                        let ok_ty = self.ctx.fresh_var();
+                        self.ctx.add_constraint(TypeConstraint::Equal(
+                            scrutinee_ty.clone(),
+                            Type::Result {
+                                ok: Box::new(ok_ty),
+                                err: Box::new(narrow_ty.clone()),
+                            },
+                            span,
+                        ));
+                    }
+                    _ => {
+                        self.errors.push(TypeError::TypePatternNotResult {
+                            ty_name: ty_name.clone(),
+                            found: resolved,
+                            span,
+                        });
+                    }
+                }
+                if let Some(name) = binding {
+                    vec![(name.clone(), narrow_ty)]
+                } else {
+                    vec![]
+                }
+            }
+
             Pattern::Or(alternatives) => {
                 if let Some(first) = alternatives.first() {
                     let bindings = self.check_pattern(first, scrutinee_ty, span);

--- a/compiler/crates/rask-types/src/checker/check_stmt.rs
+++ b/compiler/crates/rask-types/src/checker/check_stmt.rs
@@ -31,6 +31,8 @@ impl TypeChecker {
             StmtKind::Mut { name, name_span, ty, init } => {
                 let (init_ty, declared_ty) = if let Some(ty_str) = ty {
                     if let Ok(declared) = parse_type_string(ty_str, &self.types) {
+                        // ER3/ER4: validate `T or E` in let annotation.
+                        self.validate_result_types_in(&declared, *name_span);
                         let init_ty = self.infer_expr_expecting(init, &declared);
                         (init_ty, Some(declared))
                     } else {
@@ -58,6 +60,8 @@ impl TypeChecker {
             StmtKind::Const { name, name_span, ty, init } => {
                 let (init_ty, declared_ty) = if let Some(ty_str) = ty {
                     if let Ok(declared) = parse_type_string(ty_str, &self.types) {
+                        // ER3/ER4: validate `T or E` in const annotation.
+                        self.validate_result_types_in(&declared, *name_span);
                         let init_ty = self.infer_expr_expecting(init, &declared);
                         (init_ty, Some(declared))
                     } else {

--- a/compiler/crates/rask-types/src/checker/check_stmt.rs
+++ b/compiler/crates/rask-types/src/checker/check_stmt.rs
@@ -42,8 +42,13 @@ impl TypeChecker {
                     (self.infer_expr(init), None)
                 };
                 let binding_ty = if let Some(declared) = declared_ty {
-                    self.ctx
-                        .add_constraint(TypeConstraint::Equal(declared.clone(), init_ty, stmt.span));
+                    // OPT6: auto-wrap `T` into `T?`, and `T` or `E` into `T or E`
+                    // at assignment when the annotation is an Option/Result.
+                    self.ctx.add_constraint(TypeConstraint::ReturnValue {
+                        ret_ty: init_ty,
+                        expected: declared.clone(),
+                        span: stmt.span,
+                    });
                     self.define_local(name.clone(), declared.clone());
                     declared
                 } else {
@@ -71,8 +76,12 @@ impl TypeChecker {
                     (self.infer_expr(init), None)
                 };
                 let binding_ty = if let Some(declared) = declared_ty {
-                    self.ctx
-                        .add_constraint(TypeConstraint::Equal(declared.clone(), init_ty, stmt.span));
+                    // OPT6: auto-wrap at assignment (same as Mut above).
+                    self.ctx.add_constraint(TypeConstraint::ReturnValue {
+                        ret_ty: init_ty,
+                        expected: declared.clone(),
+                        span: stmt.span,
+                    });
                     self.define_local_read_only(name.clone(), declared.clone());
                     declared
                 } else {

--- a/compiler/crates/rask-types/src/checker/check_stmt.rs
+++ b/compiler/crates/rask-types/src/checker/check_stmt.rs
@@ -466,7 +466,7 @@ impl TypeChecker {
                 self.walk_sync_accesses(object, out);
                 self.walk_sync_accesses(index, out);
             }
-            ExprKind::If { cond, then_branch, else_branch } => {
+            ExprKind::If { cond, then_branch, else_branch, .. } => {
                 self.walk_sync_accesses(cond, out);
                 self.walk_sync_accesses(then_branch, out);
                 if let Some(e) = else_branch {

--- a/compiler/crates/rask-types/src/checker/declarations.rs
+++ b/compiler/crates/rask-types/src/checker/declarations.rs
@@ -141,13 +141,23 @@ impl TypeChecker {
     }
 
     pub(super) fn register_struct(&mut self, s: &StructDecl) {
-        let fields: Vec<_> = s
+        let field_tys: Vec<(Span, Type)> = s
             .fields
             .iter()
             .map(|f| {
                 let ty = parse_type_string(&f.ty, &self.types).unwrap_or(Type::Error);
-                (f.name.clone(), ty)
+                (f.name_span, ty)
             })
+            .collect();
+        // ER3/ER4: validate nested `T or E` in field types.
+        for (fspan, fty) in &field_tys {
+            self.validate_result_types_in(fty, *fspan);
+        }
+        let fields: Vec<_> = s
+            .fields
+            .iter()
+            .zip(field_tys.into_iter())
+            .map(|(f, (_, ty))| (f.name.clone(), ty))
             .collect();
 
         // V5: collect private field names for access checking
@@ -241,17 +251,32 @@ impl TypeChecker {
             }
         }
 
-        let variants: Vec<_> = e
+        // Parse variant payload types first (immutable borrow of self.types),
+        // then validate (mutable borrow of self for errors).
+        let variants: Vec<(String, Vec<(Span, Type)>)> = e
             .variants
             .iter()
             .map(|v| {
-                let field_types: Vec<_> = v
+                let field_types: Vec<(Span, Type)> = v
                     .fields
                     .iter()
-                    .map(|f| parse_type_string(&f.ty, &self.types).unwrap_or(Type::Error))
+                    .map(|f| {
+                        let ty = parse_type_string(&f.ty, &self.types).unwrap_or(Type::Error);
+                        (f.name_span, ty)
+                    })
                     .collect();
                 (v.name.clone(), field_types)
             })
+            .collect();
+        // ER3/ER4: validate nested `T or E` in variant payload types.
+        for (_, field_types) in &variants {
+            for (fspan, fty) in field_types {
+                self.validate_result_types_in(fty, *fspan);
+            }
+        }
+        let variants: Vec<_> = variants
+            .into_iter()
+            .map(|(vname, fts)| (vname, fts.into_iter().map(|(_, t)| t).collect::<Vec<_>>()))
             .collect();
 
         let methods = e.methods.iter().map(|m| self.method_signature(m)).collect();
@@ -290,6 +315,8 @@ impl TypeChecker {
         } else {
             // `type X = Y` — nominal, gets its own TypeId
             let underlying = parse_type_string(&a.target, &self.types).unwrap_or(Type::Error);
+            // ER3/ER4: validate nested `T or E` in the alias target.
+            self.validate_result_types_in(&underlying, span);
             self.types.register_type(TypeDef::NominalAlias {
                 name: a.name.clone(),
                 underlying,
@@ -299,14 +326,19 @@ impl TypeChecker {
     }
 
     pub(super) fn register_union(&mut self, u: &UnionDecl) {
-        let fields: Vec<_> = u
+        let field_tys: Vec<(String, Span, Type)> = u
             .fields
             .iter()
             .map(|f| {
                 let ty = parse_type_string(&f.ty, &self.types).unwrap_or(Type::Error);
-                (f.name.clone(), ty)
+                (f.name.clone(), f.name_span, ty)
             })
             .collect();
+        // ER3/ER4: validate nested `T or E` in union field types.
+        for (_, fspan, fty) in &field_tys {
+            self.validate_result_types_in(fty, *fspan);
+        }
+        let fields: Vec<_> = field_tys.into_iter().map(|(n, _, t)| (n, t)).collect();
 
         self.types.register_type(TypeDef::Union {
             name: u.name.clone(),

--- a/compiler/crates/rask-types/src/checker/errors.rs
+++ b/compiler/crates/rask-types/src/checker/errors.rs
@@ -316,4 +316,17 @@ pub enum TypeError {
         union: Type,
         span: Span,
     },
+
+    /// OPT2/ER2: legacy `Some(x)`/`Ok(x)`/`Err(x)` constructor — migration error
+    #[error("`{name}(...)` is no longer a valid constructor")]
+    LegacyWrapperConstructor {
+        name: String,
+        span: Span,
+    },
+
+    /// OPT NO_MATCH: match on `T?` is rejected — migration error
+    #[error("match on an Option is not supported — use the `?`-operator family")]
+    MatchOnOption {
+        span: Span,
+    },
 }

--- a/compiler/crates/rask-types/src/checker/errors.rs
+++ b/compiler/crates/rask-types/src/checker/errors.rs
@@ -279,4 +279,18 @@ pub enum TypeError {
         second: String,
         span: Span,
     },
+
+    /// ER3: success and error types in `T or E` must be distinct
+    #[error("`T or E` requires T and E to be distinct types — both sides are `{ty}`")]
+    ResultNotDisjoint {
+        ty: Type,
+        span: Span,
+    },
+
+    /// ER4: error type must implement `ErrorMessage` (structural: `message(self) -> string`)
+    #[error("error type `{ty}` must implement `ErrorMessage` — needs `func message(self) -> string`")]
+    ErrorMessageMissing {
+        ty: Type,
+        span: Span,
+    },
 }

--- a/compiler/crates/rask-types/src/checker/errors.rs
+++ b/compiler/crates/rask-types/src/checker/errors.rs
@@ -308,4 +308,12 @@ pub enum TypeError {
         found: Type,
         span: Span,
     },
+
+    /// ER23: `is TypeName` must reference a component of the union error
+    #[error("type pattern `{ty_name}` is not part of the error union `{union}`")]
+    TypePatternNotInUnion {
+        ty_name: String,
+        union: Type,
+        span: Span,
+    },
 }

--- a/compiler/crates/rask-types/src/checker/errors.rs
+++ b/compiler/crates/rask-types/src/checker/errors.rs
@@ -293,4 +293,19 @@ pub enum TypeError {
         ty: Type,
         span: Span,
     },
+
+    /// ER22: `else as e` requires a `T or E` condition to bind the error
+    #[error("`else as {name}` requires an `if r?` condition on a Result (`T or E`)")]
+    ElseBindingNotResult {
+        name: String,
+        span: Span,
+    },
+
+    /// ER23: `is TypeName as ...` requires the scrutinee to be a Result
+    #[error("type pattern `{ty_name}` requires a Result scrutinee, found `{found}`")]
+    TypePatternNotResult {
+        ty_name: String,
+        found: Type,
+        span: Span,
+    },
 }

--- a/compiler/crates/rask-types/src/checker/mod.rs
+++ b/compiler/crates/rask-types/src/checker/mod.rs
@@ -24,6 +24,7 @@ mod check_expr;
 mod unify;
 mod generics;
 mod resolve;
+mod validate;
 
 pub use type_defs::{TypeDef, MethodSig, SelfParam, ParamMode, TypedProgram};
 pub use type_table::TypeTable;

--- a/compiler/crates/rask-types/src/checker/resolve.rs
+++ b/compiler/crates/rask-types/src/checker/resolve.rs
@@ -2253,6 +2253,8 @@ impl TypeChecker {
                 let _ = self.unify(&args[0], &expected_fn, span);
                 self.unify(ret, &self_ty, span)
             }
+            // `x == none` desugars to `x.eq(none)` — presence/absence comparison
+            "eq" if args.len() == 1 => self.unify(ret, &Type::Bool, span),
             _ => Err(TypeError::NoSuchMethod {
                 ty: self_ty,
                 method: method.to_string(),

--- a/compiler/crates/rask-types/src/checker/type_table.rs
+++ b/compiler/crates/rask-types/src/checker/type_table.rs
@@ -420,6 +420,14 @@ impl TypeTable {
                 found: self.resolve_type_names(&found),
                 span,
             },
+            TypeError::ResultNotDisjoint { ty, span } => TypeError::ResultNotDisjoint {
+                ty: self.resolve_type_names(&ty),
+                span,
+            },
+            TypeError::ErrorMessageMissing { ty, span } => TypeError::ErrorMessageMissing {
+                ty: self.resolve_type_names(&ty),
+                span,
+            },
             other => other,
         }
     }

--- a/compiler/crates/rask-types/src/checker/unify.rs
+++ b/compiler/crates/rask-types/src/checker/unify.rs
@@ -134,8 +134,10 @@ impl TypeChecker {
     }
 
     /// Resolve a return value constraint with deferred auto-wrap.
-    /// Handles `T or E` and `T?`: bare `T` wraps to the success branch.
-    /// If the return expression's type is still unresolved, defer until later.
+    /// Handles `T or E` and `T?`: bare `T` wraps to the success branch,
+    /// bare `E` (or a component of a union `E`) wraps to the error branch
+    /// — ER9 auto-wrap at return, disambiguated by type (ER3 disjointness).
+    /// If the return expression's type is still unresolved, defer.
     fn resolve_return_value(
         &mut self,
         ret_ty: Type,
@@ -144,7 +146,7 @@ impl TypeChecker {
     ) -> Result<bool, TypeError> {
         let resolved_expected = self.ctx.apply(&expected);
 
-        if let Type::Result { ok: _, err } = &resolved_expected {
+        if let Type::Result { ok, err } = &resolved_expected {
             let resolved_ret = self.ctx.apply(&ret_ty);
             match &resolved_ret {
                 Type::Result { .. } => self.unify(&expected, &ret_ty, span),
@@ -157,9 +159,24 @@ impl TypeChecker {
                     Ok(false)
                 }
                 _ => {
-                    let wrapped = Type::Result {
-                        ok: Box::new(ret_ty),
-                        err: err.clone(),
+                    // ER9: pick the branch by type. A value whose type equals
+                    // (or is in) E goes to the error branch; otherwise it goes
+                    // to T. Disjointness (ER3) makes this unambiguous.
+                    let resolved_err = self.ctx.apply(err);
+                    let is_err_branch = match &resolved_err {
+                        Type::Union(variants) => variants.iter().any(|v| v == &resolved_ret),
+                        other => other == &resolved_ret,
+                    };
+                    let wrapped = if is_err_branch {
+                        Type::Result {
+                            ok: ok.clone(),
+                            err: Box::new(resolved_err),
+                        }
+                    } else {
+                        Type::Result {
+                            ok: Box::new(ret_ty),
+                            err: err.clone(),
+                        }
                     };
                     self.unify(&expected, &wrapped, span)
                 }

--- a/compiler/crates/rask-types/src/checker/validate.rs
+++ b/compiler/crates/rask-types/src/checker/validate.rs
@@ -1,0 +1,145 @@
+// SPDX-License-Identifier: (MIT OR Apache-2.0)
+//! Validation for `T or E` type formation (ER3, ER4).
+
+use rask_ast::Span;
+
+use super::errors::TypeError;
+use super::type_defs::{MethodSig, SelfParam, TypeDef};
+use super::TypeChecker;
+
+use crate::types::Type;
+
+impl TypeChecker {
+    /// Walk `ty` and validate every `Result { ok, err }` node against ER3 and ER4.
+    ///
+    /// ER3: T ≠ E (disjointness).
+    /// ER4: E (or each component of a union E) implements `ErrorMessage`.
+    ///
+    /// Unresolved components (`Var`, `Error`) are skipped to avoid false positives
+    /// during inference.
+    pub(super) fn validate_result_types_in(&mut self, ty: &Type, span: Span) {
+        let mut errs = Vec::new();
+        collect_result_errors(ty, span, self, &mut errs);
+        self.errors.extend(errs);
+    }
+}
+
+fn collect_result_errors(
+    ty: &Type,
+    span: Span,
+    checker: &TypeChecker,
+    errs: &mut Vec<TypeError>,
+) {
+    match ty {
+        Type::Result { ok, err } => {
+            validate_single_result(ok, err, span, checker, errs);
+            collect_result_errors(ok, span, checker, errs);
+            collect_result_errors(err, span, checker, errs);
+        }
+        Type::Option(inner)
+        | Type::Slice(inner)
+        | Type::RawPtr(inner) => collect_result_errors(inner, span, checker, errs),
+        Type::Array { elem, .. } | Type::SimdVector { elem, .. } => {
+            collect_result_errors(elem, span, checker, errs)
+        }
+        Type::Tuple(elems) | Type::Union(elems) => {
+            for e in elems {
+                collect_result_errors(e, span, checker, errs);
+            }
+        }
+        Type::Fn { params, ret } => {
+            for p in params {
+                collect_result_errors(p, span, checker, errs);
+            }
+            collect_result_errors(ret, span, checker, errs);
+        }
+        Type::Generic { args, .. } | Type::UnresolvedGeneric { args, .. } => {
+            for a in args {
+                if let crate::types::GenericArg::Type(inner) = a {
+                    collect_result_errors(inner, span, checker, errs);
+                }
+            }
+        }
+        _ => {}
+    }
+}
+
+fn validate_single_result(
+    ok: &Type,
+    err: &Type,
+    span: Span,
+    checker: &TypeChecker,
+    errs: &mut Vec<TypeError>,
+) {
+    let ok_r = checker.ctx.apply(ok);
+    let err_r = checker.ctx.apply(err);
+
+    if is_unresolved(&ok_r) || is_unresolved(&err_r) {
+        return;
+    }
+
+    // ER3: disjointness — T ≠ E, and T ∉ components of a union E.
+    let err_components: Vec<&Type> = match &err_r {
+        Type::Union(types) => types.iter().collect(),
+        other => vec![other],
+    };
+    for comp in &err_components {
+        if &&ok_r == comp {
+            errs.push(TypeError::ResultNotDisjoint {
+                ty: ok_r.clone(),
+                span,
+            });
+            break;
+        }
+    }
+
+    // ER4: E (or each component of a union E) must implement ErrorMessage.
+    for comp in &err_components {
+        if is_unresolved(comp) {
+            continue;
+        }
+        if !implements_error_message(comp, checker) {
+            errs.push(TypeError::ErrorMessageMissing {
+                ty: (*comp).clone(),
+                span,
+            });
+        }
+    }
+}
+
+fn is_unresolved(ty: &Type) -> bool {
+    matches!(ty, Type::Var(_) | Type::Error | Type::UnresolvedNamed(_) | Type::UnresolvedGeneric { .. })
+}
+
+/// Structural check: does `ty` have `func message(self) -> string`?
+///
+/// Primitives and builtins without user methods fail this check.
+/// For nominal aliases, methods are on the alias's `Named` TypeId (registered
+/// via `extend Alias { ... }` → `register_impl_methods`).
+fn implements_error_message(ty: &Type, checker: &TypeChecker) -> bool {
+    let type_id = match ty {
+        Type::Named(id) => *id,
+        Type::Generic { base, .. } => *base,
+        // Primitives, functions, tuples, arrays, etc. cannot have user methods.
+        _ => return false,
+    };
+
+    let def = match checker.types.get(type_id) {
+        Some(d) => d,
+        None => return false,
+    };
+
+    let methods: &[MethodSig] = match def {
+        TypeDef::Struct { methods, .. } | TypeDef::Enum { methods, .. } => methods,
+        // Nominal aliases store methods separately through impl registration;
+        // if a method list ever lives on NominalAlias, handle it here.
+        _ => return false,
+    };
+
+    methods.iter().any(|m| {
+        m.name == "message"
+            && matches!(m.self_param, SelfParam::Value)
+            && m.params.is_empty()
+            && matches!(m.ret, Type::String)
+    })
+}

--- a/stdlib/async.rk
+++ b/stdlib/async.rk
@@ -34,6 +34,15 @@ public enum JoinError {
     Cancelled,
 }
 
+extend JoinError {
+    public func message(self) -> string {
+        match self {
+            JoinError.Panicked(msg) => return "task panicked: {msg}",
+            JoinError.Cancelled => return "task was cancelled",
+        }
+    }
+}
+
 // --- Multiple tasks ---
 
 /// Wait for all tasks to complete. Returns results in order.
@@ -94,7 +103,41 @@ extend Receiver<T> {
 // --- Channel errors ---
 
 public enum SendError { Closed }
+extend SendError {
+    public func message(self) -> string { return "send on closed channel" }
+}
+
 public enum RecvError { Closed }
+extend RecvError {
+    public func message(self) -> string { return "receive on closed channel" }
+}
+
 public enum CloseError { AlreadyClosed, FlushFailed }
+extend CloseError {
+    public func message(self) -> string {
+        match self {
+            CloseError.AlreadyClosed => return "channel already closed",
+            CloseError.FlushFailed => return "flush failed on close",
+        }
+    }
+}
+
 public enum TrySendError { Full(T), Closed(T) }
+extend TrySendError<T> {
+    public func message(self) -> string {
+        match self {
+            TrySendError.Full(_) => return "channel is full",
+            TrySendError.Closed(_) => return "send on closed channel",
+        }
+    }
+}
+
 public enum TryRecvError { Empty, Closed }
+extend TryRecvError {
+    public func message(self) -> string {
+        match self {
+            TryRecvError.Empty => return "channel is empty",
+            TryRecvError.Closed => return "receive on closed channel",
+        }
+    }
+}

--- a/stdlib/bits.rk
+++ b/stdlib/bits.rk
@@ -40,6 +40,15 @@ enum ParseError {
     InvalidData { message: string }
 }
 
+extend ParseError {
+    public func message(self) -> string {
+        match self {
+            ParseError.UnexpectedEnd { expected, actual } => return "unexpected end: expected {expected} bytes, got {actual}",
+            ParseError.InvalidData { message } => return "invalid data: {message}",
+        }
+    }
+}
+
 // ── Binary building (K1-K2) ─────────────────────────────────────────
 
 struct BinaryBuilder {

--- a/stdlib/fs.rk
+++ b/stdlib/fs.rk
@@ -39,21 +39,21 @@ extend fs {
         const p = unsafe path.as_c_str()
         const f = unsafe fopen(p, "rb\0".as_ptr())
         if unsafe f.is_null() {
-            return Err("could not open file")
+            return IoError.Other("could not open file")
         }
         unsafe fseek(f, 0, 2)
         const size = unsafe ftell(f)
         unsafe fseek(f, 0, 0)
         if size <= 0 {
             unsafe fclose(f)
-            return Ok("")
+            return ""
         }
         const buf = unsafe rask_alloc(size + 1)
         const n = unsafe fread(buf, 1, size as u64, f)
         unsafe fclose(f)
         const result = unsafe string.from_raw(buf, n as usize)
         unsafe rask_free(buf)
-        return Ok(result)
+        return result
     }
 
     /// Read the entire contents of a file as bytes.
@@ -61,7 +61,7 @@ extend fs {
         const p = unsafe path.as_c_str()
         const f = unsafe fopen(p, "rb\0".as_ptr())
         if unsafe f.is_null() {
-            return Err("could not open file")
+            return IoError.Other("could not open file")
         }
         unsafe fseek(f, 0, 2)
         const size = unsafe ftell(f)
@@ -80,7 +80,7 @@ extend fs {
             unsafe rask_free(buf)
         }
         unsafe fclose(f)
-        return Ok(bytes)
+        return bytes
     }
 
     /// Write a string to a file, replacing its contents.
@@ -88,13 +88,13 @@ extend fs {
         const p = unsafe path.as_c_str()
         const f = unsafe fopen(p, "wb\0".as_ptr())
         if unsafe f.is_null() {
-            return Err("could not open file")
+            return IoError.Other("could not open file")
         }
         const ptr = unsafe content.as_ptr()
         const len = content.len() as u64
         unsafe fwrite(ptr, 1, len, f)
         unsafe fclose(f)
-        return Ok(())
+        return
     }
 
     /// Write bytes to a file, replacing its contents.
@@ -113,7 +113,7 @@ extend fs {
         for line in content.lines() {
             lines.push(line)
         }
-        return Ok(lines)
+        return lines
     }
 
     /// Return the canonical, absolute form of a path.
@@ -122,24 +122,24 @@ extend fs {
         const result = unsafe realpath(path.as_c_str(), buf)
         if unsafe result.is_null() {
             unsafe rask_free(buf)
-            return Err("could not resolve path")
+            return IoError.Other("could not resolve path")
         }
         const len = unsafe strlen(buf)
         const s = unsafe string.from_raw(buf, len as usize)
         unsafe rask_free(buf)
-        return Ok(s)
+        return s
     }
 
     /// Copy a file from one path to another. Returns bytes copied.
     public func copy(from: string, to: string) -> u64 or IoError {
         const src = unsafe fopen(from.as_c_str(), "rb\0".as_ptr())
         if unsafe src.is_null() {
-            return Err("could not open source file")
+            return IoError.Other("could not open source file")
         }
         const dst = unsafe fopen(to.as_c_str(), "wb\0".as_ptr())
         if unsafe dst.is_null() {
             unsafe fclose(src)
-            return Err("could not open destination file")
+            return IoError.Other("could not open destination file")
         }
         const buf = unsafe rask_alloc(8192)
         mut total: u64 = 0
@@ -152,34 +152,34 @@ extend fs {
         unsafe rask_free(buf)
         unsafe fclose(src)
         unsafe fclose(dst)
-        return Ok(total)
+        return total
     }
 
     /// Rename a file or directory.
     public func rename(from: string, to: string) -> () or IoError {
         const r = unsafe rask_libc_rename(from.as_c_str(), to.as_c_str())
         if r != 0 {
-            return Err("could not rename")
+            return IoError.Other("could not rename")
         }
-        return Ok(())
+        return
     }
 
     /// Remove a file.
     public func remove(path: string) -> () or IoError {
         const r = unsafe rask_libc_remove(path.as_c_str())
         if r != 0 {
-            return Err("could not remove")
+            return IoError.Other("could not remove")
         }
-        return Ok(())
+        return
     }
 
     /// Create a directory.
     public func create_dir(path: string) -> () or IoError {
         const r = unsafe rask_libc_mkdir(path.as_c_str(), 493)
         if r != 0 {
-            return Err("could not create directory")
+            return IoError.Other("could not create directory")
         }
-        return Ok(())
+        return
     }
 
     /// Create a directory and all parent directories.
@@ -190,20 +190,20 @@ extend fs {
         const p = unsafe path.as_c_str()
         const f = unsafe fopen(p, "ab\0".as_ptr())
         if unsafe f.is_null() {
-            return Err("could not open file for append")
+            return IoError.Other("could not open file for append")
         }
         const ptr = unsafe content.as_ptr()
         const len = content.len() as u64
         unsafe fwrite(ptr, 1, len, f)
         unsafe fclose(f)
-        return Ok(())
+        return
     }
 
     /// List entries in a directory.
     public func list_dir(path: string) -> Vec<string> or IoError {
         const dir = unsafe opendir(path.as_c_str())
         if unsafe dir.is_null() {
-            return Err("could not open directory")
+            return IoError.Other("could not open directory")
         }
         mut entries: Vec<string> = Vec.new()
         loop {
@@ -220,7 +220,7 @@ extend fs {
             }
         }
         unsafe closedir(dir)
-        return Ok(entries)
+        return entries
     }
 
     /// Get metadata for a file or directory.

--- a/stdlib/http.rk
+++ b/stdlib/http.rk
@@ -30,27 +30,27 @@ extend Method {
     public func from_string(s: string) -> Method? {
         const len = s.len()
         if len == 3 && s.byte_at(0) == 71 && s.byte_at(1) == 69 && s.byte_at(2) == 84 {
-            return Some(Method.Get)    // GET
+            return Method.Get    // GET
         }
         if len == 4 && s.byte_at(0) == 72 && s.byte_at(1) == 69 && s.byte_at(2) == 65 && s.byte_at(3) == 68 {
-            return Some(Method.Head)   // HEAD
+            return Method.Head   // HEAD
         }
         if len == 4 && s.byte_at(0) == 80 && s.byte_at(1) == 79 && s.byte_at(2) == 83 && s.byte_at(3) == 84 {
-            return Some(Method.Post)   // POST
+            return Method.Post   // POST
         }
         if len == 3 && s.byte_at(0) == 80 && s.byte_at(1) == 85 && s.byte_at(2) == 84 {
-            return Some(Method.Put)    // PUT
+            return Method.Put    // PUT
         }
         if len == 6 && s.byte_at(0) == 68 && s.byte_at(1) == 69 && s.byte_at(2) == 76 {
-            return Some(Method.Delete) // DELETE (check first 3 bytes)
+            return Method.Delete // DELETE (check first 3 bytes)
         }
         if len == 5 && s.byte_at(0) == 80 && s.byte_at(1) == 65 && s.byte_at(2) == 84 {
-            return Some(Method.Patch)  // PATCH (check first 3 bytes)
+            return Method.Patch  // PATCH (check first 3 bytes)
         }
         if len == 7 && s.byte_at(0) == 79 && s.byte_at(1) == 80 && s.byte_at(2) == 84 {
-            return Some(Method.Options) // OPTIONS (check first 3 bytes)
+            return Method.Options // OPTIONS (check first 3 bytes)
         }
-        return None
+        return none
     }
 
     // Serialize to the standard HTTP method string.
@@ -137,7 +137,7 @@ extend Request {
     // URL path before '?'.
     public func path(self) -> string {
         const qpos = self.url.find("?")
-        if qpos is Some(pos) {
+        if qpos? as pos {
             return self.url[0..pos]
         }
         return self.url
@@ -153,17 +153,17 @@ extend Request {
     public func query_params(self) -> Map<string, string> {
         mut result = Map<string, string>.new()
         const qpos = self.url.find("?")
-        if qpos is None { return result }
-
-        const query = self.url[qpos + 1..]
-        for pair in query.split("&") {
-            const eq = pair.find("=")
-            if eq is Some(eqpos) {
-                const key = pair[0..eqpos]
-                const value = pair[eqpos + 1..]
-                result.insert(key, value)
-            } else {
-                result.insert(pair, "")
+        if qpos? as qp {
+            const query = self.url[qp + 1..]
+            for pair in query.split("&") {
+                const eq = pair.find("=")
+                if eq? as eqpos {
+                    const key = pair[0..eqpos]
+                    const value = pair[eqpos + 1..]
+                    result.insert(key, value)
+                } else {
+                    result.insert(pair, "")
+                }
             }
         }
         return result
@@ -270,6 +270,21 @@ enum HttpError {
     NotFound
 }
 
+extend HttpError {
+    public func message(self) -> string {
+        match self {
+            HttpError.InternalServerError(msg) => return "internal server error: {msg}",
+            HttpError.ConnectionFailed(msg) => return "connection failed: {msg}",
+            HttpError.Timeout => return "request timed out",
+            HttpError.InvalidUrl(msg) => return "invalid URL: {msg}",
+            HttpError.InvalidResponse(msg) => return "invalid response: {msg}",
+            HttpError.TooManyRedirects => return "too many redirects",
+            HttpError.Io(msg) => return "I/O error: {msg}",
+            HttpError.NotFound => return "not found",
+        }
+    }
+}
+
 
 // ─── HTTP/1.1 Parser ─────────────────────────────────────────────
 //
@@ -280,7 +295,7 @@ enum HttpError {
 func parse_http_request(raw: string) -> Request or HttpError {
     const len = raw.len()
     if len == 0 {
-        return Err(HttpError.InvalidResponse("empty request"))
+        return HttpError.InvalidResponse("empty request")
     }
 
     // Find end of request line (first \r\n)
@@ -306,8 +321,8 @@ func parse_http_request(raw: string) -> Request or HttpError {
     const method_str = raw[0..first_sp]
     const path = raw[first_sp + 1..second_sp]
 
-    const method = Method.from_string(method_str) is Some else {
-        return Err(HttpError.InvalidResponse("unknown HTTP method"))
+    const method = if Method.from_string(method_str)? as m { m } else {
+        return HttpError.InvalidResponse("unknown HTTP method")
     }
 
     // Parse headers: starts after first \r\n, ends at \r\n\r\n
@@ -353,12 +368,12 @@ func parse_http_request(raw: string) -> Request or HttpError {
         string.new()
     }
 
-    return Ok(Request {
+    return Request {
         method: method,
         url: path,
         headers: headers,
         body: body,
-    })
+    }
 }
 
 // ─── HTTP/1.1 Response Formatter ─────────────────────────────────
@@ -442,14 +457,14 @@ func parse_url(url: string) -> (string, string, string) or HttpError {
     if rest.starts_with("http://") {
         rest = rest[7..].to_string()
     } else if rest.starts_with("https://") {
-        return Err(HttpError.InvalidUrl("HTTPS not supported yet"))
+        return HttpError.InvalidUrl("HTTPS not supported yet")
     }
 
     // Split host+port from path at first /
     mut host_port = rest
     mut path = "/"
     const slash = rest.find("/")
-    if slash is Some(pos) {
+    if slash? as pos {
         host_port = rest[0..pos].to_string()
         path = rest[pos..].to_string()
     }
@@ -458,16 +473,16 @@ func parse_url(url: string) -> (string, string, string) or HttpError {
     mut host = host_port
     mut port = "80"
     const colon = host_port.find(":")
-    if colon is Some(cpos) {
+    if colon? as cpos {
         host = host_port[0..cpos].to_string()
         port = host_port[cpos + 1..].to_string()
     }
 
     if host.is_empty() {
-        return Err(HttpError.InvalidUrl("empty host in URL: {url}"))
+        return HttpError.InvalidUrl("empty host in URL: {url}")
     }
 
-    return Ok((host, port, path))
+    return (host, port, path)
 }
 
 // Format an HTTP/1.1 request for the wire.
@@ -513,7 +528,7 @@ func format_http_request(req: Request, host: string) -> string {
 func parse_http_response(raw: string) -> Response or HttpError {
     const len = raw.len()
     if len == 0 {
-        return Err(HttpError.InvalidResponse("empty response"))
+        return HttpError.InvalidResponse("empty response")
     }
 
     // Find end of status line
@@ -537,8 +552,8 @@ func parse_http_response(raw: string) -> Response or HttpError {
     }
 
     const status_str = raw[first_sp + 1..second_sp]
-    const status_val = status_str.parse_int() is Ok(v) else {
-        return Err(HttpError.InvalidResponse("bad status code: {status_str}"))
+    const status_val = if status_str.parse_int()? as v { v } else {
+        return HttpError.InvalidResponse("bad status code: {status_str}")
     }
     const status = status_val as u16
 
@@ -583,11 +598,11 @@ func parse_http_response(raw: string) -> Response or HttpError {
         string.new()
     }
 
-    return Ok(Response {
+    return Response {
         status: status,
         headers: headers,
         body: body,
-    })
+    }
 }
 
 // Connect, send request, read response, close connection.
@@ -599,7 +614,7 @@ func _send_request_impl(method: Method, url: string, body: string, extra_headers
     // Connect
     const conn_fd = unsafe { rask_net_tcp_connect(addr as i64) }
     if conn_fd < 0 {
-        return Err(HttpError.ConnectionFailed("cannot connect to {addr}"))
+        return HttpError.ConnectionFailed("cannot connect to {addr}")
     }
 
     // Build and send request
@@ -638,7 +653,7 @@ func TcpConnection_read_http_request(conn_fd: i64) -> i64 or Error {
     // This matches what the codegen expects for HttpRequest struct access.
     // Once the compiler handles the new Request type natively, this shim
     // can be replaced with a direct return.
-    return Ok(request as i64)
+    return request as i64
 }
 
 // Write HTTP/1.1 response to a TCP connection.
@@ -647,7 +662,7 @@ func TcpConnection_write_http_response(conn_fd: i64, resp_ptr: i64) -> i64 or Er
     const resp = resp_ptr as Response
     const raw = format_http_response(resp)
     write_raw(conn_fd, raw)
-    return Ok(0)
+    return 0
 }
 
 // ─── Server Types ────────────────────────────────────────────────
@@ -660,22 +675,22 @@ struct HttpServer {
 
 extend HttpServer {
     public func listen(addr: string) -> HttpServer or HttpError {
-        const listener = net.tcp_listen(addr) is Ok else {
-            return Err(HttpError.ConnectionFailed("failed to bind {addr}"))
+        const listener = if net.tcp_listen(addr)? as l { l } else {
+            return HttpError.ConnectionFailed("failed to bind {addr}")
         }
-        return Ok(HttpServer { listener: listener, addr: addr })
+        return HttpServer { listener: listener, addr: addr }
     }
 
     public func accept(self) -> (Request, Responder) or HttpError {
-        const conn = self.listener.accept() is Ok else {
-            return Err(HttpError.Io("accept failed"))
+        const conn = if self.listener.accept()? as c { c } else {
+            return HttpError.Io("accept failed")
         }
         const raw = read_raw(conn as i64, 65536)
-        const request = parse_http_request(raw) is Ok else {
-            return Err(HttpError.InvalidResponse("malformed request"))
+        const request = if parse_http_request(raw)? as r { r } else {
+            return HttpError.InvalidResponse("malformed request")
         }
         const responder = Responder { conn_fd: conn as i64, sent: false }
-        return Ok((request, responder))
+        return (request, responder)
     }
 
     public func local_addr(self) -> string {
@@ -710,13 +725,14 @@ extend http {
     /// Requires `using Multitasking`.
     public func listen_and_serve(addr: string, handler: func(Request) -> Response) -> () or HttpError
     {
-        const server = HttpServer.listen(addr) is Ok else {
-            return Err(HttpError.Io("listen failed"))
+        const server = if HttpServer.listen(addr)? as s { s } else {
+            return HttpError.Io("listen failed")
         }
         ensure server.close()
         loop {
             const result = server.accept()
-            if result is Ok((req, responder)) {
+            if result? as r {
+                const (req, responder) = r
                 spawn(|| {
                     responder.respond(handler(req))
                 }).detach()

--- a/stdlib/io.rk
+++ b/stdlib/io.rk
@@ -12,6 +12,21 @@ public enum IoError {
     Other(string)
 }
 
+extend IoError {
+    public func message(self) -> string {
+        match self {
+            IoError.NotFound(msg) => return "not found: {msg}",
+            IoError.PermissionDenied(msg) => return "permission denied: {msg}",
+            IoError.AlreadyExists(msg) => return "already exists: {msg}",
+            IoError.BrokenPipe => return "broken pipe",
+            IoError.ConnectionReset => return "connection reset",
+            IoError.TimedOut => return "timed out",
+            IoError.UnexpectedEof => return "unexpected end of file",
+            IoError.Other(msg) => return msg,
+        }
+    }
+}
+
 /// Input/output module functions.
 struct io { }
 

--- a/stdlib/json.rk
+++ b/stdlib/json.rk
@@ -23,6 +23,16 @@ enum JsonError {
     MissingField(string)
 }
 
+extend JsonError {
+    public func message(self) -> string {
+        match self {
+            JsonError.ParseError(msg) => return "parse error: {msg}",
+            JsonError.TypeError(msg) => return "type error: {msg}",
+            JsonError.MissingField(field) => return "missing field: {field}",
+        }
+    }
+}
+
 // ─── JsonValue accessors ─────────────────────────────────────────
 
 extend JsonValue {
@@ -32,37 +42,37 @@ extend JsonValue {
 
     public func as_bool(self) -> bool? {
         if self is Bool(b) {
-            return Some(b)
+            return b
         }
-        return None
+        return none
     }
 
     public func as_number(self) -> f64? {
         if self is Number(n) {
-            return Some(n)
+            return n
         }
-        return None
+        return none
     }
 
     public func as_string(self) -> string? {
         if self is String(s) {
-            return Some(s)
+            return s
         }
-        return None
+        return none
     }
 
     public func as_array(self) -> Vec<JsonValue>? {
         if self is Array(a) {
-            return Some(a)
+            return a
         }
-        return None
+        return none
     }
 
     public func as_object(self) -> Map<string, JsonValue>? {
         if self is Object(m) {
-            return Some(m)
+            return m
         }
-        return None
+        return none
     }
 }
 
@@ -112,19 +122,19 @@ extend JsonParser {
     func expect(mutate self, expected: u8) -> () or JsonError {
         self.skip_ws()
         if self.pos >= self.len {
-            return Err(JsonError.ParseError("unexpected end of input"))
+            return JsonError.ParseError("unexpected end of input")
         }
         const b = self.advance()
         if b != expected {
-            return Err(JsonError.ParseError("expected '{expected}', got '{b}'"))
+            return JsonError.ParseError("expected '{expected}', got '{b}'")
         }
-        return Ok(())
+        return
     }
 
     func parse_value(mutate self) -> JsonValue or JsonError {
         self.skip_ws()
         if self.pos >= self.len {
-            return Err(JsonError.ParseError("unexpected end of input"))
+            return JsonError.ParseError("unexpected end of input")
         }
 
         const b = self.peek()
@@ -151,7 +161,7 @@ extend JsonParser {
             return self.parse_number()
         }
 
-        return Err(JsonError.ParseError("unexpected character at position {self.pos}"))
+        return JsonError.ParseError("unexpected character at position {self.pos}")
     }
 
     func parse_object(mutate self) -> JsonValue or JsonError {
@@ -162,18 +172,18 @@ extend JsonParser {
 
         if self.peek() == 125 {
             self.pos = self.pos + 1
-            return Ok(JsonValue.Object(map))
+            return JsonValue.Object(map)
         }
 
         loop {
             self.skip_ws()
             if self.peek() != 34 {
-                return Err(JsonError.ParseError("expected string key in object"))
+                return JsonError.ParseError("expected string key in object")
             }
             const key = try self.parse_raw_string()
             self.skip_ws()
             if self.advance() != 58 {
-                return Err(JsonError.ParseError("expected ':' after object key"))
+                return JsonError.ParseError("expected ':' after object key")
             }
             const value = try self.parse_value()
             // Last value wins for duplicate keys (J5)
@@ -185,10 +195,10 @@ extend JsonParser {
                 continue
             }
             if next == 125 {
-                return Ok(JsonValue.Object(map))
+                return JsonValue.Object(map)
             }
 
-            return Err(JsonError.ParseError("expected ',' or '}' in object"))
+            return JsonError.ParseError("expected ',' or '}' in object")
         }
     }
 
@@ -200,7 +210,7 @@ extend JsonParser {
 
         if self.peek() == 93 {
             self.pos = self.pos + 1
-            return Ok(JsonValue.Array(arr))
+            return JsonValue.Array(arr)
         }
 
         loop {
@@ -213,16 +223,16 @@ extend JsonParser {
                 continue
             }
             if next == 93 {
-                return Ok(JsonValue.Array(arr))
+                return JsonValue.Array(arr)
             }
 
-            return Err(JsonError.ParseError("expected ',' or ']' in array"))
+            return JsonError.ParseError("expected ',' or ']' in array")
         }
     }
 
     func parse_raw_string(mutate self) -> string or JsonError {
         if self.advance() != 34 {
-            return Err(JsonError.ParseError("expected '\"'"))
+            return JsonError.ParseError("expected '\"'")
         }
 
         mut b = StringBuilder.new()
@@ -230,11 +240,11 @@ extend JsonParser {
         while self.pos < self.len {
             const byte = self.advance()
             if byte == 34 {
-                return Ok(b.build())
+                return b.build()
             }
             if byte == 92 {
                 if self.pos >= self.len {
-                    return Err(JsonError.ParseError("unterminated escape sequence"))
+                    return JsonError.ParseError("unterminated escape sequence")
                 }
                 const esc = self.advance()
                 if esc == 34 {
@@ -257,19 +267,19 @@ extend JsonParser {
                     const cp = try self.parse_unicode_escape()
                     b.append_char(cp)
                 } else {
-                    return Err(JsonError.ParseError("invalid escape character"))
+                    return JsonError.ParseError("invalid escape character")
                 }
                 continue
             }
             b.append_char(byte as char)
         }
 
-        return Err(JsonError.ParseError("unterminated string"))
+        return JsonError.ParseError("unterminated string")
     }
 
     func parse_unicode_escape(mutate self) -> char or JsonError {
         if self.pos + 4 > self.len {
-            return Err(JsonError.ParseError("incomplete unicode escape"))
+            return JsonError.ParseError("incomplete unicode escape")
         }
         mut cp: u32 = 0
         mut i = 0
@@ -277,50 +287,50 @@ extend JsonParser {
             const b = self.advance()
             const digit = hex_digit(b)
             if digit < 0 {
-                return Err(JsonError.ParseError("invalid hex digit in unicode escape"))
+                return JsonError.ParseError("invalid hex digit in unicode escape")
             }
             cp = cp * 16 + digit as u32
             i = i + 1
         }
-        return Ok(cp as char)
+        return cp as char
     }
 
     func parse_string_value(mutate self) -> JsonValue or JsonError {
         const s = try self.parse_raw_string()
-        return Ok(JsonValue.String(s))
+        return JsonValue.String(s)
     }
 
     func parse_true(mutate self) -> JsonValue or JsonError {
         if self.pos + 4 > self.len {
-            return Err(JsonError.ParseError("unexpected end of input"))
+            return JsonError.ParseError("unexpected end of input")
         }
         if self.input[self.pos..self.pos + 4] == "true" {
             self.pos = self.pos + 4
-            return Ok(JsonValue.Bool(true))
+            return JsonValue.Bool(true)
         }
-        return Err(JsonError.ParseError("invalid token"))
+        return JsonError.ParseError("invalid token")
     }
 
     func parse_false(mutate self) -> JsonValue or JsonError {
         if self.pos + 5 > self.len {
-            return Err(JsonError.ParseError("unexpected end of input"))
+            return JsonError.ParseError("unexpected end of input")
         }
         if self.input[self.pos..self.pos + 5] == "false" {
             self.pos = self.pos + 5
-            return Ok(JsonValue.Bool(false))
+            return JsonValue.Bool(false)
         }
-        return Err(JsonError.ParseError("invalid token"))
+        return JsonError.ParseError("invalid token")
     }
 
     func parse_null(mutate self) -> JsonValue or JsonError {
         if self.pos + 4 > self.len {
-            return Err(JsonError.ParseError("unexpected end of input"))
+            return JsonError.ParseError("unexpected end of input")
         }
         if self.input[self.pos..self.pos + 4] == "null" {
             self.pos = self.pos + 4
-            return Ok(JsonValue.Null)
+            return JsonValue.Null
         }
-        return Err(JsonError.ParseError("invalid token"))
+        return JsonError.ParseError("invalid token")
     }
 
     func parse_number(mutate self) -> JsonValue or JsonError {
@@ -331,7 +341,7 @@ extend JsonParser {
         }
 
         if self.pos >= self.len {
-            return Err(JsonError.ParseError("unexpected end in number"))
+            return JsonError.ParseError("unexpected end in number")
         }
         // Leading zero — only valid as "0" or "0.xxx"
         if self.peek() == 48 {
@@ -341,14 +351,14 @@ extend JsonParser {
                 self.pos = self.pos + 1
             }
         } else {
-            return Err(JsonError.ParseError("invalid number"))
+            return JsonError.ParseError("invalid number")
         }
 
         // Fractional part
         if self.pos < self.len && self.peek() == 46 {
             self.pos = self.pos + 1
             if self.pos >= self.len || self.peek() < 48 || self.peek() > 57 {
-                return Err(JsonError.ParseError("expected digit after decimal point"))
+                return JsonError.ParseError("expected digit after decimal point")
             }
             while self.pos < self.len && self.peek() >= 48 && self.peek() <= 57 {
                 self.pos = self.pos + 1
@@ -362,7 +372,7 @@ extend JsonParser {
                 self.pos = self.pos + 1
             }
             if self.pos >= self.len || self.peek() < 48 || self.peek() > 57 {
-                return Err(JsonError.ParseError("expected digit in exponent"))
+                return JsonError.ParseError("expected digit in exponent")
             }
             while self.pos < self.len && self.peek() >= 48 && self.peek() <= 57 {
                 self.pos = self.pos + 1
@@ -370,8 +380,12 @@ extend JsonParser {
         }
 
         const num_str = self.input[start..self.pos]
-        const n = try num_str.parse<f64>().map_err(|_| JsonError.ParseError("invalid number: {num_str}"))
-        return Ok(JsonValue.Number(n))
+        const n = try {
+            try num_str.parse<f64>()
+        } else |_e| {
+            return JsonError.ParseError("invalid number: {num_str}")
+        }
+        return JsonValue.Number(n)
     }
 }
 
@@ -399,9 +413,9 @@ extend json {
         const value = try parser.parse_value()
         parser.skip_ws()
         if parser.pos < parser.len {
-            return Err(JsonError.ParseError("trailing content after JSON value"))
+            return JsonError.ParseError("trailing content after JSON value")
         }
-        return Ok(value)
+        return value
     }
 
     /// Serialize a JsonValue to a compact JSON string.


### PR DESCRIPTION
## Summary

This PR implements comprehensive validation and auto-wrapping for Rask's `T or E` (Result) type system, including disjointness checking (ER3), ErrorMessage trait enforcement (ER4), type-based branch disambiguation at return (ER9), and a dedicated `none` literal (OPT3).

## Key Changes

### Type Validation (ER3, ER4)
- **New validation module** (`rask-types/src/checker/validate.rs`): Walks type trees to validate every `Result { ok, err }` node
  - ER3: Enforces T ≠ E (disjointness) — T cannot equal E or any component of a union E
  - ER4: Validates that E (or each union component) implements `ErrorMessage` via structural check for `func message(self) -> string`
  - Skips unresolved types (`Var`, `Error`, `UnresolvedNamed`) to avoid false positives during inference
- Validation integrated into struct/enum field registration and function return type checking

### Result Type Pattern Matching (ER23, ER27, ER28)
- **Type patterns** in match arms: bare type names like `IoError.NotFound` now match against Result payloads
- **`is TypeName as binding`** syntax: Allows type-based narrowing in if-conditions for Result scrutinees
- **Descending into Result branches**: Pattern matching on `Result<T, E>` automatically descends into Ok/Err variants to match the payload
- Runtime type matching in interpreter for both enum variants and struct types

### Return Value Auto-Wrapping (ER9)
- Bare return values in `T or E` functions now auto-wrap based on runtime type
- If value matches E (or a union component), wraps as `Err`; otherwise wraps as `Ok`
- Disjointness (ER3) ensures unambiguous type-based disambiguation
- Handles union error types by extracting component names

### Dedicated `none` Literal (OPT3)
- New `ExprKind::None` variant distinct from `None` enum constructor
- Parser recognizes `none` as a dedicated absent sentinel (not `None` identifier)
- Type inference treats `none` as `Option<T>` with inner type inferred from context
- Lowering to MIR handles niche optimization for `Option<Handle<T>>`
- Interpreter evaluates `none` as `Option::None` enum value

### Control Flow Enhancements (ER21, ER22)
- **`else as e` binding**: New syntax to bind error branch in if-Result conditions
  - `if r? as ok_val { ... } else as err_val { ... }`
  - Validation ensures `else as` only used with Result conditions
- Separate error binding from success binding for clearer intent

### Standard Library Updates
- Added `ErrorMessage` implementations to all error types:
  - `HttpError`, `JsonError`, `IoError`, `JoinError`, `SendError`, `RecvError`, `CloseError`, `TrySendError`, `ParseError`
- Updated stdlib functions to use bare return values (auto-wrapped by ER9):
  - `http.rk`: Method parsing returns bare enum variants
  - `json.rk`: Parser methods return bare values or errors
  - `fs.rk`: File operations use bare returns
  - `async.rk`: Channel operations with error messages

### Diagnostic Improvements
- New error codes: E0343 (ResultNotDisjoint), E0344 (ErrorMessageMissing), E0345 (ElseBindingNotResult), E0346-E0348 (type pattern errors)
- Clear error messages with migration guidance for legacy `Some(x)`/`Ok(x)`/`Err(x)` constructors

## Implementation Details

- **Structural ErrorMessage check**: Looks up type definitions to verify presence of `message(self) -> string` method; primitives and builtins fail this check
- **Union error handling**: Extracts components from `E = A | B | C` to validate each

https://claude.ai/code/session_01S7sRBvc7pqcg221Tttpkxw