### PR TITLE
Migrate from .unwrap() to ! operator and update error handling syntax

### DIFF
--- a/examples/15_memory_management.rk
+++ b/examples/15_memory_management.rk
@@ -99,40 +99,40 @@ func main() {
     // Display entity relationships
     print("\nEntity relationships:\n")
 
-    const player_ent = entities.get(player).unwrap()
+    const player_ent = entities.get(player)!
     print(player_ent.name)
     print(" (HP: ")
     print(player_ent.health)
     print(")")
 
     if player_ent.target? as target_handle {
-        const target = entities.get(target_handle).unwrap()
+        const target = entities.get(target_handle)!
         print(" -> targets ")
         print(target.name)
     }
     print("\n")
 
-    const e1 = entities.get(enemy1).unwrap()
+    const e1 = entities.get(enemy1)!
     print(e1.name)
     print(" (HP: ")
     print(e1.health)
     print(")")
 
     if e1.target? as target_handle {
-        const target = entities.get(target_handle).unwrap()
+        const target = entities.get(target_handle)!
         print(" -> targets ")
         print(target.name)
     }
     print("\n")
 
-    const e2 = entities.get(enemy2).unwrap()
+    const e2 = entities.get(enemy2)!
     print(e2.name)
     print(" (HP: ")
     print(e2.health)
     print(")")
 
     if e2.target? as target_handle {
-        const target = entities.get(target_handle).unwrap()
+        const target = entities.get(target_handle)!
         print(" -> targets ")
         print(target.name)
     }
@@ -141,14 +141,14 @@ func main() {
     // Modify entities through handles
     print("Applying damage:\n")
 
-    entities[enemy1].health = entities.get(enemy1).unwrap().health - 20
+    entities[enemy1].health = entities.get(enemy1)!.health - 20
     print("Goblin health: ")
-    print(entities.get(enemy1).unwrap().health)
+    print(entities.get(enemy1)!.health)
     print("\n")
 
-    entities[player].health = entities.get(player).unwrap().health - 10
+    entities[player].health = entities.get(player)!.health - 10
     print("Player health: ")
-    print(entities.get(player).unwrap().health)
+    print(entities.get(player)!.health)
     print("\n\n")
 
     // Handle invalidation - removing entities

--- a/examples/19_unsafe.rk
+++ b/examples/19_unsafe.rk
@@ -144,7 +144,7 @@ func main() {
     print("  unsafe { ptr.offset(5) }  // Caller must ensure safety\n")
     print("\n")
     print("Create a safe API:\n")
-    print("  vec.get(5)  // Returns Option<T>, bounds-checked\n")
+    print("  vec.get(5)  // Returns T?, bounds-checked\n")
     print("\n")
     print("The unsafe code is contained within the implementation,\n")
     print("and users get a safe interface.\n")

--- a/examples/README.md
+++ b/examples/README.md
@@ -17,13 +17,13 @@ These examples parse and run with the current interpreter:
 | # | Example | Topic | Status |
 |---|---------|-------|--------|
 | - | `hello_world.rk` | Hello World | ✅ Runnable |
-| 01 | `01_variables.rk` | Variables (`const`, `let`) | ✅ Runnable |
+| 01 | `01_variables.rk` | Variables (`const`, `mut`) | ✅ Runnable |
 | 02 | `02_functions.rk` | Functions and returns | ✅ Runnable |
 | 03 | `03_collections.rk` | Vec and Map | ✅ Runnable |
 | 04 | `04_pattern_matching.rk` | Match expressions | ✅ Runnable |
 | 05 | `05_loops.rk` | For and while loops | ✅ Runnable |
 | 06 | `06_structs.rk` | Structs and methods | ✅ Runnable |
-| 07 | `07_error_handling.rk` | Result types, `try` | ✅ Runnable |
+| 07 | `07_error_handling.rk` | `T or E`, `try` | ✅ Runnable |
 | 08 | `08_traits.rk` | Traits and polymorphism | ✅ Runnable |
 | 13 | `13_string_operations.rk` | String methods | ✅ Runnable |
 | 16 | `16_concurrency_basics.rk` | Threads and channels | ✅ Runnable |

--- a/examples/cli_calculator.rk
+++ b/examples/cli_calculator.rk
@@ -126,7 +126,7 @@ extend Lexer {
             }
         }
 
-        const value: f64 = num_str.parse().unwrap()
+        const value: f64 = num_str.parse()!
         return Token.Number(value)
     }
 }

