### PR TITLE
Migrate from Ok/Err/Some/None wrappers to bare values and operators

### DIFF
--- a/benchmarks/features/error_handling.rk
+++ b/benchmarks/features/error_handling.rk
@@ -1,20 +1,30 @@
 // SPDX-License-Identifier: (MIT OR Apache-2.0)
 
-func checked_div(a: i64, b: i64) -> i64 or string {
-    if b == 0 {
-        return Err("division by zero")
+enum DivError { Msg(string) }
+
+extend DivError {
+    func message(self) -> string {
+        match self {
+            DivError.Msg(m) => return m
+        }
     }
-    return Ok(a / b)
 }
 
-func sum_divs(n: i64) -> i64 or string {
+func checked_div(a: i64, b: i64) -> i64 or DivError {
+    if b == 0 {
+        return DivError.Msg("division by zero")
+    }
+    return a / b
+}
+
+func sum_divs(n: i64) -> i64 or DivError {
     mut sum = 0
     mut i = 1
     while i <= n {
         sum = sum + try checked_div(1000, i)
         i = i + 1
     }
-    return Ok(sum)
+    return sum
 }
 
 benchmark "result propagation 10k" {

--- a/benchmarks/features/handle_overhead.rk
+++ b/benchmarks/features/handle_overhead.rk
@@ -11,7 +11,7 @@ benchmark "handle sequential read 1k" {
     mut i = 0
     while i < 1000 {
         mut result = p.insert(i)
-        if result is Ok(h) {
+        if result? as h {
             handles.push(h)
         }
         i = i + 1
@@ -31,7 +31,7 @@ benchmark "handle random read 1k" {
     mut i = 0
     while i < 1000 {
         mut result = p.insert(i)
-        if result is Ok(h) {
+        if result? as h {
             handles.push(h)
         }
         i = i + 1
@@ -54,7 +54,7 @@ benchmark "handle churn remove 1k" {
     mut i = 0
     while i < 1000 {
         mut result = p.insert(i)
-        if result is Ok(h) {
+        if result? as h {
             handles.push(h)
         }
         i = i + 1
@@ -82,7 +82,7 @@ benchmark "handle churn read 800" {
     mut i = 0
     while i < 1000 {
         mut result = p.insert(i)
-        if result is Ok(h) {
+        if result? as h {
             handles.push(h)
         }
         i = i + 1

--- a/compiler/crates/rask-diagnostics/src/convert.rs
+++ b/compiler/crates/rask-diagnostics/src/convert.rs
@@ -738,6 +738,23 @@ impl ToDiagnostic for rask_types::TypeError {
                     .with_help("use the ?-operator family: `if x? { ... } else { ... }`, `x?.field ?? default`, or `if x == none { return }`")
                     .with_why("Option has two states — the operator family covers both more concisely [type.optionals/NO_MATCH]")
             }
+            LegacyWrapperPattern { name, with_binding, span } => {
+                let fix = match name.as_str() {
+                    "Some" if *with_binding => "use the operator form: `if x? as v { ... }`, or `const v = x ?? return none` in guard position",
+                    "Some" => "use the operator form: `if x? { ... }`, `x?`, or `x != none`",
+                    "None" => "use `x == none` for the absent check",
+                    "Ok" if *with_binding => "use the operator form: `if r? as v { ... }`, or a type pattern: `r is <T> as v else { ... }`",
+                    "Ok" => "use `r?` for the present check",
+                    "Err" if *with_binding => "use a type pattern: `if r is <ErrType> as e { ... }`, `match r { ... <ErrType> as e => ... }`",
+                    "Err" => "use `r is <ErrType>` with the function's actual error type",
+                    _ => "use the operator form or a type pattern",
+                };
+                Diagnostic::error(format!("`{}` is not a pattern name", name))
+                    .with_code("E0350")
+                    .with_primary(*span, format!("`{}` is not a pattern", name))
+                    .with_help(fix)
+                    .with_why("Option/Result have no Some/None/Ok/Err constructors or patterns — operators and type patterns cover all cases [type.optionals/OPT2, type.errors/ER2]")
+            }
         }
     }
 }

--- a/compiler/crates/rask-parser/src/parser.rs
+++ b/compiler/crates/rask-parser/src/parser.rs
@@ -2885,7 +2885,15 @@ impl Parser {
 
                 if self.check(&TokenKind::QuestionQuestion) {
                     self.advance();
-                    let default = self.parse_expr_bp(r_bp)?;
+                    // OPT13: diverging RHS — `x ?? return y`, `?? break`, `?? continue`.
+                    // Wrap the statement in a Block expression; block type is Never.
+                    let rhs_start = self.current().span.start;
+                    let default = match self.current_kind() {
+                        TokenKind::Return | TokenKind::Break | TokenKind::Continue => {
+                            self.parse_inline_block(rhs_start)?
+                        }
+                        _ => self.parse_expr_bp(r_bp)?,
+                    };
                     let end = default.span.end;
                     lhs = Expr {
                         id: self.next_id(),
@@ -3220,7 +3228,14 @@ impl Parser {
                     self.expect(&TokenKind::Pipe)?;
                     let error_binding = self.expect_ident()?;
                     self.expect(&TokenKind::Pipe)?;
-                    let body = self.parse_expr()?;
+                    // ER18: diverging body — `else |e| return e`, `break`, `continue`.
+                    let body_start = self.current().span.start;
+                    let body = match self.current_kind() {
+                        TokenKind::Return | TokenKind::Break | TokenKind::Continue => {
+                            self.parse_inline_block(body_start)?
+                        }
+                        _ => self.parse_expr()?,
+                    };
                     end = body.span.end;
                     Some(rask_ast::expr::TryElse {
                         error_binding,
@@ -4364,12 +4379,35 @@ impl Parser {
                 self.advance();
 
                 // Handle qualified paths: Enum.Variant or Enum.Variant(args) or Enum.Variant { fields }
-                let name = if self.match_token(&TokenKind::Dot) {
+                let mut name = if self.match_token(&TokenKind::Dot) {
                     let variant = self.expect_ident()?;
                     format!("{}.{}", name, variant)
                 } else {
                     name
                 };
+
+                // rask#217: generic type patterns — `is Vec<i32>`, `is Map<K, V>`.
+                // After `is`, `<` can't be a comparison, so consume generic args.
+                if self.check(&TokenKind::Lt) {
+                    self.advance();
+                    name.push('<');
+                    loop {
+                        if let TokenKind::Int(n, _) = self.current_kind().clone() {
+                            self.advance();
+                            name.push_str(&n.to_string());
+                        } else {
+                            name.push_str(&self.parse_type_name()?);
+                        }
+                        if self.pending_gt { break; }
+                        if self.match_token(&TokenKind::Comma) {
+                            name.push_str(", ");
+                        } else {
+                            break;
+                        }
+                    }
+                    self.expect_gt_in_generic()?;
+                    name.push('>');
+                }
 
                 if self.match_token(&TokenKind::LParen) {
                     // Constructor pattern: Name(patterns...) or Enum.Variant(patterns...)

--- a/compiler/crates/rask-types/src/checker/check_expr.rs
+++ b/compiler/crates/rask-types/src/checker/check_expr.rs
@@ -1080,12 +1080,25 @@ impl TypeChecker {
             ExprKind::NullCoalesce { value, default } => {
                 let val_ty = self.infer_expr(value);
                 let def_ty = self.infer_expr(default);
-                self.ctx.add_constraint(TypeConstraint::Equal(
-                    val_ty,
-                    Type::Option(Box::new(def_ty.clone())),
-                    expr.span,
-                ));
-                def_ty
+                let resolved_def = self.ctx.apply(&def_ty);
+                // OPT13: diverging default (`?? return y`, `?? break`, `?? continue`,
+                // `?? panic(…)`) unwraps the scrutinee and yields the inner type.
+                if matches!(resolved_def, Type::Never) {
+                    let inner = self.ctx.fresh_var();
+                    self.ctx.add_constraint(TypeConstraint::Equal(
+                        val_ty,
+                        Type::Option(Box::new(inner.clone())),
+                        expr.span,
+                    ));
+                    inner
+                } else {
+                    self.ctx.add_constraint(TypeConstraint::Equal(
+                        val_ty,
+                        Type::Option(Box::new(def_ty.clone())),
+                        expr.span,
+                    ));
+                    def_ty
+                }
             }
 
             ExprKind::OptionalField { object, field } => {

--- a/compiler/crates/rask-types/src/checker/check_expr.rs
+++ b/compiler/crates/rask-types/src/checker/check_expr.rs
@@ -2,7 +2,7 @@
 //! Expression type inference and specific type checks.
 
 use rask_ast::expr::{BinOp, CallArg, Expr, ExprKind, MatchArm, Pattern};
-use rask_ast::stmt::StmtKind;
+use rask_ast::stmt::{Stmt, StmtKind};
 use rask_ast::{NodeId, Span};
 use rask_resolve::{SymbolId, SymbolKind};
 
@@ -452,6 +452,11 @@ impl TypeChecker {
                 self.push_scope();
                 for stmt in stmts {
                     self.check_stmt(stmt);
+                    // ER24 / CF22 — early-exit narrowing. Solve constraints
+                    // first so method-call return types are resolved before
+                    // we inspect the scrutinee type.
+                    self.solve_constraints();
+                    self.apply_early_exit_narrowing(stmt);
                 }
                 let result = if let Some(last) = stmts.last() {
                     match &last.kind {
@@ -2162,6 +2167,130 @@ impl TypeChecker {
             Type::Option(inner_ty) => Some((narrow_name, *inner_ty, None)),
             Type::Result { ok, err } => Some((narrow_name, *ok, Some(*err))),
             _ => None,
+        }
+    }
+
+    /// ER24/CF22 — early-exit narrowing. If `stmt` is `if cond { diverges }`
+    /// (no else, or else is non-diverging), narrow the scrutinee to the
+    /// opposite variant for the rest of the enclosing block.
+    ///
+    /// Supported cond shapes:
+    /// - `r is ErrType` (or `r is ErrType as e`) where scrutinee is `T or E` —
+    ///   narrows `r` to `T` after the if.
+    /// - `x == none` where scrutinee is `T?` — narrows `x` to `T` after.
+    /// - `!r?` is a parse error already, so not handled here.
+    /// True when `expr` always diverges — i.e. the last statement in its
+    /// block is `return` / `break` / `continue`, or the expression is
+    /// itself a bare divergent keyword. Approximate; doesn't chase every
+    /// control-flow path, which is good enough for ER24 early-exit.
+    fn block_diverges(expr: &Expr) -> bool {
+        match &expr.kind {
+            ExprKind::Block(stmts) => match stmts.last().map(|s| &s.kind) {
+                Some(StmtKind::Return(_))
+                | Some(StmtKind::Break { .. })
+                | Some(StmtKind::Continue(_)) => true,
+                Some(StmtKind::Expr(inner)) => matches!(
+                    inner.kind,
+                    ExprKind::Call { .. }
+                ) && Self::is_panic_call(inner) || Self::block_diverges(inner),
+                _ => false,
+            },
+            _ => false,
+        }
+    }
+
+    fn is_panic_call(expr: &Expr) -> bool {
+        if let ExprKind::Call { func, .. } = &expr.kind {
+            if let ExprKind::Ident(name) = &func.kind {
+                return matches!(name.as_str(), "panic" | "todo" | "unreachable");
+            }
+        }
+        false
+    }
+
+    pub(super) fn apply_early_exit_narrowing(&mut self, stmt: &Stmt) {
+        let expr = match &stmt.kind {
+            StmtKind::Expr(e) => e,
+            _ => return,
+        };
+
+        // `if <IsPattern/==none> { diverge }` — the parser lowers `is`
+        // patterns into IfLet; `== none` stays as If with a Binary cond.
+        match &expr.kind {
+            ExprKind::IfLet { expr: scrutinee, pattern, then_branch, else_branch } => {
+                if !Self::block_diverges(then_branch) { return; }
+                if let Some(else_b) = else_branch {
+                    if Self::block_diverges(else_b) { return; }
+                }
+                self.narrow_result_from_err_pattern(scrutinee, pattern);
+            }
+            ExprKind::If { cond, then_branch, else_branch, .. } => {
+                if !Self::block_diverges(then_branch) { return; }
+                if let Some(else_b) = else_branch {
+                    if Self::block_diverges(else_b) { return; }
+                }
+                // After desugar, `x == none` is `x.eq(none)`.
+                let scrutinee_opt = match &cond.kind {
+                    ExprKind::Binary { op, left, right } if matches!(op, rask_ast::expr::BinOp::Eq) => {
+                        match (&left.kind, &right.kind) {
+                            (_, ExprKind::None) => Some(left.as_ref()),
+                            (ExprKind::None, _) => Some(right.as_ref()),
+                            _ => None,
+                        }
+                    }
+                    ExprKind::MethodCall { object, method, args, .. } if method == "eq" && args.len() == 1 => {
+                        match &args[0].expr.kind {
+                            ExprKind::None => Some(object.as_ref()),
+                            _ => None,
+                        }
+                    }
+                    _ => None,
+                };
+                if let Some(scrutinee) = scrutinee_opt {
+                    let name = match &scrutinee.kind {
+                        ExprKind::Ident(n) if self.is_local_read_only(n) => n.clone(),
+                        _ => return,
+                    };
+                    let scrutinee_ty = match self.node_types.get(&scrutinee.id).cloned() {
+                        Some(t) => self.ctx.apply(&t),
+                        None => return,
+                    };
+                    if let Type::Option(inner) = scrutinee_ty {
+                        self.define_local_read_only(name, *inner);
+                    }
+                }
+            }
+            _ => {}
+        }
+    }
+
+    fn narrow_result_from_err_pattern(&mut self, scrutinee: &Expr, pattern: &rask_ast::expr::Pattern) {
+        let name = match &scrutinee.kind {
+            ExprKind::Ident(n) if self.is_local_read_only(n) => n.clone(),
+            _ => return,
+        };
+        let scrutinee_ty = match self.node_types.get(&scrutinee.id).cloned() {
+            Some(t) => self.ctx.apply(&t),
+            None => return,
+        };
+        let Type::Result { ok, err } = scrutinee_ty else { return };
+        let pattern_ty_name = match pattern {
+            rask_ast::expr::Pattern::TypePat { ty_name, .. } => ty_name.clone(),
+            rask_ast::expr::Pattern::Ident(ty_name) => ty_name.clone(),
+            _ => return,
+        };
+        let narrow_ty = super::check_pattern::normalize_type(
+            &super::parse_type::parse_type_string(&pattern_ty_name, &self.types)
+                .unwrap_or(Type::Error),
+            &self.types,
+        );
+        let err_applied = super::check_pattern::normalize_type(&self.ctx.apply(&err), &self.types);
+        let matches_err = match &err_applied {
+            Type::Union(variants) => variants.contains(&narrow_ty),
+            other => other == &narrow_ty,
+        };
+        if matches_err {
+            self.define_local_read_only(name, *ok);
         }
     }
 }

--- a/compiler/crates/rask-types/src/checker/check_fn.rs
+++ b/compiler/crates/rask-types/src/checker/check_fn.rs
@@ -148,6 +148,11 @@ impl TypeChecker {
 
         for stmt in &f.body {
             self.check_stmt(stmt);
+            // ER24: early-exit narrowing after each top-level stmt.
+            // Solve pending constraints first so method-call return types
+            // are resolved (otherwise scrutinee stays `Var`).
+            self.solve_constraints();
+            self.apply_early_exit_narrowing(stmt);
         }
 
         // ER20: Finalize error union from accumulated error types

--- a/compiler/crates/rask-types/src/checker/check_pattern.rs
+++ b/compiler/crates/rask-types/src/checker/check_pattern.rs
@@ -95,9 +95,19 @@ impl TypeChecker {
                 if name.contains('.') {
                     return self.check_constructor_pattern(name, &[], scrutinee_ty, span);
                 }
-                // Bare constructors (Ok, Err, Some, None) without parens — match, don't bind
+                // OPT2/ER2: reject `Ok`/`Err`/`Some`/`None` when the scrutinee
+                // is Result/Option. Allow them as user-enum variant names
+                // (e.g. `enum GrepResult { Ok(i32), Err(string) }`).
                 if matches!(name.as_str(), "Ok" | "Err" | "Some" | "None") {
-                    return self.check_constructor_pattern(name, &[], scrutinee_ty, span);
+                    let applied = self.ctx.apply(scrutinee_ty);
+                    if matches!(applied, Type::Result { .. } | Type::Option(_)) {
+                        self.errors.push(TypeError::LegacyWrapperPattern {
+                            name: name.clone(),
+                            with_binding: false,
+                            span,
+                        });
+                        return vec![];
+                    }
                 }
                 // ER27: bare `Type` in a Result match is a type pattern.
                 // Recognize when `name` resolves to a type matching the ok or
@@ -132,6 +142,20 @@ impl TypeChecker {
             }
 
             Pattern::Constructor { name, fields } => {
+                // OPT2/ER2: reject `Ok(v)` / `Err(e)` / `Some(v)` / `None(..)`
+                // when the scrutinee is Result/Option. User enums with these
+                // variant names (e.g. simple_grep.rk's `GrepResult`) are fine.
+                if matches!(name.as_str(), "Ok" | "Err" | "Some" | "None") {
+                    let applied = self.ctx.apply(scrutinee_ty);
+                    if matches!(applied, Type::Result { .. } | Type::Option(_)) {
+                        self.errors.push(TypeError::LegacyWrapperPattern {
+                            name: name.clone(),
+                            with_binding: !fields.is_empty(),
+                            span,
+                        });
+                        return vec![];
+                    }
+                }
                 self.check_constructor_pattern(name, fields, scrutinee_ty, span)
             }
 

--- a/compiler/crates/rask-types/src/checker/check_pattern.rs
+++ b/compiler/crates/rask-types/src/checker/check_pattern.rs
@@ -186,15 +186,17 @@ impl TypeChecker {
                         }
                     }
                     Type::Var(_) => {
-                        let ok_ty = self.ctx.fresh_var();
-                        self.ctx.add_constraint(TypeConstraint::Equal(
-                            scrutinee_ty.clone(),
-                            Type::Result {
-                                ok: Box::new(ok_ty),
-                                err: Box::new(narrow_ty.clone()),
-                            },
+                        // Defer the ok-vs-err decision until the scrutinee
+                        // resolves (e.g. a method-call return type finishes
+                        // unifying). Pinning narrow_ty to err here would
+                        // wrongly unify ok == narrow_ty when narrow_ty is
+                        // actually the ok-branch type.
+                        self.ctx.add_constraint(TypeConstraint::TypePatternMatches {
+                            scrutinee: scrutinee_ty.clone(),
+                            narrow_ty: narrow_ty.clone(),
+                            ty_name: ty_name.clone(),
                             span,
-                        ));
+                        });
                     }
                     _ => {
                         self.errors.push(TypeError::TypePatternNotResult {

--- a/compiler/crates/rask-types/src/checker/check_pattern.rs
+++ b/compiler/crates/rask-types/src/checker/check_pattern.rs
@@ -11,7 +11,69 @@ use super::type_defs::TypeDef;
 use super::type_table::TypeTable;
 use super::TypeChecker;
 
-use crate::types::Type;
+use crate::types::{GenericArg, Type};
+
+/// Recursively resolve `UnresolvedNamed` and `UnresolvedGeneric` to `Named`
+/// and `Generic` where the type table knows the name. Matches `resolve_named`
+/// but walks into `Option`, `Result`, `Generic`, `Tuple`, `Slice`, `Array`,
+/// `Fn`, and `Union` so two types built from different sources compare equal.
+pub(super) fn normalize_type(ty: &Type, types: &TypeTable) -> Type {
+    match ty {
+        Type::UnresolvedNamed(name) => {
+            if let Some(id) = types.get_type_id(name) {
+                return Type::Named(id);
+            }
+            // Stub parsers store generic forms ("Vec<string>") as UnresolvedNamed.
+            // Re-parse so they compare equal with properly-parsed Generic types.
+            if name.contains('<') {
+                if let Ok(parsed) = parse_type_string(name, types) {
+                    if parsed != *ty {
+                        return normalize_type(&parsed, types);
+                    }
+                }
+            }
+            ty.clone()
+        }
+        Type::UnresolvedGeneric { name, args } => {
+            let normalized_args: Vec<GenericArg> = args
+                .iter()
+                .map(|a| match a {
+                    GenericArg::Type(t) => GenericArg::Type(Box::new(normalize_type(t, types))),
+                    other => other.clone(),
+                })
+                .collect();
+            if let Some(id) = types.get_type_id(name) {
+                Type::Generic { base: id, args: normalized_args }
+            } else {
+                Type::UnresolvedGeneric { name: name.clone(), args: normalized_args }
+            }
+        }
+        Type::Option(inner) => Type::Option(Box::new(normalize_type(inner, types))),
+        Type::Result { ok, err } => Type::Result {
+            ok: Box::new(normalize_type(ok, types)),
+            err: Box::new(normalize_type(err, types)),
+        },
+        Type::Generic { base, args } => Type::Generic {
+            base: *base,
+            args: args.iter().map(|a| match a {
+                GenericArg::Type(t) => GenericArg::Type(Box::new(normalize_type(t, types))),
+                other => other.clone(),
+            }).collect(),
+        },
+        Type::Tuple(elems) => Type::Tuple(elems.iter().map(|e| normalize_type(e, types)).collect()),
+        Type::Slice(elem) => Type::Slice(Box::new(normalize_type(elem, types))),
+        Type::Array { elem, len } => Type::Array {
+            elem: Box::new(normalize_type(elem, types)),
+            len: *len,
+        },
+        Type::Fn { params, ret } => Type::Fn {
+            params: params.iter().map(|p| normalize_type(p, types)).collect(),
+            ret: Box::new(normalize_type(ret, types)),
+        },
+        Type::Union(variants) => Type::Union(variants.iter().map(|v| normalize_type(v, types)).collect()),
+        _ => ty.clone(),
+    }
+}
 
 /// Resolve a bare type name to a Type.
 /// Returns UnresolvedNamed when the name isn't a known primitive or user type.
@@ -156,12 +218,12 @@ impl TypeChecker {
             // Result by type. In `if r is E as e`, typically the err side.
             // Union `E = A | B | ...`: accept if TypeName is a union component.
             Pattern::TypePat { ty_name, binding } => {
-                let narrow_ty = resolve_type_name(ty_name, &self.types);
+                let narrow_ty = normalize_type(&resolve_type_name(ty_name, &self.types), &self.types);
                 let resolved = self.ctx.apply(scrutinee_ty);
                 match &resolved {
                     Type::Result { ok, err } => {
-                        let ok_applied = self.ctx.apply(ok);
-                        let err_applied = self.ctx.apply(err);
+                        let ok_applied = normalize_type(&self.ctx.apply(ok), &self.types);
+                        let err_applied = normalize_type(&self.ctx.apply(err), &self.types);
                         let matches_ok = ok_applied == narrow_ty;
                         let matches_err = match &err_applied {
                             Type::Union(variants) => variants.contains(&narrow_ty),

--- a/compiler/crates/rask-types/src/checker/errors.rs
+++ b/compiler/crates/rask-types/src/checker/errors.rs
@@ -324,6 +324,16 @@ pub enum TypeError {
         span: Span,
     },
 
+    /// OPT2/ER2: legacy `Ok`/`Err`/`Some`/`None` pattern — migration error.
+    /// `Ok`/`Err`/`Some`/`None` are not pattern names in the no-wrapper spec.
+    #[error("`{name}` is not a pattern — use the operator or type-pattern form")]
+    LegacyWrapperPattern {
+        name: String,
+        /// True if the pattern had parens (e.g. `Ok(v)` vs bare `Ok`).
+        with_binding: bool,
+        span: Span,
+    },
+
     /// OPT NO_MATCH: match on `T?` is rejected — migration error
     #[error("match on an Option is not supported — use the `?`-operator family")]
     MatchOnOption {

--- a/compiler/crates/rask-types/src/checker/inference.rs
+++ b/compiler/crates/rask-types/src/checker/inference.rs
@@ -36,6 +36,15 @@ pub enum TypeConstraint {
         expected: Type,
         span: Span,
     },
+    /// ER27: scrutinee is a `T or E`, and `narrow_ty` must match either `T`
+    /// or a component of `E`. Deferred so method-call return types can
+    /// resolve before the pattern side is decided.
+    TypePatternMatches {
+        scrutinee: Type,
+        narrow_ty: Type,
+        ty_name: String,
+        span: Span,
+    },
 }
 
 /// Kind of unsuffixed literal (for deferred defaulting).

--- a/compiler/crates/rask-types/src/checker/unify.rs
+++ b/compiler/crates/rask-types/src/checker/unify.rs
@@ -130,6 +130,68 @@ impl TypeChecker {
                 expected,
                 span,
             } => self.resolve_return_value(ret_ty, expected, span),
+            TypeConstraint::TypePatternMatches {
+                scrutinee,
+                narrow_ty,
+                ty_name,
+                span,
+            } => self.resolve_type_pattern(scrutinee, narrow_ty, ty_name, span),
+        }
+    }
+
+    /// ER27: verify that `narrow_ty` matches either the ok or err branch of
+    /// the scrutinee's `T or E` type. Defer if scrutinee is still unresolved.
+    fn resolve_type_pattern(
+        &mut self,
+        scrutinee: Type,
+        narrow_ty: Type,
+        ty_name: String,
+        span: Span,
+    ) -> Result<bool, TypeError> {
+        let resolved = self.ctx.apply(&scrutinee);
+        let narrow_applied = self.ctx.apply(&narrow_ty);
+        match &resolved {
+            Type::Result { ok, err } => {
+                let ok_applied = self.ctx.apply(ok);
+                let err_applied = self.ctx.apply(err);
+                let matches_ok = ok_applied == narrow_applied;
+                let matches_err = match &err_applied {
+                    Type::Union(variants) => variants.contains(&narrow_applied),
+                    other => other == &narrow_applied,
+                };
+                if !matches_ok && !matches_err {
+                    if matches!(&err_applied, Type::Union(_)) {
+                        Err(TypeError::TypePatternNotInUnion {
+                            ty_name,
+                            union: err_applied,
+                            span,
+                        })
+                    } else {
+                        Err(TypeError::TypePatternNotResult {
+                            ty_name,
+                            found: resolved,
+                            span,
+                        })
+                    }
+                } else {
+                    Ok(true)
+                }
+            }
+            Type::Var(_) => {
+                // Still unresolved — re-queue and try again later.
+                self.ctx.add_constraint(TypeConstraint::TypePatternMatches {
+                    scrutinee,
+                    narrow_ty,
+                    ty_name,
+                    span,
+                });
+                Ok(false)
+            }
+            _ => Err(TypeError::TypePatternNotResult {
+                ty_name,
+                found: resolved,
+                span,
+            }),
         }
     }
 

--- a/compiler/crates/rask-types/src/checker/unify.rs
+++ b/compiler/crates/rask-types/src/checker/unify.rs
@@ -149,11 +149,20 @@ impl TypeChecker {
         span: Span,
     ) -> Result<bool, TypeError> {
         let resolved = self.ctx.apply(&scrutinee);
-        let narrow_applied = self.ctx.apply(&narrow_ty);
+        let narrow_applied = super::check_pattern::normalize_type(
+            &self.ctx.apply(&narrow_ty),
+            &self.types,
+        );
         match &resolved {
             Type::Result { ok, err } => {
-                let ok_applied = self.ctx.apply(ok);
-                let err_applied = self.ctx.apply(err);
+                let ok_applied = super::check_pattern::normalize_type(
+                    &self.ctx.apply(ok),
+                    &self.types,
+                );
+                let err_applied = super::check_pattern::normalize_type(
+                    &self.ctx.apply(err),
+                    &self.types,
+                );
                 let matches_ok = ok_applied == narrow_applied;
                 let matches_err = match &err_applied {
                     Type::Union(variants) => variants.contains(&narrow_applied),

--- a/examples/03_collections.rk
+++ b/examples/03_collections.rk
@@ -20,7 +20,7 @@ func main() {
     scores.insert("Charlie", 92)
 
     const alice_score = scores.get("Alice")
-    if alice_score is Some(score) {
+    if alice_score? as score {
         print("Alice's score: ")
         print(score)
         print("\n")

--- a/examples/03_collections.rk
+++ b/examples/03_collections.rk
@@ -20,9 +20,9 @@ func main() {
     scores.insert("Charlie", 92)
 
     const alice_score = scores.get("Alice")
-    if alice_score? as score {
+    if alice_score? {
         print("Alice's score: ")
-        print(score)
+        print(alice_score)
         print("\n")
     }
 

--- a/examples/04_pattern_matching.rk
+++ b/examples/04_pattern_matching.rk
@@ -17,17 +17,17 @@ func main() {
     print("\n")
 
     // Pattern matching with Option
-    const maybe = Some(42)
+    const maybe: i32? = 42
 
-    if maybe is Some(value) {
+    if maybe? as value {
         print("Got value: ")
         print(value)
         print("\n")
     }
 
-    const nothing = None
+    const nothing: i32? = none
 
-    if nothing is None {
+    if nothing == none {
         print("Got nothing\n")
     }
 }

--- a/examples/04_pattern_matching.rk
+++ b/examples/04_pattern_matching.rk
@@ -19,9 +19,9 @@ func main() {
     // Pattern matching with Option
     const maybe: i32? = 42
 
-    if maybe? as value {
+    if maybe? {
         print("Got value: ")
-        print(value)
+        print(maybe)
         print("\n")
     }
 

--- a/examples/07_error_handling.rk
+++ b/examples/07_error_handling.rk
@@ -13,9 +13,9 @@ func main() {
     // Handling T or E with narrowing
     const result = divide(10, 2)
 
-    if result? as value {
+    if result? {
         print("10 / 2 = ")
-        print(value)
+        print(result)
         print("\n")
     } else as e {
         print("Error: ")
@@ -26,9 +26,9 @@ func main() {
     // Division by zero
     const bad = divide(10, 0)
 
-    if bad? as value {
+    if bad? {
         print("Result: ")
-        print(value)
+        print(bad)
         print("\n")
     } else as e {
         print("Error: ")
@@ -52,8 +52,8 @@ func divide(a: i32, b: i32) -> i32 or DivError {
 
 func safe_calc() -> i32 {
     const x = divide(20, 4)
-    if x? as val {
-        return val * 2
+    if x? {
+        return x * 2
     }
     return 0
 }

--- a/examples/07_error_handling.rk
+++ b/examples/07_error_handling.rk
@@ -1,55 +1,58 @@
-// Learn: Error handling with Result and try
+// Learn: Error handling with T or E and try
+
+enum DivError { Msg(string) }
+extend DivError {
+    func message(self) -> string {
+        match self {
+            DivError.Msg(m) => return m,
+        }
+    }
+}
 
 func main() {
-    // Handling Result with match
+    // Handling T or E with narrowing
     const result = divide(10, 2)
 
-    match result {
-        Ok(value) => {
-            print("10 / 2 = ")
-            print(value)
-            print("\n")
-        }
-        Err(msg) => {
-            print("Error: ")
-            print(msg)
-            print("\n")
-        }
+    if result? as value {
+        print("10 / 2 = ")
+        print(value)
+        print("\n")
+    } else as e {
+        print("Error: ")
+        print(e.message())
+        print("\n")
     }
 
     // Division by zero
     const bad = divide(10, 0)
 
-    match bad {
-        Ok(value) => {
-            print("Result: ")
-            print(value)
-            print("\n")
-        }
-        Err(msg) => {
-            print("Error: ")
-            print(msg)
-            print("\n")
-        }
+    if bad? as value {
+        print("Result: ")
+        print(value)
+        print("\n")
+    } else as e {
+        print("Error: ")
+        print(e.message())
+        print("\n")
     }
 
-    // Using try operator
+    // Using narrowing
     const safe = safe_calc()
     print("Safe calc result: ")
     print(safe)
     print("\n")
 }
 
-func divide(a: i32, b: i32) -> i32 or string {
+func divide(a: i32, b: i32) -> i32 or DivError {
     if b == 0 {
-        return Err("Cannot divide by zero")
+        return DivError.Msg("Cannot divide by zero")
     }
-    return Ok(a / b)
+    return a / b
 }
 
 func safe_calc() -> i32 {
     const x = divide(20, 4)
-    if x is Ok(val) {
+    if x? as val {
         return val * 2
     }
     return 0

--- a/examples/12_iterators.rk
+++ b/examples/12_iterators.rk
@@ -123,9 +123,9 @@ func main() {
     const first_large = numbers.iter()
         .find(|n| n > 7)
 
-    if first_large? as n {
+    if first_large? {
         print("First number > 7: ")
-        print(n)
+        print(first_large)
         print("\n")
     } else {
         print("Not found\n")

--- a/examples/12_iterators.rk
+++ b/examples/12_iterators.rk
@@ -123,13 +123,12 @@ func main() {
     const first_large = numbers.iter()
         .find(|n| n > 7)
 
-    match first_large {
-        Some(n) => {
-            print("First number > 7: ")
-            print(n)
-            print("\n")
-        }
-        None => print("Not found\n")
+    if first_large? as n {
+        print("First number > 7: ")
+        print(n)
+        print("\n")
+    } else {
+        print("Not found\n")
     }
 
     // Any/all predicates

--- a/examples/13_string_operations.rk
+++ b/examples/13_string_operations.rk
@@ -117,9 +117,9 @@ func main() {
     const num_str = "42"
     const parsed = num_str.parse<i32>()
 
-    if parsed? as num {
+    if parsed? {
         print("Parsed number: ")
-        print(num)
+        print(parsed)
         print("\n")
     } else as e {
         print("Parse error: ")
@@ -131,7 +131,7 @@ func main() {
     const bad_str = "not a number"
     const bad_parsed = bad_str.parse<i32>()
 
-    if bad_parsed? as num {
+    if bad_parsed? {
         print("This shouldn't happen\n")
     } else as e {
         print("Expected error: ")

--- a/examples/13_string_operations.rk
+++ b/examples/13_string_operations.rk
@@ -117,32 +117,26 @@ func main() {
     const num_str = "42"
     const parsed = num_str.parse<i32>()
 
-    match parsed {
-        Ok(num) => {
-            print("Parsed number: ")
-            print(num)
-            print("\n")
-        }
-        Err(e) => {
-            print("Parse error: ")
-            print(e)
-            print("\n")
-        }
+    if parsed? as num {
+        print("Parsed number: ")
+        print(num)
+        print("\n")
+    } else as e {
+        print("Parse error: ")
+        print(e.message())
+        print("\n")
     }
 
     // Parsing with error handling
     const bad_str = "not a number"
     const bad_parsed = bad_str.parse<i32>()
 
-    match bad_parsed {
-        Ok(num) => {
-            print("This shouldn't happen\n")
-        }
-        Err(e) => {
-            print("Expected error: ")
-            print(e)
-            print("\n")
-        }
+    if bad_parsed? as num {
+        print("This shouldn't happen\n")
+    } else as e {
+        print("Expected error: ")
+        print(e.message())
+        print("\n")
     }
 
     print("\n")

--- a/examples/14_borrowing_patterns.rk
+++ b/examples/14_borrowing_patterns.rk
@@ -43,9 +43,9 @@ func main() {
     const first = numbers.iter().find(|x| x > 0)
     const last = numbers.iter().find(|x| x == 5)
 
-    if first? as n {
+    if first? {
         print("First: ")
-        print(n)
+        print(first)
         print("\n")
     } else {
         print("No first\n")

--- a/examples/14_borrowing_patterns.rk
+++ b/examples/14_borrowing_patterns.rk
@@ -43,13 +43,12 @@ func main() {
     const first = numbers.iter().find(|x| x > 0)
     const last = numbers.iter().find(|x| x == 5)
 
-    match first {
-        Some(n) => {
-            print("First: ")
-            print(n)
-            print("\n")
-        }
-        None => print("No first\n")
+    if first? as n {
+        print("First: ")
+        print(n)
+        print("\n")
+    } else {
+        print("No first\n")
     }
 
     // Block-scoped views with structs

--- a/examples/15_memory_management.rk
+++ b/examples/15_memory_management.rk
@@ -105,7 +105,7 @@ func main() {
     print(player_ent.health)
     print(")")
 
-    if player_ent.target is Some(target_handle) {
+    if player_ent.target? as target_handle {
         const target = entities.get(target_handle).unwrap()
         print(" -> targets ")
         print(target.name)
@@ -118,7 +118,7 @@ func main() {
     print(e1.health)
     print(")")
 
-    if e1.target is Some(target_handle) {
+    if e1.target? as target_handle {
         const target = entities.get(target_handle).unwrap()
         print(" -> targets ")
         print(target.name)
@@ -131,7 +131,7 @@ func main() {
     print(e2.health)
     print(")")
 
-    if e2.target is Some(target_handle) {
+    if e2.target? as target_handle {
         const target = entities.get(target_handle).unwrap()
         print(" -> targets ")
         print(target.name)

--- a/examples/15_memory_management.rk
+++ b/examples/15_memory_management.rk
@@ -76,25 +76,25 @@ func main() {
         id: 1,
         name: "Player",
         health: 100,
-        target: None,
-    }).unwrap()
+        target: none,
+    })!
 
     const enemy1 = entities.alloc(Entity {
         id: 2,
         name: "Goblin",
         health: 50,
-        target: Some(player),  // Enemy targets player
-    }).unwrap()
+        target: player,  // Enemy targets player
+    })!
 
     const enemy2 = entities.alloc(Entity {
         id: 3,
         name: "Orc",
         health: 80,
-        target: Some(player),
-    }).unwrap()
+        target: player,
+    })!
 
     // Player targets first enemy
-    entities[player].target = Some(enemy1)
+    entities[player].target = enemy1
 
     // Display entity relationships
     print("\nEntity relationships:\n")

--- a/examples/15_memory_management.rk
+++ b/examples/15_memory_management.rk
@@ -31,33 +31,33 @@ func main() {
 
     print("Creating linked list with handles:\n")
 
-    // Allocate nodes in the pool — alloc returns Result<Handle>
+    // Allocate nodes in the pool — alloc returns Handle or Error
     const first = node_pool.alloc(Node {
         value: 1,
-        next: None,
-    }).unwrap()
+        next: none,
+    })!
 
     const second = node_pool.alloc(Node {
         value: 2,
-        next: None,
-    }).unwrap()
+        next: none,
+    })!
 
     const third = node_pool.alloc(Node {
         value: 3,
-        next: None,
-    }).unwrap()
+        next: none,
+    })!
 
     // Link nodes using handles (pool indexing with handle)
-    node_pool[first].next = Some(second)
-    node_pool[second].next = Some(third)
+    node_pool[first].next = second
+    node_pool[second].next = third
 
     // Traverse the list using handles
     print("List values: ")
-    mut current = Some(first)
+    mut current: Handle<Node>? = first
 
     loop {
-        if current is Some(handle) {
-            const node = node_pool.get(handle).unwrap()
+        if current? as handle {
+            const node = node_pool.get(handle)!
             print(node.value)
             print(" -> ")
             current = node.next

--- a/examples/16_concurrency_basics.rk
+++ b/examples/16_concurrency_basics.rk
@@ -151,9 +151,9 @@ func main() -> () or MainError {
     // Try to receive
     const maybe_msg = test_channel.receiver.try_recv()
 
-    if maybe_msg? as value {
+    if maybe_msg? {
         print("Got message: ")
-        print(value)
+        print(maybe_msg)
         print("\n")
     } else {
         print("No message available\n")
@@ -162,9 +162,9 @@ func main() -> () or MainError {
     // Try to receive again (should fail, channel empty)
     const no_msg = test_channel.receiver.try_recv()
 
-    if no_msg? as value {
+    if no_msg? {
         print("Got message: ")
-        print(value)
+        print(no_msg)
         print("\n")
     } else {
         print("Channel empty (expected)\n")

--- a/examples/16_concurrency_basics.rk
+++ b/examples/16_concurrency_basics.rk
@@ -22,7 +22,16 @@ func worker(id: i32, iterations: i32) -> i32 {
     return sum
 }
 
-func main() -> () or string {
+enum MainError { Msg(string) }
+extend MainError {
+    func message(self) -> string {
+        match self {
+            MainError.Msg(m) => return m,
+        }
+    }
+}
+
+func main() -> () or MainError {
     print("=== Basic Threading ===\n\n")
 
     // Spawn a thread with Thread.spawn(|| {})
@@ -142,29 +151,23 @@ func main() -> () or string {
     // Try to receive
     const maybe_msg = test_channel.receiver.try_recv()
 
-    match maybe_msg {
-        Ok(value) => {
-            print("Got message: ")
-            print(value)
-            print("\n")
-        }
-        Err(e) => {
-            print("No message available\n")
-        }
+    if maybe_msg? as value {
+        print("Got message: ")
+        print(value)
+        print("\n")
+    } else {
+        print("No message available\n")
     }
 
     // Try to receive again (should fail, channel empty)
     const no_msg = test_channel.receiver.try_recv()
 
-    match no_msg {
-        Ok(value) => {
-            print("Got message: ")
-            print(value)
-            print("\n")
-        }
-        Err(e) => {
-            print("Channel empty (expected)\n")
-        }
+    if no_msg? as value {
+        print("Got message: ")
+        print(value)
+        print("\n")
+    } else {
+        print("Channel empty (expected)\n")
     }
 
     print("\n")
@@ -204,5 +207,5 @@ func main() -> () or string {
     print("- No data races - compiler enforces safety\n")
     print("- No function coloring - threads are first-class\n")
 
-    return Ok(())
+    return ()
 }

--- a/examples/18_resource_types.rk
+++ b/examples/18_resource_types.rk
@@ -126,7 +126,7 @@ func manual_close() {
     // ensure won't run because conn was already closed
 }
 
-func demonstrate_file_resources() -> () or string {
+func demonstrate_file_resources() -> () or IoError {
     // File handles are also linear resources
     const file = try fs.create("test.txt")
     ensure {
@@ -157,9 +157,9 @@ func main() {
 
     // Demonstrate file resources (returns Result)
     const result = demonstrate_file_resources()
-    if result is Err(e) {
+    if result is IoError as e {
         print("Error: ")
-        print(e)
+        print(e.message())
         print("\n")
     }
 

--- a/examples/cli_calculator.rk
+++ b/examples/cli_calculator.rk
@@ -331,8 +331,8 @@ func main() -> () or Error {
             "help" | "h" | "?" => print_help(),
             _ => {
                 const r = calc(input.to_string())
-                if r? as result {
-                    println("= {result}")
+                if r? {
+                    println("= {r}")
                 } else as e {
                     println("Error: {e.message()}")
                 }

--- a/examples/cli_calculator.rk
+++ b/examples/cli_calculator.rk
@@ -79,7 +79,8 @@ extend Lexer {
     }
 
     func skip_whitespace(self) {
-        while self.peek_char() is Some(c) {
+        while self.peek_char()? {
+            const c = self.peek_char()!
             if !c.is_whitespace(): break
             self.advance()
         }
@@ -111,7 +112,8 @@ extend Lexer {
         const num_str = string.new()
         mut has_dot = false
 
-        while self.peek_char() is Some(c) {
+        while self.peek_char()? {
+            const c = self.peek_char()!
             if c.is_digit() {
                 num_str.push(c)
                 self.advance()

--- a/examples/cli_calculator.rk
+++ b/examples/cli_calculator.rk
@@ -68,14 +68,14 @@ extend Lexer {
     }
 
     func peek_char(self) -> char? {
-        if self.pos >= self.input.len(): return None
+        if self.pos >= self.input.len(): return none
         return self.input.char_at(self.pos)
     }
 
     func advance(self) -> char? {
         const c = try self.peek_char()
         self.pos += 1
-        return Some(c)
+        return c
     }
 
     func skip_whitespace(self) {
@@ -88,10 +88,7 @@ extend Lexer {
     func next_token(self) -> Token or CalcError {
         self.skip_whitespace()
 
-        const c = match self.peek_char() {
-            Some(c) => c,
-            None => return Ok(Token.Eof),
-        }
+        const c = if self.peek_char()? as ch { ch } else { return Token.Eof }
 
         // Single-character tokens
         const token = match c {
@@ -104,7 +101,7 @@ extend Lexer {
             '(' => { self.advance(); Token.LParen }
             ')' => { self.advance(); Token.RParen }
             _ if c.is_digit() || c == '.' => try self.read_number(),
-            _ => return Err(CalcError.UnexpectedChar(c)),
+            _ => return CalcError.UnexpectedChar(c),
         }
 
         return token
@@ -153,8 +150,8 @@ extend Parser {
         const expr = try self.parse_expression()
 
         match self.current {
-            Eof => return Ok(expr),
-            _ => return Err(CalcError.UnexpectedToken(self.token_string())),
+            Eof => return expr,
+            _ => return CalcError.UnexpectedToken(self.token_string()),
         }
     }
     
@@ -250,11 +247,11 @@ extend Parser {
                         try self.advance()
                         return expr
                     }
-                    _ => return Err(CalcError.UnexpectedToken("expected ')'".to_string())),
+                    _ => return CalcError.UnexpectedToken("expected ')'".to_string()),
                 }
             }
-            Eof => return Err(CalcError.EmptyExpression),
-            _ => return Err(CalcError.UnexpectedToken(self.token_string())),
+            Eof => return CalcError.EmptyExpression,
+            _ => return CalcError.UnexpectedToken(self.token_string()),
         }
     }
 }
@@ -277,11 +274,11 @@ func evaluate(expr: Expr) -> f64 or CalcError {
                 Sub => return l - r,
                 Mul => return l * r,
                 Div => {
-                    if r == 0.0: return Err(CalcError.DivisionByZero)
+                    if r == 0.0: return CalcError.DivisionByZero
                     return l / r
                 }
                 Mod => {
-                    if r == 0.0: return Err(CalcError.DivisionByZero)
+                    if r == 0.0: return CalcError.DivisionByZero
                     return l % r
                 }
                 Pow => return l.powf(r),
@@ -331,9 +328,11 @@ func main() -> () or Error {
             "quit" | "exit" | "q" => break,
             "help" | "h" | "?" => print_help(),
             _ => {
-                match calc(input.to_string()) {
-                    Ok(result) => println("= {result}"),
-                    Err(e) => println("Error: {e.message()}"),
+                const r = calc(input.to_string())
+                if r? as result {
+                    println("= {result}")
+                } else as e {
+                    println("Error: {e.message()}")
                 }
             }
         }
@@ -347,70 +346,70 @@ func main() -> () or Error {
 // ============================================================================
 
 test "addition" {
-    assert calc("2 + 3") == Ok(5.0)
-    assert calc("10 + 20 + 30") == Ok(60.0)
+    assert calc("2 + 3")! == 5.0
+    assert calc("10 + 20 + 30")! == 60.0
 }
 
 test "subtraction" {
-    assert calc("10 - 3") == Ok(7.0)
-    assert calc("5 - 10") == Ok(-5.0)
+    assert calc("10 - 3")! == 7.0
+    assert calc("5 - 10")! == -5.0
 }
 
 test "multiplication" {
-    assert calc("4 * 5") == Ok(20.0)
-    assert calc("2 * 3 * 4") == Ok(24.0)
+    assert calc("4 * 5")! == 20.0
+    assert calc("2 * 3 * 4")! == 24.0
 }
 
 test "division" {
-    assert calc("20 / 4") == Ok(5.0)
-    assert calc("7 / 2") == Ok(3.5)
+    assert calc("20 / 4")! == 5.0
+    assert calc("7 / 2")! == 3.5
 }
 
 test "precedence" {
     // Multiplication before addition
-    assert calc("2 + 3 * 4") == Ok(14.0)
-    assert calc("2 * 3 + 4") == Ok(10.0)
+    assert calc("2 + 3 * 4")! == 14.0
+    assert calc("2 * 3 + 4")! == 10.0
 
     // Division before subtraction
-    assert calc("10 - 6 / 2") == Ok(7.0)
+    assert calc("10 - 6 / 2")! == 7.0
 }
 
 test "parentheses" {
-    assert calc("(2 + 3) * 4") == Ok(20.0)
-    assert calc("2 * (3 + 4)") == Ok(14.0)
-    assert calc("((1 + 2) * (3 + 4))") == Ok(21.0)
+    assert calc("(2 + 3) * 4")! == 20.0
+    assert calc("2 * (3 + 4)")! == 14.0
+    assert calc("((1 + 2) * (3 + 4))")! == 21.0
 }
 
 test "power right associative" {
     // 2^3^2 = 2^(3^2) = 2^9 = 512, not (2^3)^2 = 64
-    assert calc("2 ^ 3 ^ 2") == Ok(512.0)
-    assert calc("2 ^ 3") == Ok(8.0)
+    assert calc("2 ^ 3 ^ 2")! == 512.0
+    assert calc("2 ^ 3")! == 8.0
 }
 
 test "unary negation" {
-    assert calc("-5") == Ok(-5.0)
-    assert calc("-5 + 3") == Ok(-2.0)
-    assert calc("--5") == Ok(5.0)  // Double negation
-    assert calc("3 * -2") == Ok(-6.0)
+    assert calc("-5")! == -5.0
+    assert calc("-5 + 3")! == -2.0
+    assert calc("--5")! == 5.0  // Double negation
+    assert calc("3 * -2")! == -6.0
 }
 
 test "modulo" {
-    assert calc("10 % 3") == Ok(1.0)
-    assert calc("15 % 4") == Ok(3.0)
+    assert calc("10 % 3")! == 1.0
+    assert calc("15 % 4")! == 3.0
 }
 
 test "floating point" {
-    assert calc("3.14 * 2") == Ok(6.28)
-    assert calc("1.5 + 2.5") == Ok(4.0)
+    assert calc("3.14 * 2")! == 6.28
+    assert calc("1.5 + 2.5")! == 4.0
 }
 
 test "division by zero" {
-    assert calc("5 / 0") == Err(CalcError.DivisionByZero)
-    assert calc("10 % 0") == Err(CalcError.DivisionByZero)
+    assert calc("5 / 0") is CalcError.DivisionByZero
+    assert calc("10 % 0") is CalcError.DivisionByZero
 }
 
 test "invalid input" {
-    assert calc("2 +").is_err()
-    assert calc("") == Err(CalcError.EmptyExpression)
-    assert calc("@").is_err()
+    assert !calc("2 +")?
+    assert calc("") is CalcError.EmptyExpression
+    assert !calc("@")?
 }

--- a/examples/cli_calculator.rk
+++ b/examples/cli_calculator.rk
@@ -409,7 +409,7 @@ test "division by zero" {
 }
 
 test "invalid input" {
-    assert !calc("2 +")?
+    assert calc("2 +") is CalcError
     assert calc("") is CalcError.EmptyExpression
-    assert !calc("@")?
+    assert calc("@") is CalcError
 }

--- a/examples/file_copy.rk
+++ b/examples/file_copy.rk
@@ -106,8 +106,8 @@ func copy_file(opts: CopyOptions) -> u64 or CopyError {
         else |e| CopyError.ReadError(e)
     const dst_canonical = fs.canonicalize(opts.dest).ok()
 
-    if dst_canonical? as dst {
-        if src_canonical == dst {
+    if dst_canonical? {
+        if src_canonical == dst_canonical {
             return CopyError.SameFile
         }
     }
@@ -135,8 +135,8 @@ func main() {
     const args = cli.args()
 
     const parsed = parse_args(own args)
-    const opts = if parsed? as o {
-        o
+    const opts = if parsed? {
+        parsed
     } else as e {
         println("rcopy: {e.message()}")
         std.exit(1)
@@ -147,9 +147,9 @@ func main() {
     }
 
     const result = copy_file(opts)
-    if result? as bytes {
+    if result? {
         if opts.verbose {
-            const size = format_size(bytes)
+            const size = format_size(result)
             println("Copied {size}")
         }
     } else as e {

--- a/examples/file_copy.rk
+++ b/examples/file_copy.rk
@@ -106,7 +106,7 @@ func copy_file(opts: CopyOptions) -> u64 or CopyError {
         else |e| CopyError.ReadError(e)
     const dst_canonical = fs.canonicalize(opts.dest).ok()
 
-    if dst_canonical is Some(dst) {
+    if dst_canonical? as dst {
         if src_canonical == dst {
             return CopyError.SameFile
         }

--- a/examples/file_copy.rk
+++ b/examples/file_copy.rk
@@ -27,6 +27,15 @@ extend CopyError {
     }
 }
 
+enum ArgError { Msg(string) }
+extend ArgError {
+    func message(self) -> string {
+        match self {
+            ArgError.Msg(m) => return m,
+        }
+    }
+}
+
 struct CopyOptions {
     source: string
     dest: string
@@ -34,7 +43,7 @@ struct CopyOptions {
     verbose: bool
 }
 
-func parse_args(take args: Vec<string>) -> CopyOptions or string {
+func parse_args(take args: Vec<string>) -> CopyOptions or ArgError {
     mut opts = CopyOptions {
         source: "",
         dest: "",
@@ -60,13 +69,13 @@ func parse_args(take args: Vec<string>) -> CopyOptions or string {
     }
 
     if positional.len() < 2 {
-        return Err("usage: rcopy [-fv] SOURCE DEST")
+        return ArgError.Msg("usage: rcopy [-fv] SOURCE DEST")
     }
 
     opts.source = positional.remove(0)
     opts.dest = positional.remove(0)
 
-    return Ok(opts)
+    return opts
 }
 
 func print_usage() {
@@ -83,12 +92,12 @@ func print_usage() {
 func copy_file(opts: CopyOptions) -> u64 or CopyError {
     // O3 borrows opts — fs calls borrow the fields, only error enums need owned strings
     if !fs.exists(opts.source) {
-        return Err(CopyError.SourceNotFound(opts.source))
+        return CopyError.SourceNotFound(opts.source)
     }
 
     if fs.exists(opts.dest) {
         if !opts.force {
-            return Err(CopyError.DestinationExists(opts.dest))
+            return CopyError.DestinationExists(opts.dest)
         }
     }
 
@@ -99,7 +108,7 @@ func copy_file(opts: CopyOptions) -> u64 or CopyError {
 
     if dst_canonical is Some(dst) {
         if src_canonical == dst {
-            return Err(CopyError.SameFile)
+            return CopyError.SameFile
         }
     }
 
@@ -107,7 +116,7 @@ func copy_file(opts: CopyOptions) -> u64 or CopyError {
     const bytes = try fs.copy(opts.source, opts.dest)
         else |e| CopyError.WriteError(e)
 
-    return Ok(bytes)
+    return bytes
 }
 
 func format_size(bytes: u64) -> string {
@@ -125,29 +134,27 @@ func format_size(bytes: u64) -> string {
 func main() {
     const args = cli.args()
 
-    const opts = match parse_args(own args) {
-        Ok(o) => o,
-        Err(msg) => {
-            println("rcopy: {msg}")
-            std.exit(1)
-        }
+    const parsed = parse_args(own args)
+    const opts = if parsed? as o {
+        o
+    } else as e {
+        println("rcopy: {e.message()}")
+        std.exit(1)
     }
 
     if opts.verbose {
         println("Copying '{opts.source}' to '{opts.dest}'...")
     }
 
-    match copy_file(opts) {
-        Ok(bytes) => {
-            if opts.verbose {
-                const size = format_size(bytes)
-                println("Copied {size}")
-            }
+    const result = copy_file(opts)
+    if result? as bytes {
+        if opts.verbose {
+            const size = format_size(bytes)
+            println("Copied {size}")
         }
-        Err(e) => {
-            const msg = e.message()
-            println("rcopy: {msg}")
-            std.exit(1)
-        }
+    } else as e {
+        const msg = e.message()
+        println("rcopy: {msg}")
+        std.exit(1)
     }
 }

--- a/examples/game_loop.rk
+++ b/examples/game_loop.rk
@@ -266,7 +266,7 @@ func main() -> () or Error {
             // Handle input (simulated - would be real input in actual game)
             if frame_count % 30 == 0 {
                 // Fire projectile
-                if state.player is Some(player_h) {
+                if state.player? as player_h {
                     const px = state.entities[player_h].position.x
                     const py = state.entities[player_h].position.y
                     try state.spawn_projectile(px + 20.0f32, py, 300.0f32, 0.0f32)
@@ -292,7 +292,7 @@ func main() -> () or Error {
         if frame_count % 60 == 0 {
             const entity_count = state.entities.len()
             mut player_health = 0
-            if state.player is Some(h) {
+            if state.player? as h {
                 player_health = state.entities[h].health.current
             }
             println("Frame {frame_count}: Entities={entity_count}, Health={player_health}, Score={state.score}")

--- a/examples/game_loop.rk
+++ b/examples/game_loop.rk
@@ -76,12 +76,12 @@ extend GameState {
             entity_type: EntityType.Player,
         })
 
-        return Ok(GameState {
+        return GameState {
             entities: entities,
-            player: Some(player_handle),
+            player: player_handle,
             score: 0,
             game_over: false,
-        })
+        }
     }
 
     func spawn_enemy(self, x: f32, y: f32) -> Handle<Entity> or Error {

--- a/examples/grep_clone.rk
+++ b/examples/grep_clone.rk
@@ -127,8 +127,8 @@ func grep_file(path: string, opts: GrepOptions) -> i64 or GrepError {
 func main() {
     const args = cli.args()
     const parsed = parse_args(own args)
-    mut opts = if parsed? as o {
-        o
+    mut opts = if parsed? {
+        parsed
     } else as e {
         const msg = e.message()
         println("rgrep: {msg}")
@@ -143,8 +143,8 @@ func main() {
     while fi < opts.files.len() {
         const file_path = opts.files[fi]
         const r = grep_file(file_path, opts)
-        if r? as count {
-            total_matches = total_matches + count
+        if r? {
+            total_matches = total_matches + r
         } else as e {
             const msg = e.message()
             println("rgrep: {msg}")

--- a/examples/grep_clone.rk
+++ b/examples/grep_clone.rk
@@ -61,13 +61,13 @@ func parse_args(take args: Vec<string>) -> GrepOptions or GrepError {
         i = i + 1
     }
 
-    if positional.is_empty(): return Err(GrepError.NoPattern)
-    if positional.len() < 2: return Err(GrepError.NoFiles)
+    if positional.is_empty(): return GrepError.NoPattern
+    if positional.len() < 2: return GrepError.NoFiles
 
     opts.pattern = positional.remove(0)
     opts.files = positional
 
-    return Ok(opts)
+    return opts
 }
 
 func print_usage() {
@@ -121,19 +121,19 @@ func grep_file(path: string, opts: GrepOptions) -> i64 or GrepError {
         println("{match_count}")
     }
 
-    return Ok(match_count)
+    return match_count
 }
 
 func main() {
     const args = cli.args()
-    mut opts = match parse_args(own args) {
-        Ok(o) => o,
-        Err(e) => {
-            const msg = e.message()
-            println("rgrep: {msg}")
-            print_usage()
-            std.exit(1)
-        }
+    const parsed = parse_args(own args)
+    mut opts = if parsed? as o {
+        o
+    } else as e {
+        const msg = e.message()
+        println("rgrep: {msg}")
+        print_usage()
+        std.exit(1)
     }
 
     mut total_matches = 0
@@ -142,13 +142,13 @@ func main() {
     mut fi: usize = 0
     while fi < opts.files.len() {
         const file_path = opts.files[fi]
-        match grep_file(file_path, opts) {
-            Ok(count) => total_matches = total_matches + count,
-            Err(e) => {
-                const msg = e.message()
-                println("rgrep: {msg}")
-                had_errors = true
-            }
+        const r = grep_file(file_path, opts)
+        if r? as count {
+            total_matches = total_matches + count
+        } else as e {
+            const msg = e.message()
+            println("rgrep: {msg}")
+            had_errors = true
         }
         fi = fi + 1
     }

--- a/examples/http_api_server.rk
+++ b/examples/http_api_server.rk
@@ -101,10 +101,11 @@ func get_user(id: i64) -> Response {
         })
     }
 
-    return match user {
-        Some(u) => Response.json(json.encode(u)),
-        None => Response.json(json.encode(ErrorResponse { error: "user not found" }))
-            .with_status(404),
+    if user? as u {
+        return Response.json(json.encode(u))
+    } else {
+        return Response.json(json.encode(ErrorResponse { error: "user not found" }))
+            .with_status(404)
     }
 }
 
@@ -129,10 +130,11 @@ func create_user(body: string) -> Response {
 func delete_user(id: i64) -> Response {
     const removed = db.write().users.remove(id)
 
-    return match removed {
-        Some(_) => Response.no_content(),
-        None => Response.json(json.encode(ErrorResponse { error: "user not found" }))
-            .with_status(404),
+    if removed? {
+        return Response.no_content()
+    } else {
+        return Response.json(json.encode(ErrorResponse { error: "user not found" }))
+            .with_status(404)
     }
 }
 

--- a/examples/http_api_server.rk
+++ b/examples/http_api_server.rk
@@ -64,7 +64,7 @@ func handle(req: Request) -> Response {
         (Method.Get, "/users") => list_users(),
         (Method.Get, path) if path.starts_with("/users/") => {
             const id_str = path[7..]
-            const id = id_str.parse<i64>() is Ok else {
+            const id = id_str.parse<i64>() is i64 else {
                 return Response.bad_request("invalid user id")
             }
             get_user(id)
@@ -72,7 +72,7 @@ func handle(req: Request) -> Response {
         (Method.Post, "/users") => create_user(req.body),
         (Method.Delete, path) if path.starts_with("/users/") => {
             const id_str = path[7..]
-            const id = id_str.parse<i64>() is Ok else {
+            const id = id_str.parse<i64>() is i64 else {
                 return Response.bad_request("invalid user id")
             }
             delete_user(id)
@@ -110,7 +110,7 @@ func get_user(id: i64) -> Response {
 }
 
 func create_user(body: string) -> Response {
-    const req = json.decode<CreateUserRequest>(body) is Ok else {
+    const req = json.decode<CreateUserRequest>(body) is CreateUserRequest else {
         return Response.bad_request(json.encode(ErrorResponse {
             error: "invalid JSON"
         }))

--- a/examples/http_api_server.rk
+++ b/examples/http_api_server.rk
@@ -101,8 +101,8 @@ func get_user(id: i64) -> Response {
         })
     }
 
-    if user? as u {
-        return Response.json(json.encode(u))
+    if user? {
+        return Response.json(json.encode(user))
     } else {
         return Response.json(json.encode(ErrorResponse { error: "user not found" }))
             .with_status(404)

--- a/examples/litmus_edge_cases.rk
+++ b/examples/litmus_edge_cases.rk
@@ -94,10 +94,25 @@ test "Vec.get unwrap matches expected value" {
 enum InnerError {
     BadInput(string),
 }
+extend InnerError {
+    func message(self) -> string {
+        match self {
+            InnerError.BadInput(m) => return m,
+        }
+    }
+}
 
 enum OuterError {
     Wrapped(InnerError),
     Other(string),
+}
+extend OuterError {
+    func message(self) -> string {
+        match self {
+            OuterError.Wrapped(e) => return e.message(),
+            OuterError.Other(m) => return m,
+        }
+    }
 }
 
 struct Validator {
@@ -107,21 +122,21 @@ struct Validator {
 extend Validator {
     func check(self, value: i32) -> i32 or InnerError {
         if value < self.threshold {
-            return Err(InnerError.BadInput("below threshold"))
+            return InnerError.BadInput("below threshold")
         }
-        return Ok(value * 2)
+        return value * 2
     }
 }
 
 func use_validator(v: Validator, x: i32) -> i32 or OuterError {
     const result = try v.check(x) else |e| OuterError.Wrapped(e)
-    return Ok(result)
+    return result
 }
 
 func use_validator_multiline(v: Validator, x: i32) -> i32 or OuterError {
     const result = try v.check(x)
         else |e| OuterError.Wrapped(e)
-    return Ok(result)
+    return result
 }
 
 test "try-else with method call — success" {
@@ -153,10 +168,25 @@ test "try-else multiline with method call — error transforms" {
 enum ParseError {
     InvalidFormat(string),
 }
+extend ParseError {
+    func message(self) -> string {
+        match self {
+            ParseError.InvalidFormat(m) => return m,
+        }
+    }
+}
 
 enum ProcessError {
     Parse(ParseError),
     Logic(string),
+}
+extend ProcessError {
+    func message(self) -> string {
+        match self {
+            ProcessError.Parse(e) => return e.message(),
+            ProcessError.Logic(m) => return m,
+        }
+    }
 }
 
 trait Parser {
@@ -168,22 +198,22 @@ struct StrictParser {}
 extend StrictParser with Parser {
     func parse(self, input: string) -> i32 or ParseError {
         if input == "42" {
-            return Ok(42)
+            return 42
         }
-        return Err(ParseError.InvalidFormat("not 42"))
+        return ParseError.InvalidFormat("not 42")
     }
 }
 
 func process_with_parser(p: any Parser, input: string) -> i32 or ProcessError {
     const val = try p.parse(input) else |e| ProcessError.Parse(e)
-    return Ok(val * 2)
+    return val * 2
 }
 
 test "try-else with trait object — success" {
     const p = StrictParser {}
     const result = process_with_parser(p, "42")
-    assert result is Ok
-    assert result.unwrap() == 84
+    assert result?
+    assert result! == 84
 }
 
 test "try-else with trait object — error transforms" {
@@ -290,7 +320,7 @@ test "try-else — error value is correctly transformed" {
     const v = Validator { threshold: 10 }
     const result = use_validator(v, 3)
     match result {
-        Err(OuterError.Wrapped(InnerError.BadInput(msg))) => {
+        OuterError.Wrapped(InnerError.BadInput(msg)) => {
             assert msg == "below threshold"
         }
         _ => assert false, "expected Wrapped(BadInput)"
@@ -303,39 +333,56 @@ enum ChainError {
     Step1(string),
     Step2(string),
 }
-
-func step1(x: i32) -> i32 or string {
-    if x < 0 { return Err("negative") }
-    return Ok(x + 1)
+extend ChainError {
+    func message(self) -> string {
+        match self {
+            ChainError.Step1(m) => return m,
+            ChainError.Step2(m) => return m,
+        }
+    }
 }
 
-func step2(x: i32) -> i32 or string {
-    if x > 100 { return Err("too large") }
-    return Ok(x * 2)
+enum StepError { Msg(string) }
+extend StepError {
+    func message(self) -> string {
+        match self {
+            StepError.Msg(m) => return m,
+        }
+    }
+}
+
+func step1(x: i32) -> i32 or StepError {
+    if x < 0 { return StepError.Msg("negative") }
+    return x + 1
+}
+
+func step2(x: i32) -> i32 or StepError {
+    if x > 100 { return StepError.Msg("too large") }
+    return x * 2
 }
 
 func chained(x: i32) -> i32 or ChainError {
-    const a = try step1(x) else |e| ChainError.Step1(e)
-    const b = try step2(a) else |e| ChainError.Step2(e)
-    return Ok(b)
+    const a = try step1(x) else |e| ChainError.Step1(e.message())
+    const b = try step2(a) else |e| ChainError.Step2(e.message())
+    return b
 }
 
 test "chained try-else — all succeed" {
     const result = chained(5)
-    assert result is Ok
-    assert result.unwrap() == 12
+    assert result?
+    assert result! == 12
 }
 
 test "chained try-else — first fails" {
     const result = chained(-1)
-    assert result is Err(ChainError.Step1(_))
+    assert result is ChainError.Step1(_)
 }
 
 test "chained try-else — second fails" {
     const result = chained(99)
     const result2 = chained(200)
-    assert result is Ok
-    assert result2 is Err(ChainError.Step2(_))
+    assert result?
+    assert result2 is ChainError.Step2(_)
 }
 
 // ─── HTTP types (Response constructors, Request.path) ───────────
@@ -389,11 +436,12 @@ test "fs write and read round-trip" {
 test "fs read_lines returns correct line count" {
     const path = "/tmp/rask_test_litmus2.txt"
     fs.write_file(path, "line1\nline2\nline3\n")
-    const lines = fs.read_lines(path) is Ok(l) else {
+    const r = fs.read_lines(path)
+    if r? as lines {
+        assert lines.len() == 3
+    } else {
         assert false, "failed to read lines"
-        return
     }
-    assert lines.len() == 3
 }
 
 // ─── Entry point ────────────────────────────────────────────────

--- a/examples/litmus_edge_cases.rk
+++ b/examples/litmus_edge_cases.rk
@@ -310,7 +310,7 @@ test "Vec.get — pattern match None" {
 test "Vec.get — guard pattern" {
     const v = Vec.new()
     v.push(42)
-    const val = v.get(0) is Some else { panic("missing") }
+    const val = v.get(0) ?? panic("missing")
     assert val == 42
 }
 

--- a/examples/litmus_edge_cases.rk
+++ b/examples/litmus_edge_cases.rk
@@ -67,7 +67,7 @@ test "Vec.get returns Some for valid index" {
     v.push(30)
 
     const first = v.get(0)
-    assert first is Some
+    assert first?
 
     const second = v.get(1).unwrap()
     assert second == 20
@@ -78,7 +78,7 @@ test "Vec.get returns None for out of bounds" {
     v.push(42)
 
     const out = v.get(5)
-    assert out is None
+    assert out == none
 }
 
 test "Vec.get unwrap matches expected value" {
@@ -142,25 +142,25 @@ func use_validator_multiline(v: Validator, x: i32) -> i32 or OuterError {
 test "try-else with method call — success" {
     const v = Validator { threshold: 5 }
     const result = use_validator(v, 10)
-    assert result is Ok
+    assert result?
 }
 
 test "try-else with method call — error transforms" {
     const v = Validator { threshold: 5 }
     const result = use_validator(v, 3)
-    assert result is Err
+    assert result is OuterError
 }
 
 test "try-else multiline with method call — success" {
     const v = Validator { threshold: 5 }
     const result = use_validator_multiline(v, 10)
-    assert result is Ok
+    assert result?
 }
 
 test "try-else multiline with method call — error transforms" {
     const v = Validator { threshold: 5 }
     const result = use_validator_multiline(v, 3)
-    assert result is Err
+    assert result is OuterError
 }
 
 // ─── try-else with trait objects ────────────────────────────────
@@ -219,7 +219,7 @@ test "try-else with trait object — success" {
 test "try-else with trait object — error transforms" {
     const p = StrictParser {}
     const result = process_with_parser(p, "bad")
-    assert result is Err
+    assert result is ProcessError
 }
 
 // ─── String Copy in collections ─────────────────────────────────
@@ -292,7 +292,7 @@ test "Pool — modify non-string field after reading string" {
 test "Vec.get — pattern match Some" {
     const v = Vec.new()
     v.push("hello")
-    if v.get(0) is Some(val) {
+    if v.get(0)? as val {
         assert val == "hello"
     } else {
         assert false, "expected Some"
@@ -302,7 +302,7 @@ test "Vec.get — pattern match Some" {
 test "Vec.get — pattern match None" {
     const v = Vec.new()
     v.push(1)
-    if v.get(99) is Some {
+    if v.get(99)? {
         assert false, "expected None"
     }
 }

--- a/examples/litmus_edge_cases.rk
+++ b/examples/litmus_edge_cases.rk
@@ -437,8 +437,8 @@ test "fs read_lines returns correct line count" {
     const path = "/tmp/rask_test_litmus2.txt"
     fs.write_file(path, "line1\nline2\nline3\n")
     const r = fs.read_lines(path)
-    if r? as lines {
-        assert lines.len() == 3
+    if r? {
+        assert r.len() == 3
     } else {
         assert false, "failed to read lines"
     }

--- a/examples/litmus_edge_cases.rk
+++ b/examples/litmus_edge_cases.rk
@@ -426,7 +426,7 @@ test "fs write and read round-trip" {
     const path = "/tmp/rask_test_litmus.txt"
     const content = "hello from rask\nsecond line\n"
     fs.write_file(path, content)
-    const read_back = fs.read_file(path) is Ok(data) else {
+    const read_back = fs.read_file(path) is string as data else {
         assert false, "failed to read back"
         return
     }

--- a/examples/lsm_database/bloom.rk
+++ b/examples/lsm_database/bloom.rk
@@ -70,9 +70,9 @@ func encode_bloom(filter: BloomFilter) -> string {
 func decode_bloom(data: string) -> BloomFilter or SstError {
     const parts = data.split(",").collect()
     if parts.len() != BLOOM_BITS {
-        return Err(SstError.BloomFilterCorrupt(
+        return SstError.BloomFilterCorrupt(
             "expected {BLOOM_BITS} bits, got {parts.len()}"
-        ))
+        )
     }
     mut bits = Vec.new()
     mut count = 0
@@ -81,7 +81,7 @@ func decode_bloom(data: string) -> BloomFilter or SstError {
         bits.push(val)
         if val { count += 1 }
     }
-    return Ok(BloomFilter { bits: bits, count: count })
+    return BloomFilter { bits: bits, count: count }
 }
 
 // ─── Tests ──────────────────────────────────────────────────────────

--- a/examples/lsm_database/cache.rk
+++ b/examples/lsm_database/cache.rk
@@ -35,7 +35,7 @@ extend BlockCache {
 
     func get(mutate self, sst_id: i32, block_id: i32) -> Vec<KeyValue>? {
         const key = BlockCache.cache_key(sst_id, block_id)
-        const handle = self.by_key.get(key) is Some(h) else { return none }
+        const handle = self.by_key.get(key) ?? return none
         const handle = handle.clone()
 
         self.access_counter += 1
@@ -129,9 +129,7 @@ func sst_point_lookup(
     }
 
     const index = try read_sstable_index(meta.path)
-    const target_block = find_block_for_key(index, key) is Some(idx) else {
-        return none
-    }
+    const target_block = find_block_for_key(index, key) ?? return none
 
     // Cache hit path
     if cache.get(meta.id, target_block)? as entries {
@@ -166,7 +164,7 @@ test "block cache put and get" {
 
     cache.put(1, 0, entries.clone())
 
-    const result = cache.get(1, 0) is Some else { panic("expected Some") }
+    const result = cache.get(1, 0) ?? panic("expected Some")
     assert result.len() == 2
     assert result[0].key == "k1"
 

--- a/examples/lsm_database/cache.rk
+++ b/examples/lsm_database/cache.rk
@@ -35,13 +35,13 @@ extend BlockCache {
 
     func get(mutate self, sst_id: i32, block_id: i32) -> Vec<KeyValue>? {
         const key = BlockCache.cache_key(sst_id, block_id)
-        const handle = self.by_key.get(key) is Some(h) else { return None }
+        const handle = self.by_key.get(key) is Some(h) else { return none }
         const handle = handle.clone()
 
         self.access_counter += 1
         with self.blocks[handle] as block {
             block.access_count = self.access_counter
-            return Some(block.entries.clone())
+            return block.entries.clone()
         }
     }
 
@@ -65,12 +65,12 @@ extend BlockCache {
 
     func evict_one(mutate self) {
         mut min_access: i64 = i64.MAX
-        mut victim: Handle<CacheBlock>? = None
+        mut victim: Handle<CacheBlock>? = none
 
         for handle in self.blocks {
             if self.blocks[handle].access_count < min_access {
                 min_access = self.blocks[handle].access_count
-                victim = Some(handle)
+                victim = handle
             }
         }
 
@@ -125,22 +125,22 @@ func sst_point_lookup(
     mutate cache: BlockCache,
 ) -> KeyValue? or SstError {
     if !meta.bloom.may_contain(key) {
-        return Ok(None)
+        return none
     }
 
     const index = try read_sstable_index(meta.path)
     const target_block = find_block_for_key(index, key) is Some(idx) else {
-        return Ok(None)
+        return none
     }
 
     // Cache hit path
     if cache.get(meta.id, target_block) is Some(entries) {
         for entry in entries {
             if entry.key == key {
-                return Ok(Some(entry))
+                return entry
             }
         }
-        return Ok(None)
+        return none
     }
 
     // Cache miss — read from disk, populate cache
@@ -149,10 +149,10 @@ func sst_point_lookup(
 
     for entry in entries {
         if entry.key == key {
-            return Ok(Some(entry))
+            return entry
         }
     }
-    return Ok(None)
+    return none
 }
 
 // ─── Tests ──────────────────────────────────────────────────────────

--- a/examples/lsm_database/cache.rk
+++ b/examples/lsm_database/cache.rk
@@ -74,7 +74,7 @@ extend BlockCache {
             }
         }
 
-        if victim is Some(h) {
+        if victim? as h {
             const key = with self.blocks[h] as block {
                 BlockCache.cache_key(block.sst_id, block.block_id)
             }
@@ -134,7 +134,7 @@ func sst_point_lookup(
     }
 
     // Cache hit path
-    if cache.get(meta.id, target_block) is Some(entries) {
+    if cache.get(meta.id, target_block)? as entries {
         for entry in entries {
             if entry.key == key {
                 return entry
@@ -170,8 +170,8 @@ test "block cache put and get" {
     assert result.len() == 2
     assert result[0].key == "k1"
 
-    assert cache.get(1, 99) is None
-    assert cache.get(99, 0) is None
+    assert cache.get(1, 99) == none
+    assert cache.get(99, 0) == none
 }
 
 test "block cache eviction" {
@@ -199,7 +199,7 @@ test "block cache invalidate" {
 
     cache.invalidate(1)
 
-    assert cache.get(1, 0) is None
-    assert cache.get(1, 1) is None
-    assert cache.get(2, 0) is Some
+    assert cache.get(1, 0) == none
+    assert cache.get(1, 1) == none
+    assert cache.get(2, 0)?
 }

--- a/examples/lsm_database/compaction.rk
+++ b/examples/lsm_database/compaction.rk
@@ -101,8 +101,8 @@ func spawn_background_compaction(
         tx.send(CompactionMsg.Started(a.id, b.id))
 
         match compact_sstables(a.clone(), b.clone(), new_id, target_level, dir) {
-            Ok(meta) => tx.send(CompactionMsg.Completed(meta, a.id, b.id)),
-            Err(e) => tx.send(CompactionMsg.Failed(e)),
+            SstMeta as meta => tx.send(CompactionMsg.Completed(meta, a.id, b.id)),
+            CompactionError as e => tx.send(CompactionMsg.Failed(e)),
         }
     }).detach()
 }

--- a/examples/lsm_database/compaction.rk
+++ b/examples/lsm_database/compaction.rk
@@ -54,10 +54,10 @@ func compact_sstables(
     dir: string,
 ) -> SstMeta or CompactionError {
     const entries_a = read_all_sstable_entries(a.path) is Ok(e) else {
-        return Err(CompactionError.MergeConflict("cannot read SSTable {a.id}"))
+        return CompactionError.MergeConflict("cannot read SSTable {a.id}")
     }
     const entries_b = read_all_sstable_entries(b.path) is Ok(e) else {
-        return Err(CompactionError.MergeConflict("cannot read SSTable {b.id}"))
+        return CompactionError.MergeConflict("cannot read SSTable {b.id}")
     }
 
     mut merged = merge_entries(entries_a, entries_b)
@@ -68,17 +68,17 @@ func compact_sstables(
     }
 
     if merged.is_empty() {
-        return Err(CompactionError.MergeConflict("merge produced empty result"))
+        return CompactionError.MergeConflict("merge produced empty result")
     }
 
     const meta = write_sstable(new_id, target_level, dir, merged) is Ok(m) else {
-        return Err(CompactionError.OutputFailure("failed to write merged SSTable"))
+        return CompactionError.OutputFailure("failed to write merged SSTable")
     }
 
     fs.remove(a.path)
     fs.remove(b.path)
 
-    return Ok(meta)
+    return meta
 }
 
 // ─── Background Compaction ──────────────────────────────────────────

--- a/examples/lsm_database/compaction.rk
+++ b/examples/lsm_database/compaction.rk
@@ -71,7 +71,7 @@ func compact_sstables(
         return CompactionError.MergeConflict("merge produced empty result")
     }
 
-    const meta = write_sstable(new_id, target_level, dir, merged) is Ok(m) else {
+    const meta = write_sstable(new_id, target_level, dir, merged) is SstMeta as m else {
         return CompactionError.OutputFailure("failed to write merged SSTable")
     }
 

--- a/examples/lsm_database/compaction.rk
+++ b/examples/lsm_database/compaction.rk
@@ -53,10 +53,10 @@ func compact_sstables(
     target_level: i32,
     dir: string,
 ) -> SstMeta or CompactionError {
-    const entries_a = read_all_sstable_entries(a.path) is Ok(e) else {
+    const entries_a = read_all_sstable_entries(a.path) is Vec<KeyValue> as e else {
         return CompactionError.MergeConflict("cannot read SSTable {a.id}")
     }
-    const entries_b = read_all_sstable_entries(b.path) is Ok(e) else {
+    const entries_b = read_all_sstable_entries(b.path) is Vec<KeyValue> as e else {
         return CompactionError.MergeConflict("cannot read SSTable {b.id}")
     }
 

--- a/examples/lsm_database/db.rk
+++ b/examples/lsm_database/db.rk
@@ -105,7 +105,7 @@ extend Db {
 
     func get(mutate self, key: string) -> string or DbError {
         // Memtable first (newest data)
-        if self.memtable.get(key) is Some(kv) {
+        if self.memtable.get(key)? as kv {
             if kv.deleted {
                 return DbError.KeyNotFound(key)
             }
@@ -126,7 +126,7 @@ extend Db {
                 const result = try self.lookup.lookup(meta, key, mutate self.cache)
                     else |e| DbError.Sst(e)
 
-                if result is Some(kv) {
+                if result? as kv {
                     if kv.deleted {
                         return DbError.KeyNotFound(key)
                     }
@@ -290,8 +290,8 @@ extend Db {
             const id = self.next_sst_id
             const entries = self.memtable.take_sorted()
             match write_sstable(id, 0, self.config.dir, entries) {
-                Ok(_) => {}
-                Err(_) => {}
+                SstMeta => {}
+                SstError => {}
             }
         }
         try self.wal.close()

--- a/examples/lsm_database/db.rk
+++ b/examples/lsm_database/db.rk
@@ -39,7 +39,7 @@ struct Db {
 extend Db {
     func open(config: DbConfig) -> Db or DbError {
         try fs.create_dir_all(config.dir)
-            else |e| DbError.Io("cannot create directory: {config.dir}: {e}")
+            else |e| DbError.Io("cannot create directory: {config.dir}: {e.message()}")
 
         mut wal = try Wal.open(config.wal_path)
             else |e| DbError.Wal(e)
@@ -73,7 +73,7 @@ extend Db {
             }
         }
 
-        return Ok(Db {
+        return Db {
             config: config,
             memtable: memtable,
             wal: wal,
@@ -82,7 +82,7 @@ extend Db {
             next_sst_id: next_sst_id,
             next_seq: max_seq + 1,
             lookup: DefaultLookup {},
-        })
+        }
     }
 
     func put(mutate self, key: string, value: string) -> () or DbError {
@@ -100,16 +100,16 @@ extend Db {
             try self.flush()
         }
 
-        return Ok(())
+        return ()
     }
 
     func get(mutate self, key: string) -> string or DbError {
         // Memtable first (newest data)
         if self.memtable.get(key) is Some(kv) {
             if kv.deleted {
-                return Err(DbError.KeyNotFound(key))
+                return DbError.KeyNotFound(key)
             }
-            return Ok(kv.value)
+            return kv.value
         }
 
         // Search levels from newest to oldest
@@ -128,15 +128,15 @@ extend Db {
 
                 if result is Some(kv) {
                     if kv.deleted {
-                        return Err(DbError.KeyNotFound(key))
+                        return DbError.KeyNotFound(key)
                     }
-                    return Ok(kv.value)
+                    return kv.value
                 }
             }
             level_idx += 1
         }
 
-        return Err(DbError.KeyNotFound(key))
+        return DbError.KeyNotFound(key)
     }
 
     func delete(mutate self, key: string) -> () or DbError {
@@ -154,7 +154,7 @@ extend Db {
             try self.flush()
         }
 
-        return Ok(())
+        return ()
     }
 
     func scan(mutate self, start: string, end: string) -> Vec<KeyValue> or DbError {
@@ -196,11 +196,11 @@ extend Db {
             }
         }
 
-        return Ok(deduped)
+        return deduped
     }
 
     func flush(mutate self) -> () or DbError {
-        if self.memtable.is_empty() { return Ok(()) }
+        if self.memtable.is_empty() { return () }
 
         const id = self.next_sst_id
         self.next_sst_id += 1
@@ -223,13 +223,13 @@ extend Db {
             try self.compact_level(0)
         }
 
-        return Ok(())
+        return ()
     }
 
     func compact_level(mutate self, level: i32) -> () or DbError {
         const level_idx = level as usize
-        if self.levels[level_idx].len() < 2 { return Ok(()) }
-        if level >= MAX_LEVELS - 1 { return Ok(()) }
+        if self.levels[level_idx].len() < 2 { return () }
+        if level >= MAX_LEVELS - 1 { return () }
 
         const a = self.levels[level_idx][0].clone()
         const b = self.levels[level_idx][1].clone()
@@ -253,7 +253,7 @@ extend Db {
             ssts.push(merged)
         }
 
-        return Ok(())
+        return ()
     }
 
     func stats(self) -> DbStats {
@@ -282,7 +282,7 @@ extend Db {
             try self.compact_level(level)
             level += 1
         }
-        return Ok(())
+        return ()
     }
 
     func close(take self) -> () or DbError {
@@ -296,7 +296,7 @@ extend Db {
         }
         try self.wal.close()
             else |e| DbError.Wal(e)
-        return Ok(())
+        return ()
     }
 }
 
@@ -347,5 +347,5 @@ func execute_batch(mutate db: Db, entries: Vec<BatchEntry>) -> i32 or DbError {
         }
         success_count += 1
     }
-    return Ok(success_count)
+    return success_count
 }

--- a/examples/lsm_database/db.rk
+++ b/examples/lsm_database/db.rk
@@ -126,11 +126,11 @@ extend Db {
                 const result = try self.lookup.lookup(meta, key, mutate self.cache)
                     else |e| DbError.Sst(e)
 
-                if result? as kv {
-                    if kv.deleted {
+                if result? {
+                    if result.deleted {
                         return DbError.KeyNotFound(key)
                     }
-                    return kv.value
+                    return result.value
                 }
             }
             level_idx += 1

--- a/examples/lsm_database/kv.rk
+++ b/examples/lsm_database/kv.rk
@@ -31,7 +31,7 @@ func decode_kv(line: string) -> KeyValue or WalError {
     if parts.len() < 4 {
         return WalError.CorruptEntry(0, "expected 4 tab-separated fields")
     }
-    const seq = parts[2].parse_int() is Ok(v) else {
+    const seq = parts[2].parse_int() is i64 as v else {
         return WalError.CorruptEntry(0, "invalid sequence number: {parts[2]}")
     }
     const deleted = parts[3].trim() == "1"

--- a/examples/lsm_database/kv.rk
+++ b/examples/lsm_database/kv.rk
@@ -29,18 +29,18 @@ func encode_kv(kv: KeyValue) -> string {
 func decode_kv(line: string) -> KeyValue or WalError {
     const parts = line.split("\t").collect()
     if parts.len() < 4 {
-        return Err(WalError.CorruptEntry(0, "expected 4 tab-separated fields"))
+        return WalError.CorruptEntry(0, "expected 4 tab-separated fields")
     }
     const seq = parts[2].parse_int() is Ok(v) else {
-        return Err(WalError.CorruptEntry(0, "invalid sequence number: {parts[2]}"))
+        return WalError.CorruptEntry(0, "invalid sequence number: {parts[2]}")
     }
     const deleted = parts[3].trim() == "1"
-    return Ok(KeyValue {
+    return KeyValue {
         key: parts[0].to_string(),
         value: parts[1].to_string(),
         seq: seq as i64,
         deleted: deleted,
-    })
+    }
 }
 
 // ─── Tests ──────────────────────────────────────────────────────────

--- a/examples/lsm_database/main.rk
+++ b/examples/lsm_database/main.rk
@@ -40,7 +40,7 @@ func parse_cli_args(args: Vec<string>) -> CliArgs or DbError {
             "--count" => {
                 i += 1
                 if i < args.len() {
-                    const n = args[i].parse_int() is Ok(v) else {
+                    const n = args[i].parse_int() is i64 as v else {
                         return DbError.Io("invalid count: {args[i]}")
                     }
                     result.count = n as i32

--- a/examples/lsm_database/main.rk
+++ b/examples/lsm_database/main.rk
@@ -120,8 +120,8 @@ func run_benchmark(mutate db: Db, count: i32, prefix: string) -> () or DbError {
     while i < count {
         const key = "{prefix}_{i:06}"
         match db.get(key) {
-            Ok(_) => found += 1,
-            Err(_) => missing += 1,
+            string => found += 1,
+            DbError => missing += 1,
         }
         i += 1
     }
@@ -155,8 +155,8 @@ func run_benchmark(mutate db: Db, count: i32, prefix: string) -> () or DbError {
     while i < count {
         const key = "{prefix}_{i:06}"
         match db.get(key) {
-            Ok(_) => still_found += 1,
-            Err(_) => correctly_deleted += 1,
+            string => still_found += 1,
+            DbError => correctly_deleted += 1,
         }
         i += 1
     }
@@ -244,19 +244,19 @@ func run(args: CliArgs) -> () or DbError {
 func main() {
     const args = cli.args()
     const cli_args = match parse_cli_args(args) {
-        Ok(a) => a,
-        Err(e) => {
+        CliArgs as a => a,
+        DbError as e => {
             println("rask-db: {e.message()}")
             print_usage()
             std.exit(1)
         }
     }
 
-    match run(cli_args) {
-        Ok(()) => {}
-        Err(e) => {
-            println("error: {e.message()}")
-            std.exit(1)
-        }
+    const run_result = run(cli_args)
+    if run_result? {
+        // success
+    } else as e {
+        println("error: {e.message()}")
+        std.exit(1)
     }
 }

--- a/examples/lsm_database/main.rk
+++ b/examples/lsm_database/main.rk
@@ -41,7 +41,7 @@ func parse_cli_args(args: Vec<string>) -> CliArgs or DbError {
                 i += 1
                 if i < args.len() {
                     const n = args[i].parse_int() is Ok(v) else {
-                        return Err(DbError.Io("invalid count: {args[i]}"))
+                        return DbError.Io("invalid count: {args[i]}")
                     }
                     result.count = n as i32
                 }
@@ -62,14 +62,14 @@ func parse_cli_args(args: Vec<string>) -> CliArgs or DbError {
     }
 
     if positional.is_empty() {
-        return Err(DbError.Io("no command specified"))
+        return DbError.Io("no command specified")
     }
     result.command = positional[0].to_string()
     if positional.len() > 1 { result.key = positional[1].to_string() }
     if positional.len() > 2 { result.value = positional[2].to_string() }
     if positional.len() > 3 { result.end_key = positional[3].to_string() }
 
-    return Ok(result)
+    return result
 }
 
 func print_usage() {
@@ -169,7 +169,7 @@ func run_benchmark(mutate db: Db, count: i32, prefix: string) -> () or DbError {
     println("")
     println("Benchmark complete.")
 
-    return Ok(())
+    return ()
 }
 
 // ─── Main ───────────────────────────────────────────────────────────
@@ -182,28 +182,28 @@ func run(args: CliArgs) -> () or DbError {
     match args.command {
         "put" => {
             if args.key.is_empty() || args.value.is_empty() {
-                return Err(DbError.Io("put requires <key> <value>"))
+                return DbError.Io("put requires <key> <value>")
             }
             try db.put(args.key, args.value)
             println("OK")
         }
         "get" => {
             if args.key.is_empty() {
-                return Err(DbError.Io("get requires <key>"))
+                return DbError.Io("get requires <key>")
             }
             const value = try db.get(args.key)
             println("{value}")
         }
         "delete" => {
             if args.key.is_empty() {
-                return Err(DbError.Io("delete requires <key>"))
+                return DbError.Io("delete requires <key>")
             }
             try db.delete(args.key)
             println("OK")
         }
         "scan" => {
             if args.key.is_empty() {
-                return Err(DbError.Io("scan requires <start> <end>"))
+                return DbError.Io("scan requires <start> <end>")
             }
             const end = if args.value.is_empty(): "{args.key}\u{FF}" else: args.value
             const results = try db.scan(args.key, end)
@@ -238,7 +238,7 @@ func run(args: CliArgs) -> () or DbError {
         }
     }
 
-    return Ok(())
+    return ()
 }
 
 func main() {

--- a/examples/lsm_database/memtable.rk
+++ b/examples/lsm_database/memtable.rk
@@ -100,7 +100,7 @@ test "memtable put and get" {
     const b = mt.get("b") is Some else { panic("expected Some") }
     assert b.value == "2"
 
-    assert mt.get("z") is None
+    assert mt.get("z") == none
 }
 
 test "memtable overwrites by key" {

--- a/examples/lsm_database/memtable.rk
+++ b/examples/lsm_database/memtable.rk
@@ -42,9 +42,9 @@ extend Memtable {
     func get(self, key: string) -> KeyValue? {
         const pos = self.find_pos(key)
         if pos < self.entries.len() && self.entries[pos].key == key {
-            return Some(self.entries[pos].clone())
+            return self.entries[pos].clone()
         }
-        return None
+        return none
     }
 
     func should_flush(self) -> bool {

--- a/examples/lsm_database/memtable.rk
+++ b/examples/lsm_database/memtable.rk
@@ -94,10 +94,10 @@ test "memtable put and get" {
     mt.put(KeyValue.new("a", "1", 2))
     mt.put(KeyValue.new("c", "3", 3))
 
-    const a = mt.get("a") is Some else { panic("expected Some") }
+    const a = mt.get("a") ?? panic("expected Some")
     assert a.value == "1"
 
-    const b = mt.get("b") is Some else { panic("expected Some") }
+    const b = mt.get("b") ?? panic("expected Some")
     assert b.value == "2"
 
     assert mt.get("z") == none
@@ -108,7 +108,7 @@ test "memtable overwrites by key" {
     mt.put(KeyValue.new("k", "old", 1))
     mt.put(KeyValue.new("k", "new", 2))
 
-    const kv = mt.get("k") is Some else { panic("expected Some") }
+    const kv = mt.get("k") ?? panic("expected Some")
     assert kv.value == "new"
     assert kv.seq == 2
     assert mt.entries.len() == 1

--- a/examples/lsm_database/sstable.rk
+++ b/examples/lsm_database/sstable.rk
@@ -115,9 +115,7 @@ func read_sstable_block(path: string, block_offset: i32) -> Vec<KeyValue> or Sst
     const content = try fs.read_file(path)
         else |e| SstError.ReadFailure("cannot read {path}: {e}")
 
-    const sep_pos = content.find("---\n") is Some(pos) else {
-        return SstError.IndexCorrupt("missing data separator in {path}")
-    }
+    const sep_pos = content.find("---\n") ?? return SstError.IndexCorrupt("missing data separator in {path}")
     const data = content[sep_pos + 4..].to_string()
 
     mut current_block = 0
@@ -200,9 +198,7 @@ func read_all_sstable_entries(path: string) -> Vec<KeyValue> or SstError {
     const content = try fs.read_file(path)
         else |e| SstError.ReadFailure("cannot read {path}: {e}")
 
-    const sep_pos = content.find("---\n") is Some(pos) else {
-        return SstError.IndexCorrupt("missing data separator in {path}")
-    }
+    const sep_pos = content.find("---\n") ?? return SstError.IndexCorrupt("missing data separator in {path}")
     const data = content[sep_pos + 4..].to_string()
 
     mut entries = Vec.new()
@@ -248,7 +244,7 @@ func discover_sstables(dir: string) -> Vec<SstMeta> {
         const stem = file[0..file.len() - 4].to_string()
         if !stem.starts_with("L") { continue }
 
-        const underscore = stem.find("_") is Some(pos) else { continue }
+        const underscore = stem.find("_") ?? continue
         const level = stem[1..underscore].parse_int() is i64 as v else { continue }
         const id = stem[underscore + 1..].parse_int() is i64 as v else { continue }
 

--- a/examples/lsm_database/sstable.rk
+++ b/examples/lsm_database/sstable.rk
@@ -147,7 +147,7 @@ func read_sstable_block(path: string, block_offset: i32) -> Vec<KeyValue> or Sst
 func parse_block_lines(lines: Vec<string>, block_id: i32) -> Vec<KeyValue> or SstError {
     mut entries = Vec.new()
     for line in lines {
-        const kv = decode_kv(line) is Ok(entry) else {
+        const kv = decode_kv(line) is KeyValue as entry else {
             return SstError.BlockCorrupt(block_id, "corrupt entry")
         }
         entries.push(kv)
@@ -169,8 +169,8 @@ func read_sstable_index(path: string) -> Vec<BlockIndex> or SstError {
         const parts = entry.split("\t").collect()
         if parts.len() < 3 { continue }
 
-        const offset = parts[1].trim().parse_int() is Ok(v) else { continue }
-        const count = parts[2].trim().parse_int() is Ok(v) else { continue }
+        const offset = parts[1].trim().parse_int() is i64 as v else { continue }
+        const count = parts[2].trim().parse_int() is i64 as v else { continue }
 
         index.push(BlockIndex {
             first_key: parts[0].to_string(),
@@ -210,7 +210,7 @@ func read_all_sstable_entries(path: string) -> Vec<KeyValue> or SstError {
         const trimmed = line.trim()
         if trimmed.is_empty() { continue }
         if trimmed == "===" { continue }
-        const kv = decode_kv(trimmed) is Ok(entry) else { continue }
+        const kv = decode_kv(trimmed) is KeyValue as entry else { continue }
         entries.push(kv)
     }
     return entries
@@ -249,12 +249,12 @@ func discover_sstables(dir: string) -> Vec<SstMeta> {
         if !stem.starts_with("L") { continue }
 
         const underscore = stem.find("_") is Some(pos) else { continue }
-        const level = stem[1..underscore].parse_int() is Ok(v) else { continue }
-        const id = stem[underscore + 1..].parse_int() is Ok(v) else { continue }
+        const level = stem[1..underscore].parse_int() is i64 as v else { continue }
+        const id = stem[underscore + 1..].parse_int() is i64 as v else { continue }
 
         const path = "{dir}/{file}"
 
-        const bloom = read_sstable_bloom(path) is Ok(b) else { continue }
+        const bloom = read_sstable_bloom(path) is BloomFilter as b else { continue }
         const index = read_sstable_index(path) is Ok(idx) else { continue }
         if index.is_empty() { continue }
 

--- a/examples/lsm_database/sstable.rk
+++ b/examples/lsm_database/sstable.rk
@@ -39,7 +39,7 @@ func write_sstable(
     entries: Vec<KeyValue>,
 ) -> SstMeta or SstError {
     if entries.is_empty() {
-        return Err(SstError.WriteFailure("cannot write empty SSTable"))
+        return SstError.WriteFailure("cannot write empty SSTable")
     }
 
     const path = "{dir}/L{level}_{id}.sst"
@@ -98,7 +98,7 @@ func write_sstable(
     const min_key = entries[0].key
     const max_key = entries[entries.len() - 1].key
 
-    return Ok(SstMeta {
+    return SstMeta {
         id: id,
         level: level,
         path: path,
@@ -106,7 +106,7 @@ func write_sstable(
         max_key: max_key,
         entry_count: entries.len() as i32,
         bloom: bloom,
-    })
+    }
 }
 
 // ─── Read ───────────────────────────────────────────────────────────
@@ -116,7 +116,7 @@ func read_sstable_block(path: string, block_offset: i32) -> Vec<KeyValue> or Sst
         else |e| SstError.ReadFailure("cannot read {path}: {e}")
 
     const sep_pos = content.find("---\n") is Some(pos) else {
-        return Err(SstError.IndexCorrupt("missing data separator in {path}"))
+        return SstError.IndexCorrupt("missing data separator in {path}")
     }
     const data = content[sep_pos + 4..].to_string()
 
@@ -141,18 +141,18 @@ func read_sstable_block(path: string, block_offset: i32) -> Vec<KeyValue> or Sst
         return parse_block_lines(block_lines, block_offset)
     }
 
-    return Err(SstError.BlockCorrupt(block_offset, "block not found in {path}"))
+    return SstError.BlockCorrupt(block_offset, "block not found in {path}")
 }
 
 func parse_block_lines(lines: Vec<string>, block_id: i32) -> Vec<KeyValue> or SstError {
     mut entries = Vec.new()
     for line in lines {
         const kv = decode_kv(line) is Ok(entry) else {
-            return Err(SstError.BlockCorrupt(block_id, "corrupt entry"))
+            return SstError.BlockCorrupt(block_id, "corrupt entry")
         }
         entries.push(kv)
     }
-    return Ok(entries)
+    return entries
 }
 
 func read_sstable_index(path: string) -> Vec<BlockIndex> or SstError {
@@ -178,7 +178,7 @@ func read_sstable_index(path: string) -> Vec<BlockIndex> or SstError {
             count: count as i32,
         })
     }
-    return Ok(index)
+    return index
 }
 
 func read_sstable_bloom(path: string) -> BloomFilter or SstError {
@@ -193,7 +193,7 @@ func read_sstable_bloom(path: string) -> BloomFilter or SstError {
         }
         if trimmed == "---" { break }
     }
-    return Err(SstError.BloomFilterCorrupt("no bloom filter in {path}"))
+    return SstError.BloomFilterCorrupt("no bloom filter in {path}")
 }
 
 func read_all_sstable_entries(path: string) -> Vec<KeyValue> or SstError {
@@ -201,7 +201,7 @@ func read_all_sstable_entries(path: string) -> Vec<KeyValue> or SstError {
         else |e| SstError.ReadFailure("cannot read {path}: {e}")
 
     const sep_pos = content.find("---\n") is Some(pos) else {
-        return Err(SstError.IndexCorrupt("missing data separator in {path}"))
+        return SstError.IndexCorrupt("missing data separator in {path}")
     }
     const data = content[sep_pos + 4..].to_string()
 
@@ -213,7 +213,7 @@ func read_all_sstable_entries(path: string) -> Vec<KeyValue> or SstError {
         const kv = decode_kv(trimmed) is Ok(entry) else { continue }
         entries.push(kv)
     }
-    return Ok(entries)
+    return entries
 }
 
 // ─── Index Lookup ───────────────────────────────────────────────────
@@ -221,12 +221,12 @@ func read_all_sstable_entries(path: string) -> Vec<KeyValue> or SstError {
 func find_block_for_key(index: Vec<BlockIndex>, key: string) -> i32? {
     mut lo: usize = 0
     mut hi: usize = index.len()
-    mut result: i32? = None
+    mut result: i32? = none
 
     while lo < hi {
         const mid = lo + (hi - lo) / 2
         if index[mid].first_key <= key {
-            result = Some(index[mid].offset)
+            result = index[mid].offset
             lo = mid + 1
         } else {
             hi = mid
@@ -295,8 +295,8 @@ test "find block for key" {
         BlockIndex { first_key: "zzz", offset: 2, count: 32 },
     ])
 
-    assert find_block_for_key(index, "abc") == Some(0)
-    assert find_block_for_key(index, "nnn") == Some(1)
-    assert find_block_for_key(index, "zzz") == Some(2)
-    assert find_block_for_key(index, "000") is None
+    assert find_block_for_key(index, "abc")! == 0
+    assert find_block_for_key(index, "nnn")! == 1
+    assert find_block_for_key(index, "zzz")! == 2
+    assert find_block_for_key(index, "000") == none
 }

--- a/examples/lsm_database/sstable.rk
+++ b/examples/lsm_database/sstable.rk
@@ -236,7 +236,7 @@ func find_block_for_key(index: Vec<BlockIndex>, key: string) -> i32? {
 func discover_sstables(dir: string) -> Vec<SstMeta> {
     mut metas = Vec.new()
 
-    const files = fs.list_dir(dir) is Ok(f) else { return metas }
+    const files = fs.list_dir(dir) is Vec<string> as f else { return metas }
 
     for file in files {
         if !file.ends_with(".sst") { continue }
@@ -251,13 +251,13 @@ func discover_sstables(dir: string) -> Vec<SstMeta> {
         const path = "{dir}/{file}"
 
         const bloom = read_sstable_bloom(path) is BloomFilter as b else { continue }
-        const index = read_sstable_index(path) is Ok(idx) else { continue }
+        const index = read_sstable_index(path) is Vec<BlockIndex> as idx else { continue }
         if index.is_empty() { continue }
 
         const min_key = index[0].first_key
 
         const last_block_offset = index[index.len() - 1].offset
-        const last_entries = read_sstable_block(path, last_block_offset) is Ok(e) else {
+        const last_entries = read_sstable_block(path, last_block_offset) is Vec<KeyValue> as e else {
             continue
         }
         if last_entries.is_empty() { continue }

--- a/examples/lsm_database/wal.rk
+++ b/examples/lsm_database/wal.rk
@@ -19,7 +19,7 @@ extend Wal {
             try fs.write_file(path, "")
                 else |e| WalError.WriteFailure("cannot create WAL: {path}: {e}")
         }
-        return Ok(Wal { path: path, entry_count: 0 })
+        return Wal { path: path, entry_count: 0 }
     }
 
     func append(mutate self, kv: KeyValue) -> () or WalError {
@@ -27,32 +27,32 @@ extend Wal {
         try fs.append_file(self.path, line)
             else |e| WalError.WriteFailure("write failed: {e}")
         self.entry_count += 1
-        return Ok(())
+        return ()
     }
 
     func sync(mutate self) -> () or WalError {
         // No-op: string-based I/O flushes on each write
-        return Ok(())
+        return ()
     }
 
     func close(take self) -> () or WalError {
         // No file handle to close with string-based I/O
-        return Ok(())
+        return ()
     }
 
     func truncate(mutate self) -> () or WalError {
         try fs.write_file(self.path, "")
             else |e| WalError.WriteFailure("cannot truncate WAL: {e}")
         self.entry_count = 0
-        return Ok(())
+        return ()
     }
 }
 
 func recover_wal(path: string) -> Vec<KeyValue> or WalError {
-    if !fs.exists(path) { return Ok(Vec.new()) }
+    if !fs.exists(path) { return Vec.new() }
 
     const content = fs.read_file(path) is Ok(c) else {
-        return Err(WalError.RecoveryFailure("cannot read WAL: {path}"))
+        return WalError.RecoveryFailure("cannot read WAL: {path}")
     }
 
     mut entries = Vec.new()
@@ -63,5 +63,5 @@ func recover_wal(path: string) -> Vec<KeyValue> or WalError {
         const kv = decode_kv(trimmed) is Ok(entry) else { continue }
         entries.push(kv)
     }
-    return Ok(entries)
+    return entries
 }

--- a/examples/lsm_database/wal.rk
+++ b/examples/lsm_database/wal.rk
@@ -51,7 +51,7 @@ extend Wal {
 func recover_wal(path: string) -> Vec<KeyValue> or WalError {
     if !fs.exists(path) { return Vec.new() }
 
-    const content = fs.read_file(path) is Ok(c) else {
+    const content = fs.read_file(path) is string as c else {
         return WalError.RecoveryFailure("cannot read WAL: {path}")
     }
 
@@ -60,7 +60,7 @@ func recover_wal(path: string) -> Vec<KeyValue> or WalError {
         const trimmed = line.trim()
         if trimmed.is_empty() { continue }
         // Skip corrupt tail entries — partial writes from crash
-        const kv = decode_kv(trimmed) is Ok(entry) else { continue }
+        const kv = decode_kv(trimmed) is KeyValue as entry else { continue }
         entries.push(kv)
     }
     return entries

--- a/examples/markdown_renderer.rk
+++ b/examples/markdown_renderer.rk
@@ -159,7 +159,7 @@ func ordered_list_start(line: string) -> i32? {
     if dot_pos + 1 >= line.len() {
         return none
     }
-    if line.char_at(dot_pos + 1) is Some(c) {
+    if line.char_at(dot_pos + 1)? as c {
         if c != ' ' {
             return none
         }
@@ -254,7 +254,8 @@ extend Scanner {
 
     func scan_until_char(self, target: char) -> string? {
         const start = self.pos
-        while self.peek() is Some(c) {
+        while self.peek()? {
+            const c = self.peek()!
             if c == target {
                 const result = self.input[start..self.pos].to_string()
                 self.pos = self.pos + target.len_utf8()
@@ -349,7 +350,7 @@ func parse_inline_until(mutate scanner: Scanner, stop: string) -> Vec<Inline> or
         }
         if scanner.matches("\\") {
             scanner.advance()
-            if scanner.peek() is Some(c) {
+            if scanner.peek()? as c {
                 scanner.advance()
                 text_buf.push_char(c)
                 continue
@@ -594,7 +595,7 @@ func parse_blocks(input: string) -> Vec<Block> or MarkdownError {
         }
 
         // Ordered list: 1. item
-        if ordered_list_start(trimmed) is Some(start_num) {
+        if ordered_list_start(trimmed)? as start_num {
             mut items = Vec.new()
             while i < line_count {
                 const il = lines[i]
@@ -606,7 +607,7 @@ func parse_blocks(input: string) -> Vec<Block> or MarkdownError {
                     // Continuation
                 }
 
-                if ordered_list_start(it) is Some {
+                if ordered_list_start(it)? {
                     const dot_pos = it.find(".") is Some(pos) else {
                         continue
                     }
@@ -659,7 +660,7 @@ func parse_blocks(input: string) -> Vec<Block> or MarkdownError {
             if pt.starts_with("- ") || pt.starts_with("* ") {
                 break
             }
-            if ordered_list_start(pt) is Some {
+            if ordered_list_start(pt)? {
                 break
             }
             para_lines.push(pl)

--- a/examples/markdown_renderer.rk
+++ b/examples/markdown_renderer.rk
@@ -131,9 +131,7 @@ func is_hr_line(line: string) -> bool {
     if trimmed.len() < 3 {
         return false
     }
-    const first = trimmed.char_at(0) is Some(c) else {
-        return false
-    }
+    const first = trimmed.char_at(0) ?? return false
     if first != '-' && first != '*' && first != '_' {
         return false
     }
@@ -150,9 +148,7 @@ func is_hr_line(line: string) -> bool {
 }
 
 func ordered_list_start(line: string) -> i32? {
-    const dot_pos = line.find(".") is Some(p) else {
-        return none
-    }
+    const dot_pos = line.find(".") ?? return none
     if dot_pos == 0 {
         return none
     }
@@ -214,9 +210,7 @@ extend Scanner {
     }
 
     func advance(self) -> char? {
-        const c = self.peek() is Some else {
-            return none
-        }
+        const c = self.peek() ?? return none
         self.pos = self.pos + c.len_utf8()
         return c
     }
@@ -244,9 +238,7 @@ extend Scanner {
                 self.pos = self.pos + target.len()
                 return result
             }
-            const c = self.peek() is Some else {
-                break
-            }
+            const c = self.peek() ?? break
             self.pos = self.pos + c.len_utf8()
         }
         return none
@@ -290,9 +282,7 @@ func parse_references(input: string) -> Map<string, string> {
             continue
         }
 
-        const close = trimmed.find("]:") is Some(pos) else {
-            continue
-        }
+        const close = trimmed.find("]:") ?? continue
         const id = trimmed[1..close].to_string().to_lowercase()
         if id.is_empty() {
             continue
@@ -314,9 +304,7 @@ func is_reference_def(line: string) -> bool {
     if !trimmed.starts_with("[") {
         return false
     }
-    const close = trimmed.find("]:") is Some else {
-        return false
-    }
+    const close = trimmed.find("]:") ?? return false
     return true
 }
 
@@ -444,9 +432,7 @@ func parse_inline_until(mutate scanner: Scanner, stop: string) -> Vec<Inline> or
             result.push(Inline.LineBreak)
             continue
         }
-        const ch = scanner.advance() is Some else {
-            break
-        }
+        const ch = scanner.advance() ?? break
         text_buf.push_char(ch)
     }
 
@@ -608,9 +594,7 @@ func parse_blocks(input: string) -> Vec<Block> or MarkdownError {
                 }
 
                 if ordered_list_start(it)? {
-                    const dot_pos = it.find(".") is Some(pos) else {
-                        continue
-                    }
+                    const dot_pos = it.find(".") ?? continue
                     const item_text = it[dot_pos + 2..].to_string()
                     const item_inlines = try parse_inline(item_text)
                     items.push(ListItem {

--- a/examples/markdown_renderer.rk
+++ b/examples/markdown_renderer.rk
@@ -877,8 +877,8 @@ func main() {
     }
 
     const read_result = fs.read_file(input_path)
-    const content = if read_result? as c {
-        c
+    const content = if read_result? {
+        read_result
     } else as e {
         println("Error: cannot read {input_path}: {e.message()}")
         std.exit(1)
@@ -890,8 +890,8 @@ func main() {
         render_full_page(content)
     }
 
-    const html = if result? as h {
-        h
+    const html = if result? {
+        result
     } else as e {
         println("Error: {e.message()}")
         std.exit(1)

--- a/examples/markdown_renderer.rk
+++ b/examples/markdown_renderer.rk
@@ -31,16 +31,25 @@ extend MarkdownError {
     }
 }
 
+enum IoMsg { Msg(string) }
+extend IoMsg {
+    func message(self) -> string {
+        match self {
+            IoMsg.Msg(m) => return m,
+        }
+    }
+}
+
 enum RenderError {
     Parse(MarkdownError)
-    Io(string)
+    Io(IoMsg)
 }
 
 extend RenderError {
     func message(self) -> string {
         match self {
             Parse(e) => return "parse error: {e.message()}"
-            Io(msg) => return "I/O error: {msg}"
+            Io(e) => return "I/O error: {e.message()}"
         }
     }
 }
@@ -142,32 +151,32 @@ func is_hr_line(line: string) -> bool {
 
 func ordered_list_start(line: string) -> i32? {
     const dot_pos = line.find(".") is Some(p) else {
-        return None
+        return none
     }
     if dot_pos == 0 {
-        return None
+        return none
     }
     if dot_pos + 1 >= line.len() {
-        return None
+        return none
     }
     if line.char_at(dot_pos + 1) is Some(c) {
         if c != ' ' {
-            return None
+            return none
         }
     } else {
-        return None
+        return none
     }
 
     const num_slice = line[0..dot_pos]
     for ch in num_slice.chars() {
         if !ch.is_digit() {
-            return None
+            return none
         }
     }
     const n = num_slice.parse_int() is Ok(v) else {
-        return None
+        return none
     }
-    return Some(n as i32)
+    return n as i32
 }
 
 // ─── Scanner ────────────────────────────────────────────────────────
@@ -191,7 +200,7 @@ extend Scanner {
 
     func peek(self) -> char? {
         if self.is_done() {
-            return None
+            return none
         }
         return self.input.char_at(self.pos)
     }
@@ -199,17 +208,17 @@ extend Scanner {
     func peek_at(self, offset: usize) -> char? {
         const idx = self.pos + offset
         if idx >= self.input.len() {
-            return None
+            return none
         }
         return self.input.char_at(idx)
     }
 
     func advance(self) -> char? {
         const c = self.peek() is Some else {
-            return None
+            return none
         }
         self.pos = self.pos + c.len_utf8()
-        return Some(c)
+        return c
     }
 
     func matches(self, s: string) -> bool {
@@ -233,14 +242,14 @@ extend Scanner {
             if self.matches(target) {
                 const result = self.input[start..self.pos].to_string()
                 self.pos = self.pos + target.len()
-                return Some(result)
+                return result
             }
             const c = self.peek() is Some else {
                 break
             }
             self.pos = self.pos + c.len_utf8()
         }
-        return None
+        return none
     }
 
     func scan_until_char(self, target: char) -> string? {
@@ -249,11 +258,11 @@ extend Scanner {
             if c == target {
                 const result = self.input[start..self.pos].to_string()
                 self.pos = self.pos + target.len_utf8()
-                return Some(result)
+                return result
             }
             self.pos = self.pos + c.len_utf8()
         }
-        return None
+        return none
     }
 
     func remaining(self) -> string {
@@ -336,7 +345,7 @@ func parse_inline_until(mutate scanner: Scanner, stop: string) -> Vec<Inline> or
         if !stop.is_empty() && scanner.matches(stop) {
             scanner.consume(stop)
             flush_text(mutate result, mutate text_buf)
-            return Ok(result)
+            return result
         }
         if scanner.matches("\\") {
             scanner.advance()
@@ -442,10 +451,10 @@ func parse_inline_until(mutate scanner: Scanner, stop: string) -> Vec<Inline> or
 
     flush_text(mutate result, mutate text_buf)
     if !stop.is_empty() {
-        return Err(MarkdownError.UnexpectedEnd("expected closing '{stop}'"))
+        return MarkdownError.UnexpectedEnd("expected closing '{stop}'")
     }
 
-    return Ok(result)
+    return result
 }
 
 // ─── Block Parser ───────────────────────────────────────────────────
@@ -664,7 +673,7 @@ func parse_blocks(input: string) -> Vec<Block> or MarkdownError {
         }
     }
 
-    return Ok(blocks)
+    return blocks
 }
 
 func join_lines(lines: Vec<string>) -> string {
@@ -808,7 +817,7 @@ func render_markdown(input: string) -> string or RenderError {
 
     mut out = string.new()
     render_children(blocks, mutate out, refs)
-    return Ok(out)
+    return out
 }
 
 func render_full_page(input: string) -> string or RenderError {
@@ -826,7 +835,7 @@ func render_full_page(input: string) -> string or RenderError {
 """)
     out.push_str(body)
     out.push_str("</body>\n</html>\n")
-    return Ok(out)
+    return out
 }
 
 // ─── CLI ────────────────────────────────────────────────────────────
@@ -885,12 +894,12 @@ func main() {
         std.exit(1)
     }
 
-    const content = match fs.read_file(input_path) {
-        Ok(c) => c
-        Err(e) => {
-            println("Error: cannot read {input_path}: {e}")
-            std.exit(1)
-        }
+    const read_result = fs.read_file(input_path)
+    const content = if read_result? as c {
+        c
+    } else as e {
+        println("Error: cannot read {input_path}: {e.message()}")
+        std.exit(1)
     }
 
     const result = if fragment {
@@ -899,12 +908,11 @@ func main() {
         render_full_page(content)
     }
 
-    const html = match result {
-        Ok(h) => h
-        Err(e) => {
-            println("Error: {e.message()}")
-            std.exit(1)
-        }
+    const html = if result? as h {
+        h
+    } else as e {
+        println("Error: {e.message()}")
+        std.exit(1)
     }
 
     if use_stdout {
@@ -918,12 +926,12 @@ func main() {
             }
         }
 
-        match fs.write_file(output_path, html) {
-            Ok(()) => println("Written: {output_path}")
-            Err(e) => {
-                println("Error: cannot write {output_path}: {e}")
-                std.exit(1)
-            }
+        const write_result = fs.write_file(output_path, html)
+        if write_result? {
+            println("Written: {output_path}")
+        } else as e {
+            println("Error: cannot write {output_path}: {e.message()}")
+            std.exit(1)
         }
     }
 }

--- a/examples/markdown_renderer.rk
+++ b/examples/markdown_renderer.rk
@@ -361,68 +361,65 @@ func parse_inline_until(mutate scanner: Scanner, stop: string) -> Vec<Inline> or
         if scanner.matches("`") {
             flush_text(mutate result, mutate text_buf)
             scanner.advance()
-            const code = scanner.scan_until_char('`') is Some(s) else {
+            if scanner.scan_until_char('`')? as code {
+                result.push(Inline.Code(code))
+            } else {
                 text_buf.push_char('`')
-                continue
             }
-            result.push(Inline.Code(code))
             continue
         }
         if scanner.matches("![") {
             flush_text(mutate result, mutate text_buf)
             scanner.consume("![")
-            const alt = scanner.scan_until_char(']') is Some(s) else {
+            if scanner.scan_until_char(']')? as alt {
+                if !scanner.consume("(") {
+                    text_buf.push_str("![")
+                    text_buf.push_str(alt)
+                    text_buf.push_char(']')
+                } else if scanner.scan_until_char(')')? as url {
+                    result.push(Inline.Image(url, alt))
+                } else {
+                    text_buf.push_str("![")
+                    text_buf.push_str(alt)
+                    text_buf.push_str("](")
+                }
+            } else {
                 text_buf.push_str("![")
-                continue
             }
-            if !scanner.consume("(") {
-                text_buf.push_str("![")
-                text_buf.push_str(alt)
-                text_buf.push_char(']')
-                continue
-            }
-            const url = scanner.scan_until_char(')') is Some(s) else {
-                text_buf.push_str("![")
-                text_buf.push_str(alt)
-                text_buf.push_str("](")
-                continue
-            }
-            result.push(Inline.Image(url, alt))
             continue
         }
         if scanner.matches("[") {
             flush_text(mutate result, mutate text_buf)
             scanner.advance()
             const link_start = scanner.pos
-            const text_content = scanner.scan_until_char(']') is Some(s) else {
-                text_buf.push_char('[')
-                continue
-            }
-
-            if scanner.matches("(") {
-                scanner.advance()
-                const url = scanner.scan_until_char(')') is Some(s) else {
+            if scanner.scan_until_char(']')? as text_content {
+                if scanner.matches("(") {
+                    scanner.advance()
+                    if scanner.scan_until_char(')')? as url {
+                        const link_inlines = try parse_inline(text_content)
+                        result.push(Inline.Link(url, link_inlines))
+                    } else {
+                        text_buf.push_char('[')
+                        text_buf.push_str(text_content)
+                        text_buf.push_str("](")
+                    }
+                } else if scanner.matches("[") {
+                    scanner.advance()
+                    if scanner.scan_until_char(']')? as ref_id {
+                        const link_inlines = try parse_inline(text_content)
+                        result.push(Inline.RefLink(ref_id.to_lowercase(), link_inlines))
+                    } else {
+                        text_buf.push_char('[')
+                        text_buf.push_str(text_content)
+                        text_buf.push_str("][")
+                    }
+                } else {
                     text_buf.push_char('[')
                     text_buf.push_str(text_content)
-                    text_buf.push_str("](")
-                    continue
+                    text_buf.push_char(']')
                 }
-                const link_inlines = try parse_inline(text_content)
-                result.push(Inline.Link(url, link_inlines))
-            } else if scanner.matches("[") {
-                scanner.advance()
-                const ref_id = scanner.scan_until_char(']') is Some(s) else {
-                    text_buf.push_char('[')
-                    text_buf.push_str(text_content)
-                    text_buf.push_str("][")
-                    continue
-                }
-                const link_inlines = try parse_inline(text_content)
-                result.push(Inline.RefLink(ref_id.to_lowercase(), link_inlines))
             } else {
                 text_buf.push_char('[')
-                text_buf.push_str(text_content)
-                text_buf.push_char(']')
             }
             continue
         }

--- a/examples/markdown_renderer.rk
+++ b/examples/markdown_renderer.rk
@@ -169,7 +169,7 @@ func ordered_list_start(line: string) -> i32? {
             return none
         }
     }
-    const n = num_slice.parse_int() is Ok(v) else {
+    const n = num_slice.parse_int() is i64 as v else {
         return none
     }
     return n as i32

--- a/examples/package_manager.rk
+++ b/examples/package_manager.rk
@@ -327,7 +327,7 @@ func parse_manifest(content: string) -> Manifest or ManifestError {
         return ManifestError.MissingField("package name")
     }
 
-    const version = Version.parse(version_str) is Ok(v) else {
+    const version = Version.parse(version_str) is Version as v else {
         return ManifestError.InvalidConstraint("bad package version: {version_str}")
     }
 
@@ -362,7 +362,7 @@ func parse_package_line(line: string, line_num: i32) -> (string, string) or Mani
 func parse_dep_line(line: string, line_num: i32) -> Dependency or ManifestError {
     const name = try extract_nth_quoted(line, 0, line_num, "dep name")
     const constraint_str = try extract_nth_quoted(line, 1, line_num, "constraint")
-    const constraint = Constraint.parse(constraint_str) is Ok(c) else {
+    const constraint = Constraint.parse(constraint_str) is Constraint as c else {
         return ManifestError.InvalidConstraint(constraint_str)
     }
     return Dependency { name: name, constraint: constraint }
@@ -405,7 +405,7 @@ func local_available(root: string, name: string) -> Vec<PackageMeta> or Registry
         return RegistryError.PackageNotFound(name)
     }
 
-    const parsed = json.parse(index_content) is Ok(v) else {
+    const parsed = json.parse(index_content) is JsonValue as v else {
         return RegistryError.IoError("invalid JSON in {index_path}")
     }
     const version_list = parsed.as_array() ?? return RegistryError.IoError("expected array in {index_path}")
@@ -439,7 +439,7 @@ func load_package_meta(path: string) -> PackageMeta or RegistryError {
     const content = fs.read_file(path) is string as c else {
         return RegistryError.IoError("cannot read {path}")
     }
-    const parsed = json.parse(content) is Ok(v) else {
+    const parsed = json.parse(content) is JsonValue as v else {
         return RegistryError.IoError("invalid JSON in {path}")
     }
     return parse_meta_from_json(parsed, path)
@@ -453,7 +453,7 @@ func parse_meta_from_json(obj: JsonValue, source: string) -> PackageMeta or Regi
     const name = m.get("name")?.as_string() ?? return RegistryError.IoError("missing 'name' in {source}")
     const ver_str = m.get("version")?.as_string() ?? return RegistryError.IoError("missing 'version' in {source}")
     const checksum = m.get("checksum")?.as_string() ?? ""
-    const version = Version.parse(ver_str) is Ok(v) else {
+    const version = Version.parse(ver_str) is Version as v else {
         return RegistryError.IoError("bad version in {source}: {ver_str}")
     }
 
@@ -464,7 +464,7 @@ func parse_meta_from_json(obj: JsonValue, source: string) -> PackageMeta or Regi
             const dn = d_obj.get("name")?.as_string() ?? ""
             const dc = d_obj.get("constraint")?.as_string() ?? ""
             if dn.is_empty() || dc.is_empty() { continue }
-            const constraint = Constraint.parse(dc) is Ok(c) else { continue }
+            const constraint = Constraint.parse(dc) is Constraint as c else { continue }
             deps.push(Dependency { name: dn, constraint: constraint })
         }
     }
@@ -495,7 +495,7 @@ extend HttpRegistry with Registry {
 
 func http_available(base_url: string, name: string) -> Vec<PackageMeta> or RegistryError {
     const url = "{base_url}/packages/{name}"
-    const resp = http.get(url) is Ok(r) else {
+    const resp = http.get(url) is Response as r else {
         return RegistryError.NetworkError("failed to fetch {url}")
     }
 
@@ -506,7 +506,7 @@ func http_available(base_url: string, name: string) -> Vec<PackageMeta> or Regis
         return RegistryError.NetworkError("registry returned {resp.status} for {name}")
     }
 
-    const parsed = json.parse(resp.body) is Ok(v) else {
+    const parsed = json.parse(resp.body) is JsonValue as v else {
         return RegistryError.NetworkError("invalid JSON from registry for {name}")
     }
     const arr = parsed.as_array() ?? return RegistryError.NetworkError("expected array from registry for {name}")
@@ -526,7 +526,7 @@ func http_available(base_url: string, name: string) -> Vec<PackageMeta> or Regis
 func http_fetch(base_url: string, name: string, version: Version) -> string or RegistryError {
     const ver_str = version.to_string()
     const url = "{base_url}/packages/{name}/{ver_str}/download"
-    const resp = http.get(url) is Ok(r) else {
+    const resp = http.get(url) is Response as r else {
         return RegistryError.NetworkError("failed to download {name}@{ver_str}")
     }
 

--- a/examples/package_manager.rk
+++ b/examples/package_manager.rk
@@ -740,7 +740,7 @@ func fetch_packages(
             const item_counter = counter.clone()
             spawn(|| {
                 const result = fetch_one(item, registry)
-                if result? as msg {
+                if result? {
                     with item_counter as c { c += 1 }
                     item_tx.send(result)
                 } else {
@@ -754,8 +754,8 @@ func fetch_packages(
         mut received = 0
         while received < items.len() {
             if rx.recv()? as result {
-                if result? as msg {
-                    println("  {msg}")
+                if result? {
+                    println("  {result}")
                 } else as e {
                     if first_error == none {
                         first_error = e
@@ -1216,8 +1216,8 @@ func run(args: CliArgs) -> () or FetchError {
 func main() {
     const args = cli.args()
     const parsed = parse_cli_args(args)
-    const cli_args = if parsed? as a {
-        a
+    const cli_args = if parsed? {
+        parsed
     } else as e {
         println("rask-fetch: {e.message()}")
         print_usage()

--- a/examples/package_manager.rk
+++ b/examples/package_manager.rk
@@ -33,13 +33,13 @@ extend Version {
             return VersionError.InvalidFormat("expected MAJOR.MINOR.PATCH, got: {s}")
         }
 
-        const major = parts[0].trim().parse_int() is Ok(v) else {
+        const major = parts[0].trim().parse_int() is i64 as v else {
             return VersionError.InvalidFormat("bad major version in: {s}")
         }
-        const minor = parts[1].trim().parse_int() is Ok(v) else {
+        const minor = parts[1].trim().parse_int() is i64 as v else {
             return VersionError.InvalidFormat("bad minor version in: {s}")
         }
-        const patch = parts[2].trim().parse_int() is Ok(v) else {
+        const patch = parts[2].trim().parse_int() is i64 as v else {
             return VersionError.InvalidFormat("bad patch version in: {s}")
         }
 
@@ -405,7 +405,7 @@ extend LocalRegistry with Registry {
 func local_available(root: string, name: string) -> Vec<PackageMeta> or RegistryError {
     // Read index file listing available versions
     const index_path = "{root}/{name}/index.json"
-    const index_content = fs.read_file(index_path) is Ok(c) else {
+    const index_content = fs.read_file(index_path) is string as c else {
         return RegistryError.PackageNotFound(name)
     }
 
@@ -420,7 +420,7 @@ func local_available(root: string, name: string) -> Vec<PackageMeta> or Registry
     for entry in version_list {
         const ver_str = entry.as_string() is Some(s) else { continue }
         const meta_path = "{root}/{name}/{ver_str}/meta.json"
-        const meta = load_package_meta(meta_path) is Ok(m) else { continue }
+        const meta = load_package_meta(meta_path) is PackageMeta as m else { continue }
         versions.push(meta)
     }
 
@@ -442,7 +442,7 @@ func local_fetch(root: string, name: string, version: Version) -> string or Regi
 // ─── Package Meta Loader ────────────────────────────────────────────
 
 func load_package_meta(path: string) -> PackageMeta or RegistryError {
-    const content = fs.read_file(path) is Ok(c) else {
+    const content = fs.read_file(path) is string as c else {
         return RegistryError.IoError("cannot read {path}")
     }
     const parsed = json.parse(content) is Ok(v) else {
@@ -527,7 +527,7 @@ func http_available(base_url: string, name: string) -> Vec<PackageMeta> or Regis
 
     mut versions = Vec.new()
     for entry in arr {
-        const meta = parse_meta_from_json(entry, name) is Ok(m) else { continue }
+        const meta = parse_meta_from_json(entry, name) is PackageMeta as m else { continue }
         versions.push(meta)
     }
 
@@ -801,7 +801,7 @@ func fetch_one(item: FetchItem, registry: any Registry) -> string or FetchError 
 
     // Verify checksum if present
     if !item.checksum.is_empty() {
-        const content = fs.read_file("{pkg_path}/meta.json") is Ok(c) else {
+        const content = fs.read_file("{pkg_path}/meta.json") is string as c else {
             return "fetch   {item.name}@{item.version.to_string()}"
         }
         try verify_checksum(content, item.checksum, item.name)
@@ -875,7 +875,7 @@ func write_lockfile(graph: DepGraph, path: string) -> () or FetchError {
 func read_lockfile(path: string) -> Map<string, LockedPackage> or FetchError {
     mut packages = Map.new()
 
-    const content = fs.read_file(path) is Ok(c) else {
+    const content = fs.read_file(path) is string as c else {
         // No lock file yet — that's fine
         return packages
     }

--- a/examples/package_manager.rk
+++ b/examples/package_manager.rk
@@ -470,7 +470,7 @@ func parse_meta_from_json(obj: JsonValue, source: string) -> PackageMeta or Regi
     }
 
     mut deps = Vec.new()
-    if m.get("deps")?.as_array() is Some(dep_arr) {
+    if m.get("deps")?.as_array()? as dep_arr {
         for d_val in dep_arr {
             const d_obj = d_val.as_object() is Some(dm) else { continue }
             const dn = d_obj.get("name")?.as_string() ?? ""
@@ -772,7 +772,7 @@ func fetch_packages(
         mut first_error: FetchError? = none
         mut received = 0
         while received < items.len() {
-            if rx.recv() is Ok(result) {
+            if rx.recv()? as result {
                 if result? as msg {
                     println("  {msg}")
                 } else as e {

--- a/examples/package_manager.rk
+++ b/examples/package_manager.rk
@@ -30,24 +30,24 @@ extend Version {
     func parse(s: string) -> Version or VersionError {
         const parts = s.split(".").collect()
         if parts.len() != 3 {
-            return Err(VersionError.InvalidFormat("expected MAJOR.MINOR.PATCH, got: {s}"))
+            return VersionError.InvalidFormat("expected MAJOR.MINOR.PATCH, got: {s}")
         }
 
         const major = parts[0].trim().parse_int() is Ok(v) else {
-            return Err(VersionError.InvalidFormat("bad major version in: {s}"))
+            return VersionError.InvalidFormat("bad major version in: {s}")
         }
         const minor = parts[1].trim().parse_int() is Ok(v) else {
-            return Err(VersionError.InvalidFormat("bad minor version in: {s}"))
+            return VersionError.InvalidFormat("bad minor version in: {s}")
         }
         const patch = parts[2].trim().parse_int() is Ok(v) else {
-            return Err(VersionError.InvalidFormat("bad patch version in: {s}"))
+            return VersionError.InvalidFormat("bad patch version in: {s}")
         }
 
-        return Ok(Version {
+        return Version {
             major: major as i32,
             minor: minor as i32,
             patch: patch as i32,
-        })
+        }
     }
 
     func to_string(self) -> string {
@@ -70,24 +70,24 @@ extend Constraint {
 
         if trimmed.starts_with("^") {
             const ver = try Version.parse(trimmed[1..].to_string())
-            return Ok(Constraint.Compatible(ver))
+            return Constraint.Compatible(ver)
         }
         if trimmed.starts_with("~") {
             const ver = try Version.parse(trimmed[1..].to_string())
-            return Ok(Constraint.Tilde(ver))
+            return Constraint.Tilde(ver)
         }
         if trimmed.starts_with(">=") {
             const ver = try Version.parse(trimmed[2..].to_string())
-            return Ok(Constraint.Minimum(ver))
+            return Constraint.Minimum(ver)
         }
         if trimmed.starts_with("=") {
             const ver = try Version.parse(trimmed[1..].to_string())
-            return Ok(Constraint.Exact(ver))
+            return Constraint.Exact(ver)
         }
 
         // Bare version string treated as compatible
         const ver = try Version.parse(trimmed.to_string())
-        return Ok(Constraint.Compatible(ver))
+        return Constraint.Compatible(ver)
     }
 
     func satisfies(self, v: Version) -> bool {
@@ -200,12 +200,21 @@ extend ResolveError {
     }
 }
 
+enum IoErrorMsg { Msg(string) }
+extend IoErrorMsg {
+    func message(self) -> string {
+        match self {
+            IoErrorMsg.Msg(m) => return m,
+        }
+    }
+}
+
 enum FetchError {
     Manifest(ManifestError)
     Version(VersionError)
     Registry(RegistryError)
     Resolve(ResolveError)
-    Io(string)
+    Io(IoErrorMsg)
 }
 
 extend FetchError {
@@ -215,7 +224,7 @@ extend FetchError {
             Version(e) => return e.message(),
             Registry(e) => return e.message(),
             Resolve(e) => return e.message(),
-            Io(msg) => return "I/O error: {msg}",
+            Io(e) => return "I/O error: {e.message()}",
         }
     }
 }
@@ -268,7 +277,7 @@ struct LockedPackage {
 //   }
 
 func load_manifest(path: string) -> Manifest or FetchError {
-    const content = try fs.read_file(path) else |e| FetchError.Io("cannot read {path}: {e}")
+    const content = try fs.read_file(path) else |e| FetchError.Io(IoErrorMsg.Msg("cannot read {path}: {e.message()}"))
     return try parse_manifest(content) else |e| FetchError.Manifest(e)
 }
 
@@ -315,14 +324,14 @@ func parse_manifest(content: string) -> Manifest or ManifestError {
     }
 
     if name.is_empty() {
-        return Err(ManifestError.MissingField("package name"))
+        return ManifestError.MissingField("package name")
     }
 
     const version = Version.parse(version_str) is Ok(v) else {
-        return Err(ManifestError.InvalidConstraint("bad package version: {version_str}"))
+        return ManifestError.InvalidConstraint("bad package version: {version_str}")
     }
 
-    return Ok(Manifest { name: name, version: version, deps: deps })
+    return Manifest { name: name, version: version, deps: deps }
 }
 
 // Extract the nth quoted string from a line, or error.
@@ -331,26 +340,26 @@ func extract_nth_quoted(line: string, n: i32, line_num: i32, label: string) -> s
     mut found = 0
     while found <= n {
         const open = line[pos..].find("\"") is Some(idx) else {
-            return Err(ManifestError.ParseError(line_num, "expected quoted {label}"))
+            return ManifestError.ParseError(line_num, "expected quoted {label}")
         }
         const start = pos + open + 1
         const close = line[start..].find("\"") is Some(idx) else {
-            return Err(ManifestError.ParseError(line_num, "unterminated {label}"))
+            return ManifestError.ParseError(line_num, "unterminated {label}")
         }
         if found == n {
-            return Ok(line[start..start + close].to_string())
+            return line[start..start + close].to_string()
         }
         pos = start + close + 1
         found += 1
     }
-    return Err(ManifestError.ParseError(line_num, "expected quoted {label}"))
+    return ManifestError.ParseError(line_num, "expected quoted {label}")
 }
 
 // Extract name and version from: package "name" "version" {
 func parse_package_line(line: string, line_num: i32) -> (string, string) or ManifestError {
     const name = try extract_nth_quoted(line, 0, line_num, "package name")
     const version = try extract_nth_quoted(line, 1, line_num, "version")
-    return Ok((name, version))
+    return (name, version)
 }
 
 // Extract dependency from: dep "name" "constraint"
@@ -358,9 +367,9 @@ func parse_dep_line(line: string, line_num: i32) -> Dependency or ManifestError 
     const name = try extract_nth_quoted(line, 0, line_num, "dep name")
     const constraint_str = try extract_nth_quoted(line, 1, line_num, "constraint")
     const constraint = Constraint.parse(constraint_str) is Ok(c) else {
-        return Err(ManifestError.InvalidConstraint(constraint_str))
+        return ManifestError.InvalidConstraint(constraint_str)
     }
-    return Ok(Dependency { name: name, constraint: constraint })
+    return Dependency { name: name, constraint: constraint }
 }
 
 // ─── Registry ───────────────────────────────────────────────────────
@@ -397,14 +406,14 @@ func local_available(root: string, name: string) -> Vec<PackageMeta> or Registry
     // Read index file listing available versions
     const index_path = "{root}/{name}/index.json"
     const index_content = fs.read_file(index_path) is Ok(c) else {
-        return Err(RegistryError.PackageNotFound(name))
+        return RegistryError.PackageNotFound(name)
     }
 
     const parsed = json.parse(index_content) is Ok(v) else {
-        return Err(RegistryError.IoError("invalid JSON in {index_path}"))
+        return RegistryError.IoError("invalid JSON in {index_path}")
     }
     const version_list = parsed.as_array() is Some(arr) else {
-        return Err(RegistryError.IoError("expected array in {index_path}"))
+        return RegistryError.IoError("expected array in {index_path}")
     }
 
     mut versions = Vec.new()
@@ -416,28 +425,28 @@ func local_available(root: string, name: string) -> Vec<PackageMeta> or Registry
     }
 
     if versions.is_empty() {
-        return Err(RegistryError.PackageNotFound(name))
+        return RegistryError.PackageNotFound(name)
     }
-    return Ok(versions)
+    return versions
 }
 
 func local_fetch(root: string, name: string, version: Version) -> string or RegistryError {
     const ver_str = version.to_string()
     const pkg_path = "{root}/{name}/{ver_str}"
     if !fs.exists(pkg_path) {
-        return Err(RegistryError.PackageNotFound("{name}@{ver_str}"))
+        return RegistryError.PackageNotFound("{name}@{ver_str}")
     }
-    return Ok(pkg_path)
+    return pkg_path
 }
 
 // ─── Package Meta Loader ────────────────────────────────────────────
 
 func load_package_meta(path: string) -> PackageMeta or RegistryError {
     const content = fs.read_file(path) is Ok(c) else {
-        return Err(RegistryError.IoError("cannot read {path}"))
+        return RegistryError.IoError("cannot read {path}")
     }
     const parsed = json.parse(content) is Ok(v) else {
-        return Err(RegistryError.IoError("invalid JSON in {path}"))
+        return RegistryError.IoError("invalid JSON in {path}")
     }
     return parse_meta_from_json(parsed, path)
 }
@@ -446,18 +455,18 @@ func load_package_meta(path: string) -> PackageMeta or RegistryError {
 // Takes the parsed JSON object value, avoiding type duplication.
 func parse_meta_from_json(obj: JsonValue, source: string) -> PackageMeta or RegistryError {
     const m = obj.as_object() is Some(o) else {
-        return Err(RegistryError.IoError("expected object in {source}"))
+        return RegistryError.IoError("expected object in {source}")
     }
 
     const name = m.get("name")?.as_string() is Some else {
-        return Err(RegistryError.IoError("missing 'name' in {source}"))
+        return RegistryError.IoError("missing 'name' in {source}")
     }
     const ver_str = m.get("version")?.as_string() is Some else {
-        return Err(RegistryError.IoError("missing 'version' in {source}"))
+        return RegistryError.IoError("missing 'version' in {source}")
     }
     const checksum = m.get("checksum")?.as_string() ?? ""
     const version = Version.parse(ver_str) is Ok(v) else {
-        return Err(RegistryError.IoError("bad version in {source}: {ver_str}"))
+        return RegistryError.IoError("bad version in {source}: {ver_str}")
     }
 
     mut deps = Vec.new()
@@ -472,12 +481,12 @@ func parse_meta_from_json(obj: JsonValue, source: string) -> PackageMeta or Regi
         }
     }
 
-    return Ok(PackageMeta {
+    return PackageMeta {
         name: name,
         version: version,
         checksum: checksum,
         deps: deps,
-    })
+    }
 }
 
 // ─── HTTP Registry ──────────────────────────────────────────────────
@@ -499,21 +508,21 @@ extend HttpRegistry with Registry {
 func http_available(base_url: string, name: string) -> Vec<PackageMeta> or RegistryError {
     const url = "{base_url}/packages/{name}"
     const resp = http.get(url) is Ok(r) else {
-        return Err(RegistryError.NetworkError("failed to fetch {url}"))
+        return RegistryError.NetworkError("failed to fetch {url}")
     }
 
     if resp.status == 404 {
-        return Err(RegistryError.PackageNotFound(name))
+        return RegistryError.PackageNotFound(name)
     }
     if !resp.is_ok() {
-        return Err(RegistryError.NetworkError("registry returned {resp.status} for {name}"))
+        return RegistryError.NetworkError("registry returned {resp.status} for {name}")
     }
 
     const parsed = json.parse(resp.body) is Ok(v) else {
-        return Err(RegistryError.NetworkError("invalid JSON from registry for {name}"))
+        return RegistryError.NetworkError("invalid JSON from registry for {name}")
     }
     const arr = parsed.as_array() is Some(a) else {
-        return Err(RegistryError.NetworkError("expected array from registry for {name}"))
+        return RegistryError.NetworkError("expected array from registry for {name}")
     }
 
     mut versions = Vec.new()
@@ -523,27 +532,27 @@ func http_available(base_url: string, name: string) -> Vec<PackageMeta> or Regis
     }
 
     if versions.is_empty() {
-        return Err(RegistryError.PackageNotFound(name))
+        return RegistryError.PackageNotFound(name)
     }
-    return Ok(versions)
+    return versions
 }
 
 func http_fetch(base_url: string, name: string, version: Version) -> string or RegistryError {
     const ver_str = version.to_string()
     const url = "{base_url}/packages/{name}/{ver_str}/download"
     const resp = http.get(url) is Ok(r) else {
-        return Err(RegistryError.NetworkError("failed to download {name}@{ver_str}"))
+        return RegistryError.NetworkError("failed to download {name}@{ver_str}")
     }
 
     if !resp.is_ok() {
-        return Err(RegistryError.NetworkError("download failed: {resp.status} for {name}@{ver_str}"))
+        return RegistryError.NetworkError("download failed: {resp.status} for {name}@{ver_str}")
     }
 
     // Write to cache
     const cache_dir = "/tmp/rask-cache/{name}-{ver_str}"
     fs.create_dir_all(cache_dir)
     fs.write_file("{cache_dir}/package.tar", resp.body)
-    return Ok(cache_dir)
+    return cache_dir
 }
 
 // ─── Dependency Resolver ────────────────────────────────────────────
@@ -586,11 +595,11 @@ func resolve(manifest: Manifest, registry: any Registry) -> DepGraph or FetchErr
         }
     }
 
-    return Ok(DepGraph {
+    return DepGraph {
         packages: state.packages,
         root: root,
         by_name: state.by_name,
-    })
+    }
 }
 
 func resolve_one(
@@ -603,28 +612,28 @@ func resolve_one(
     for v in state.visiting {
         if v == name {
             const chain = format_cycle(state.visiting, name)
-            return Err(FetchError.Resolve(ResolveError.Cycle(chain)))
+            return FetchError.Resolve(ResolveError.Cycle(chain))
         }
     }
 
     // Already resolved? Check compatibility.
     if state.by_name.contains_key(name) {
         const existing_handle = state.by_name.get(name) is Some(h) else {
-            return Err(FetchError.Io("impossible: key exists but get failed"))
+            return FetchError.Io(IoErrorMsg.Msg("impossible: key exists but get failed"))
         }
         const existing_handle = existing_handle.clone()
 
         with state.packages[existing_handle] as existing {
             if constraint.satisfies(existing.meta.version) {
-                return Ok(existing_handle)
+                return existing_handle
             }
             const con_str = constraint.to_string()
             const ver_str = existing.meta.version.to_string()
-            return Err(FetchError.Resolve(ResolveError.Conflict(
+            return FetchError.Resolve(ResolveError.Conflict(
                 name,
                 ver_str,
                 con_str,
-            )))
+            ))
         }
     }
 
@@ -638,7 +647,7 @@ func resolve_one(
 
     const meta = candidates.first() is Some else {
         const con_str = constraint.to_string()
-        return Err(FetchError.Resolve(ResolveError.NoMatch(name, con_str)))
+        return FetchError.Resolve(ResolveError.NoMatch(name, con_str))
     }
 
     const handle = state.packages.insert(ResolvedPkg {
@@ -663,7 +672,7 @@ func resolve_one(
     }
     state.visiting.pop()
 
-    return Ok(handle)
+    return handle
 }
 
 func format_cycle(chain: Vec<string>, name: string) -> string {
@@ -711,7 +720,7 @@ func collect_fetch_items(graph: DepGraph, cache_dir: string) -> Vec<FetchItem> {
 }
 
 func verify_checksum(data: string, expected: string, pkg_name: string) -> () or RegistryError {
-    if expected.is_empty() { return Ok(()) }
+    if expected.is_empty() { return () }
     // Simple hash: sum all bytes mod 2^32 (real impl would SHA-256)
     mut hash: i64 = 0
     for ch in data.chars() {
@@ -719,9 +728,9 @@ func verify_checksum(data: string, expected: string, pkg_name: string) -> () or 
     }
     const got = "{hash}"
     if got != expected {
-        return Err(RegistryError.ChecksumMismatch(pkg_name, expected, got))
+        return RegistryError.ChecksumMismatch(pkg_name, expected, got)
     }
-    return Ok(())
+    return ()
 }
 
 func fetch_packages(
@@ -734,7 +743,7 @@ func fetch_packages(
     const items = collect_fetch_items(graph, cache_dir)
     if items.is_empty() {
         println("All packages cached")
-        return Ok(())
+        return ()
     }
 
     println("Fetching {items.len()} packages...")
@@ -750,42 +759,40 @@ func fetch_packages(
             const item_counter = counter.clone()
             spawn(|| {
                 const result = fetch_one(item, registry)
-                match result {
-                    Ok(msg) => {
-                        with item_counter as c { c += 1 }
-                        item_tx.send(Ok(msg))
-                    }
-                    Err(e) => item_tx.send(Err(e)),
+                if result? as msg {
+                    with item_counter as c { c += 1 }
+                    item_tx.send(result)
+                } else {
+                    item_tx.send(result)
                 }
             }).detach()
         }
 
         // Collect results — first error is fatal
-        mut first_error: FetchError? = None
+        mut first_error: FetchError? = none
         mut received = 0
         while received < items.len() {
             if rx.recv() is Ok(result) {
-                match result {
-                    Ok(msg) => println("  {msg}"),
-                    Err(e) => {
-                        if first_error is None {
-                            first_error = Some(e)
-                        }
+                if result? as msg {
+                    println("  {msg}")
+                } else as e {
+                    if first_error == none {
+                        first_error = e
                     }
                 }
             }
             received += 1
         }
 
-        if first_error is Some(e) {
-            return Err(e)
+        if first_error? as e {
+            return e
         }
 
         const fetched = with counter as c { c }
         println("Fetched {fetched} packages")
     }
 
-    return Ok(())
+    return ()
 }
 
 func fetch_one(item: FetchItem, registry: any Registry) -> string or FetchError {
@@ -795,13 +802,13 @@ func fetch_one(item: FetchItem, registry: any Registry) -> string or FetchError 
     // Verify checksum if present
     if !item.checksum.is_empty() {
         const content = fs.read_file("{pkg_path}/meta.json") is Ok(c) else {
-            return Ok("fetch   {item.name}@{item.version.to_string()}")
+            return "fetch   {item.name}@{item.version.to_string()}"
         }
         try verify_checksum(content, item.checksum, item.name)
             else |e| FetchError.Registry(e)
     }
 
-    return Ok("fetch   {item.name}@{item.version.to_string()}")
+    return "fetch   {item.name}@{item.version.to_string()}"
 }
 
 // ─── Lock File ──────────────────────────────────────────────────────
@@ -819,7 +826,7 @@ func write_lockfile(graph: DepGraph, path: string) -> () or FetchError {
     const tmp_path = "{path}.tmp"
 
     const tmp_file = try fs.create(tmp_path)
-        else |e| FetchError.Io("cannot create temp lock file: {e}")
+        else |e| FetchError.Io(IoErrorMsg.Msg("cannot create temp lock file: {e.message()}"))
     ensure fs.remove(tmp_path) else |_| {}
 
     mut out = string.new()
@@ -854,15 +861,15 @@ func write_lockfile(graph: DepGraph, path: string) -> () or FetchError {
     }
 
     try tmp_file.write_all(out)
-        else |e| FetchError.Io("cannot write lock file: {e}")
+        else |e| FetchError.Io(IoErrorMsg.Msg("cannot write lock file: {e.message()}"))
     try tmp_file.close()
-        else |e| FetchError.Io("cannot close lock file: {e}")
+        else |e| FetchError.Io(IoErrorMsg.Msg("cannot close lock file: {e.message()}"))
 
     // Atomic rename: success path — cancels ensure (EN6)
     try fs.rename(tmp_path, path)
-        else |e| FetchError.Io("cannot rename lock file: {e}")
+        else |e| FetchError.Io(IoErrorMsg.Msg("cannot rename lock file: {e.message()}"))
 
-    return Ok(())
+    return ()
 }
 
 func read_lockfile(path: string) -> Map<string, LockedPackage> or FetchError {
@@ -870,7 +877,7 @@ func read_lockfile(path: string) -> Map<string, LockedPackage> or FetchError {
 
     const content = fs.read_file(path) is Ok(c) else {
         // No lock file yet — that's fine
-        return Ok(packages)
+        return packages
     }
 
     mut current_name = ""
@@ -918,7 +925,7 @@ func read_lockfile(path: string) -> Map<string, LockedPackage> or FetchError {
         })
     }
 
-    return Ok(packages)
+    return packages
 }
 
 func extract_quoted_value(line: string) -> string {
@@ -1060,7 +1067,7 @@ func parse_cli_args(args: Vec<string>) -> CliArgs or FetchError {
                     match args[i] {
                         "local" => result.registry_type = RegistryType.Local,
                         "http" => result.registry_type = RegistryType.Http,
-                        _ => return Err(FetchError.Io(
+                        _ => return FetchError.Io(IoErrorMsg.Msg(
                             "unknown registry type: {args[i]} (expected 'local' or 'http')"
                         )),
                     }
@@ -1106,11 +1113,11 @@ func parse_cli_args(args: Vec<string>) -> CliArgs or FetchError {
     }
 
     if positional.is_empty() {
-        return Err(FetchError.Io("no command specified"))
+        return FetchError.Io(IoErrorMsg.Msg("no command specified"))
     }
     result.command = positional[0].to_string()
 
-    return Ok(result)
+    return result
 }
 
 func print_usage() {
@@ -1224,25 +1231,25 @@ func run(args: CliArgs) -> () or FetchError {
         }
     }
 
-    return Ok(())
+    return ()
 }
 
 func main() {
     const args = cli.args()
-    const cli_args = match parse_cli_args(args) {
-        Ok(a) => a,
-        Err(e) => {
-            println("rask-fetch: {e.message()}")
-            print_usage()
-            std.exit(1)
-        }
+    const parsed = parse_cli_args(args)
+    const cli_args = if parsed? as a {
+        a
+    } else as e {
+        println("rask-fetch: {e.message()}")
+        print_usage()
+        std.exit(1)
     }
 
-    match run(cli_args) {
-        Ok(()) => {}
-        Err(e) => {
-            println("error: {e.message()}")
-            std.exit(1)
-        }
+    const run_result = run(cli_args)
+    if run_result? {
+        // success
+    } else as e {
+        println("error: {e.message()}")
+        std.exit(1)
     }
 }

--- a/examples/package_manager.rk
+++ b/examples/package_manager.rk
@@ -339,13 +339,9 @@ func extract_nth_quoted(line: string, n: i32, line_num: i32, label: string) -> s
     mut pos = 0
     mut found = 0
     while found <= n {
-        const open = line[pos..].find("\"") is Some(idx) else {
-            return ManifestError.ParseError(line_num, "expected quoted {label}")
-        }
+        const open = line[pos..].find("\"") ?? return ManifestError.ParseError(line_num, "expected quoted {label}")
         const start = pos + open + 1
-        const close = line[start..].find("\"") is Some(idx) else {
-            return ManifestError.ParseError(line_num, "unterminated {label}")
-        }
+        const close = line[start..].find("\"") ?? return ManifestError.ParseError(line_num, "unterminated {label}")
         if found == n {
             return line[start..start + close].to_string()
         }
@@ -412,13 +408,11 @@ func local_available(root: string, name: string) -> Vec<PackageMeta> or Registry
     const parsed = json.parse(index_content) is Ok(v) else {
         return RegistryError.IoError("invalid JSON in {index_path}")
     }
-    const version_list = parsed.as_array() is Some(arr) else {
-        return RegistryError.IoError("expected array in {index_path}")
-    }
+    const version_list = parsed.as_array() ?? return RegistryError.IoError("expected array in {index_path}")
 
     mut versions = Vec.new()
     for entry in version_list {
-        const ver_str = entry.as_string() is Some(s) else { continue }
+        const ver_str = entry.as_string() ?? continue
         const meta_path = "{root}/{name}/{ver_str}/meta.json"
         const meta = load_package_meta(meta_path) is PackageMeta as m else { continue }
         versions.push(meta)
@@ -454,16 +448,10 @@ func load_package_meta(path: string) -> PackageMeta or RegistryError {
 // Shared JSON→PackageMeta extraction — used by both local and HTTP registries.
 // Takes the parsed JSON object value, avoiding type duplication.
 func parse_meta_from_json(obj: JsonValue, source: string) -> PackageMeta or RegistryError {
-    const m = obj.as_object() is Some(o) else {
-        return RegistryError.IoError("expected object in {source}")
-    }
+    const m = obj.as_object() ?? return RegistryError.IoError("expected object in {source}")
 
-    const name = m.get("name")?.as_string() is Some else {
-        return RegistryError.IoError("missing 'name' in {source}")
-    }
-    const ver_str = m.get("version")?.as_string() is Some else {
-        return RegistryError.IoError("missing 'version' in {source}")
-    }
+    const name = m.get("name")?.as_string() ?? return RegistryError.IoError("missing 'name' in {source}")
+    const ver_str = m.get("version")?.as_string() ?? return RegistryError.IoError("missing 'version' in {source}")
     const checksum = m.get("checksum")?.as_string() ?? ""
     const version = Version.parse(ver_str) is Ok(v) else {
         return RegistryError.IoError("bad version in {source}: {ver_str}")
@@ -472,7 +460,7 @@ func parse_meta_from_json(obj: JsonValue, source: string) -> PackageMeta or Regi
     mut deps = Vec.new()
     if m.get("deps")?.as_array()? as dep_arr {
         for d_val in dep_arr {
-            const d_obj = d_val.as_object() is Some(dm) else { continue }
+            const d_obj = d_val.as_object() ?? continue
             const dn = d_obj.get("name")?.as_string() ?? ""
             const dc = d_obj.get("constraint")?.as_string() ?? ""
             if dn.is_empty() || dc.is_empty() { continue }
@@ -521,9 +509,7 @@ func http_available(base_url: string, name: string) -> Vec<PackageMeta> or Regis
     const parsed = json.parse(resp.body) is Ok(v) else {
         return RegistryError.NetworkError("invalid JSON from registry for {name}")
     }
-    const arr = parsed.as_array() is Some(a) else {
-        return RegistryError.NetworkError("expected array from registry for {name}")
-    }
+    const arr = parsed.as_array() ?? return RegistryError.NetworkError("expected array from registry for {name}")
 
     mut versions = Vec.new()
     for entry in arr {
@@ -618,9 +604,7 @@ func resolve_one(
 
     // Already resolved? Check compatibility.
     if state.by_name.contains_key(name) {
-        const existing_handle = state.by_name.get(name) is Some(h) else {
-            return FetchError.Io(IoErrorMsg.Msg("impossible: key exists but get failed"))
-        }
+        const existing_handle = state.by_name.get(name) ?? return FetchError.Io(IoErrorMsg.Msg("impossible: key exists but get failed"))
         const existing_handle = existing_handle.clone()
 
         with state.packages[existing_handle] as existing {
@@ -645,10 +629,7 @@ func resolve_one(
     mut candidates = versions.filter(|m| constraint.satisfies(m.version))
     candidates.sort_by(|a, b| b.version.compare(a.version))
 
-    const meta = candidates.first() is Some else {
-        const con_str = constraint.to_string()
-        return FetchError.Resolve(ResolveError.NoMatch(name, con_str))
-    }
+    const meta = candidates.first() ?? return FetchError.Resolve(ResolveError.NoMatch(name, constraint.to_string()))
 
     const handle = state.packages.insert(ResolvedPkg {
         meta: PackageMeta {
@@ -929,9 +910,9 @@ func read_lockfile(path: string) -> Map<string, LockedPackage> or FetchError {
 }
 
 func extract_quoted_value(line: string) -> string {
-    const first = line.find("\"") is Some(pos) else { return "" }
+    const first = line.find("\"") ?? return ""
     const rest = first + 1
-    const second = line[rest..].find("\"") is Some(pos) else { return "" }
+    const second = line[rest..].find("\"") ?? return ""
     return line[rest..rest + second].to_string()
 }
 
@@ -1005,7 +986,7 @@ func print_lock_diff(old_lock: Map<string, LockedPackage>, graph: DepGraph) {
             const ver = pkg.meta.version.to_string()
 
             if old_lock.contains_key(pkg.meta.name) {
-                const locked = old_lock.get(pkg.meta.name) is Some(l) else { continue }
+                const locked = old_lock.get(pkg.meta.name) ?? continue
                 if locked.version == ver {
                     unchanged += 1
                 } else {
@@ -1203,9 +1184,7 @@ func run(args: CliArgs) -> () or FetchError {
                     const ver = pkg.meta.version.to_string()
 
                     if old_lock.contains_key(pkg.meta.name) {
-                        const locked = old_lock.get(pkg.meta.name) is Some(l) else {
-                            continue
-                        }
+                        const locked = old_lock.get(pkg.meta.name) ?? continue
                         if locked.version != ver {
                             println("  DRIFT {pkg.meta.name}: locked={locked.version}, resolved={ver}")
                             drift = true

--- a/examples/pool_test.rk
+++ b/examples/pool_test.rk
@@ -52,13 +52,13 @@ func main() {
 
     // Safe get on valid handle
     const maybe = pool.get(h1)
-    if maybe is Some(entity) {
+    if maybe? as entity {
         println("Got h1: {entity.name}")
     }
 
     // Safe get on stale handle (should be None)
     const stale = pool.get(h3)
-    if stale is None {
+    if stale == none {
         println("Correctly got None for stale handle")
     }
 

--- a/examples/pool_test.rk
+++ b/examples/pool_test.rk
@@ -52,8 +52,8 @@ func main() {
 
     // Safe get on valid handle
     const maybe = pool.get(h1)
-    if maybe? as entity {
-        println("Got h1: {entity.name}")
+    if maybe? {
+        println("Got h1: {maybe.name}")
     }
 
     // Safe get on stale handle (should be None)

--- a/examples/simple_grep.rk
+++ b/examples/simple_grep.rk
@@ -15,22 +15,21 @@ enum GrepResult {
 func grep_file(pattern: string, path: string) -> GrepResult {
     const lines_result = fs.read_lines(path)
 
-    match lines_result {
-        Ok(lines) => {
-            mut match_count = 0
-            mut line_num = 0
+    if lines_result? as lines {
+        mut match_count = 0
+        mut line_num = 0
 
-            for line in lines {
-                line_num = line_num + 1
-                if line.contains(pattern) {
-                    match_count = match_count + 1
-                    println("{line_num}: {line}")
-                }
+        for line in lines {
+            line_num = line_num + 1
+            if line.contains(pattern) {
+                match_count = match_count + 1
+                println("{line_num}: {line}")
             }
-
-            return GrepResult.Ok(match_count)
         }
-        Err(e) => return GrepResult.Err(e)
+
+        return GrepResult.Ok(match_count)
+    } else as e {
+        return GrepResult.Err(e.message())
     }
 }
 

--- a/examples/simple_grep.rk
+++ b/examples/simple_grep.rk
@@ -15,11 +15,11 @@ enum GrepResult {
 func grep_file(pattern: string, path: string) -> GrepResult {
     const lines_result = fs.read_lines(path)
 
-    if lines_result? as lines {
+    if lines_result? {
         mut match_count = 0
         mut line_num = 0
 
-        for line in lines {
+        for line in lines_result {
             line_num = line_num + 1
             if line.contains(pattern) {
                 match_count = match_count + 1

--- a/examples/test_example.rk
+++ b/examples/test_example.rk
@@ -9,9 +9,18 @@ func add(a: i32, b: i32) -> i32 {
     return a + b
 }
 
-func divide(a: f64, b: f64) -> f64 or string {
+enum DivideError { Msg(string) }
+extend DivideError {
+    func message(self) -> string {
+        match self {
+            DivideError.Msg(m) => return m,
+        }
+    }
+}
+
+func divide(a: f64, b: f64) -> f64 or DivideError {
     if b == 0.0 {
-        return Err("division by zero")
+        return DivideError.Msg("division by zero")
     }
     return a / b
 }
@@ -29,12 +38,12 @@ test "add negative" {
 }
 
 test "divide success" {
-    assert divide(10.0, 2.0).is_ok()
-    assert divide(6.0, 3.0).is_ok()
+    assert divide(10.0, 2.0)?
+    assert divide(6.0, 3.0)?
 }
 
 test "divide by zero" {
-    assert divide(1.0, 0.0).is_err()
+    assert !divide(1.0, 0.0)?
 }
 
 test "check gathers all failures" {

--- a/examples/test_example.rk
+++ b/examples/test_example.rk
@@ -43,7 +43,7 @@ test "divide success" {
 }
 
 test "divide by zero" {
-    assert !divide(1.0, 0.0)?
+    assert divide(1.0, 0.0) is DivideError
 }
 
 test "check gathers all failures" {

--- a/examples/text_editor.rk
+++ b/examples/text_editor.rk
@@ -58,17 +58,17 @@ extend Document {
             const h = doc.lines.insert(Line { text: text })
             doc.line_order.push(h)
         }
-        return Ok(doc)
+        return doc
     }
 
     func line_count(self) -> i32 {
         return self.line_order.len() as i32
     }
 
-    func get_line(self, index: i32) -> Option<string> {
-        if index < 0 || index >= self.line_count(): return None
+    func get_line(self, index: i32) -> string? {
+        if index < 0 || index >= self.line_count(): return none
         const h = self.line_order[index as usize]
-        return Some(self.lines[h].text)
+        return self.lines[h].text
     }
 
     // Insert a new line after the given index (-1 for beginning)
@@ -86,7 +86,7 @@ extend Document {
 
     // Delete a line at the given index
     func delete_line(self, at: i32) -> () or Error {
-        if at < 0 || at >= self.line_count(): return Err(Error.IndexOutOfBounds)
+        if at < 0 || at >= self.line_count(): return Error.IndexOutOfBounds
 
         const h = self.line_order.remove(at as i64)
         const deleted = self.lines.remove(h).unwrap()
@@ -99,7 +99,7 @@ extend Document {
 
     // Modify text at the given line
     func modify_line(self, at: i32, new_text: string) -> () or Error {
-        if at < 0 || at >= self.line_count(): return Err(Error.IndexOutOfBounds)
+        if at < 0 || at >= self.line_count(): return Error.IndexOutOfBounds
 
         const h = self.line_order[at as usize]
         const old_text = self.lines[h].text
@@ -113,28 +113,24 @@ extend Document {
 
     // Undo the last edit
     func undo(self) -> bool or Error {
-        const cmd = match self.undo_stack.pop() {
-            Some(c) => c,
-            None => return Ok(false),
-        }
+        const popped = self.undo_stack.pop()
+        const cmd = if popped? as c { c } else { return false }
 
         // Apply inverse without recording to undo stack
         try self.apply_command_silent(cmd.inverse())
         self.redo_stack.push(cmd)
-        return Ok(true)
+        return true
     }
 
     // Redo the last undone edit
     func redo(self) -> bool or Error {
-        const cmd = match self.redo_stack.pop() {
-            Some(c) => c,
-            None => return Ok(false),
-        }
+        const popped = self.redo_stack.pop()
+        const cmd = if popped? as c { c } else { return false }
 
         // Apply command without recording to undo stack
         try self.apply_command_silent(cmd.clone())
         self.undo_stack.push(cmd)
-        return Ok(true)
+        return true
     }
 
     // Apply a command without recording it
@@ -166,7 +162,7 @@ extend Document {
         }
 
         self.modified = false
-        return Ok(())
+        return ()
     }
 
     // Display the document
@@ -191,35 +187,35 @@ enum EditorCommand {
     Help,
 }
 
-func parse_command(input: string) -> Option<EditorCommand> {
+func parse_command(input: string) -> EditorCommand? {
     const parts: Vec<string> = Vec.new()
     for part in input.trim().split_whitespace() {
         parts.push(part.to_owned())
     }
-    if parts.is_empty(): return None
+    if parts.is_empty(): return none
 
     return match parts[0] {
         "i" | "insert" if parts.len() >= 3 => {
             const after = try parts[1].parse<i32>().ok()
             const text = parts[2..].join(" ")
-            Some(EditorCommand.Insert(after: after, text: text))
+            EditorCommand.Insert(after: after, text: text)
         }
         "d" | "delete" if parts.len() >= 2 => {
             const line = try parts[1].parse<i32>().ok()
-            Some(EditorCommand.Delete(line: line))
+            EditorCommand.Delete(line: line)
         }
         "e" | "edit" if parts.len() >= 3 => {
             const line = try parts[1].parse<i32>().ok()
             const text = parts[2..].join(" ")
-            Some(EditorCommand.Edit(line: line, text: text))
+            EditorCommand.Edit(line: line, text: text)
         }
-        "u" | "undo" => Some(EditorCommand.Undo),
-        "r" | "redo" => Some(EditorCommand.Redo),
-        "w" | "save" if parts.len() >= 2 => Some(EditorCommand.Save(path: parts[1])),
-        "p" | "print" => Some(EditorCommand.Print),
-        "q" | "quit" => Some(EditorCommand.Quit),
-        "h" | "help" => Some(EditorCommand.Help),
-        _ => None,
+        "u" | "undo" => EditorCommand.Undo,
+        "r" | "redo" => EditorCommand.Redo,
+        "w" | "save" if parts.len() >= 2 => EditorCommand.Save(path: parts[1]),
+        "p" | "print" => EditorCommand.Print,
+        "q" | "quit" => EditorCommand.Quit,
+        "h" | "help" => EditorCommand.Help,
+        _ => none,
     }
 }
 
@@ -245,12 +241,12 @@ func main() -> () or Error {
         print("> ")
         const input = try io.read_line()
 
-        const cmd = match parse_command(input) {
-            Some(c) => c,
-            None => {
-                println("Unknown command. Type 'help' for usage.")
-                continue
-            }
+        const parsed = parse_command(input)
+        const cmd = if parsed? as c {
+            c
+        } else {
+            println("Unknown command. Type 'help' for usage.")
+            continue
         }
 
         match cmd {
@@ -287,5 +283,5 @@ func main() -> () or Error {
         }
     }
 
-    return Ok(())
+    return ()
 }

--- a/examples/text_editor.rk
+++ b/examples/text_editor.rk
@@ -114,7 +114,7 @@ extend Document {
     // Undo the last edit
     func undo(self) -> bool or Error {
         const popped = self.undo_stack.pop()
-        const cmd = if popped? as c { c } else { return false }
+        const cmd = if popped? { popped } else { return false }
 
         // Apply inverse without recording to undo stack
         try self.apply_command_silent(cmd.inverse())
@@ -125,7 +125,7 @@ extend Document {
     // Redo the last undone edit
     func redo(self) -> bool or Error {
         const popped = self.redo_stack.pop()
-        const cmd = if popped? as c { c } else { return false }
+        const cmd = if popped? { popped } else { return false }
 
         // Apply command without recording to undo stack
         try self.apply_command_silent(cmd.clone())
@@ -242,8 +242,8 @@ func main() -> () or Error {
         const input = try io.read_line()
 
         const parsed = parse_command(input)
-        const cmd = if parsed? as c {
-            c
+        const cmd = if parsed? {
+            parsed
         } else {
             println("Unknown command. Type 'help' for usage.")
             continue

--- a/projects/raido/src/arena.rk
+++ b/projects/raido/src/arena.rk
@@ -61,11 +61,11 @@ extend Arena {
     func alloc(self, kind: ObjectKind, body_size: i64) -> i64 or ArenaError {
         // --- Internal allocation ---
         if body_size > MAX_BODY {
-            return Err(ArenaError.ObjectTooLarge)
+            return ArenaError.ObjectTooLarge
         }
         const aligned = (HEADER_SIZE + body_size + 3) / 4 * 4
         if self.top + aligned > self.capacity {
-            return Err(ArenaError.Exhausted)
+            return ArenaError.Exhausted
         }
         ensure_size(self.buf, self.top + aligned)
         const offset = self.top
@@ -208,7 +208,7 @@ extend Arena {
         const body = offset + HEADER_SIZE
         const cap = read_u32le(self.buf, body + 4)
         if cap == 0 {
-            return None
+            return none
         }
         const idx_start = body + 8
         const entries_start = idx_start + cap * 4
@@ -216,15 +216,15 @@ extend Arena {
         for _ in 0..cap {
             const entry_idx = read_u32le(self.buf, idx_start + slot * 4)
             if entry_idx == EMPTY_SLOT {
-                return None
+                return none
             }
             const entry_base = entries_start + entry_idx * MAP_ENTRY_SIZE
             if read_i64le(self.buf, entry_base) == key {
-                return Some(read_i64le(self.buf, entry_base + 8))
+                return read_i64le(self.buf, entry_base + 8)
             }
             slot = (slot + 1) % cap
         }
-        return None
+        return none
     }
 
     func map_set(self, offset: i64, key: i64, hash: i64, val: i64) -> i64 or ArenaError {
@@ -268,7 +268,7 @@ extend Arena {
             }
             slot = (slot + 1) % cap
         }
-        return Err(ArenaError.Exhausted)
+        return ArenaError.Exhausted
 
         // Re-insert all entries in insertion order
     }

--- a/projects/raido/src/chunk.rk
+++ b/projects/raido/src/chunk.rk
@@ -76,7 +76,7 @@ extend Prototype {
         mut out = "== {self.name} (regs={self.num_registers}, args={self.arity}) ==\n"
         mut i = 0
         while i < self.code.len() {
-            const instr = self.code.get(i) is Some else { break }
+            const instr = self.code.get(i) ?? break
             out = "{out}{disassemble_instr(instr, i)}\n"
             i = i + 1
         }

--- a/projects/raido/src/compiler.rk
+++ b/projects/raido/src/compiler.rk
@@ -155,8 +155,8 @@ extend Compiler {
         const prev = self.current
         self.previous = prev
         match self.lexer.next_token() {
-            Ok(tok) => self.current = tok
-            Err(e) => return CompileError.LexError(e)
+            Token as tok => self.current = tok
+            LexError as e => return CompileError.LexError(e)
         }
         self.current_line = self.lexer.line
         return ()
@@ -245,7 +245,7 @@ extend Compiler {
         mut i = self.scope.locals.len() - 1
         while i >= 0 {
             const local = self.scope.locals.get(i as i64)
-            if local is Some(l) {
+            if local? as l {
                 if l.name == name {
                     return l.reg
                 }

--- a/projects/raido/src/compiler.rk
+++ b/projects/raido/src/compiler.rk
@@ -156,10 +156,10 @@ extend Compiler {
         self.previous = prev
         match self.lexer.next_token() {
             Ok(tok) => self.current = tok
-            Err(e) => return Err(CompileError.LexError(e))
+            Err(e) => return CompileError.LexError(e)
         }
         self.current_line = self.lexer.line
-        return Ok(())
+        return ()
     }
 
     func expect(self, expected: string) -> () or CompileError {
@@ -294,7 +294,7 @@ extend Compiler {
         // Emit implicit return None at end
         self.emit_abx(Opcode.RETURN, 255, 0)
 
-        return Ok(Chunk.new(self.proto))
+        return Chunk.new(self.proto)
     }
 
     func compile_statement(self) -> () or CompileError {
@@ -309,7 +309,7 @@ extend Compiler {
         //
         // TODO: match self.current to decide which kind of statement
         // Start with just: expression statements (compile_expression + discard result)
-        return Ok(())
+        return ()
     }
 
     func compile_expression(self, min_bp: i64) -> i64 or CompileError {
@@ -335,7 +335,7 @@ extend Compiler {
         //   Ident(name) → resolve_local(name), return register
         //   True/False → emit LOAD_TRUE/FALSE, return register
 
-        return Err(CompileError.UnexpectedToken("not implemented", self.current_line))
+        return CompileError.UnexpectedToken("not implemented", self.current_line)
     }
 }
 

--- a/projects/raido/src/compiler.rk
+++ b/projects/raido/src/compiler.rk
@@ -245,9 +245,9 @@ extend Compiler {
         mut i = self.scope.locals.len() - 1
         while i >= 0 {
             const local = self.scope.locals.get(i as i64)
-            if local? as l {
-                if l.name == name {
-                    return l.reg
+            if local? {
+                if local.name == name {
+                    return local.reg
                 }
             }
             i = i - 1

--- a/projects/raido/src/lexer.rk
+++ b/projects/raido/src/lexer.rk
@@ -123,7 +123,9 @@ extend Lexer {
         if self.pos >= self.source.len(): return none
         const c = self.source.char_at(self.pos)
         self.pos = self.pos + 1
-        if c is Some(cc) && cc == '\n' { self.line = self.line + 1 }
+        if c? as cc {
+            if cc == '\n' { self.line = self.line + 1 }
+        }
         return c
     }
 
@@ -142,7 +144,7 @@ extend Lexer {
 
     // Skip whitespace (spaces and tabs, NOT newlines — those are tokens)
     func skip_whitespace(self) {
-        while self.peek() is Some(c) {
+        while self.peek()? as c {
             if c == ' ' || c == '\t' || c == '\r' {
                 self.advance()
             } else if c == '/' {
@@ -151,7 +153,7 @@ extend Lexer {
                     const next = self.source.char_at(self.pos + 1) is Some else { break }
                     if next == '/' {
                         // Line comment — skip to end of line
-                        while self.peek() is Some(ch) {
+                        while self.peek()? as ch {
                             if ch == '\n': break
                             self.advance()
                         }
@@ -159,7 +161,7 @@ extend Lexer {
                         // Block comment — skip to */
                         self.advance()  // skip /
                         self.advance()  // skip *
-                        while self.peek() is Some(ch) {
+                        while self.peek()? as ch {
                             if ch == '*' {
                                 self.advance()
                                 if self.match_char('/') { break }
@@ -289,7 +291,7 @@ extend Lexer {
         const start = self.pos
         mut frac_start = self.pos
 
-        while self.peek() is Some(c) {
+        while self.peek()? as c {
             match c {
                 '0'..='9' => { self.advance() }
                 '.' => {
@@ -297,8 +299,13 @@ extend Lexer {
                         return LexError.UnexpectedChar('.', self.line)  // second dot in number
                     }
                     self.advance() // consume the dot
-                    if self.peek() is Some(next) && next >= '0' && next <= '9' {
-                        frac_start = self.pos
+                    const peeked = self.peek()
+                    if peeked? as next {
+                        if next >= '0' && next <= '9' {
+                            frac_start = self.pos
+                        } else {
+                            return LexError.UnexpectedChar('.', self.line)  // dot not followed by digits
+                        }
                     } else {
                         return LexError.UnexpectedChar('.', self.line)  // dot not followed by digits
                     }
@@ -337,7 +344,7 @@ extend Lexer {
                 break end_pos
            } else if c == '\\' {
                 self.advance() // skip the backslash
-                if self.peek() is Some(esc) {
+                if self.peek()? as esc {
                     match esc {
                         'n' | 't' | '\\' | '"' => self.advance(), // valid escape, consume it
                         _ => return LexError.UnexpectedChar(esc, self.line) // invalid escape
@@ -357,7 +364,7 @@ extend Lexer {
 
     func read_identifier(self) -> Token or LexError {
         const start = self.pos
-        while self.peek() is Some(c) {
+        while self.peek()? as c {
             if (c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z') || (c >= '0' && c <= '9') || c == '_' {
                 self.advance()
             } else {

--- a/projects/raido/src/lexer.rk
+++ b/projects/raido/src/lexer.rk
@@ -123,8 +123,8 @@ extend Lexer {
         if self.pos >= self.source.len(): return none
         const c = self.source.char_at(self.pos)
         self.pos = self.pos + 1
-        if c? as cc {
-            if cc == '\n' { self.line = self.line + 1 }
+        if c? {
+            if c == '\n' { self.line = self.line + 1 }
         }
         return c
     }
@@ -300,8 +300,8 @@ extend Lexer {
                     }
                     self.advance() // consume the dot
                     const peeked = self.peek()
-                    if peeked? as next {
-                        if next >= '0' && next <= '9' {
+                    if peeked? {
+                        if peeked >= '0' && peeked <= '9' {
                             frac_start = self.pos
                         } else {
                             return LexError.UnexpectedChar('.', self.line)  // dot not followed by digits

--- a/projects/raido/src/lexer.rk
+++ b/projects/raido/src/lexer.rk
@@ -112,15 +112,15 @@ extend Lexer {
     }
 
     // Look at the current character without consuming it.
-    // Returns None if we're at the end of source.
+    // Returns none if we're at the end of source.
     func peek(self) -> char? {
-        if self.pos >= self.source.len(): return None
+        if self.pos >= self.source.len(): return none
         return self.source.char_at(self.pos)
     }
 
     // Consume the current character and advance.
     func advance(self) -> char? {
-        if self.pos >= self.source.len(): return None
+        if self.pos >= self.source.len(): return none
         const c = self.source.char_at(self.pos)
         self.pos = self.pos + 1
         if c is Some(cc) && cc == '\n' { self.line = self.line + 1 }
@@ -129,15 +129,14 @@ extend Lexer {
 
     // Check if current char matches expected, and consume it if so.
     func match_char(self, expected: char) -> bool {
-        match self.peek() {
-            Some(c) => {
-                if c == expected {
-                    self.advance()
-                    return true
-                }
-                return false
+        if self.peek()? as c {
+            if c == expected {
+                self.advance()
+                return true
             }
-            None => return false,
+            return false
+        } else {
+            return false
         }
     }
 
@@ -267,7 +266,7 @@ extend Lexer {
                 if self.match_char('&') {
                     return Token.AmpAmp
                 } else {
-                    return Err(LexError.UnexpectedChar('&', self.line))
+                    return LexError.UnexpectedChar('&', self.line)
                 }
             }
             '|' => {
@@ -280,7 +279,7 @@ extend Lexer {
             }
             c => {
                 self.advance()
-                return Err(LexError.UnexpectedChar(c, self.line))
+                return LexError.UnexpectedChar(c, self.line)
             }
         }
     }
@@ -295,13 +294,13 @@ extend Lexer {
                 '0'..='9' => { self.advance() }
                 '.' => {
                     if is_num_lit {
-                        return Err(LexError.UnexpectedChar('.', self.line))  // second dot in number
+                        return LexError.UnexpectedChar('.', self.line)  // second dot in number
                     }
                     self.advance() // consume the dot
                     if self.peek() is Some(next) && next >= '0' && next <= '9' {
                         frac_start = self.pos
                     } else {
-                        return Err(LexError.UnexpectedChar('.', self.line))  // dot not followed by digits
+                        return LexError.UnexpectedChar('.', self.line)  // dot not followed by digits
                     }
                     is_num_lit = true
                 }
@@ -311,17 +310,17 @@ extend Lexer {
         if is_num_lit {
             
             const int_part = self.source.substring(start, frac_start - 1).parse_i64() is Some else {
-                return Err(LexError.UnexpectedChar('.', self.line))  // invalid integer part
+                return LexError.UnexpectedChar('.', self.line)  // invalid integer part
             }
             const frac_part = self.source.substring(frac_start, self.pos).parse_i64() is Some else {
-                return Err(LexError.UnexpectedChar('.', self.line))  // invalid fractional part
+                return LexError.UnexpectedChar('.', self.line)  // invalid fractional part
             }
             const frac_digits = self.pos - frac_start
             const raw = (int_part << 32) + (frac_part << 32) / i64.pow(10, frac_digits)
             return Token.NumLit(raw)
         } else {
             const value = self.source.substring(start, self.pos).parse_i64() is Some else {
-                return Err(LexError.UnexpectedChar('.', self.line))  // invalid integer
+                return LexError.UnexpectedChar('.', self.line)  // invalid integer
             }
             return Token.IntLit(value)
         }
@@ -331,7 +330,7 @@ extend Lexer {
         self.advance()  // skip opening quote
         const start = self.pos
         const end = loop {
-           const c = self.peek() is Some else { return Err(LexError.UnterminatedString(self.line)) }
+           const c = self.peek() is Some else { return LexError.UnterminatedString(self.line) }
            if c == '"' {
                 const end_pos = self.pos
                 self.advance() // consume the ending quote
@@ -341,13 +340,13 @@ extend Lexer {
                 if self.peek() is Some(esc) {
                     match esc {
                         'n' | 't' | '\\' | '"' => self.advance(), // valid escape, consume it
-                        _ => return Err(LexError.UnexpectedChar(esc, self.line)) // invalid escape
+                        _ => return LexError.UnexpectedChar(esc, self.line) // invalid escape
                     }
                 } else {
-                    return Err(LexError.UnterminatedString(self.line)) // string ends with a backslash
+                    return LexError.UnterminatedString(self.line) // string ends with a backslash
                 }
             } else if c == '\n' || c == '\r' {
-                return Err(LexError.UnterminatedString(self.line)) // strings cannot contain newlines
+                return LexError.UnterminatedString(self.line) // strings cannot contain newlines
             } else {
                 self.advance() // consume regular character
             }

--- a/projects/raido/src/lexer.rk
+++ b/projects/raido/src/lexer.rk
@@ -150,7 +150,7 @@ extend Lexer {
             } else if c == '/' {
                 // Check for comments
                 if self.pos + 1 < self.source.len() {
-                    const next = self.source.char_at(self.pos + 1) is Some else { break }
+                    const next = self.source.char_at(self.pos + 1) ?? break
                     if next == '/' {
                         // Line comment — skip to end of line
                         while self.peek()? as ch {
@@ -215,7 +215,7 @@ extend Lexer {
 
     func next_token(self) -> Token or LexError {
         self.skip_whitespace()
-        const c = self.peek() is Some else { return Token.Eof }
+        const c = self.peek() ?? return Token.Eof
         match c {
             '\n' => {self.advance(); return Token.Newline}
             '0'..='9' => {
@@ -316,19 +316,13 @@ extend Lexer {
         }
         if is_num_lit {
             
-            const int_part = self.source.substring(start, frac_start - 1).parse_i64() is Some else {
-                return LexError.UnexpectedChar('.', self.line)  // invalid integer part
-            }
-            const frac_part = self.source.substring(frac_start, self.pos).parse_i64() is Some else {
-                return LexError.UnexpectedChar('.', self.line)  // invalid fractional part
-            }
+            const int_part = self.source.substring(start, frac_start - 1).parse_i64() ?? return LexError.UnexpectedChar('.', self.line)  // invalid integer part
+            const frac_part = self.source.substring(frac_start, self.pos).parse_i64() ?? return LexError.UnexpectedChar('.', self.line)  // invalid fractional part
             const frac_digits = self.pos - frac_start
             const raw = (int_part << 32) + (frac_part << 32) / i64.pow(10, frac_digits)
             return Token.NumLit(raw)
         } else {
-            const value = self.source.substring(start, self.pos).parse_i64() is Some else {
-                return LexError.UnexpectedChar('.', self.line)  // invalid integer
-            }
+            const value = self.source.substring(start, self.pos).parse_i64() ?? return LexError.UnexpectedChar('.', self.line)  // invalid integer
             return Token.IntLit(value)
         }
     }
@@ -337,7 +331,7 @@ extend Lexer {
         self.advance()  // skip opening quote
         const start = self.pos
         const end = loop {
-           const c = self.peek() is Some else { return LexError.UnterminatedString(self.line) }
+           const c = self.peek() ?? return LexError.UnterminatedString(self.line)
            if c == '"' {
                 const end_pos = self.pos
                 self.advance() // consume the ending quote

--- a/projects/raido/src/main.rk
+++ b/projects/raido/src/main.rk
@@ -38,7 +38,7 @@ func vm_run(code: Vec<u32>, fuel: i64) -> Value {
         const instr = code_get(code, pc)
         pc = pc + 1
 
-        const op = decode_opcode(instr) is Some else {
+        const op = decode_opcode(instr) ?? {
             print("UNKNOWN OPCODE: {decode_op(instr)}\n")
             return Value.None
         }

--- a/projects/raido/src/opcodes.rk
+++ b/projects/raido/src/opcodes.rk
@@ -159,9 +159,7 @@ func decode_sbx(instr: u32) -> i64 {
 // Prints a human-readable representation of a single instruction
 
 func disassemble_instr(instr: u32, offset: i64) -> string {
-    const op = decode_opcode(instr) is Some else {
-        return "{offset}: UNKNOWN"
-    }
+    const op = decode_opcode(instr) ?? return "{offset}: UNKNOWN"
     const a = decode_a(instr)
     const name = op.name()
 

--- a/projects/raido/src/vm.rk
+++ b/projects/raido/src/vm.rk
@@ -139,13 +139,9 @@ extend Vm {
                 return Value.None
             }
 
-            const instr = code.get(pc) is Some else {
-                return VmError.ScriptError("pc out of bounds: {pc}")
-            }
+            const instr = code.get(pc) ?? return VmError.ScriptError("pc out of bounds: {pc}")
             pc = pc + 1
-            const op = decode_opcode(instr) is Some else {
-                return VmError.ScriptError("unknown opcode: {decode_op(instr)}")
-            }
+            const op = decode_opcode(instr) ?? return VmError.ScriptError("unknown opcode: {decode_op(instr)}")
 
             match op {
                 Opcode.LOAD_TRUE => {
@@ -169,7 +165,7 @@ extend Vm {
                 Opcode.LOAD_CONST => {
                     const a = decode_a(instr)
                     const bx = decode_bx(instr)
-                    const val = self.chunk.main.constants.get(bx) is Some else { continue }
+                    const val = self.chunk.main.constants.get(bx) ?? continue
                     self.set_reg(a, val)
                 }
                 Opcode.LOAD_NONE => {

--- a/projects/raido/src/vm.rk
+++ b/projects/raido/src/vm.rk
@@ -131,20 +131,20 @@ extend Vm {
 
         loop {
             if self.fuel <= 0 {
-                return Err(VmError.FuelExhausted)
+                return VmError.FuelExhausted
             }
             self.fuel = self.fuel - 1
 
             if pc >= code.len() {
-                return Ok(Value.None)
+                return Value.None
             }
 
             const instr = code.get(pc) is Some else {
-                return Err(VmError.ScriptError("pc out of bounds: {pc}"))
+                return VmError.ScriptError("pc out of bounds: {pc}")
             }
             pc = pc + 1
             const op = decode_opcode(instr) is Some else {
-                return Err(VmError.ScriptError("unknown opcode: {decode_op(instr)}"))
+                return VmError.ScriptError("unknown opcode: {decode_op(instr)}")
             }
 
             match op {
@@ -179,11 +179,11 @@ extend Vm {
                 Opcode.RETURN => {
                     const a = decode_a(instr)
                     if a == 255 {
-                        return Ok(Value.None)
+                        return Value.None
                     }
-                    return Ok(self.get_reg(a))
+                    return self.get_reg(a)
                 }
-                _ => return Err(VmError.ScriptError("unimplemented opcode: {op.name()}"))
+                _ => return VmError.ScriptError("unimplemented opcode: {op.name()}")
             }
         }
     }

--- a/projects/tiwaz/backend.rk
+++ b/projects/tiwaz/backend.rk
@@ -14,7 +14,7 @@ extend BackendPool {
             mut checked = 0
             loop {
                 if checked >= count {
-                    return Err(ProxyError.UpstreamUnreachable)
+                    return ProxyError.UpstreamUnreachable
                 }
                 const backend = self.backends[idx]
                 idx = (idx + 1) % count

--- a/projects/tiwaz/backend.rk
+++ b/projects/tiwaz/backend.rk
@@ -22,7 +22,7 @@ extend BackendPool {
                 with status.read() as s {
                     const healthy = s.get(backend.url)
                     // Treat unknown backends as healthy until a health check runs.
-                    if healthy is None || healthy is Some(true) {
+                    if healthy == none || healthy == true {
                         return backend
                     }
                 }

--- a/projects/tiwaz/errors.rk
+++ b/projects/tiwaz/errors.rk
@@ -6,6 +6,15 @@ enum ProxyError {
 }
 
 extend ProxyError {
+    public func message(self) -> string {
+        match self {
+            ProxyError.UpstreamUnreachable => return "upstream unreachable",
+            ProxyError.UpstreamTimeout    => return "upstream timeout",
+            ProxyError.BadResponse        => return "bad response from upstream",
+            ProxyError.NoMatchingRoute    => return "no matching route",
+        }
+    }
+
     public func to_http_error(self) -> HttpError {
         return match self {
             ProxyError.UpstreamUnreachable => HttpError.InternalServerError("upstream unreachable".to_string())

--- a/projects/tiwaz/health.rk
+++ b/projects/tiwaz/health.rk
@@ -9,7 +9,7 @@ const health_check_interval = 10 // seconds
 func health_checker(backends : Vec<Backend>) -> () {
     loop {
         const result = check_health(backends)
-        if result is Err(e) {
+        if result is HttpError as e {
             // Log the error and continue with the next check.
             println("health check error: {e}")
         }

--- a/projects/tiwaz/main.rk
+++ b/projects/tiwaz/main.rk
@@ -29,13 +29,15 @@ func main() -> () or Error {
                 }
 
                 const matched_route = match_route(request.path(), all_routes)
-                if matched_route is Some(route) {
+                if matched_route? as route {
                     const route_and_forward = |request: Request| -> Response {
-                        const backend = route.pool.next_healthy() is Ok else {
+                        const healthy = route.pool.next_healthy()
+                        if healthy is ProxyError {
                             return Response.internal_error("no healthy backends")
                         }
+                        const backend = healthy!
                         const result = forward(request, backend.url, route.path)
-                        if result is Ok(response) {
+                        if result? as response {
                             return response
                         }
                         println("error forwarding request")

--- a/projects/tiwaz/main.rk
+++ b/projects/tiwaz/main.rk
@@ -35,8 +35,8 @@ func main() -> () or Error {
                         if healthy is ProxyError {
                             return Response.internal_error("no healthy backends")
                         }
-                        const backend = healthy!
-                        const result = forward(request, backend.url, route.path)
+                        // ER24: early-exit narrow — `healthy` is the success type here
+                        const result = forward(request, healthy.url, route.path)
                         if result? as response {
                             return response
                         }

--- a/projects/tiwaz/main.rk
+++ b/projects/tiwaz/main.rk
@@ -37,8 +37,8 @@ func main() -> () or Error {
                         }
                         // ER24: early-exit narrow — `healthy` is the success type here
                         const result = forward(request, healthy.url, route.path)
-                        if result? as response {
-                            return response
+                        if result? {
+                            return result
                         }
                         println("error forwarding request")
                         return Response.internal_error("upstream error")

--- a/projects/tiwaz/router.rk
+++ b/projects/tiwaz/router.rk
@@ -7,8 +7,8 @@ func match_route(path: string, routes: Vec<Route>) -> MatchedRoute? {
     for route in routes {
         if path.starts_with(route.prefix) {
             const stripped = path.substring(route.prefix.len(), path.len())
-            return Some(MatchedRoute { path: stripped, pool: route.pool })
+            return MatchedRoute { path: stripped, pool: route.pool }
         }
     }
-    return None
+    return none
 }

--- a/stdlib/collections.rk
+++ b/stdlib/collections.rk
@@ -133,7 +133,7 @@ extend Vec<T> {
     /// Reduce to a single value using an accumulator.
     public func fold(self, init: U, f: func(U, T) -> U) -> U { }
 
-    /// Reduce without initial value. Returns None if empty.
+    /// Reduce without initial value. Returns none if empty.
     public func reduce(self, f: func(T, T) -> T) -> Option<T> { }
 
     /// Yield (index, element) pairs.

--- a/stdlib/memory.rk
+++ b/stdlib/memory.rk
@@ -8,14 +8,14 @@ public struct Pool<T> { }
 public struct Handle<T> { }
 
 /// Non-owning reference into a Pool. May become invalid if the element is removed.
-/// Use `upgrade()` to convert back to a Handle (returns None if invalidated).
+/// Use `upgrade()` to convert back to a Handle (returns none if invalidated).
 public struct WeakHandle<T> { }
 
 extend WeakHandle<T> {
     /// Check if the weak handle is still valid (element hasn't been removed).
     public func valid(self) -> bool { }
 
-    /// Attempt to convert back to a strong Handle. Returns None if the element
+    /// Attempt to convert back to a strong Handle. Returns none if the element
     /// was removed since the weak handle was created.
     public func upgrade(self) -> Handle<T>? { }
 }
@@ -66,7 +66,7 @@ extend Pool<T> {
     /// Iterate over elements only.
     public func values(self) -> Iterator<T> { }
 
-    /// Try to insert, returning None if at capacity.
+    /// Try to insert, returning none if at capacity.
     public func try_insert(mutate self, value: T) -> Handle<T>? { }
 
     /// Remove all elements, returning them as a Vec.

--- a/stdlib/string.rk
+++ b/stdlib/string.rk
@@ -43,18 +43,18 @@ extend string {
 
     // ── Character and byte access ───────────────────────────
 
-    /// Byte at byte index. Returns None if out of bounds.
+    /// Byte at byte index. Returns none if out of bounds.
     public func byte_at(self, idx: usize) -> u8? { }
 
-    /// Unicode scalar at char index (not byte index). Returns None if out of bounds.
+    /// Unicode scalar at char index (not byte index). Returns none if out of bounds.
     public func char_at(self, idx: usize) -> char? { }
 
     // ── Searching ───────────────────────────────────────────
 
-    /// Byte index of first occurrence. None if not found.
+    /// Byte index of first occurrence. none if not found.
     public func find(self, pat: string) -> usize? { }
 
-    /// Byte index of last occurrence. None if not found.
+    /// Byte index of last occurrence. none if not found.
     public func rfind(self, pat: string) -> usize? { }
 
     /// True if the string contains the substring.
@@ -221,7 +221,7 @@ extend StringPool {
     /// Create a validated slice from a handle and byte indices.
     public func slice(self, h: Handle<string>, start: usize, end: usize) -> StringSlice or Error { }
 
-    /// Safe access — returns None on invalid handle/slice.
+    /// Safe access — returns none on invalid handle/slice.
     public func get(self, slice: StringSlice) -> string? { }
 
     /// Remove string by handle, returning ownership.

--- a/stdlib/sync.rk
+++ b/stdlib/sync.rk
@@ -13,10 +13,10 @@ extend Shared<T> {
     /// Expression-scoped write lock.
     public func write(self) -> T { }
 
-    /// Non-blocking read. Returns None if contended.
+    /// Non-blocking read. Returns none if contended.
     public func try_read(self, f: func(T)) -> Option<T> { }
 
-    /// Non-blocking write. Returns None if contended.
+    /// Non-blocking write. Returns none if contended.
     public func try_write(self, f: func(T)) -> Option<T> { }
 }
 
@@ -30,6 +30,6 @@ extend Mutex<T> {
     /// Expression-scoped exclusive lock.
     public func lock(self) -> T { }
 
-    /// Non-blocking lock. Returns None if held.
+    /// Non-blocking lock. Returns none if held.
     public func try_lock(self, f: func(T)) -> Option<T> { }
 }

--- a/tests/compile_errors/borrow_stored.rk
+++ b/tests/compile_errors/borrow_stored.rk
@@ -49,7 +49,7 @@ func parse_header(line: string) -> Option<(string, string)> {
     const colon = try line.find(':')
     const key = line[0..colon].trim().to_string()        // borrow -> owned
     const value = line[colon+1..].trim().to_string()     // borrow -> owned
-    return Some((key, value))
+    return (key, value)
 }
 
 func main() {}

--- a/tests/compile_errors/error_mismatch.rk
+++ b/tests/compile_errors/error_mismatch.rk
@@ -28,7 +28,7 @@ func read_file(path: string) -> string or IoError {
 // This function returns ParseError
 func parse_config(content: string) -> Config or ParseError {
     // ... parsing logic
-    Ok(Config { value: 0 })
+    return Config { value: 0 }
 }
 
 // COMPILE ERROR: Incompatible error types
@@ -39,11 +39,11 @@ func load_config(path: string) -> Config or IoError {
     // The `try` operator cannot automatically convert between them
     const config = try parse_config(content)
 
-    Ok(config)
+    return config
 }
 
 // Why this is an error:
-// The `try` operator extracts Ok or returns Err early.
+// The `try` operator extracts the success branch, or returns the error early.
 // But it can only return errors compatible with the function's return type.
 // ParseError and IoError are unrelated - no automatic conversion exists.
 
@@ -56,9 +56,9 @@ enum ConfigError {
 }
 
 func load_config_v1(path: string) -> Config or ConfigError {
-    const content = try read_file(path).map_err(ConfigError.Io)
-    const config = try parse_config(content).map_err(ConfigError.Parse)
-    Ok(config)
+    const content = try read_file(path).map_err(|e| ConfigError.Io(e))
+    const config = try parse_config(content).map_err(|e| ConfigError.Parse(e))
+    return config
 }
 
 // Option 2: Implement From traits for automatic conversion
@@ -76,14 +76,14 @@ extend ConfigError {
 func load_config_v2(path: string) -> Config or ConfigError {
     const content = try read_file(path)     // IoError -> ConfigError via From
     const config = try parse_config(content)  // ParseError -> ConfigError via From
-    Ok(config)
+    return config
 }
 
 // Option 3: Use a generic error type
 func load_config_v3(path: string) -> Config or Error {
     const content = try read_file(path)     // IoError -> Error (widening)
     const config = try parse_config(content)  // ParseError -> Error (widening)
-    Ok(config)
+    return config
 }
 
 // Another error case: error type can't widen
@@ -93,11 +93,11 @@ func narrow_error() -> i32 or ParseError {
     // ERROR: IoError cannot convert to ParseError
     // Widening works (specific -> general), narrowing doesn't
 
-    Ok(x)
+    return x
 }
 
 func might_fail() -> i32 or IoError {
-    Ok(42)
+    return 42
 }
 
 struct Config {

--- a/tests/compile_errors/match_errors.rk
+++ b/tests/compile_errors/match_errors.rk
@@ -24,8 +24,8 @@ struct File { fd: i32 }
 func test_wildcard_linear() {
     const result: File or GuardError = File { fd: 1 }
     match result {
-        Ok(_) => {},        // ERROR: _ discards linear File
-        Err(e) => {},
+        File => {},        // ERROR: _ discards linear File
+        GuardError as e => {},
     }
 }
 
@@ -67,8 +67,8 @@ func close(take f: File) {}
 func test_partial_consume() {
     const result: File or GuardError = File { fd: 1 }
     match result {
-        Ok(file) => close(file),   // consumed here
-        Err(e) => {},              // but what if there was a File?
+        File as file => close(file),   // consumed here
+        GuardError as e => {},         // but what if there was a File?
     }
     // Actually this is fine — the success and error branches are disjoint.
     // The real error is consuming in only *one* branch of the *same* variant.

--- a/tests/compile_errors/match_errors.rk
+++ b/tests/compile_errors/match_errors.rk
@@ -22,7 +22,7 @@ func test_nonexhaustive() {
 struct File { fd: i32 }
 
 func test_wildcard_linear() {
-    const result: File or string = Ok(File { fd: 1 })
+    const result: File or GuardError = File { fd: 1 }
     match result {
         Ok(_) => {},        // ERROR: _ discards linear File
         Err(e) => {},
@@ -32,7 +32,7 @@ func test_wildcard_linear() {
 // --- guard pattern else doesn't diverge (CF13) ---
 // ERROR: else block must diverge
 func test_guard_no_diverge() {
-    const opt: i32? = Some(42)
+    const opt: i32? = 42
     mut value = opt is Some else { 0 }   // ERROR: 0 doesn't diverge
     // else must use return, break, panic, etc.
 }
@@ -65,12 +65,12 @@ func test_match_expr_missing_arm() -> string {
 func close(take f: File) {}
 
 func test_partial_consume() {
-    const result: File or string = Ok(File { fd: 1 })
+    const result: File or GuardError = File { fd: 1 }
     match result {
         Ok(file) => close(file),   // consumed here
         Err(e) => {},              // but what if there was a File?
     }
-    // Actually this is fine — Ok and Err are different branches.
+    // Actually this is fine — the success and error branches are disjoint.
     // The real error is consuming in only *one* branch of the *same* variant.
 }
 

--- a/tests/compile_errors/resource_leak.rk
+++ b/tests/compile_errors/resource_leak.rk
@@ -20,7 +20,7 @@ func process_data() -> () or Error {
     // COMPILE ERROR: 'file' is a resource that must be consumed
     // We forgot to close it!
 
-    Ok(())
+    // implicit unit success (ER10)
 }
 
 // Why this is an error:
@@ -39,7 +39,7 @@ func process_data_v1() -> () or Error {
     const data = try file.read_all()
     process(data)
     try file.close()  // Consumes the resource
-    Ok(())
+    // implicit unit success (ER10)
 }
 
 // Option 2: Use 'ensure' for automatic cleanup
@@ -51,10 +51,10 @@ func process_data_v2() -> () or Error {
     process(data)
 
     if data.is_empty() {
-        return Err(Error.new("empty file"))  // ensure still runs!
+        return Error.new("empty file")  // ensure still runs!
     }
 
-    Ok(())
+    // implicit unit success (ER10)
 }
 
 // Option 3: Scoped resource pattern
@@ -62,7 +62,7 @@ func process_data_v3() -> () or Error {
     (try fs.open("data.txt")).use(|file| {
         const data = try file.read_all()
         process(data)
-        Ok(())
+        // implicit unit success (ER10)
     })
 }
 
@@ -75,7 +75,7 @@ func conditional_leak(flag: bool) -> () or Error {
     }
     // COMPILE ERROR: 'file' may not be consumed (false branch doesn't close)
 
-    Ok(())
+    // implicit unit success (ER10)
 }
 
 // THE FIX: All branches must consume
@@ -90,7 +90,7 @@ func conditional_fixed(flag: bool) -> () or Error {
         try file.close()  // Must close in both branches
     }
 
-    Ok(())
+    // implicit unit success (ER10)
 }
 
 func process(data: string) {
@@ -103,5 +103,5 @@ func main() -> () or Error {
     try process_data()
     try process_data_v1()
     try process_data_v2()
-    Ok(())
+    // implicit unit success (ER10)
 }

--- a/tests/compile_errors/type_errors.rk
+++ b/tests/compile_errors/type_errors.rk
@@ -50,14 +50,14 @@ func test_float_compare() {
 // --- Option<T> does not auto-unwrap (OPT9) ---
 // ERROR: expected i32, found i32?
 func test_option_no_auto_unwrap() {
-    const opt: i32? = Some(42)
+    const opt: i32? = 42
     const x: i32 = opt
 }
 
 // --- try in non-Option function (OPT13) ---
 // ERROR: cannot use try on Option in non-Option function
 func test_try_option_wrong_return() -> i32 {
-    const opt: i32? = Some(42)
+    const opt: i32? = 42
     const x = try opt
     return x
 }
@@ -86,7 +86,7 @@ func load() -> i32 or IoError {
 // --- wrong number of type arguments ---
 // ERROR: Option takes 1 type argument, found 2
 func test_wrong_type_args() {
-    const x: Option<i32, string> = Some(42)
+    const x: Option<i32, string> = 42
 }
 
 // --- branch type mismatch in if expression (CF6) ---

--- a/tests/suite/t07_option.rk
+++ b/tests/suite/t07_option.rk
@@ -17,12 +17,12 @@ func safe_div(a: i32, b: i32) -> i32? {
 
 test "present value auto-wraps" {
     const x: i32? = 42
-    assert x is Some
+    assert x?
 }
 
 test "none construction" {
     const x: i32? = none
-    assert x is None
+    assert x == none
 }
 
 test "force unwrap present" {
@@ -32,7 +32,7 @@ test "force unwrap present" {
 
 test "is Some with binding" {
     const x: i32? = 10
-    if x is Some(val) {
+    if x? as val {
         assert val == 10
     } else {
         assert false, "expected present"
@@ -41,16 +41,16 @@ test "is Some with binding" {
 
 test "is None" {
     const x: i32? = none
-    assert x is None
-    if x is Some {
+    assert x == none
+    if x? {
         assert false, "expected none"
     }
 }
 
 test "optional from function" {
-    assert safe_div(10, 2) is Some
+    assert safe_div(10, 2)?
     assert safe_div(10, 2)! == 5
-    assert safe_div(10, 0) is None
+    assert safe_div(10, 0) == none
 }
 
 test "optional with Vec" {
@@ -60,11 +60,11 @@ test "optional with Vec" {
     v.push(30)
 
     const found = find(v, 20)
-    assert found is Some
+    assert found?
     assert found! == 20
 
     const not_found = find(v, 99)
-    assert not_found is None
+    assert not_found == none
 }
 
 func main() {}

--- a/tests/suite/t07_option.rk
+++ b/tests/suite/t07_option.rk
@@ -1,10 +1,10 @@
 // SPDX-License-Identifier: (MIT OR Apache-2.0)
-// Optional types, Some/None, pattern matching.
+// Optional types: auto-wrap, none literal, operators, is-patterns.
 
 func find(items: Vec<i32>, target: i32) -> i32? {
     for i in 0..items.len() {
         if items[i] == target {
-            return Some(items[i])
+            return items[i]
         }
     }
     return none
@@ -12,11 +12,11 @@ func find(items: Vec<i32>, target: i32) -> i32? {
 
 func safe_div(a: i32, b: i32) -> i32? {
     if b == 0 { return none }
-    return Some(a / b)
+    return a / b
 }
 
-test "Some construction" {
-    const x = Some(42)
+test "present value auto-wraps" {
+    const x: i32? = 42
     assert x is Some
 }
 
@@ -25,17 +25,17 @@ test "none construction" {
     assert x is None
 }
 
-test "unwrap Some" {
-    const x = Some(42)
+test "force unwrap present" {
+    const x: i32? = 42
     assert x! == 42
 }
 
 test "is Some with binding" {
-    const x = Some(10)
+    const x: i32? = 10
     if x is Some(val) {
         assert val == 10
     } else {
-        assert false, "expected Some"
+        assert false, "expected present"
     }
 }
 
@@ -43,7 +43,7 @@ test "is None" {
     const x: i32? = none
     assert x is None
     if x is Some {
-        assert false, "expected None"
+        assert false, "expected none"
     }
 }
 

--- a/tests/suite/t07_option.rk
+++ b/tests/suite/t07_option.rk
@@ -32,8 +32,8 @@ test "force unwrap present" {
 
 test "is Some with binding" {
     const x: i32? = 10
-    if x? as val {
-        assert val == 10
+    if x? {
+        assert x == 10
     } else {
         assert false, "expected present"
     }

--- a/tests/suite/t08_result.rk
+++ b/tests/suite/t08_result.rk
@@ -1,22 +1,32 @@
 // SPDX-License-Identifier: (MIT OR Apache-2.0)
-// Result type, try propagation, error handling.
+// Result type: auto-wrap, try propagation, match.
 
-func divide(a: i32, b: i32) -> i32 or string {
-    if b == 0 {
-        return Err("division by zero")
+enum DivError { ByZero }
+
+extend DivError {
+    func message(self) -> string {
+        match self {
+            DivError.ByZero => return "division by zero",
+        }
     }
-    return Ok(a / b)
 }
 
-func double_divide(a: i32, b: i32) -> i32 or string {
+func divide(a: i32, b: i32) -> i32 or DivError {
+    if b == 0 {
+        return DivError.ByZero
+    }
+    return a / b
+}
+
+func double_divide(a: i32, b: i32) -> i32 or DivError {
     const result = try divide(a, b)
-    return Ok(result * 2)
+    return result * 2
 }
 
-func chained(a: i32, b: i32, c: i32) -> i32 or string {
+func chained(a: i32, b: i32, c: i32) -> i32 or DivError {
     const x = try divide(a, b)
     const y = try divide(x, c)
-    return Ok(y)
+    return y
 }
 
 test "Ok result" {

--- a/tests/suite/t08_result.rk
+++ b/tests/suite/t08_result.rk
@@ -31,44 +31,44 @@ func chained(a: i32, b: i32, c: i32) -> i32 or DivError {
 
 test "Ok result" {
     const r = divide(10, 2)
-    assert r is Ok
+    assert r?
     assert r! == 5
 }
 
 test "Err result" {
     const r = divide(10, 0)
-    assert r is Err
+    assert r is DivError
 }
 
 test "match on result" {
     const r = divide(10, 2)
     match r {
-        Ok(v) => assert v == 5
-        Err(_) => assert false, "expected Ok"
+        i32 as v => assert v == 5
+        DivError => assert false, "expected Ok"
     }
 }
 
 test "try propagation success" {
     const r = double_divide(10, 2)
-    assert r is Ok
+    assert r?
     assert r! == 10
 }
 
 test "try propagation failure" {
     const r = double_divide(10, 0)
-    assert r is Err
+    assert r is DivError
 }
 
 test "chained try" {
     const r1 = chained(100, 2, 5)
-    assert r1 is Ok
+    assert r1?
     assert r1! == 10
 
     const r2 = chained(100, 0, 5)
-    assert r2 is Err
+    assert r2 is DivError
 
     const r3 = chained(100, 2, 0)
-    assert r3 is Err
+    assert r3 is DivError
 }
 
 func main() {}

--- a/tests/suite/t09_vec.rk
+++ b/tests/suite/t09_vec.rk
@@ -43,7 +43,7 @@ test "vec pop" {
 test "vec pop empty" {
     const v = Vec<i32>.new()
     const popped = v.pop()
-    assert popped is None
+    assert popped == none
 }
 
 test "vec sum via loop" {
@@ -81,9 +81,9 @@ test "vec string read twice" {
 test "vec get returns option" {
     const v = Vec.new()
     v.push(42)
-    assert v.get(0) is Some
+    assert v.get(0)?
     assert v.get(0)! == 42
-    assert v.get(99) is None
+    assert v.get(99) == none
 }
 
 func main() {}

--- a/tests/suite/t17_option.rk
+++ b/tests/suite/t17_option.rk
@@ -1,31 +1,33 @@
 // SPDX-License-Identifier: (MIT OR Apache-2.0)
-// Option type: Some, None, pattern matching.
+// Option: auto-wrap, none literal, operator form.
 // Spec: type.optionals (OPT1-OPT9)
-// BUG: Option match arm assignment broken in native codegen (Some arm doesn't execute)
+// BUG: Option narrowing + native codegen interaction can misfire.
 
 func find_positive(n: i32) -> i32? {
     if n > 0 {
-        return Some(n)
+        return n
     }
     return none
 }
 
-test "option some match" {
+test "option present operator form" {
     const result = find_positive(5)
     mut value = 0
-    match result {
-        Some(v) => value = v
-        None => value = -1
+    if result? as v {
+        value = v
+    } else {
+        value = -1
     }
     assert value == 5
 }
 
-test "option none match" {
+test "option absent operator form" {
     const result = find_positive(-3)
     mut value = 0
-    match result {
-        Some(v) => value = v
-        None => value = -1
+    if result? as v {
+        value = v
+    } else {
+        value = -1
     }
     assert value == -1
 }

--- a/tests/suite/t17_option.rk
+++ b/tests/suite/t17_option.rk
@@ -13,8 +13,8 @@ func find_positive(n: i32) -> i32? {
 test "option present operator form" {
     const result = find_positive(5)
     mut value = 0
-    if result? as v {
-        value = v
+    if result? {
+        value = result
     } else {
         value = -1
     }
@@ -24,8 +24,8 @@ test "option present operator form" {
 test "option absent operator form" {
     const result = find_positive(-3)
     mut value = 0
-    if result? as v {
-        value = v
+    if result? {
+        value = result
     } else {
         value = -1
     }

--- a/tests/suite/t17b_result.rk
+++ b/tests/suite/t17b_result.rk
@@ -24,8 +24,8 @@ test "result ok match" {
     const r = divide(10, 2)
     mut value = 0
     match r {
-        Ok(v) => value = v
-        Err(_) => value = -1
+        i32 as v => value = v
+        DivError => value = -1
     }
     assert value == 5
 }
@@ -34,8 +34,8 @@ test "result err match" {
     const r = divide(10, 0)
     mut is_err = false
     match r {
-        Ok(_) => is_err = false
-        Err(_) => is_err = true
+        i32 => is_err = false
+        DivError => is_err = true
     }
     assert is_err
 }
@@ -50,8 +50,8 @@ test "try propagates error" {
     const r = compute()
     mut got_err = false
     match r {
-        Ok(_) => got_err = false
-        Err(_) => got_err = true
+        i32 => got_err = false
+        DivError => got_err = true
     }
     assert got_err
 }
@@ -66,8 +66,8 @@ test "try passes through ok" {
     const r = compute_ok()
     mut value = 0
     match r {
-        Ok(v) => value = v
-        Err(_) => value = -1
+        i32 as v => value = v
+        DivError => value = -1
     }
     assert value == 7
 }
@@ -80,8 +80,8 @@ test "auto-wrap at return" {
     const r = always_ok(21)
     mut value = 0
     match r {
-        Ok(v) => value = v
-        Err(_) => value = -1
+        i32 as v => value = v
+        DivError => value = -1
     }
     assert value == 42
 }

--- a/tests/suite/t17b_result.rk
+++ b/tests/suite/t17b_result.rk
@@ -1,11 +1,21 @@
 // SPDX-License-Identifier: (MIT OR Apache-2.0)
-// Result type: Ok, Err, try propagation, match.
-// Spec: type.errors (ER2-ER7)
+// Result: no wrappers, auto-wrap at return, try propagation, match.
+// Spec: type.errors (ER1-ER12)
 // BUG: functions returning `T or E` may break test discovery in native codegen
 
-func divide(a: i32, b: i32) -> i32 or string {
+enum DivError { ByZero }
+
+extend DivError {
+    func message(self) -> string {
+        match self {
+            DivError.ByZero => return "division by zero",
+        }
+    }
+}
+
+func divide(a: i32, b: i32) -> i32 or DivError {
     if b == 0 {
-        return Err("division by zero")
+        return DivError.ByZero
     }
     return a / b
 }
@@ -15,7 +25,7 @@ test "result ok match" {
     mut value = 0
     match r {
         Ok(v) => value = v
-        Err(e) => value = -1
+        Err(_) => value = -1
     }
     assert value == 5
 }
@@ -24,13 +34,13 @@ test "result err match" {
     const r = divide(10, 0)
     mut is_err = false
     match r {
-        Ok(v) => is_err = false
-        Err(e) => is_err = true
+        Ok(_) => is_err = false
+        Err(_) => is_err = true
     }
     assert is_err
 }
 
-func compute() -> i32 or string {
+func compute() -> i32 or DivError {
     const x = try divide(10, 2)
     const y = try divide(x, 0)
     return x + y
@@ -40,13 +50,13 @@ test "try propagates error" {
     const r = compute()
     mut got_err = false
     match r {
-        Ok(v) => got_err = false
-        Err(e) => got_err = true
+        Ok(_) => got_err = false
+        Err(_) => got_err = true
     }
     assert got_err
 }
 
-func compute_ok() -> i32 or string {
+func compute_ok() -> i32 or DivError {
     const x = try divide(10, 2)
     const y = try divide(6, 3)
     return x + y
@@ -57,21 +67,21 @@ test "try passes through ok" {
     mut value = 0
     match r {
         Ok(v) => value = v
-        Err(e) => value = -1
+        Err(_) => value = -1
     }
     assert value == 7
 }
 
-func always_ok(n: i32) -> i32 or string {
+func always_ok(n: i32) -> i32 or DivError {
     return n * 2
 }
 
-test "auto-ok wrapping" {
+test "auto-wrap at return" {
     const r = always_ok(21)
     mut value = 0
     match r {
         Ok(v) => value = v
-        Err(e) => value = -1
+        Err(_) => value = -1
     }
     assert value == 42
 }

--- a/tests/suite/t18_option_operators.rk
+++ b/tests/suite/t18_option_operators.rk
@@ -12,10 +12,10 @@ func returns_none() -> i32? {
 
 test "none literal" {
     const x: i32? = none
-    assert x is None
+    assert x == none
 
     const y = returns_none()
-    assert y is None
+    assert y == none
 }
 
 // --- force unwrap x! (OPT14) ---
@@ -69,21 +69,21 @@ func get_user(has_profile: bool) -> User? {
 test "optional chaining present path" {
     const user = get_user(true)
     const name = user?.profile?.name
-    assert name is Some
+    assert name?
     assert name! == "Alice"
 }
 
 test "optional chaining absent short-circuits" {
     const user = get_user(false)
     const name = user?.profile?.name
-    assert name is None
+    assert name == none
 }
 
 test "optional chaining on none field" {
     const p: Profile? = none
     const user: User? = User { profile: p }
     const name = user?.profile?.name
-    assert name is None
+    assert name == none
 }
 
 // --- auto-wrap T to T? (OPT5) ---
@@ -94,7 +94,7 @@ func maybe_value() -> i32? {
 
 test "auto-wrap T to T?" {
     const x = maybe_value()
-    assert x is Some
+    assert x?
     assert x! == 42
 }
 
@@ -116,13 +116,13 @@ func try_propagates_none() -> i32? {
 
 test "try on Option extracts" {
     const result = outer_option()
-    assert result is Some
+    assert result?
     assert result! == 20
 }
 
 test "try on Option propagates none" {
     const result = try_propagates_none()
-    assert result is None
+    assert result == none
 }
 
 // --- Option methods from spec ---
@@ -136,7 +136,7 @@ test "map on present" {
 test "map on absent" {
     const x: i32? = none
     const y = x.map(|v| v * 2)
-    assert y is None
+    assert y == none
 }
 
 test "filter keeps matching" {
@@ -148,14 +148,14 @@ test "filter keeps matching" {
 test "filter rejects non-matching" {
     const x: i32? = 3
     const y = x.filter(|v| v > 5)
-    assert y is None
+    assert y == none
 }
 
 // --- is-patterns and narrowing (OPT19-OPT20) ---
 
 test "is Some with implicit narrowing" {
     const opt: i32? = 42
-    if opt is Some {
+    if opt? {
         assert opt == 42
     } else {
         assert false, "expected present"

--- a/tests/suite/t18_option_operators.rk
+++ b/tests/suite/t18_option_operators.rk
@@ -166,7 +166,7 @@ test "is Some with implicit narrowing" {
 // Match on Option is rejected by the compiler; operator form is idiomatic.
 test "operator-form branch" {
     const x: i32? = 7
-    const result = if x? as v { v * 2 } else { 0 }
+    const result = if x? { x * 2 } else { 0 }
     assert result == 14
 }
 

--- a/tests/suite/t18_option_operators.rk
+++ b/tests/suite/t18_option_operators.rk
@@ -1,18 +1,10 @@
 // SPDX-License-Identifier: (MIT OR Apache-2.0)
-// Option operators: none literal, x! force unwrap, ?? nil-coalescing,
-// ?. optional chaining, try on Option, auto-wrapping.
+// Option operators: none literal, x! force unwrap, ?? fallback,
+// ?. chaining, try on Option, auto-wrap.
 //
-// Spec: type.optionals (OPT1-OPT14)
-//
-// SPEC ISSUE: Existing tests (t07, t17) use .unwrap() but the spec defines
-// x! as the force unwrap operator (OPT7). There is no .unwrap() method in the
-// spec's Option method table. Tests here use x! per spec.
-//
-// SPEC ISSUE: SYNTAX.md line 908 shows assert(expr) with parens, but every
-// existing test uses `assert expr` without parens. The compiler accepts both.
-// SYNTAX.md should document both forms or pick one.
+// Spec: type.optionals (OPT1-OPT26)
 
-// --- none literal (OPT4) ---
+// --- none literal (OPT9) ---
 
 func returns_none() -> i32? {
     return none
@@ -26,39 +18,36 @@ test "none literal" {
     assert y is None
 }
 
-// --- force unwrap x! (OPT7) ---
+// --- force unwrap x! (OPT14) ---
 
-test "force unwrap Some" {
-    const x = Some(42)
+test "force unwrap present" {
+    const x: i32? = 42
     assert x! == 42
 }
 
-test "force unwrap nested" {
-    const x = Some(Some(10))
-    assert x!! == 10
+test "force unwrap" {
+    const inner: i32? = 10
+    assert inner! == 10
 }
 
-// --- nil-coalescing ?? (OPT6) ---
+// --- value fallback ?? (OPT12) ---
 
-test "nil-coalescing with None" {
+test "fallback with none" {
     const x: i32? = none
     assert (x ?? 99) == 99
 }
 
-test "nil-coalescing with Some" {
-    const x = Some(42)
+test "fallback with present" {
+    const x: i32? = 42
     assert (x ?? 99) == 42
 }
 
-test "nil-coalescing short-circuits" {
-    // ?? must not evaluate the right-hand side when left is Some
-    const x = Some(1)
-    // If short-circuit fails this would still work for this test,
-    // but the spec (OPT6) requires short-circuit semantics.
+test "fallback short-circuits" {
+    const x: i32? = 1
     assert (x ?? 999) == 1
 }
 
-// --- optional chaining ?. (OPT5) ---
+// --- optional chaining ?. (OPT11) ---
 
 struct Profile {
     name: string
@@ -71,46 +60,48 @@ struct User {
 
 func get_user(has_profile: bool) -> User? {
     if has_profile {
-        return Some(User { profile: Some(Profile { name: "Alice", age: 30 }) })
+        const p: Profile? = Profile { name: "Alice", age: 30 }
+        return User { profile: p }
     }
     return none
 }
 
-test "optional chaining Some path" {
+test "optional chaining present path" {
     const user = get_user(true)
     const name = user?.profile?.name
     assert name is Some
     assert name! == "Alice"
 }
 
-test "optional chaining None short-circuits" {
+test "optional chaining absent short-circuits" {
     const user = get_user(false)
     const name = user?.profile?.name
     assert name is None
 }
 
-test "optional chaining on None field" {
-    const user = Some(User { profile: none })
+test "optional chaining on none field" {
+    const p: Profile? = none
+    const user: User? = User { profile: p }
     const name = user?.profile?.name
     assert name is None
 }
 
-// --- auto-wrapping T to Option<T> (OPT8) ---
+// --- auto-wrap T to T? (OPT5) ---
 
 func maybe_value() -> i32? {
     return 42
 }
 
-test "auto-wrapping T to Option" {
+test "auto-wrap T to T?" {
     const x = maybe_value()
     assert x is Some
     assert x! == 42
 }
 
-// --- try on Option (OPT12-OPT14) ---
+// --- try on Option (OPT15, OPT18) ---
 
 func inner_option() -> i32? {
-    return Some(10)
+    return 10
 }
 
 func outer_option() -> i32? {
@@ -120,74 +111,62 @@ func outer_option() -> i32? {
 
 func try_propagates_none() -> i32? {
     const val = try returns_none()
-    // Should not reach here
     return val + 1
 }
 
-test "try on Option extracts Some" {
+test "try on Option extracts" {
     const result = outer_option()
     assert result is Some
     assert result! == 20
 }
 
-test "try on Option propagates None" {
+test "try on Option propagates none" {
     const result = try_propagates_none()
     assert result is None
 }
 
 // --- Option methods from spec ---
 
-test "is_some and is_none" {
-    const a = Some(1)
-    const b: i32? = none
-    assert a.is_some()
-    assert !a.is_none()
-    assert b.is_none()
-    assert !b.is_some()
-}
-
-test "map on Some" {
-    const x = Some(5)
+test "map on present" {
+    const x: i32? = 5
     const y = x.map(|v| v * 2)
     assert y! == 10
 }
 
-test "map on None" {
+test "map on absent" {
     const x: i32? = none
     const y = x.map(|v| v * 2)
     assert y is None
 }
 
 test "filter keeps matching" {
-    const x = Some(10)
+    const x: i32? = 10
     const y = x.filter(|v| v > 5)
     assert y! == 10
 }
 
 test "filter rejects non-matching" {
-    const x = Some(3)
+    const x: i32? = 3
     const y = x.filter(|v| v > 5)
     assert y is None
 }
 
-// --- Pattern matching (OPT10 + CF8-CF12) ---
+// --- is-patterns and narrowing (OPT19-OPT20) ---
 
-test "is Some with implicit unwrap" {
-    const opt = Some(42)
-    // OPT10: `if opt is Some` reuses outer name
+test "is Some with implicit narrowing" {
+    const opt: i32? = 42
     if opt is Some {
         assert opt == 42
     } else {
-        assert false, "expected Some"
+        assert false, "expected present"
     }
 }
 
-test "match on Option" {
-    const x = Some(7)
-    const result = match x {
-        Some(v) => v * 2,
-        None => 0,
-    }
+// Operator-form replacement for the old `match x { Some(v) => ..., None => ... }`.
+// Match on Option is rejected by the compiler; operator form is idiomatic.
+test "operator-form branch" {
+    const x: i32? = 7
+    const result = if x? as v { v * 2 } else { 0 }
     assert result == 14
 }
 

--- a/tests/suite/t19_result_operators.rk
+++ b/tests/suite/t19_result_operators.rk
@@ -1,17 +1,12 @@
 // SPDX-License-Identifier: (MIT OR Apache-2.0)
-// Result operators: x! force unwrap, auto-Ok wrapping, try...else,
-// error composition, error methods.
+// Result operators: x! force unwrap, auto-wrap at return, try...else,
+// error union composition, error methods.
 //
-// Spec: type.errors (ER1-ER26)
-//
-// SPEC ISSUE: Existing tests (t08) use .unwrap() but the spec defines x! as
-// the force unwrap operator. There is no .unwrap() in the Result method table.
-//
-// SPEC ISSUE: The spec says x! "msg" provides a custom panic message, but
-// doesn't clarify precedence. Is `x! "msg".len()` parsed as `(x! "msg").len()`
-// or `x! ("msg".len())`? Spec should clarify.
+// Spec: type.errors (ER1-ER42)
 
-struct DivError {
+struct DivError {}
+
+extend DivError {
     func message(self) -> string {
         return "division by zero"
     }
@@ -19,69 +14,71 @@ struct DivError {
 
 struct ParseError {
     detail: string
+}
+
+extend ParseError {
     func message(self) -> string {
         return "parse error: {self.detail}"
     }
 }
 
-// --- x! force unwrap on Result (ER spec) ---
+// --- force unwrap (ER15) ---
 
 func safe_div(a: i32, b: i32) -> i32 or DivError {
-    if b == 0 { return Err(DivError {}) }
+    if b == 0 { return DivError {} }
     return a / b
 }
 
-test "force unwrap Ok" {
+test "force unwrap present" {
     const result = safe_div(10, 2)
     assert result! == 5
 }
 
-// --- auto-Ok wrapping (ER7) ---
+// --- auto-wrap at return (ER9) ---
 
 func double(x: i32) -> i32 or DivError {
     return x * 2
 }
 
-test "auto-Ok wrapping" {
+test "auto-wrap at return" {
     const result = double(21)
     assert result is Ok
     assert result! == 42
 }
 
-// --- implicit Ok(()) for () or E (ER8) ---
+// --- implicit unit success (ER10) ---
 
 func do_nothing() -> () or DivError {
-    // No explicit return — ER8 says implicit Ok(())
+    // No explicit return — ER10 says implicit unit success
 }
 
-test "implicit Ok unit" {
+test "implicit unit success" {
     const result = do_nothing()
     assert result is Ok
 }
 
-// --- try propagation (ER4-ER5) ---
+// --- try propagation (ER16) ---
 
 func compute(a: i32, b: i32) -> i32 or DivError {
     const x = try safe_div(a, b)
     return x + 1
 }
 
-test "try extracts Ok" {
+test "try extracts present" {
     const result = compute(10, 2)
     assert result! == 6
 }
 
-test "try propagates Err" {
+test "try propagates error" {
     const result = compute(10, 0)
     assert result is Err
 }
 
-// --- try binds to full expression (ER5) ---
-// (try file.read()).trim() — parens needed for chaining
+// --- try with method chaining ---
 
 func parse_number(s: string) -> i32 or ParseError {
     if s == "42" { return 42 }
-    return Err(ParseError { detail: "not a number" })
+    return ParseError { detail: "not a number" }
 }
 
 func parse_and_double(s: string) -> i32 or ParseError {
@@ -95,15 +92,12 @@ test "try with chaining" {
 }
 
 // --- try...else (ER18) ---
-//
-// SPEC ISSUE: ER18 syntax is `try expr else |e| error_expr`. The spec says
-// this "transforms and propagates in one step" but doesn't clarify whether
-// the else branch must return an Err or can return any diverging expression.
-// The examples show `try expr else |e| ContextError.wrap(e)` which returns
-// a new error that gets auto-wrapped in Err.
 
 struct ContextError {
     source: string
+}
+
+extend ContextError {
     func message(self) -> string {
         return "context: {self.source}"
     }
@@ -119,49 +113,34 @@ test "try else transforms error" {
     assert result is Err
 }
 
-test "try else passes through Ok" {
+test "try else passes through" {
     const result = load_value("42")
     assert result! == 42
 }
 
 // --- Result methods from spec ---
 
-test "is_ok and is_err" {
-    const ok = safe_div(10, 2)
-    const err = safe_div(10, 0)
-    assert ok.is_ok()
-    assert !ok.is_err()
-    assert err.is_err()
-    assert !err.is_ok()
-}
-
-test "map on Ok" {
+test "map on present" {
     const result = safe_div(10, 2).map(|v| v * 3)
     assert result! == 15
 }
 
-test "map on Err" {
+test "map on error" {
     const result = safe_div(10, 0).map(|v| v * 3)
     assert result is Err
 }
 
-test "to_option on Ok" {
-    const opt = safe_div(10, 2).to_option()
+test "ok() lifts to Option (present)" {
+    const opt = safe_div(10, 2).ok()
     assert opt! == 5
 }
 
-test "to_option on Err" {
-    const opt = safe_div(10, 0).to_option()
+test "ok() lifts to Option (absent)" {
+    const opt = safe_div(10, 0).ok()
     assert opt is None
 }
 
-// --- Error union composition (ER12-ER14) ---
-//
-// SPEC ISSUE: The spec says `T or (A | B)` is the union syntax, and try
-// auto-widens when the return error is a superset. But the spec doesn't
-// define how to match on union errors. Is it `match result { Err(e) => ... }`
-// where e is `A | B`? Or do you match on variants? The enums spec doesn't
-// cover union error matching.
+// --- Error union composition (ER31) ---
 
 func combined(s: string, b: i32) -> i32 or (ParseError | DivError) {
     const n = try parse_number(s)
@@ -169,7 +148,7 @@ func combined(s: string, b: i32) -> i32 or (ParseError | DivError) {
     return result
 }
 
-test "error union Ok path" {
+test "error union present path" {
     assert combined("42", 2)! == 21
 }
 
@@ -186,8 +165,8 @@ test "error union div error" {
 test "match on Result" {
     const result = safe_div(10, 2)
     const value = match result {
-        Ok(v) => v,
-        Err(_) => -1,
+        Ok(v) => v
+        Err(_) => -1
     }
     assert value == 5
 }

--- a/tests/suite/t19_result_operators.rk
+++ b/tests/suite/t19_result_operators.rk
@@ -42,7 +42,7 @@ func double(x: i32) -> i32 or DivError {
 
 test "auto-wrap at return" {
     const result = double(21)
-    assert result is Ok
+    assert result?
     assert result! == 42
 }
 
@@ -54,7 +54,7 @@ func do_nothing() -> () or DivError {
 
 test "implicit unit success" {
     const result = do_nothing()
-    assert result is Ok
+    assert result?
 }
 
 // --- try propagation (ER16) ---
@@ -71,7 +71,7 @@ test "try extracts present" {
 
 test "try propagates error" {
     const result = compute(10, 0)
-    assert result is Err
+    assert result is DivError
 }
 
 // --- try with method chaining ---
@@ -88,7 +88,7 @@ func parse_and_double(s: string) -> i32 or ParseError {
 
 test "try with chaining" {
     assert parse_and_double("42")! == 84
-    assert parse_and_double("bad") is Err
+    assert parse_and_double("bad") is ParseError
 }
 
 // --- try...else (ER18) ---
@@ -110,7 +110,7 @@ func load_value(s: string) -> i32 or ContextError {
 
 test "try else transforms error" {
     const result = load_value("bad")
-    assert result is Err
+    assert result is ContextError
 }
 
 test "try else passes through" {
@@ -127,7 +127,7 @@ test "map on present" {
 
 test "map on error" {
     const result = safe_div(10, 0).map(|v| v * 3)
-    assert result is Err
+    assert result is DivError
 }
 
 test "ok() lifts to Option (present)" {
@@ -137,7 +137,7 @@ test "ok() lifts to Option (present)" {
 
 test "ok() lifts to Option (absent)" {
     const opt = safe_div(10, 0).ok()
-    assert opt is None
+    assert opt == none
 }
 
 // --- Error union composition (ER31) ---
@@ -153,11 +153,11 @@ test "error union present path" {
 }
 
 test "error union parse error" {
-    assert combined("bad", 2) is Err
+    assert combined("bad", 2) is ParseError
 }
 
 test "error union div error" {
-    assert combined("42", 0) is Err
+    assert combined("42", 0) is DivError
 }
 
 // --- match on Result ---
@@ -165,8 +165,8 @@ test "error union div error" {
 test "match on Result" {
     const result = safe_div(10, 2)
     const value = match result {
-        Ok(v) => v
-        Err(_) => -1
+        i32 as v => v
+        DivError => -1
     }
     assert value == 5
 }

--- a/tests/suite/t20_control_expressions.rk
+++ b/tests/suite/t20_control_expressions.rk
@@ -157,7 +157,7 @@ test "is pattern with combined condition" {
 
 test "is Some implicit unwrap" {
     const opt: i32? = 42
-    if opt is Some {
+    if opt? {
         // Per OPT10/CF12, `opt` is rebound to the inner value
         assert opt == 42
     } else {
@@ -179,7 +179,7 @@ test "while is pattern" {
     mut sum = 0
     mut idx = 0
     while idx < items.len() {
-        if items[idx] is Some(v) {
+        if items[idx]? as v {
             sum += v
         }
         idx += 1
@@ -190,8 +190,8 @@ test "while is pattern" {
 // --- guard pattern: mut...is...else (CF13-CF15) ---
 
 func extract_or_zero(opt: i32?) -> i32 {
-    mut value = opt is Some else { return 0 }
-    return value * 2
+    if opt? as value { return value * 2 }
+    return 0
 }
 
 test "guard pattern Some" {
@@ -221,8 +221,8 @@ func err_result() -> i32 or GuardError {
 }
 
 func extract_ok(result: i32 or GuardError) -> i32 {
-    mut value = result is Ok else { return -1 }
-    return value
+    if result? as value { return value }
+    return -1
 }
 
 test "guard pattern Ok" {

--- a/tests/suite/t20_control_expressions.rk
+++ b/tests/suite/t20_control_expressions.rk
@@ -156,22 +156,25 @@ test "is pattern with combined condition" {
 // --- is Some implicit unwrap (CF12, OPT10) ---
 
 test "is Some implicit unwrap" {
-    const opt = Some(42)
+    const opt: i32? = 42
     if opt is Some {
         // Per OPT10/CF12, `opt` is rebound to the inner value
         assert opt == 42
     } else {
-        assert false, "expected Some"
+        assert false, "expected present"
     }
 }
 
 // --- while...is pattern (CF8) ---
 
 test "while is pattern" {
-    const items = Vec.new()
-    items.push(Some(1))
-    items.push(Some(2))
-    items.push(Some(3))
+    const items: Vec<i32?> = Vec.new()
+    const a: i32? = 1
+    const b: i32? = 2
+    const c: i32? = 3
+    items.push(a)
+    items.push(b)
+    items.push(c)
 
     mut sum = 0
     mut idx = 0
@@ -192,24 +195,42 @@ func extract_or_zero(opt: i32?) -> i32 {
 }
 
 test "guard pattern Some" {
-    assert extract_or_zero(Some(5)) == 10
+    const x: i32? = 5
+    assert extract_or_zero(x) == 10
 }
 
 test "guard pattern None diverges" {
     assert extract_or_zero(none) == 0
 }
 
-func extract_ok(result: i32 or string) -> i32 {
+enum GuardError { Fail }
+extend GuardError {
+    func message(self) -> string {
+        match self {
+            GuardError.Fail => return "fail",
+        }
+    }
+}
+
+func ok_result(v: i32) -> i32 or GuardError {
+    return v
+}
+
+func err_result() -> i32 or GuardError {
+    return GuardError.Fail
+}
+
+func extract_ok(result: i32 or GuardError) -> i32 {
     mut value = result is Ok else { return -1 }
     return value
 }
 
 test "guard pattern Ok" {
-    assert extract_ok(Ok(42)) == 42
+    assert extract_ok(ok_result(42)) == 42
 }
 
 test "guard pattern Err diverges" {
-    assert extract_ok(Err("fail")) == -1
+    assert extract_ok(err_result()) == -1
 }
 
 // --- inline colon syntax (CF5) ---

--- a/tests/suite/t25_iterator_adapters.rk
+++ b/tests/suite/t25_iterator_adapters.rk
@@ -113,7 +113,7 @@ test "find existing" {
     v.push(3)
 
     const found = v.find(|x| x == 2)
-    assert found is Some
+    assert found?
     assert found! == 2
 }
 
@@ -123,7 +123,7 @@ test "find missing" {
     v.push(2)
 
     const found = v.find(|x| x == 99)
-    assert found is None
+    assert found == none
 }
 
 // --- any / all ---

--- a/tests/suite/t27_error_narrowing.rk
+++ b/tests/suite/t27_error_narrowing.rk
@@ -1,0 +1,153 @@
+// SPDX-License-Identifier: (MIT OR Apache-2.0)
+// Error/Option narrowing and spec operators not covered by t07/t08/t17-t20.
+//
+// Spec: type.optionals (OPT13, OPT19-OPT22), type.errors (ER23, ER24, ER27)
+
+// --- E0350: Ok/Err/Some/None rejected as patterns ---
+// Covered as compile-error tests; here we confirm the *correct* forms compile.
+
+// --- OPT13: diverging fallback (?? return / break / continue) ---
+
+func opt() -> i32? { return 42 }
+
+func use_return() -> i32 {
+    const v = opt() ?? return -1
+    return v + 1
+}
+
+test "?? return unwraps present" {
+    assert use_return() == 43
+}
+
+func accum() -> i32 {
+    const xs: Vec<i32?> = Vec.new()
+    const a: i32? = 1
+    const absent: i32? = none
+    const c: i32? = 3
+    xs.push(a)
+    xs.push(absent)
+    xs.push(c)
+
+    mut total = 0
+    for x in xs {
+        const v = x ?? continue
+        total = total + v
+    }
+    return total
+}
+
+test "?? continue skips absent" {
+    assert accum() == 4
+}
+
+// --- OPT13 via block fallback (?? { ...; return }) ---
+
+func use_block() -> i32 {
+    const v = opt() ?? {
+        println("absent")
+        return -1
+    }
+    return v * 2
+}
+
+test "?? { return } unwraps present" {
+    assert use_block() == 84
+}
+
+// --- ER18: try expr else |e| return (diverging handler) ---
+
+enum FetchError { NotFound }
+extend FetchError {
+    func message(self) -> string {
+        match self {
+            FetchError.NotFound => return "not found",
+        }
+    }
+}
+
+func inner() -> i32 or FetchError { return 10 }
+
+func try_else_return() -> i32 {
+    const v = try inner() else |e| return -1
+    return v
+}
+
+test "try expr else |e| return unwraps present" {
+    assert try_else_return() == 10
+}
+
+// --- ER23 / ER27: type pattern in guard (is <T> as v else) ---
+
+func use_type_pattern() -> i32 {
+    const v = inner() is i32 as v else { return -1 }
+    return v + 5
+}
+
+test "is T as v else binds the success type" {
+    assert use_type_pattern() == 15
+}
+
+// --- ER24: early-exit narrowing on is ErrType ---
+
+struct Cfg { port: i32 }
+
+enum CfgError { BadPort }
+extend CfgError {
+    func message(self) -> string {
+        match self {
+            CfgError.BadPort => return "bad port",
+        }
+    }
+}
+
+func load_cfg() -> Cfg or CfgError { return Cfg { port: 8080 } }
+
+func cfg_port() -> i32 {
+    const c = load_cfg()
+    if c is CfgError {
+        return -1
+    }
+    // ER24: c is narrowed to Cfg here
+    return c.port
+}
+
+test "early-exit narrows c to ok after is ErrType diverges" {
+    assert cfg_port() == 8080
+}
+
+// --- ER24 via if x == none { return } ---
+
+func opt_source() -> i32? { return 7 }
+
+func narrow_via_none() -> i32 {
+    const x = opt_source()
+    if x == none {
+        return -1
+    }
+    // Early-exit narrow: x is i32 here
+    return x + 100
+}
+
+test "early-exit narrows x after x == none diverges" {
+    assert narrow_via_none() == 107
+}
+
+// --- rask#217: generic type patterns parse ---
+
+func make_vec() -> Vec<i32> or CfgError {
+    const v: Vec<i32> = Vec.new()
+    v.push(1)
+    v.push(2)
+    return v
+}
+
+func generic_guard() -> i32 {
+    const v = make_vec() is Vec<i32> as v else { return -1 }
+    return v.len() as i32
+}
+
+test "generic type pattern in is ... else guard" {
+    assert generic_guard() == 2
+}
+
+func main() {}

--- a/tutorials/learn-rask/04_collections.rk
+++ b/tutorials/learn-rask/04_collections.rk
@@ -30,8 +30,8 @@
 //         println("got {score}")
 //     }
 //
-//   Or pattern-test with `is Some(v)` / `is None`:
-//     if result is Some(score) { println("got {score}") }
+//   Or test for absence with `== none`:
+//     if result == none { println("missing") }
 //
 //   This forces you to handle the missing case. No more KeyError crashes.
 //   We'll cover Option in depth in lesson 08. For now, just know it exists.
@@ -142,10 +142,10 @@ test "sum vec" {
 
 test "periodic table" {
     const table = periodic_table()
-    assert table.get("H") is Some(1)
-    assert table.get("He") is Some(2)
-    assert table.get("C") is Some(6)
-    assert table.get("O") is Some(8)
+    assert table.get("H")! == 1
+    assert table.get("He")! == 2
+    assert table.get("C")! == 6
+    assert table.get("O")! == 8
 }
 
 test "dot product" {
@@ -155,9 +155,9 @@ test "dot product" {
 
 test "count occurrences" {
     const counts = count_occurrences(Vec.from([1, 2, 1, 3, 2, 1]))
-    assert counts.get(1) is Some(3)
-    assert counts.get(2) is Some(2)
-    assert counts.get(3) is Some(1)
+    assert counts.get(1)! == 3
+    assert counts.get(2)! == 2
+    assert counts.get(3)! == 1
 }
 
 func main() {

--- a/tutorials/learn-rask/04_collections.rk
+++ b/tutorials/learn-rask/04_collections.rk
@@ -19,16 +19,19 @@
 //
 // IMPORTANT — Map.get() and the Option type:
 //   In Python, dict["key"] crashes if the key is missing.
-//   In Rask, map.get("key") returns an Option — a value that is
-//   either Some(value) if found, or None if missing.
+//   In Rask, map.get("key") returns an Option (written `T?`) — a value
+//   that is either present, or the sentinel `none` if missing.
 //
-//   const result = scores.get("alice")  // result is Some(95)
-//   const result = scores.get("bob")    // result is None
+//   const result = scores.get("alice")  // result is a bare value
+//   const result = scores.get("bob")    // result is none
 //
-//   To use the value inside, use `if ... is Some`:
-//     if result is Some(score) {
+//   To use the value inside, narrow with `if x? as v`:
+//     if result? as score {
 //         println("got {score}")
 //     }
+//
+//   Or pattern-test with `is Some(v)` / `is None`:
+//     if result is Some(score) { println("got {score}") }
 //
 //   This forces you to handle the missing case. No more KeyError crashes.
 //   We'll cover Option in depth in lesson 08. For now, just know it exists.
@@ -52,9 +55,9 @@ func example_map() {
     elements.insert("He", 2)
     elements.insert("Li", 3)
 
-    // .get() returns Option — Some(value) or None
+    // .get() returns Option — a bare value or `none`
     const h = elements.get("H")
-    if h is Some(num) {
+    if h? as num {
         println("Hydrogen: atomic number {num}")
     }
 }
@@ -110,9 +113,9 @@ func dot_product(a: Vec<f64>, b: Vec<f64>) -> f64 {
 //   [1, 2, 1, 3, 2, 1] → {1: 3, 2: 2, 3: 1}
 //
 // Hint: use .get() to check if a key exists. Remember, .get() returns
-// an Option — either Some(count) or None.
+// an Option — a bare count when present, else `none`.
 //
-//   if existing is Some(c) {
+//   if existing? as c {
 //       map.insert(item, c + 1)
 //   } else {
 //       map.insert(item, 1)

--- a/tutorials/learn-rask/04_collections.rk
+++ b/tutorials/learn-rask/04_collections.rk
@@ -57,8 +57,8 @@ func example_map() {
 
     // .get() returns Option — a bare value or `none`
     const h = elements.get("H")
-    if h? as num {
-        println("Hydrogen: atomic number {num}")
+    if h? {
+        println("Hydrogen: atomic number {h}")
     }
 }
 

--- a/tutorials/learn-rask/08_error_handling.rk
+++ b/tutorials/learn-rask/08_error_handling.rk
@@ -195,8 +195,8 @@ test "temperature at boundary" {
 test "parse altitude" {
     const r = parse_altitude("35000")
     assert r?
-    if r? as alt {
-        assert alt == 35000
+    if r? {
+        assert r == 35000
     } else {
         assert false
     }
@@ -213,8 +213,8 @@ test "parse empty altitude" {
 test "average valid readings" {
     const r = average_readings(20.0, 22.0, 21.0)
     assert r?
-    if r? as avg {
-        assert avg == 21.0
+    if r? {
+        assert r == 21.0
     } else {
         assert false
     }

--- a/tutorials/learn-rask/08_error_handling.rk
+++ b/tutorials/learn-rask/08_error_handling.rk
@@ -8,43 +8,44 @@
 // In Rask, errors are values. A function that might fail says so in its
 // return type with `T or E`:
 //
-//   func divide(a: f64, b: f64) -> f64 or string {
-//       if b == 0.0 { return Err("division by zero") }
-//       return a / b    // automatically wrapped in Ok
+//   func divide(a: f64, b: f64) -> f64 or DivError {
+//       if b == 0.0 { return DivError.Msg("division by zero") }
+//       return a / b    // bare T auto-wraps to the success branch at return
 //   }
 //
 // `T or E` means:
 //   - T is the success type (what you return on success)
 //   - E is the error type (what you return on failure)
-//   - `f64 or string` = success gives f64, failure gives string
+//   - `f64 or DivError` = success gives f64, failure gives DivError
 //
-// Under the hood, `T or E` is sugar for `Result<T, E>`, but the
-// `or` syntax reads more naturally.
+// Error types must implement `func message(self) -> string`. Primitives
+// (string, i32, …) don't qualify — give your error its own enum.
 //
-// The caller MUST handle the result:
+// The caller can match on the result — types name the branches, no
+// Ok/Err wrappers:
 //
 //   match divide(10.0, 0.0) {
-//       Ok(val)  => println("got {val}"),
-//       Err(msg) => println("error: {msg}"),
+//       f64 as v      => println("got {v}"),
+//       DivError as e => println("error: {e.message()}"),
 //   }
 //
-// Or propagate the error with `try` — if the result is Err, the
-// current function returns immediately with that error:
+// Or propagate the error with `try` — if the result is the error branch,
+// the current function returns immediately with that error:
 //
-//   func calc() -> f64 or string {
-//       const val = try divide(10.0, 3.0)   // unwraps Ok, or returns Err
+//   func calc() -> f64 or DivError {
+//       const val = try divide(10.0, 3.0)   // unwraps T, or returns E
 //       return val * 2.0
 //   }
 //
-// Remember Option from lesson 04? It's the same idea:
-//   Some(value) or None — for "might not exist"
-//   Ok(value) or Err(e) — for "might fail"
+// Remember Option from lesson 04? It's the same idea, but simpler:
+//   a bare value or `none` — for "might not exist"
+//   a bare value or an error value — for "might fail"
 //
 // Quick shortcuts:
-//   result.is_ok()     → true if Ok
-//   result.is_err()    → true if Err
-//   option ?? default  → unwrap Option, use default if None
-//   result!            → unwraps Ok, panics if Err
+//   r?                 → true if success branch
+//   r is MyError       → true if error branch
+//   option ?? default  → unwrap Option, use default if none
+//   r!                 → unwraps success, panics with e.message() if error
 //
 // === Panic vs Error ===
 //
@@ -54,7 +55,7 @@
 //   const config = load_config()!   // if this fails, we can't continue
 //   const x = items[0]!              // we know items is non-empty here
 //
-// **Error (`try`)** — the function returns an Err. Use for expected failures:
+// **Error (`try`)** — the function returns the error. Use for expected failures:
 //   const temp = try validate_temperature(reading)  // sensor might fail
 //   const user = try authenticate(token)             // token might be invalid
 //
@@ -63,33 +64,42 @@
 //   - Is this a bug in the code? Use `panic()` or `!`
 //
 // In Python, everything is an exception. Rask separates:
-//   - Errors = values you handle (Ok/Err)
+//   - Errors = values you handle (typed, with .message())
 //   - Panics = bugs you don't (crash)
 //
 
 // --- Examples ---
 
-func safe_divide(a: f64, b: f64) -> f64 or string {
+enum SensorError { Msg(string) }
+extend SensorError {
+    func message(self) -> string {
+        match self {
+            SensorError.Msg(m) => return m,
+        }
+    }
+}
+
+func safe_divide(a: f64, b: f64) -> f64 or SensorError {
     if b == 0.0 {
-        return Err("division by zero")
+        return SensorError.Msg("division by zero")
     }
     return a / b
 }
 
 func example_error_handling() {
     match safe_divide(10.0, 3.0) {
-        Ok(val) => println("10 / 3 = {val}"),
-        Err(msg) => println("Error: {msg}"),
+        f64 as v         => println("10 / 3 = {v}"),
+        SensorError as e => println("Error: {e.message()}"),
     }
 
     match safe_divide(10.0, 0.0) {
-        Ok(val) => println("10 / 0 = {val}"),
-        Err(msg) => println("Error: {msg}"),
+        f64 as v         => println("10 / 0 = {v}"),
+        SensorError as e => println("Error: {e.message()}"),
     }
 }
 
 // Using try to chain operations
-func calc() -> f64 or string {
+func calc() -> f64 or SensorError {
     const a = try safe_divide(100.0, 4.0)    // 25.0
     const b = try safe_divide(a, 5.0)         // 5.0
     return b
@@ -110,27 +120,27 @@ func sqrt(x: f64) -> f64 {
 
 // --- Puzzle 1: Validate sensor reading ---
 // A temperature sensor should read between -40.0 and 150.0 °C.
-// Return the reading if valid, or an error string if out of range.
+// Return the reading if valid, or a SensorError if out of range.
 //
 // Sensors fail all the time in the real world. The Mars Climate Orbiter
 // was lost because one team used pounds and another used newtons.
 // Validating inputs is boring but saves missions.
-func validate_temperature(reading: f64) -> f64 or string {
+func validate_temperature(reading: f64) -> f64 or SensorError {
     todo()
 }
 
 // --- Puzzle 2: Parse altitude ---
 // Parse a string like "35000" into an i32 altitude.
-// Return Err if the string is empty.
-// Return Err if the altitude is negative.
+// Return a SensorError if the string is empty.
+// Return a SensorError if the altitude is negative.
 //
 // In a real system, you'd also validate against the aircraft's service
 // ceiling. The Boeing 737 MAX can go to 41,000 ft. The Concorde
 // cruised at 60,000 ft — pilots could see the curvature of Earth.
 //
 // For this puzzle: just check empty and negative.
-// Hint: use string.parse_i32() which returns `i32 or string`
-func parse_altitude(s: string) -> i32 or string {
+// Hint: use string.parse_i32() which returns `i32 or ParseIntError`
+func parse_altitude(s: string) -> i32 or SensorError {
     todo()
 }
 
@@ -149,15 +159,15 @@ func parse_altitude(s: string) -> i32 or string {
 //       ...
 //
 // In Rask, the `try` keyword does the same but at each step:
-func average_readings(r1: f64, r2: f64, r3: f64) -> f64 or string {
+func average_readings(r1: f64, r2: f64, r3: f64) -> f64 or SensorError {
     todo()
 }
 
 // --- Puzzle 4: Option — safe Vec access ---
-// Return the element at index i, or None if out of bounds.
+// Return the element at index i, or none if out of bounds.
 //
-// The return type `i32?` is shorthand for `Option<i32>`.
-// Return Some(value) or None.
+// The return type `i32?` is the builtin Option — a bare i32 when
+// present, `none` when absent. No Some/None wrappers.
 func safe_get(v: Vec<i32>, i: i32) -> i32? {
     todo()
 }
@@ -166,62 +176,64 @@ func safe_get(v: Vec<i32>, i: i32) -> i32? {
 
 test "valid temperature" {
     const r = validate_temperature(20.0)
-    assert r.is_ok()
+    assert r?
 }
 
 test "temperature too high" {
-    assert validate_temperature(200.0).is_err()
+    assert validate_temperature(200.0) is SensorError
 }
 
 test "temperature too low" {
-    assert validate_temperature(-50.0).is_err()
+    assert validate_temperature(-50.0) is SensorError
 }
 
 test "temperature at boundary" {
-    assert validate_temperature(-40.0).is_ok()
-    assert validate_temperature(150.0).is_ok()
+    assert validate_temperature(-40.0)?
+    assert validate_temperature(150.0)?
 }
 
 test "parse altitude" {
     const r = parse_altitude("35000")
-    assert r.is_ok()
-    match r {
-        Ok(alt) => assert alt == 35000
-        Err(_) => assert false
+    assert r?
+    if r? as alt {
+        assert alt == 35000
+    } else {
+        assert false
     }
 }
 
 test "parse negative altitude" {
-    assert parse_altitude("-100").is_err()
+    assert parse_altitude("-100") is SensorError
 }
 
 test "parse empty altitude" {
-    assert parse_altitude("").is_err()
+    assert parse_altitude("") is SensorError
 }
 
 test "average valid readings" {
     const r = average_readings(20.0, 22.0, 21.0)
-    assert r.is_ok()
-    match r {
-        Ok(avg) => assert avg == 21.0
-        Err(_) => assert false
+    assert r?
+    if r? as avg {
+        assert avg == 21.0
+    } else {
+        assert false
     }
 }
 
 test "average with invalid reading" {
-    assert average_readings(20.0, 200.0, 21.0).is_err()
+    assert average_readings(20.0, 200.0, 21.0) is SensorError
 }
 
 test "safe get in bounds" {
     const v = Vec.from([10, 20, 30])
-    assert safe_get(v, 0) is Some(10)
-    assert safe_get(v, 2) is Some(30)
+    if safe_get(v, 0)? as x { assert x == 10 } else { assert false }
+    if safe_get(v, 2)? as x { assert x == 30 } else { assert false }
 }
 
 test "safe get out of bounds" {
     const v = Vec.from([10, 20, 30])
-    assert safe_get(v, 5) is None
-    assert safe_get(v, -1) is None
+    assert safe_get(v, 5) == none
+    assert safe_get(v, -1) == none
 }
 
 func main() {

--- a/tutorials/learn-rask/17_resource_types.rk
+++ b/tutorials/learn-rask/17_resource_types.rk
@@ -141,12 +141,12 @@ func process_flights(flights: Vec<string>) -> i32 or string {
 
 test "booking commit" {
     const result = book_flight(1, "Besse")
-    assert result is Ok
+    assert result?
 }
 
 test "booking failure" {
     const result = book_flight(2, "FAIL")
-    assert result is Err
+    assert result is string
 }
 
 test "booking pattern" {

--- a/tutorials/learn-rask/solutions/04_collections.rk
+++ b/tutorials/learn-rask/solutions/04_collections.rk
@@ -37,7 +37,7 @@ func count_occurrences(items: Vec<i32>) -> Map<i32, i32> {
     const counts = Map.new()
     for item in items {
         const existing = counts.get(item)
-        if existing is Some(c) {
+        if existing? as c {
             counts.insert(item, c + 1)
         } else {
             counts.insert(item, 1)
@@ -62,10 +62,10 @@ test "sum vec" {
 
 test "periodic table" {
     const table = periodic_table()
-    assert table.get("H") is Some(1)
-    assert table.get("He") is Some(2)
-    assert table.get("C") is Some(6)
-    assert table.get("O") is Some(8)
+    assert table.get("H")! == 1
+    assert table.get("He")! == 2
+    assert table.get("C")! == 6
+    assert table.get("O")! == 8
 }
 
 test "dot product" {
@@ -75,9 +75,9 @@ test "dot product" {
 
 test "count occurrences" {
     const counts = count_occurrences(Vec.from([1, 2, 1, 3, 2, 1]))
-    assert counts.get(1) is Some(3)
-    assert counts.get(2) is Some(2)
-    assert counts.get(3) is Some(1)
+    assert counts.get(1)! == 3
+    assert counts.get(2)! == 2
+    assert counts.get(3)! == 1
 }
 
 func main() {

--- a/tutorials/learn-rask/solutions/08_error_handling.rk
+++ b/tutorials/learn-rask/solutions/08_error_handling.rk
@@ -84,14 +84,14 @@ test "average with invalid reading" {
 
 test "safe get in bounds" {
     const v = Vec.from([10, 20, 30])
-    assert safe_get(v, 0) is Some(10)
-    assert safe_get(v, 2) is Some(30)
+    assert safe_get(v, 0)! == 10
+    assert safe_get(v, 2)! == 30
 }
 
 test "safe get out of bounds" {
     const v = Vec.from([10, 20, 30])
-    assert safe_get(v, 5) is None
-    assert safe_get(v, -1) is None
+    assert safe_get(v, 5) == none
+    assert safe_get(v, -1) == none
 }
 
 func main() { println("All solutions for lesson 08") }

--- a/tutorials/learn-rask/solutions/08_error_handling.rk
+++ b/tutorials/learn-rask/solutions/08_error_handling.rk
@@ -1,5 +1,14 @@
 // Solution: Lesson 08
 
+enum SensorError { Msg(string) }
+extend SensorError {
+    func message(self) -> string {
+        match self {
+            SensorError.Msg(m) => return m,
+        }
+    }
+}
+
 func sqrt(x: f64) -> f64 {
     if x <= 0.0 { return 0.0 }
     mut g = x / 2.0
@@ -7,20 +16,20 @@ func sqrt(x: f64) -> f64 {
     return g
 }
 
-func validate_temperature(reading: f64) -> f64 or string {
-    if reading < -40.0 { return Err("too low") }
-    if reading > 150.0 { return Err("too high") }
+func validate_temperature(reading: f64) -> f64 or SensorError {
+    if reading < -40.0 { return SensorError.Msg("too low") }
+    if reading > 150.0 { return SensorError.Msg("too high") }
     return reading
 }
 
-func parse_altitude(s: string) -> i32 or string {
-    if s.len() == 0 { return Err("empty string") }
-    const alt = try s.parse_i32()
-    if alt < 0 { return Err("negative altitude") }
+func parse_altitude(s: string) -> i32 or SensorError {
+    if s.len() == 0 { return SensorError.Msg("empty string") }
+    const alt = try s.parse_i32() else |e| SensorError.Msg(e.message())
+    if alt < 0 { return SensorError.Msg("negative altitude") }
     return alt
 }
 
-func average_readings(r1: f64, r2: f64, r3: f64) -> f64 or string {
+func average_readings(r1: f64, r2: f64, r3: f64) -> f64 or SensorError {
     const a = try validate_temperature(r1)
     const b = try validate_temperature(r2)
     const c = try validate_temperature(r3)
@@ -28,49 +37,49 @@ func average_readings(r1: f64, r2: f64, r3: f64) -> f64 or string {
 }
 
 func safe_get(v: Vec<i32>, i: i32) -> i32? {
-    if i < 0 { return None }
-    if i >= v.len() { return None }
+    if i < 0 { return none }
+    if i >= v.len() { return none }
     return v[i]
 }
 
 test "valid temperature" {
     const r = validate_temperature(20.0)
-    assert r.is_ok()
+    assert r?
 }
 
 test "temperature too high" {
-    assert validate_temperature(200.0).is_err()
+    assert validate_temperature(200.0) is SensorError
 }
 
 test "temperature too low" {
-    assert validate_temperature(-50.0).is_err()
+    assert validate_temperature(-50.0) is SensorError
 }
 
 test "temperature at boundary" {
-    assert validate_temperature(-40.0).is_ok()
-    assert validate_temperature(150.0).is_ok()
+    assert validate_temperature(-40.0)?
+    assert validate_temperature(150.0)?
 }
 
 test "parse altitude" {
     const r = parse_altitude("35000")
-    assert r.is_ok()
+    assert r?
 }
 
 test "parse negative altitude" {
-    assert parse_altitude("-100").is_err()
+    assert parse_altitude("-100") is SensorError
 }
 
 test "parse empty altitude" {
-    assert parse_altitude("").is_err()
+    assert parse_altitude("") is SensorError
 }
 
 test "average valid readings" {
     const r = average_readings(20.0, 22.0, 21.0)
-    assert r.is_ok()
+    assert r?
 }
 
 test "average with invalid reading" {
-    assert average_readings(20.0, 200.0, 21.0).is_err()
+    assert average_readings(20.0, 200.0, 21.0) is SensorError
 }
 
 test "safe get in bounds" {

--- a/tutorials/learn-rask/solutions/16_shared_state.rk
+++ b/tutorials/learn-rask/solutions/16_shared_state.rk
@@ -4,7 +4,7 @@
 //
 //   1. h.join()! — panic if task panicked (simplest, good for tests)
 //   2. try h.join() — propagate JoinError (function must return or JoinError)
-//   3. match h.join() { Ok(v) => ..., Err(e) => ... } — explicit handling
+//   3. match h.join() { T as v => ..., JoinError as e => ... } — explicit handling
 //
 import async.spawn
 import sync.AtomicI64
@@ -111,10 +111,10 @@ test "shared config update" {
 //       return result
 //   }
 //
-// Approach 3: Explicit match
+// Approach 3: Explicit match or narrowing
 //   const result = h.join()
-//   if result is Ok(val) { use(val) }
-//   else if result is Err(e) { handle(e) }
+//   if result? as val { use(val) }
+//   else if result is JoinError as e { handle(e) }
 
 func main() {
     println("All solutions for lesson 16")

--- a/tutorials/learn-rask/solutions/17_resource_types.rk
+++ b/tutorials/learn-rask/solutions/17_resource_types.rk
@@ -1,5 +1,14 @@
 // Solution: Lesson 17
 
+enum BookingError { Msg(string) }
+extend BookingError {
+    func message(self) -> string {
+        match self {
+            BookingError.Msg(m) => return m,
+        }
+    }
+}
+
 struct Booking {
     id: i32
     committed: bool
@@ -19,11 +28,11 @@ extend Booking {
     }
 }
 
-func book_flight(id: i32, passenger: string) -> i32 or string {
+func book_flight(id: i32, passenger: string) -> i32 or BookingError {
     mut booking = Booking.new(id)
 
     if passenger == "FAIL" {
-        return Err("payment failed")
+        return BookingError.Msg("payment failed")
     }
 
     booking.commit()
@@ -47,18 +56,18 @@ func two_bookings() -> BookingStatus {
     }
 }
 
-func process_flights(flights: Vec<string>) -> i32 or string {
+func process_flights(flights: Vec<string>) -> i32 or BookingError {
     return flights.len()
 }
 
 test "booking commit" {
     const result = book_flight(1, "Besse")
-    assert result.is_ok()
+    assert result?
 }
 
 test "booking failure" {
     const result = book_flight(2, "FAIL")
-    assert result.is_err()
+    assert result is BookingError
 }
 
 test "booking pattern" {


### PR DESCRIPTION
This PR modernizes error and option handling throughout the codebase to use Rask's newer syntax, removing explicit `Ok()`, `Err()`, `Some()`, and `None` wrappers in favor of:

- **Bare value returns**: Functions returning `T or E` now return bare `T` values (auto-wrapped at return) instead of `Ok(T)`, and bare error values instead of `Err(E)`
- **none literal**: Replaces `None` with the `none` keyword for option types
- **Operator syntax**: Replaces pattern matching with modern operators:
  - `x?` for optional chaining / presence check (replaces `is Some`)
  - `x ?? default` for fallback (replaces nil-coalescing with explicit `Some`/`None` checks)
  - `x!` for force unwrap (replaces `.unwrap()`)
  - `if x? as v { ... } else as e { ... }` for narrowing (replaces `match` on `T or E`)

**Key changes:**

- **Error handling**: All functions returning `T or E` now use bare value returns. Error enums now require a `message(self) -> string` method. Removed `Ok()` and `Err()` wrappers throughout examples and tests.
- **Option handling**: Replaced `Some(v)` with bare `v` at return, `None` with `none`, and pattern matching with `?` operator and `??` fallback operator.
- **Type pattern matching**: Added compiler support for matching against union branches by type name (e.g., `is i64 as v` instead of `is Ok(v)`).
- **Error type wrapping**: String error types replaced with proper enum types that implement `message()` (e.g., `IoErrorMsg`, `ArgError`, `DivError`).
- **Operator precedence**: Parser updated to handle diverging RHS in `??` (e.g., `x ?? return y`).

**Files modified:**
- Examples: package_manager, markdown_renderer, cli_calculator, text_editor, file_copy, and 15+ others
- Tests: t07_option, t08_result, t17_option, t18_option_operators, t19_result_operators, t20_control_expressions
- Tutorials: 08_error_handling and solutions
- Compiler: check_pattern, check_expr, unify, inference, errors, parser
- Stdlib: string, memory, sync, collections

This aligns the codebase with Rask's current language design where errors and options are first-class values with dedicated operators, improving readability and reducing boilerplate.

https://claude.ai/code/session_0196YboWbegeKUuoBWTmmLHt