--- a/examples/collections_test.rk
+++ b/examples/collections_test.rk
@@ -15,9 +15,9 @@ func main() {
     v.push(30)
     const vlen = v.len()
     println("Vec length: {vlen}")
-    const v0 = v.get(0).unwrap()
-    const v1 = v.get(1).unwrap()
-    const v2 = v.get(2).unwrap()
+    const v0 = v.get(0)!
+    const v1 = v.get(1)!
+    const v2 = v.get(2)!
     println("v[0] = {v0}")
     println("v[1] = {v1}")
     println("v[2] = {v2}")

--- a/examples/litmus_edge_cases.rk
+++ b/examples/litmus_edge_cases.rk
@@ -2,7 +2,7 @@
 // Edge case tests discovered during litmus program validation.
 //
 // Tests: string Copy semantics, try-else with method calls, Vec.get() returning
-// Option<T>, and basic type system features.
+// T?, and basic type system features.
 //
 // Run: rask test examples/litmus_edge_cases.rk
 
@@ -58,9 +58,9 @@ test "string Copy — assign from struct field" {
     assert n2 == "Alice"
 }
 
-// ─── Vec.get() returns Option<T> (collections/V3) ───────────────
+// ─── Vec.get() returns T? (collections/V3) ──────────────────────
 
-test "Vec.get returns Some for valid index" {
+test "Vec.get — present for valid index" {
     const v = Vec.new()
     v.push(10)
     v.push(20)
@@ -69,11 +69,11 @@ test "Vec.get returns Some for valid index" {
     const first = v.get(0)
     assert first?
 
-    const second = v.get(1).unwrap()
+    const second = v.get(1)!
     assert second == 20
 }
 
-test "Vec.get returns None for out of bounds" {
+test "Vec.get — none for out of bounds" {
     const v = Vec.new()
     v.push(42)
 
@@ -81,12 +81,12 @@ test "Vec.get returns None for out of bounds" {
     assert out == none
 }
 
-test "Vec.get unwrap matches expected value" {
+test "Vec.get — force-extract matches expected value" {
     const v = Vec.new()
     v.push(100)
     v.push(200)
-    assert v.get(0).unwrap() == 100
-    assert v.get(1).unwrap() == 200
+    assert v.get(0)! == 100
+    assert v.get(1)! == 200
 }
 
 // ─── try-else with method calls ────────────────────────────────
@@ -287,23 +287,23 @@ test "Pool — modify non-string field after reading string" {
     assert pool[h].health == 50
 }
 
-// ─── Vec.get with pattern matching ──────────────────────────────
+// ─── Vec.get with narrowing ─────────────────────────────────────
 
-test "Vec.get — pattern match Some" {
+test "Vec.get — narrow on present" {
     const v = Vec.new()
     v.push("hello")
     if v.get(0)? as val {
         assert val == "hello"
     } else {
-        assert false, "expected Some"
+        assert false, "expected present"
     }
 }
 
-test "Vec.get — pattern match None" {
+test "Vec.get — else branch on absent" {
     const v = Vec.new()
     v.push(1)
     if v.get(99)? {
-        assert false, "expected None"
+        assert false, "expected none"
     }
 }
 

--- a/examples/lsm_database/bloom.rk
+++ b/examples/lsm_database/bloom.rk
@@ -102,7 +102,7 @@ test "bloom filter encode/decode roundtrip" {
     bloom.insert("key3")
 
     const encoded = encode_bloom(bloom)
-    const decoded = decode_bloom(encoded).unwrap()
+    const decoded = decode_bloom(encoded)!
     assert decoded.may_contain("key1")
     assert decoded.may_contain("key2")
     assert decoded.may_contain("key3")

--- a/examples/lsm_database/cache.rk
+++ b/examples/lsm_database/cache.rk
@@ -164,7 +164,7 @@ test "block cache put and get" {
 
     cache.put(1, 0, entries.clone())
 
-    const result = cache.get(1, 0) ?? panic("expected Some")
+    const result = cache.get(1, 0) ?? panic("expected present")
     assert result.len() == 2
     assert result[0].key == "k1"
 

--- a/examples/lsm_database/kv.rk
+++ b/examples/lsm_database/kv.rk
@@ -48,7 +48,7 @@ func decode_kv(line: string) -> KeyValue or WalError {
 test "kv encode/decode roundtrip" {
     const kv = KeyValue.new("test_key", "test_value", 42)
     const encoded = encode_kv(kv)
-    const decoded = decode_kv(encoded).unwrap()
+    const decoded = decode_kv(encoded)!
 
     assert decoded.key == "test_key"
     assert decoded.value == "test_value"
@@ -59,7 +59,7 @@ test "kv encode/decode roundtrip" {
 test "kv tombstone encode/decode" {
     const kv = KeyValue.tombstone("deleted_key", 99)
     const encoded = encode_kv(kv)
-    const decoded = decode_kv(encoded).unwrap()
+    const decoded = decode_kv(encoded)!
 
     assert decoded.key == "deleted_key"
     assert decoded.deleted

--- a/examples/lsm_database/memtable.rk
+++ b/examples/lsm_database/memtable.rk
@@ -94,10 +94,10 @@ test "memtable put and get" {
     mt.put(KeyValue.new("a", "1", 2))
     mt.put(KeyValue.new("c", "3", 3))
 
-    const a = mt.get("a") ?? panic("expected Some")
+    const a = mt.get("a") ?? panic("expected present")
     assert a.value == "1"
 
-    const b = mt.get("b") ?? panic("expected Some")
+    const b = mt.get("b") ?? panic("expected present")
     assert b.value == "2"
 
     assert mt.get("z") == none
@@ -108,7 +108,7 @@ test "memtable overwrites by key" {
     mt.put(KeyValue.new("k", "old", 1))
     mt.put(KeyValue.new("k", "new", 2))
 
-    const kv = mt.get("k") ?? panic("expected Some")
+    const kv = mt.get("k") ?? panic("expected present")
     assert kv.value == "new"
     assert kv.seq == 2
     assert mt.entries.len() == 1

--- a/examples/markdown_renderer.rk
+++ b/examples/markdown_renderer.rk
@@ -108,7 +108,7 @@ func html_escape(input: string) -> string {
     return builder
 
     // All same char: '-' or '*' or '_', ignoring spaces
-    // Returns start number if line matches "N. " pattern, else None
+    // Returns start number if line matches "N. " pattern, else none
 }
 
 func count_leading(line: string, ch: char) -> i32 {
@@ -929,51 +929,51 @@ test "html escaping" {
 }
 
 test "headings" {
-    const result = render_markdown("# Hello").unwrap()
+    const result = render_markdown("# Hello")!
     assert result.contains("<h1>Hello</h1>")
 
     const result2 = render_markdown("""
 ## Sub
 ### Third
-""").unwrap()
+""")!
     assert result2.contains("<h2>Sub</h2>")
     assert result2.contains("<h3>Third</h3>")
 }
 
 test "paragraphs" {
-    const result = render_markdown("Hello world").unwrap()
+    const result = render_markdown("Hello world")!
     assert result.contains("<p>Hello world</p>")
 
     const result2 = render_markdown("""
 Line one
 Line two
-""").unwrap()
+""")!
     assert result2.contains("<p>Line one\nLine two</p>")
 }
 
 test "bold and italic" {
-    const result = render_markdown("**bold** and *italic*").unwrap()
+    const result = render_markdown("**bold** and *italic*")!
     assert result.contains("<strong>bold</strong>")
     assert result.contains("<em>italic</em>")
 }
 
 test "nested bold italic" {
-    const result = render_markdown("**bold *and italic***").unwrap()
+    const result = render_markdown("**bold *and italic***")!
     assert result.contains("<strong>bold <em>and italic</em></strong>")
 }
 
 test "inline code" {
-    const result = render_markdown("use `println` here").unwrap()
+    const result = render_markdown("use `println` here")!
     assert result.contains("<code>println</code>")
 }
 
 test "links" {
-    const result = render_markdown("[click](http://example.com)").unwrap()
+    const result = render_markdown("[click](http://example.com)")!
     assert result.contains("<a href=\"http://example.com\">click</a>")
 }
 
 test "images" {
-    const result = render_markdown("![alt text](img.png)").unwrap()
+    const result = render_markdown("![alt text](img.png)")!
     assert result.contains("<img src=\"img.png\" alt=\"alt text\">")
 }
 
@@ -983,7 +983,7 @@ test "code blocks" {
 fn main() {}
 ```
 """
-    const result = render_markdown(input).unwrap()
+    const result = render_markdown(input)!
     assert result.contains("<pre><code class=\"language-rust\">")
     assert result.contains("fn main() {}")
 }
@@ -994,12 +994,12 @@ test "code block no language" {
 plain code
 ```
 """
-    const result = render_markdown(input).unwrap()
+    const result = render_markdown(input)!
     assert result.contains("<pre><code>plain code</code></pre>")
 }
 
 test "blockquotes" {
-    const result = render_markdown("> quoted text").unwrap()
+    const result = render_markdown("> quoted text")!
     assert result.contains("<blockquote>")
     assert result.contains("<p>quoted text</p>")
     assert result.contains("</blockquote>")
@@ -1011,7 +1011,7 @@ test "unordered lists" {
 - two
 - three
 """
-    const result = render_markdown(input).unwrap()
+    const result = render_markdown(input)!
     assert result.contains("<ul>")
     assert result.contains("<li>one</li>")
     assert result.contains("<li>two</li>")
@@ -1025,7 +1025,7 @@ test "ordered lists" {
 2. second
 3. third
 """
-    const result = render_markdown(input).unwrap()
+    const result = render_markdown(input)!
     assert result.contains("<ol>")
     assert result.contains("<li>first</li>")
     assert result.contains("<li>second</li>")
@@ -1033,9 +1033,9 @@ test "ordered lists" {
 }
 
 test "horizontal rules" {
-    assert render_markdown("---").unwrap().contains("<hr>")
-    assert render_markdown("***").unwrap().contains("<hr>")
-    assert render_markdown("___").unwrap().contains("<hr>")
+    assert render_markdown("---")!.contains("<hr>")
+    assert render_markdown("***")!.contains("<hr>")
+    assert render_markdown("___")!.contains("<hr>")
 }
 
 test "reference links" {
@@ -1044,12 +1044,12 @@ See [the site][ex] for details.
 
 [ex]: http://example.com
 """
-    const result = render_markdown(input).unwrap()
+    const result = render_markdown(input)!
     assert result.contains("<a href=\"http://example.com\">the site</a>")
 }
 
 test "escaped characters" {
-    const result = render_markdown("not \\*italic\\*").unwrap()
+    const result = render_markdown("not \\*italic\\*")!
     assert result.contains("not *italic*")
     assert !result.contains("<em>")
 }
@@ -1067,7 +1067,7 @@ A **bold** paragraph.
 
 > quote
 """
-    const result = render_markdown(input).unwrap()
+    const result = render_markdown(input)!
     assert result.contains("<h1>Title</h1>")
     assert result.contains("<strong>bold</strong>")
     assert result.contains("<ul>")
@@ -1081,22 +1081,22 @@ test "html escape in code blocks" {
 <div class="x">&</div>
 ```
 """
-    const result = render_markdown(input).unwrap()
+    const result = render_markdown(input)!
     assert result.contains("&lt;div class=&quot;x&quot;&gt;&amp;&lt;/div&gt;")
 }
 
 test "link with formatted text" {
-    const result = render_markdown("[**bold link**](url)").unwrap()
+    const result = render_markdown("[**bold link**](url)")!
     assert result.contains("<a href=\"url\"><strong>bold link</strong></a>")
 }
 
 test "empty document" {
-    const result = render_markdown("").unwrap()
+    const result = render_markdown("")!
     assert result == ""
 }
 
 test "full page output" {
-    const result = render_full_page("# Hello").unwrap()
+    const result = render_full_page("# Hello")!
     assert result.contains("<!DOCTYPE html>")
     assert result.contains("<h1>Hello</h1>")
     assert result.contains("</body>")

--- a/examples/pool_test.rk
+++ b/examples/pool_test.rk
@@ -56,10 +56,10 @@ func main() {
         println("Got h1: {maybe.name}")
     }
 
-    // Safe get on stale handle (should be None)
+    // Safe get on stale handle (should be none)
     const stale = pool.get(h3)
     if stale == none {
-        println("Correctly got None for stale handle")
+        println("Correctly got none for stale handle")
     }
 
     // Iteration via cursor

--- a/examples/sensor_processor.rk
+++ b/examples/sensor_processor.rk
@@ -29,8 +29,8 @@ func crc8(data: Vec<i64>, table: Vec<i64>) -> i64 {
     mut crc: i64 = 0
     const n = data.len()
     for i in 0..n {
-        const byte = data.get(i).unwrap()
-        crc = table.get((crc ^ byte) & 255).unwrap()
+        const byte = data.get(i)!
+        crc = table.get((crc ^ byte) & 255)!
     }
     return crc
 }
@@ -179,9 +179,9 @@ extend ProcessorState {
         mut pres_sum = 0.0
         mut hum_sum = 0.0
         for i in 0..self.history_count {
-            temp_sum += self.temp_history.get(i).unwrap()
-            pres_sum += self.pressure_history.get(i).unwrap()
-            hum_sum += self.humidity_history.get(i).unwrap()
+            temp_sum += self.temp_history.get(i)!
+            pres_sum += self.pressure_history.get(i)!
+            hum_sum += self.humidity_history.get(i)!
         }
 
         const n = self.history_count as f64
@@ -270,8 +270,8 @@ func main() {
 
         // Drain available samples — each reading is 3 consecutive i64s
         while read_idx + 2 < readings.len() {
-            const sensor_id = readings.get(read_idx).unwrap()
-            const value_bits = readings.get(read_idx + 1).unwrap()
+            const sensor_id = readings.get(read_idx)!
+            const value_bits = readings.get(read_idx + 1)!
             const value = value_bits as f64
             read_idx += 3
             state.process_reading(sensor_id, value)

--- a/examples/simple_grep.rk
+++ b/examples/simple_grep.rk
@@ -1,18 +1,22 @@
 // SPDX-License-Identifier: (MIT OR Apache-2.0)
 // Simple grep - Pattern search using module syntax
 // Usage: rask run simple_grep.rk <pattern> <file>
-// Demonstrates: cli.args, fs.read_lines, string methods, match, Vec, loops
+// Demonstrates: cli.args, fs.read_lines, string methods, T or E, Vec, loops
 
 import fs
 import cli
 import std
 
-enum GrepResult {
-    Ok(i32)
-    Err(string)
+enum GrepError { Msg(string) }
+extend GrepError {
+    func message(self) -> string {
+        match self {
+            GrepError.Msg(m) => return m,
+        }
+    }
 }
 
-func grep_file(pattern: string, path: string) -> GrepResult {
+func grep_file(pattern: string, path: string) -> i32 or GrepError {
     const lines_result = fs.read_lines(path)
 
     if lines_result? {
@@ -27,9 +31,9 @@ func grep_file(pattern: string, path: string) -> GrepResult {
             }
         }
 
-        return GrepResult.Ok(match_count)
+        return match_count
     } else as e {
-        return GrepResult.Err(e.message())
+        return GrepError.Msg(e.message())
     }
 }
 
@@ -42,24 +46,21 @@ func main() {
         std.exit(1)
     }
 
-    const pattern = args.get(1).unwrap()
-    const file_path = args.get(2).unwrap()
+    const pattern = args.get(1)!
+    const file_path = args.get(2)!
 
     println("Searching for '{pattern}' in {file_path}...")
 
     const result = grep_file(pattern, file_path)
 
-    match result {
-        Ok(count) => {
-            println("")
-            println("Found {count} matching lines")
-            if count == 0 {
-                std.exit(1)
-            }
+    if result? as count {
+        println("")
+        println("Found {count} matching lines")
+        if count == 0 {
+            std.exit(1)
         }
-        Err(e) => {
-            println("Error: {e}")
-            std.exit(2)
-        }
+    } else as e {
+        println("Error: {e.message()}")
+        std.exit(2)
     }
 }

--- a/examples/text_editor.rk
+++ b/examples/text_editor.rk
@@ -89,7 +89,7 @@ extend Document {
         if at < 0 || at >= self.line_count(): return Error.IndexOutOfBounds
 
         const h = self.line_order.remove(at as i64)
-        const deleted = self.lines.remove(h).unwrap()
+        const deleted = self.lines.remove(h)!
 
         // Record for undo
         self.undo_stack.push(EditCommand.DeleteLine(at: at, deleted_text: deleted.text))
@@ -168,7 +168,7 @@ extend Document {
     // Display the document
     func display(self) {
         for i in 0..self.line_count() {
-            const line = self.get_line(i).unwrap()
+            const line = self.get_line(i)!
             println("{i + 1}: {line}")
         }
     }

--- a/tutorials/learn-rask/README.md
+++ b/tutorials/learn-rask/README.md
@@ -29,7 +29,7 @@ won't allow, read the error, and understand why. Those are the most important on
 | Python | Rask | What changed |
 |--------|------|-------|
 | `x = 42` | `const x = 42` | Immutable by default |
-| `x = 0; x = 1` | `let x = 0; x = 1` | `let` = mutable |
+| `x = 0; x = 1` | `mut x = 0; x = 1` | `mut` = rebindable |
 | `def f(a, b):` | `func f(a: i32, b: i32) -> i32 {` | You declare types |
 | `return x` | `return x` | Same, but always required |
 | `[1, 2, 3]` | `Vec.from([1, 2, 3])` | Vec = Python's list |
@@ -37,7 +37,7 @@ won't allow, read the error, and understand why. Those are the most important on
 | `for x in range(10):` | `for x in 0..10 {` | `..` = range |
 | `if x > 0:` | `if x > 0 {` | Braces instead of colons |
 | `class Foo:` | `struct Foo {}` + `extend Foo {}` | Data and methods are separate |
-| `try/except` | `try expr` / `match result { Ok/Err }` | No exceptions — errors are values |
+| `try/except` | `try expr` / `if r? { … } else as e { … }` | No exceptions — errors are values |
 | `# comment` | `// comment` | |
 | `print(x)` | `println(x)` | |
 


### PR DESCRIPTION
## Summary
This PR modernizes the codebase to use Rask's newer error handling syntax, replacing `.unwrap()` method calls with the `!` force-unwrap operator and updating documentation to reflect the current `T or E` error type syntax instead of `Result<T, E>`.

## Key Changes

- **Replaced `.unwrap()` with `!` operator**: Updated all instances across example files (`markdown_renderer.rk`, `15_memory_management.rk`, `sensor_processor.rk`, `collections_test.rk`, `cli_calculator.rk`, `lsm_database/*.rk`, `text_editor.rk`) to use the more concise `!` syntax for force-unwrapping optional/result values
- **Updated error handling patterns**: Converted custom `GrepResult` enum in `simple_grep.rk` to use the `T or E` syntax with proper error type definition, replacing pattern matching with try-else control flow
- **Fixed documentation and comments**: 
  - Updated README.md to reflect `T or E` instead of "Result types"
  - Changed variable binding keyword from `let` to `mut` in documentation
  - Updated comments referencing `Option<T>` to use `T?` notation
  - Fixed test names and comments to use "present/absent" terminology instead of "Some/None"
- **Standardized error messages**: Changed panic messages from "expected Some" to "expected present" for consistency with new terminology

## Notable Implementation Details

- The `simple_grep.rk` example was refactored to demonstrate the modern error handling approach with a custom `GrepError` type and `extend` block for methods
- All test assertions and example code now consistently use the `!` operator for unwrapping, making the code more readable and idiomatic
- Comments and documentation strings were updated to match the current language terminology and syntax conventions

https://claude.ai/code/session_01ErtFaNGJ6HDZBHrp35ZmGH