### PR TITLE
specs: sweep remaining wrapper syntax from stdlib/memory/control/compiler docs



### DIFF
--- a/specs/METRICS.md
+++ b/specs/METRICS.md
@@ -137,7 +137,7 @@ Logic: actual computation, data transformation, control flow
 
 **Examples:**
 - ✅ `users.get(id)?.name` — minimal ceremony
-- ❌ `users.get(id) or { return None }.name or { return None }` — ceremony dominates
+- ❌ `users.get(id) or { return none }.name or { return none }` — ceremony dominates
 - ✅ `for user in users { ... }` — clean iteration
 - ❌ `users.lock(ref) { |user| ... } or continue` — nested callback noise
 

--- a/specs/README.md
+++ b/specs/README.md
@@ -93,8 +93,8 @@ Quick navigation by task or concept:
 | [simd.md](types/simd.md) | SIMD vectors, masking, reductions, shuffles |
 | [structs.md](types/structs.md) | Struct definition, methods, visibility |
 | [enums.md](types/enums.md) | Sum types, pattern matching |
-| [optionals.md](types/optionals.md) | Option<T>, T? syntax |
-| [error-types.md](types/error-types.md) | Error trait, Result, union composition |
+| [optionals.md](types/optionals.md) | Option status type, `T?` syntax |
+| [error-types.md](types/error-types.md) | `T or E`, `ErrorMessage` trait, union composition |
 | [generics.md](types/generics.md) | Parametric polymorphism, constraints |
 | [gradual-constraints.md](types/gradual-constraints.md) | Type/bound inference for private functions |
 | [traits.md](types/traits.md) | Trait objects, dynamic dispatch |

--- a/specs/SYNTAX.md
+++ b/specs/SYNTAX.md
@@ -311,7 +311,7 @@ extend File {
 
 ### Enums (Sum Types)
 
-`Option<T>` (`T?`) and `Result<T, E>` (`T or E`) are builtin tagged unions, not user enums. See [types/optionals.md](types/optionals.md) and [types/error-types.md](types/error-types.md). User enums cover everything else:
+Option (`T?`) and the error union (`T or E`) are builtin tagged unions, not user enums — no `Some`/`None` or `Ok`/`Err` constructors. See [types/optionals.md](types/optionals.md) and [types/error-types.md](types/error-types.md). User enums cover everything else:
 
 ```rask
 // Positional payloads — clean for wrappers and simple cases
@@ -665,7 +665,7 @@ Match a single pattern in `if` or `while` with automatic binding:
 // Check enum variant with binding
 if state is Connected(sock): sock.send(data)
 
-if result is Ok(value) {
+if result? as value {
     process(value)
 } else {
     handle_error()
@@ -815,15 +815,15 @@ Pool access, `ensure` cleanup, and `@resource` types are shown in the sections a
 ```rask
 // Option shorthand — bare value auto-wraps
 const x: i32? = 42
-const name = user?.profile?.name    // None if any step is None
+const name = user?.profile?.name    // `none` if any step is `none`
 const port = config.port ?? 8080
 const must_exist = optional!
 
-// Result
+// Error union
 func load_config() -> Config or (IoError | ParseError) {
     const content = try read_file("config.json")
     const config = try parse_json(content)
-    return config                                   // Auto-wrapped in Ok
+    return config                                   // Bare T — auto-wraps to success branch
 }
 ```
 
@@ -1117,8 +1117,8 @@ println("{sum}")
 | Rebindable | `mut x = ...` | Can reassign |
 | Mutable | `mutate param` | Explicit mutable borrow |
 | Ownership | `take param` | Explicit when consuming |
-| Optional | `T?` | Type and chaining |
-| Result | `T or E` | Same as `Result<T, E>` |
+| Optional | `T?` | Type and chaining; bare value + `none`, no `Some`/`None` |
+| Error union | `T or E` | No `Ok`/`Err` — bare T auto-wraps at return; E is its own type |
 | Error prop | `try expr` | Prefix keyword |
 | Match | `match x { ... }` | Expression with `=>` arms |
 | Pattern condition | `if x is Pattern` | Non-exhaustive, binds `v` |

--- a/specs/analysis/complexity-stress-test.md
+++ b/specs/analysis/complexity-stress-test.md
@@ -123,7 +123,7 @@ func update_entities(mutate world: GameWorld) -> () or Error {
         body.close(world.physics)
     }
 
-    return Ok(())
+    return
 }
 ```
 
@@ -141,7 +141,7 @@ func render_frame(world: GameWorld) {
 
 func render_entities(world: GameWorld) using frozen Pool<Entity>, frozen Pool<Mesh> {
     for (h, entity) in world.entities.entries() {
-        if world.meshes.get(entity.mesh) is Some(mesh) {
+        if world.meshes.get(entity.mesh)? as mesh {
             draw_mesh(mesh.vertex_buffer, mesh.index_count, entity.position)
         }
     }
@@ -162,7 +162,7 @@ func game_loop_parallel(mutate world: GameWorld, dt: f32) -> () or Error
 
     const render_handle = ThreadPool.spawn(|| {
         for (h, entity) in entity_snap.entries() {
-            if mesh_snap.get(entity.mesh) is Some(mesh) {
+            if mesh_snap.get(entity.mesh)? as mesh {
                 draw_mesh(mesh.vertex_buffer, mesh.index_count, entity.position)
             }
         }
@@ -177,7 +177,7 @@ func game_loop_parallel(mutate world: GameWorld, dt: f32) -> () or Error
     sync_physics(world)
     try update_entities(world)
 
-    return Ok(())
+    return
 }
 ```
 

--- a/specs/compiler/advanced-analyses.md
+++ b/specs/compiler/advanced-analyses.md
@@ -51,7 +51,7 @@ func bad_example() using Pool<Player> {
 |-----------|--------------|-------------|--------------|
 | `h = pool.insert(x)` | — | Fresh | None (new handle) |
 | `pool[h]` access | Any | Valid | Unchanged |
-| `pool.get(h) is Some` | Any | Valid (true branch) | Unchanged |
+| `pool.get(h)?` narrow | Any | Valid (true branch) | Unchanged |
 | `pool.remove(h)` | Any | Invalid | All become Invalid |
 | `pool.insert(x)` | Unknown/Valid | Unknown | Unchanged |
 | `h2 = h1` | s | s | h2 aliases h1 |
@@ -81,7 +81,7 @@ func alias_example() using Pool<Player> {
 
 | Rule | Description |
 |------|-------------|
-| **FN1: Check narrows** | Successful `pool.get(h) is Some` narrows h to Valid in the true branch |
+| **FN1: Check narrows** | Successful `pool.get(h)?` predicate narrows h to Valid in the true branch |
 | **FN2: Access narrows** | `pool[h]` access narrows h to Valid for subsequent uses in same basic block |
 | **FN3: Mutation widens** | Pool structural mutation (insert/remove of other handles) widens to Unknown |
 | **FN4: Loop reset** | Each loop iteration resets to pre-loop state |
@@ -90,7 +90,7 @@ func alias_example() using Pool<Player> {
 ```rask
 func safe_access(h: Handle<Player>) using Pool<Player> {
     // h: Unknown (parameter)
-    if pool.get(h) is None {
+    if pool.get(h) == none {
         return  // h: Invalid here (narrowed in false continuation)
     }
     // h: Valid here (narrowed by check)

--- a/specs/compiler/codegen.md
+++ b/specs/compiler/codegen.md
@@ -58,7 +58,7 @@ All MIR types have known sizes. No generics remain.
 | **T1: Concrete only** | All types fully resolved before MIR lowering |
 | **T2: Field ordering** | Struct fields sorted by alignment (largest first) to minimize padding |
 | **T3: C layout override** | `@layout(C)` forces declaration order for C interop |
-| **T4: Niche optimization** | `Option<Ptr>` uses null as `None`; `Option<Handle>` uses sentinel generation `0` |
+| **T4: Niche optimization** | `Ptr?` uses null as `none`; `Handle?` uses sentinel generation `0` |
 
 ```
 MirType:
@@ -219,7 +219,7 @@ rask build main.rk -o myapp
 
 | Case | Handling | Rule |
 |------|---------|------|
-| Niche optimization for Option | `Option<Ptr>` uses null as None, no tag needed | T4 |
+| Niche optimization for optional | `Ptr?` uses null as `none`, no tag needed | T4 |
 | `@layout(C)` structs | Declaration order preserved, no field reordering | T3 |
 | Storable closures | Copy/move captured values into env struct at creation | L6 |
 | Expression-scoped closures | Take pointer to enclosing stack frame | L6 |

--- a/specs/compiler/effects.md
+++ b/specs/compiler/effects.md
@@ -36,7 +36,7 @@ func load_config(path: string) -> Config or Error {
 // No IO effect — pure computation
 func parse_header(raw: string) -> Header or ParseError {
     const parts = raw.split(":").collect()
-    if parts.len() != 2 { return Err(ParseError.MalformedHeader) }
+    if parts.len() != 2 { return ParseError.MalformedHeader }
     return Header { key: parts[0].trim(), value: parts[1].trim() }
 }
 ```
@@ -125,7 +125,7 @@ func add(a: i32, b: i32) -> i32 {
 
 // Pure — errors are values, not effects
 func parse(input: string) -> Config or ParseError {
-    if input.is_empty() { return Err(ParseError.Empty) }
+    if input.is_empty() { return ParseError.Empty }
     return Config { value: input }
 }
 

--- a/specs/compiler/memory-layout.md
+++ b/specs/compiler/memory-layout.md
@@ -67,9 +67,10 @@ Layout:
 ### Enums with Payloads
 
 ```rask
-enum Result<T, E> {
-    Ok(T),      // variant 0
-    Err(E),     // variant 1
+// `T or E` is a builtin sum; layout matches a two-variant enum
+T or E {
+    T,      // variant 0 (success value, bare)
+    E,      // variant 1 (error value, bare)
 }
 ```
 
@@ -87,15 +88,15 @@ Layout structure:
 | **E5: Enum alignment** | Alignment = max(discriminant_align, max variant alignment) |
 | **E6: Padding after tag** | Discriminant padded to alignment of largest variant |
 
-Example: `Result<i32, string>`
+Example: `i32 or string`
 
 ```
-Result<i32, string>:
+i32 or string:
   discriminant: u8 at offset 0
   padding: 7 bytes (to align to 8-byte string)
   payload union at offset 8:
-    - Ok variant: i32 (4 bytes)
-    - Err variant: string (16 bytes: tagged union, see String section)
+    - ok variant: i32 (4 bytes)
+    - err variant: string (16 bytes: tagged union, see String section)
 
 Total size: 8 (discriminant+padding) + 16 (union) = 24 bytes
 Alignment: 8 bytes (string's alignment)
@@ -119,15 +120,15 @@ Certain types have unused bit patterns that can encode enum discriminants withou
 
 | Rule | Description |
 |------|-------------|
-| **N1: Handle niche** | `Option<Handle<T>>` uses generation=0 to represent None (8 bytes, not 16) |
-| **N2: Reference niche** | `Option<&T>` uses null pointer for None (8 bytes, not 16) |
-| **N3: NonZero types** | Future: `Option<NonZeroU32>` etc. use zero as None |
+| **N1: Handle niche** | `Handle<T>?` uses generation=0 to represent `none` (8 bytes, not 16) |
+| **N2: Reference niche** | `(&T)?` uses null pointer for `none` (8 bytes, not 16) |
+| **N3: NonZero types** | Future: `NonZeroU32?` etc. use zero as `none` |
 
-**Option<Handle<T>> Layout:**
+**Handle<T>? Layout:**
 ```
 // Without niche (naive):       16 bytes = [tag: u8][pad: 7][Handle: 8]
 // With niche (optimized):        8 bytes = [index: u32][generation: u32]
-//   where generation=0 means None, generation>0 means Some
+//   where generation=0 means `none`, generation>0 means present
 ```
 
 **Priority:** Handle niche optimization MUST be implemented before ABI stabilization. This is critical for graph algorithms using Pool handles.

--- a/specs/compiler/name-mangling.md
+++ b/specs/compiler/name-mangling.md
@@ -75,8 +75,8 @@ myapp.net.http  → 5myapp3net4http
 | `i32` | `i32` | `_Gi32` |
 | `Vec<i32>` | `Vec[i32]` | `_GVec[i32]` |
 | `Map<string, User>` | `Map[string,4User]` | `_GMap[string,4User]` |
-| `Option<T>` | `Option[T]` | `_GOption[T]` |
-| `Result<T, HttpError>` | `Result[T,9HttpError]` | `_GResult[T,9HttpError]` |
+| `T?` | `Opt[T]` | `_GOpt[T]` |
+| `T or HttpError` | `Or[T,9HttpError]` | `_GOr[T,9HttpError]` |
 
 **Encoding rules:**
 - **Primitives:** No length prefix (i32, u64, bool, str, f32, f64)
@@ -241,21 +241,21 @@ C-compatible types:
 
 **Not C-compatible** (compile error if used with `@export`):
 - `string` (use `*u8` + `usize` or `.as_c_str()`)
-- `Result<T, E>` (use return codes + out params)
-- `Option<T>` (use nullable pointers or sentinel values)
+- `T or E` (use return codes + out params)
+- `T?` (use nullable pointers or sentinel values)
 - `Vec<T>`, `Map<K,V>` (use `*T` + `usize`)
 - Trait objects `any Trait`
 
 Example error:
 ```rask
 @export("process_data")
-public func process(data: string) -> Result<(), Error>  // ERROR
+public func process(data: string) -> () or Error  // ERROR
 ```
 ```
 ERROR [compiler.mangling/CV2]: @export function uses non-C-compatible types
   |
-3 | public func process(data: string) -> Result<(), Error>
-  |                           ^^^^^^    ^^^^^^^^^^^^^^^^^^^
+3 | public func process(data: string) -> () or Error
+  |                           ^^^^^^    ^^^^^^^^^^^^^
   |
 WHY: Functions exported to C must use only C-compatible types.
      See struct.c-interop/TM1 for type mapping.
@@ -289,7 +289,7 @@ Built-in runtime functions use reserved prefix `_Rrt`:
 ```rask
 // package: myapp.api.handlers.user.profile
 public func get_profile<T>(user: User, opts: Options<T>)
-    using Database using Logger -> Result<Profile<T>, Error>
+    using Database using Logger -> Profile<T> or Error
 ```
 
 Full symbol (>200 chars):

--- a/specs/compiler/semantic-hash-caching.md
+++ b/specs/compiler/semantic-hash-caching.md
@@ -26,7 +26,7 @@ The compiler creates a fingerprint (hash) of each function's simplified code tre
 | Type annotations | `: i32`, `-> string` |
 | Parameter modes | `take x: File` |
 | Field names | `.health`, `.position` |
-| Pattern structure | `Some(x)`, `Point { x, y }` |
+| Pattern structure | `Point { x, y }`, `Variant(x)` |
 | Attributes | `@inline`, `@unsafe` |
 
 | Excluded | Why |

--- a/specs/compiler/sequence-implementation.md
+++ b/specs/compiler/sequence-implementation.md
@@ -118,11 +118,8 @@ Each stage is independently shippable and testable.
       public func stream(take self) -> Sequence<T> {
           return |yield| {
               loop {
-                  const msg = match self.recv() {
-                      Ok(m) => m,
-                      Err(_) => break,
-                  }
-                  if not yield(msg): break
+                  const r = self.recv()
+                  if r? as msg { if not yield(msg): break } else { break }
               }
           }
       }

--- a/specs/compiler/stdlib-audit.md
+++ b/specs/compiler/stdlib-audit.md
@@ -12,10 +12,10 @@ Comparison of interpreter builtins implementation against spec requirements. Tra
 
 | Method | Status | Notes |
 |--------|--------|-------|
-| `push(item)` | ✓ Implemented | Returns `()`, panics on failure. `try_push` returns Result |
-| `pop()` | ✓ Implemented | Returns `Option<T>` |
+| `push(item)` | ✓ Implemented | Returns `()`, panics on failure. `try_push` returns `() or PushError` |
+| `pop()` | ✓ Implemented | Returns `T?` |
 | `len()` | ✓ Implemented | Returns count |
-| `get(i)` | ✓ Implemented | Returns `Option<T>` (copies) |
+| `get(i)` | ✓ Implemented | Returns `T?` (copies) |
 | `is_empty()` | ✓ Implemented | Returns bool |
 | `clear()` | ✓ Implemented | Empties vec |
 | `reverse()` | ✓ Implemented | In-place reversal |
@@ -26,8 +26,8 @@ Comparison of interpreter builtins implementation against spec requirements. Tra
 | `clone()` | ✓ Implemented | Deep copy |
 | `insert(idx, item)` | ✓ Implemented | Insert at position |
 | `remove(idx)` | ✓ Implemented | Remove at position |
-| `first()` | ✓ Implemented | Returns `Option<T>` |
-| `last()` | ✓ Implemented | Returns `Option<T>` |
+| `first()` | ✓ Implemented | Returns `T?` |
+| `last()` | ✓ Implemented | Returns `T?` |
 
 ### Iterator Methods (Implemented)
 
@@ -88,9 +88,9 @@ These are compile-target features, not needed for interpreter MVP:
 
 | Method | Status | Notes |
 |--------|--------|-------|
-| `insert(k, v)` | ✓ Implemented | Returns `Option<V>` (previous value) |
-| `get(k)` | ✓ Implemented | Returns `Option<V>` |
-| `remove(k)` | ✓ Implemented | Returns `Option<V>` |
+| `insert(k, v)` | ✓ Implemented | Returns `V?` (previous value) |
+| `get(k)` | ✓ Implemented | Returns `V?` |
+| `remove(k)` | ✓ Implemented | Returns `V?` |
 | `len()` | ✓ Implemented | Returns count |
 | `is_empty()` | ✓ Implemented | Returns bool |
 | `contains(k)` | ✓ Implemented | Check key exists |
@@ -185,21 +185,21 @@ To complete value-first iteration:
 
 ## Error Handling
 
-Current interpreter returns Rust `Result<Value, RuntimeError>` but doesn't wrap in Rask `Result<Ok, Err>` enum values consistently.
+Current interpreter returns Rust `Result<Value, RuntimeError>` but doesn't wrap in Rask `T or E` sum values consistently.
 
 ### Growth Operations
 
 Per spec (C2), default growth operations panic on failure:
 - `vec.push(x)` → `()` (panics on OOM/full)
-- `map.insert(k, v)` → `Option<V>` (panics on OOM/full)
+- `map.insert(k, v)` → `V?` (panics on OOM/full)
 - `vec.reserve(n)` → `()` (panics on OOM)
 
-Fallible `try_` variants return Result:
+Fallible `try_` variants return an error union:
 - `vec.try_push(x)` → `() or PushError<T>`
-- `map.try_insert(k, v)` → `Option<V> or InsertError<V>`
+- `map.try_insert(k, v)` → `V? or InsertError<V>`
 - `vec.try_reserve(n)` → `() or AllocError`
 
-Current interpreter matches: panics on allocation failure (Rust default), `try_push` wraps in Result.
+Current interpreter matches: panics on allocation failure (Rust default), `try_push` wraps in error union.
 
 ## Priority Fixes
 

--- a/specs/concurrency/async.md
+++ b/specs/concurrency/async.md
@@ -59,9 +59,9 @@ h.join()!
 // Handle explicitly
 const h = spawn(|| { fallible_work() })
 match h.join() {
-    Ok(val) => process(val),
-    Err(JoinError.Panicked(msg)) => println("task panicked: {msg}"),
-    Err(JoinError.Cancelled) => println("task was cancelled"),
+    T as val                   => process(val),
+    JoinError.Panicked(msg)    => println("task panicked: {msg}"),
+    JoinError.Cancelled        => println("task was cancelled"),
 }
 
 spawn(|| { background_work() }).detach()
@@ -188,7 +188,7 @@ match h.join() { }    // explicit handling
 |------|-------------|
 | **CN1: Cooperative** | Cancellation sets a flag; task checks `cancelled()` |
 | **CN2: Ensure runs** | `ensure` blocks always run, even on cancellation |
-| **CN3: I/O checks** | I/O operations check cancel flag and return `Err(Cancelled)` if set |
+| **CN3: I/O checks** | I/O operations check cancel flag and return `Cancelled` error if set |
 
 <!-- test: skip -->
 ```rask
@@ -226,10 +226,11 @@ const producer = spawn(|| {
 }
 
 const consumer = spawn(|| {
-    while rx.recv() is Ok(msg) {
-        process(msg)
-    })
-}
+    loop {
+        const r = rx.recv()
+        if r? as msg { process(msg) } else { break }
+    }
+})
 
 try join_all(producer, consumer)
 ```
@@ -252,7 +253,7 @@ try join_all(producer, consumer)
 | Sender closed, buffer has items | Items remain — receivers can drain |
 | All senders closed | Channel closed for writing, readable until empty |
 | Receiver closed, buffer has items | Items discarded (lost) |
-| All receivers closed | Senders get `Err(Closed)` on next send |
+| All receivers closed | Senders get a `Closed` error on next send |
 
 ## Error Messages
 
@@ -307,8 +308,8 @@ Install a `using Multitasking { ... }` block that encloses the call.
 | Direct `spawn` outside any block | CC1 | Compile error |
 | Call to function transitively reaching `spawn`, outside any block | CC2 | Compile error |
 | Closure stored / trait object dispatch reaches `spawn` outside a block | CC3 | Runtime panic |
-| `.join()` on cancelled task | H2, CN1 | Returns `Err(Cancelled)` |
-| Channel send after all receivers closed | CH3 | Returns `Err(Closed)` |
+| `.join()` on cancelled task | H2, CN1 | Returns `Cancelled` error |
+| Channel send after all receivers closed | CH3 | Returns `Closed` error |
 | Nested `using Multitasking` blocks | C1 | Error — second `enter` aborts (compile error if lexically nested, runtime panic otherwise) |
 | Library opens `using Multitasking` while app already did | C6 | Falls under C1 — runtime panic |
 | Detached task outlives `using` block body | C4 | Block exit still drains detached tasks. Truly outliving the block is impossible |

--- a/specs/concurrency/phase-b-transforms.md
+++ b/specs/concurrency/phase-b-transforms.md
@@ -231,7 +231,7 @@ using Multitasking, ThreadPool {
 | Case | Rule | Behavior |
 |------|------|----------|
 | Trait with no I/O methods (e.g., `Display`) | VT1 | Clean vtable, implementations never touch RUNTIME_SLOT, zero cost |
-| `any Reader` in non-async context | VT2 | Implementation reads RUNTIME_SLOT, finds `None`, takes blocking path |
+| `any Reader` in non-async context | VT2 | Implementation reads RUNTIME_SLOT, finds `none`, takes blocking path |
 | Pure closure stored in variable, called in spawn | FP1, FP3 | Clean ABI, yield point generated conservatively. Poll returns Ready immediately |
 | Cross-module function gains `spawn` internally | SC3 | Caller sees a new CC2 scope requirement. Source-level breakage, same as any API change |
 | Cross-module generic with type-dependent effects | SC4 | Conservative metadata (union of effects). Precise after monomorphization |

--- a/specs/concurrency/select.md
+++ b/specs/concurrency/select.md
@@ -68,9 +68,9 @@ result = select {
 
 | Rule | Description |
 |------|-------------|
-| **CL1: All closed** | If all recv channels closed, immediate return with `Err(Closed)` |
+| **CL1: All closed** | If all recv channels closed, immediate return with `Closed` error |
 | **CL2: Some closed** | Skip closed channels, wait on remaining |
-| **CL3: Send closed** | Send arm returns `Err(Closed)` |
+| **CL3: Send closed** | Send arm returns `Closed` error |
 
 ## Timer
 
@@ -101,7 +101,7 @@ ERROR [conc.select/P3]: select requires at least one arm
 | Case | Rule | Handling |
 |------|------|----------|
 | Select with 0 arms | P3 | Compile error |
-| All channels closed | CL1 | Returns immediately with `Err(Closed)` |
+| All channels closed | CL1 | Returns immediately with `Closed` error |
 | Timer in select | A1 | Regular receive arm — `Timer.after()` returns `Receiver<()>` |
 | Non-selected send value | OW2 | Value returned to caller, not consumed |
 
@@ -121,8 +121,8 @@ ERROR [conc.select/P3]: select requires at least one arm
 <!-- test: skip -->
 ```rask
 result = select {
-    rx -> v: Ok(v),
-    Timer.after(5.seconds) -> _: Err(Timeout),
+    rx -> v: v,
+    Timer.after(5.seconds) -> _: Timeout,
 }
 ```
 

--- a/specs/concurrency/sync.md
+++ b/specs/concurrency/sync.md
@@ -30,7 +30,7 @@ Cross-task shared state when channels aren't enough.
 | **R1: Read** | `with shared.read() as v { ... }` — shared read lock; multiple readers concurrent. Mutation through binding is a compile error |
 | **R2: Write** | `with shared.write() as v { ... }` — exclusive write lock; blocks until readers finish |
 | **R2a: Unused write warning** | Compiler warns when `.write()` used but binding never mutated — suggests `.read()` |
-| **R3: Try variants** | `try_read(f)` / `try_write(f)` — non-blocking closures, return `None` if contended |
+| **R3: Try variants** | `try_read(f)` / `try_write(f)` — non-blocking closures, return `none` if contended |
 | **R4: Bare access forbidden** | `with shared as v { ... }` is a compile error — must use `.read()` or `.write()` |
 | **R5: Inline access** | `shared.read().chain` and `shared.write().chain` — expression-scoped lock for single-expression access. Follows `mem.borrowing/E5` rules. Standalone `.read()`/`.write()` without chaining is a compile error |
 
@@ -64,15 +64,15 @@ extend Shared<T> {
     func new(value: T) -> Shared<T>
     func read(self) -> T             // inline access (R5) — expression-scoped read lock
     func write(self) -> T            // inline access (R5) — expression-scoped write lock
-    func try_read<R>(self, f: |T| -> R) -> Option<R>
-    func try_write<R>(self, f: |T| -> R) -> Option<R>
+    func try_read<R>(self, f: |T| -> R) -> R?
+    func try_write<R>(self, f: |T| -> R) -> R?
 }
 ```
 
 Three access patterns:
 - **Inline:** `shared.read().field` / `shared.write().field = x` — single-expression access, lock scoped to expression
 - **`with` block:** `with shared.read() as v { ... }` / `with shared.write() as v { ... }` — multi-statement access
-- **Non-blocking closures:** `try_read(f)` / `try_write(f)` — return `None` if contended
+- **Non-blocking closures:** `try_read(f)` / `try_write(f)` — return `none` if contended
 
 Bare `with shared as v` is a compile error — the lock type must be explicit.
 
@@ -81,7 +81,7 @@ Bare `with shared as v` is a compile error — the lock type must be explicit.
 | Rule | Description |
 |------|-------------|
 | **MX1: Lock** | `with mutex as v { ... }` — exclusive lock; blocks until available |
-| **MX2: Try lock** | `try_lock(f)` — non-blocking closure, returns `None` if held |
+| **MX2: Try lock** | `try_lock(f)` — non-blocking closure, returns `none` if held |
 | **MX3: Inline access** | `mutex.lock().chain` — expression-scoped exclusive lock for single-expression access. Follows `mem.borrowing/E5` rules |
 
 <!-- test: skip -->
@@ -108,14 +108,14 @@ struct Mutex<T> { }
 extend Mutex<T> {
     func new(value: T) -> Mutex<T>
     func lock(self) -> T             // inline access (MX3) — expression-scoped exclusive lock
-    func try_lock<R>(self, f: |T| -> R) -> Option<R>
+    func try_lock<R>(self, f: |T| -> R) -> R?
 }
 ```
 
 Three access patterns:
 - **Inline:** `mutex.lock().field` — single-expression access, lock scoped to expression
 - **`with` block:** `with mutex as v { ... }` — multi-statement access
-- **Non-blocking closure:** `try_lock(f)` — returns `None` if held
+- **Non-blocking closure:** `try_lock(f)` — returns `none` if held
 
 ## `with`-Based Access
 

--- a/specs/control/comptime.md
+++ b/specs/control/comptime.md
@@ -273,17 +273,22 @@ const CONFIG: Config = comptime parse_config(@embed_file("config.toml"))
 
 | Rule | Description |
 |------|-------------|
-| **CT45: Result support** | Comptime functions can use `Result` and `try` |
+| **CT45: Error-type support** | Comptime functions can use `T or E` and `try` |
 | **CT46: Panics as compile errors** | Comptime panics become compile errors with call stack |
 | **CT47: Error propagation** | Errors propagate to compile error with context |
 
 <!-- test: parse -->
 ```rask
-comptime func safe_divide(a: i32, b: i32) -> i32 or string {
+enum DivError { ByZero }
+extend DivError {
+    func message(self) -> string { "Division by zero" }
+}
+
+comptime func safe_divide(a: i32, b: i32) -> i32 or DivError {
     if b == 0 {
-        return Err("Division by zero")
+        return DivError.ByZero
     }
-    return Ok(a / b)
+    return a / b
 }
 
 const X = try comptime safe_divide(10, 2)  // OK: unwraps to 5
@@ -440,9 +445,9 @@ func read_packet<comptime MAX_SIZE: usize>(socket: Socket) -> [u8; MAX_SIZE] or 
     const buffer = [0u8; MAX_SIZE]
     const n = try socket.read(buffer[..])
     if n > MAX_SIZE {
-        return Err(Error.new("Packet too large"))
+        return Error.new("Packet too large")
     }
-    return Ok(buffer)
+    return buffer
 }
 
 // Usage with different sizes
@@ -465,7 +470,7 @@ func process(data: []u8) -> () or Error {
         comptime if DEBUG_MODE {
             // Validation only in debug builds
             if byte > 127 {
-                return Err(Error.new("Invalid byte"))
+                return Error.new("Invalid byte")
             }
         }
 

--- a/specs/control/comptime.md
+++ b/specs/control/comptime.md
@@ -12,7 +12,7 @@ Explicit `comptime` keyword marks compile-time evaluation. Restricted subset: pu
 
 | Rule | Form | Syntax | Meaning |
 |------|------|--------|---------|
-| **CT1: Comptime variable** | Variable | `comptime let x = expr` | Expression evaluated at compile time |
+| **CT1: Comptime variable** | Variable | `comptime mut x = expr` | Expression evaluated at compile time |
 | **CT2: Comptime constant** | Constant | `const X = comptime expr` | Constant initialized at compile time |
 | **CT3: Comptime function** | Function | `comptime func name() -> T { ... }` | Function can only be called at compile time |
 | **CT4: Comptime parameter** | Parameter | `func f<comptime N: usize>() { ... }` | Generic parameter must be compile-time known |

--- a/specs/control/control-flow.md
+++ b/specs/control/control-flow.md
@@ -76,16 +76,17 @@ if state is Connected(sock) {
 }
 
 // Implicit unwrap for single-payload variants
-if user is Some {
-    process(user)  // user unwrapped, same name
+if event is Tick {
+    process(event)  // event unwrapped, same name
 }
 
-if result is Ok {
-    use(result)  // result unwrapped
+// Status types use `?` predicate + `as` binding
+if user? as u {
+    process(u)
 }
 
-// Loop while pattern matches
-while reader.next() is Some(line) {
+// Loop while status holds a value
+while reader.next()? as line {
     process(line)
 }
 
@@ -105,11 +106,11 @@ if state is Connected(sock) && sock.is_ready() {
 
 ```rask
 // Early return on error
-const value = result is Ok else { return Err(e) }
+const value = result? else as e { return e }
 // value available here
 
-// Break from loop on None
-const item = queue.pop() is Some else { break }
+// Break from loop when queue empty
+const item = queue.pop()? else { break }
 // item available here
 ```
 

--- a/specs/control/control-flow.md
+++ b/specs/control/control-flow.md
@@ -96,7 +96,7 @@ if state is Connected(sock) && sock.is_ready() {
 }
 ```
 
-## Guard Pattern: let...is...else
+## Guard Pattern: const...is...else
 
 | Rule | Description |
 |------|-------------|
@@ -105,13 +105,13 @@ if state is Connected(sock) && sock.is_ready() {
 | **CF15: Linear in else** | Pattern fails, value available in `else` for cleanup |
 
 ```rask
-// Early return on error
-const value = result? else as e { return e }
-// value available here
+// Early return on non-matching variant
+const sock = state is Connected else { return }
+// sock available here
 
-// Break from loop when queue empty
-const item = queue.pop()? else { break }
-// item available here
+// Break from loop when task missing
+const task = event is Ready else { break }
+// task available here
 ```
 
 ## Infinite Loop: loop
@@ -167,10 +167,10 @@ outer: for i in rows {
 search: loop {
     for i in 0..n {
         if found(i) {
-            break search Some(i)
+            break search i
         }
     }
-    break None
+    break none
 }
 ```
 
@@ -203,7 +203,7 @@ func process_items(items: Vec<Item>) -> Vec<string> {
 func process(file: File) -> Data or Error {
     ensure file.close()
     const data = try file.read()   // try may return early
-    Ok(transform(data))
+    return transform(data)
 }
 ```
 
@@ -315,15 +315,15 @@ FIX: Ensure all break expressions match:
 ```
 ERROR [ctrl.flow/CF13]: else block must diverge
    |
-3  |  const x = opt is Some else { None }
-   |                               ^^^^ doesn't diverge
+3  |  const x = event is Tick else { 0 }
+   |                               ^ doesn't diverge
 
-WHY: let...is...else requires the else block to exit via return,
+WHY: const...is...else requires the else block to exit via return,
      break, continue, or panic.
 
 FIX: Use if is instead:
 
-  const x = if opt is Some(v) { v } else { default_value }
+  const x = if event is Tick(v) { v } else { default_value }
 ```
 
 **Linear resource consumed only in one branch [CF11]:**
@@ -359,12 +359,12 @@ FIX: Consume in both branches or use ensure:
 | Rule | Description |
 |------|-------------|
 | **DS1: Const destructuring** | `const (a, b) = expr` binds tuple elements as immutable |
-| **DS2: Let destructuring** | `let (a, b) = expr` binds tuple elements as mutable |
+| **DS2: Mut destructuring** | `mut (a, b) = expr` binds tuple elements as rebindable |
 | **DS3: For destructuring** | `for (k, v) in iter` destructures each iteration element |
 | **DS4: Arity match** | Number of bindings must match tuple length (compile error otherwise) |
 | **DS5: Nested** | `const (a, (b, c)) = expr` destructures nested tuples |
 | **DS6: Wildcard** | `_` discards an element: `const (_, b) = pair` |
-| **DS7: Guard pattern** | `const (a, b) = expr is Ok else { return }` combines destructuring with pattern matching |
+| **DS7: Guard pattern** | `const (a, b) = expr is Paired else { return }` combines destructuring with pattern matching on a user enum variant |
 
 <!-- test: parse -->
 ```rask
@@ -422,7 +422,7 @@ FIX: Match the number of bindings, use _ to discard:
 
 The diverging `else` requirement (CF13) ensures the binding is always valid after the statement.
 
-**CF12 (implicit unwrap):** For single-payload variants like `Some(T)` or `Ok(T)`, omitting the binding in `if x is Some` unwraps using the outer variable name. Reduces friction for the common case. Multi-field variants require explicit destructuring.
+**CF12 (implicit unwrap):** For single-payload variants on user-defined enums, omitting the binding in `if x is Variant` unwraps using the outer variable name. Reduces friction for the common case. Multi-field variants require explicit destructuring. Status types (`T?`, `T or E`) use dedicated operators (`?`, `? as v`, `??`, `try`), not `is`.
 
 **CF22-25 (labels):** Labels enable breaking/continuing outer loops without extra flags or state. The `label:` syntax is clear and unambiguous.
 
@@ -437,7 +437,7 @@ The diverging `else` requirement (CF13) ensures the binding is always valid afte
 | Value from repeated checks | `const x = loop { break ... }` | Clear exit |
 | Side effect conditional | `if c { f() }` | No value needed |
 | Check other enum variant | `if x is Variant` | Pattern match |
-| Early exit on error | `let v = x is Ok else { return }` | Guard |
+| Early exit on error | `if r? as v { … } else as e { return e }` | Guard |
 | Loop over iterator | `for x in iter` | Standard |
 | Loop until condition | `while cond { ... }` | Clear intent |
 | Infinite loop | `loop { ... }` | Explicit |
@@ -540,10 +540,10 @@ const color = match status {
 // Inline if
 const sign = if x > 0: "+" else: "-"
 
-// Match with block arms
+// Match with block arms on error union
 const opts = match parse_args(args) {
-    Ok(o) => o,
-    Err(e) => {
+    Args as o => o,
+    ParseError as e => {
         println("error: {e}")
         std.exit(1)
     }
@@ -564,14 +564,14 @@ const input = loop {
 **Search pattern:**
 <!-- test: skip -->
 ```rask
-func find_first<T: Equal>(items: Vec<T>, target: T) -> Option<usize> {
+func find_first<T: Equal>(items: Vec<T>, target: T) -> usize? {
     mut i = 0
     loop {
         if i >= items.len() {
-            break None
+            break none
         }
         if items[i] == target {
-            break Some(i)
+            break i
         }
         i += 1
     }
@@ -580,16 +580,16 @@ func find_first<T: Equal>(items: Vec<T>, target: T) -> Option<usize> {
 
 **Labeled break with value:**
 ```rask
-func find_in_matrix<T: Equal>(matrix: Vec<Vec<T>>, target: T) -> Option<(usize, usize)> {
+func find_in_matrix<T: Equal>(matrix: Vec<Vec<T>>, target: T) -> (usize, usize)? {
     search: loop {
         for i in 0..matrix.len() {
             for j in 0..matrix[i].len() {
                 if matrix[i][j] == target {
-                    break search Some((i, j))
+                    break search (i, j)
                 }
             }
         }
-        break None
+        break none
     }
 }
 ```
@@ -626,13 +626,13 @@ if state is Connected(sock) {
     sock.send(data)
 }
 
-// Loop while pattern matches
-while reader.next() is Some(line) {
+// Loop while optional has a value
+while reader.next()? as line {
     process(line)
 }
 
-// With else
-if result is Ok(value) {
+// With else on error union
+if result? as value {
     use(value)
 } else {
     handle_error()
@@ -650,13 +650,11 @@ func process_file(path: string) -> () or Error {
     const file = try open(path)
     ensure file.close()
 
-    const line = file.read_line() is Some else { return Ok(()) }
-    // line available here
-
-    const value = parse(line) is Ok else { return Err("invalid") }
-    // value available here
-
-    Ok(())
+    if file.read_line()? as line {
+        const value = try parse(line)
+        use(value)
+    }
+    return
 }
 ```
 

--- a/specs/control/ensure.md
+++ b/specs/control/ensure.md
@@ -113,7 +113,7 @@ Cleanup actions may fail. Errors are ignored by default; opt-in handling with `e
 
 | Rule | Description |
 |------|-------------|
-| **ER1: Default ignore** | If ensure body returns `Err(e)`, error silently ignored |
+| **ER1: Default ignore** | If ensure body returns an error, error silently ignored |
 | **ER2: Opt-in else clause** | `ensure expr else \|e\| handler` passes error to handler |
 | **ER3: Infallible handler** | `else` handler must not use `try`—nowhere to propagate |
 | **ER4: try forbidden** | Cannot use `try` inside ensure body |
@@ -146,7 +146,7 @@ func process() -> () or Error {
     ensure c.close() else |e| log("c close failed: {e}")
 
     try do_work()
-    Ok(())
+    return
 }
 // If do_work() fails with WorkError:
 //   1. c.close() runs — if it fails, logs and continues
@@ -165,7 +165,7 @@ func write_important(data: Data) -> () or Error {
     const file = try create("important.txt")
     try file.write(data)
     try file.close()                 // Explicit: propagate close error
-    Ok(())
+    return
 }
 ```
 
@@ -187,7 +187,7 @@ func process() -> () or Error {
 
     // file is already closed, config still available
     log(config.summary)
-    Ok(())
+    return
 }
 ```
 
@@ -245,7 +245,7 @@ ensure tx.rollback()    // Scheduled
 // ... operations ...
 
 tx.commit()             // Consumes tx, cancels ensure (C1)
-Ok(())
+return
 ```
 
 **Transaction pattern:** Ensure the unhappy path (rollback), explicitly handle the happy path (commit).
@@ -258,7 +258,7 @@ func transfer(db: Database, from: AccountId, to: AccountId, amount: i64) -> () o
 
     const from_balance = try tx.get_balance(from)
     if from_balance < amount {
-        return Err(InsufficientFunds)  // ensure runs: rollback
+        return InsufficientFunds  // ensure runs: rollback
     }
 
     try tx.set_balance(from, from_balance - amount)
@@ -266,7 +266,7 @@ func transfer(db: Database, from: AccountId, to: AccountId, amount: i64) -> () o
     try tx.set_balance(to, to_balance + amount)
 
     tx.commit()               // Consumes tx, cancels ensure (C1)
-    Ok(())
+    return
 }
 ```
 
@@ -288,7 +288,7 @@ func process_many_files(paths: Vec<string>) -> () or Error {
 
     // Normal exit: ensure takes and closes all files
     // Early return (error): ensure still takes and closes all files
-    Ok(())
+    return
 }
 ```
 
@@ -309,7 +309,7 @@ func process_many_files_careful(paths: Vec<string>) -> () or Error {
     for file in files.take_all() {
         try file.close()
     }
-    Ok(())
+    return
 }
 ```
 
@@ -385,7 +385,7 @@ FIX: Use ensure to guarantee cleanup:
 NOTE [ctrl.ensure/ER1]: ensure result ignored
    |
 5  |  ensure file.close()
-   |         ^^^^^^^^^^^^ returns Result<(), Error>, error will be ignored
+   |         ^^^^^^^^^^^^ returns `() or Error`, error will be ignored
 
 WHY: Ensure errors are silently ignored by default.
 
@@ -432,7 +432,7 @@ func copy_file(src: string, dst: string) -> () or Error {
 
     const data = try input.read_all()
     try output.write_all(data)
-    Ok(())
+    return
 }
 ```
 
@@ -450,7 +450,7 @@ func modify_database(db: Database) -> () or Error {
     try tx.execute("INSERT ...")
 
     tx.commit()             // Happy path: consumes tx, cancels ensure
-    Ok(())
+    return
 }
 ```
 
@@ -468,7 +468,7 @@ func process_many(paths: Vec<string>) -> () or Error {
     }
 
     // Process resources...
-    Ok(())
+    return
 }
 ```
 

--- a/specs/memory/allocators.md
+++ b/specs/memory/allocators.md
@@ -261,7 +261,7 @@ FIX: Add a using clause:
 | Multiple allocators in scope | CC8 (reused) | Compile error — use named context (AL8) to disambiguate |
 | `using Allocator` + `using Pool<T>` on same function | AL20 | Both contexts threaded independently |
 | Arena-backed Pool, handle sent via channel | AL13 | Compile error — handle type includes arena scope |
-| `try_push` on FixedBuffer-backed Vec | AL3 | Returns Err(PushError) when buffer full |
+| `try_push` on FixedBuffer-backed Vec | AL3 | Returns `PushError` when buffer full |
 | Comptime allocations | — | Use compiler arena (CT17), not runtime allocators |
 
 ---

--- a/specs/memory/atomics.md
+++ b/specs/memory/atomics.md
@@ -109,7 +109,7 @@ const old = counter.swap(new_value, AcqRel)
 
 | Operation | Signature | Description |
 |-----------|-----------|-------------|
-| `compare_exchange(current, new, success, fail)` | `self, T, T, Ordering, Ordering -> T or T` | If value == current, set to new. Ok(old) on success, Err(actual) on failure |
+| `compare_exchange(current, new, success, fail)` | `self, T, T, Ordering, Ordering -> T or CasFailed<T>` | If value == current, set to new. Returns old on success, `CasFailed(actual)` on failure |
 | `compare_exchange_weak(current, new, success, fail)` | Same | May spuriously fail. Use in loops |
 
 - `compare_exchange`: Must succeed if value matches. Use for single-attempt operations.
@@ -123,8 +123,8 @@ loop {
         break
     }
     match counter.compare_exchange_weak(current, current + 1, AcqRel, Relaxed) {
-        Ok(_) => break,
-        Err(_) => continue,
+        u64 as _ => break,
+        CasFailed as _ => continue,
     }
 }
 ```
@@ -167,7 +167,7 @@ unsafe {
 | Rule | Description |
 |------|-------------|
 | **AH1: Packing** | Handle fields packed into `AtomicU64` (≤8 byte handles) or `AtomicU128` (≤16 byte, requires `target.has_atomic128`) |
-| **AH2: Nullable** | Holds `Handle<T>?` — `None` is a sentinel bit pattern distinct from any valid handle |
+| **AH2: Nullable** | Holds `Handle<T>?` — `none` is a sentinel bit pattern distinct from any valid handle |
 | **AH3: ABA protection** | Generation counter in the handle prevents ABA — a reused slot gets a different generation, so CAS on a recycled handle correctly fails |
 | **AH4: Pool validation** | Atomicity guarantees a consistent load, not that the handle is live. Validate with `pool.get(h)` before access |
 
@@ -178,7 +178,7 @@ unsafe {
 | `load(order)` | `self, Ordering -> Handle<T>?` | Atomically read |
 | `store(h, order)` | `self, Handle<T>?, Ordering` | Atomically write |
 | `swap(h, order)` | `self, Handle<T>?, Ordering -> Handle<T>?` | Replace, return old |
-| `compare_exchange(cur, new, succ, fail)` | `self, Handle<T>?, Handle<T>?, Ordering, Ordering -> Handle<T>? or Handle<T>?` | CAS |
+| `compare_exchange(cur, new, succ, fail)` | `self, Handle<T>?, Handle<T>?, Ordering, Ordering -> Handle<T>? or CasFailed<Handle<T>?>` | CAS |
 | `compare_exchange_weak(cur, new, succ, fail)` | Same | May spuriously fail |
 
 **Handle size:** Default `Handle<T>` is 12 bytes — requires `AtomicU128` (x86-64, ARM64). Compact handles (`Pool<T, PoolId=u16, Index=u16, Gen=u32>`) are 8 bytes — work everywhere via `AtomicU64`. Compile error if handle exceeds the available atomic word size.
@@ -190,15 +190,15 @@ const latest: AtomicHandle<Reading> = AtomicHandle.none()
 
 func publish(mutate pool: Pool<Reading>, value: Reading) {
     const h = pool.insert(value)
-    const prev = latest.swap(Some(h), Release)
-    if prev is Some(old_h) {
+    const prev = latest.swap(h, Release)
+    if prev? as old_h {
         pool.remove(old_h)
     }
 }
 
 func read_latest(pool: Pool<Reading>) -> Reading? {
-    const h = latest.load(Acquire) ?? return None
-    pool.get(h)   // None if writer just swapped and removed
+    const h = latest.load(Acquire) ?? return none
+    return pool.get(h)   // none if writer just swapped and removed
 }
 ```
 
@@ -354,7 +354,7 @@ FIX 2: Use comptime if target.has_atomic128 { ... } for platform-specific paths.
 | Handle too large for atomic word | AH1 | Compile error — use compact pool config or platform with `AtomicU128` |
 | `AtomicHandle.load` then `pool[h]` | AH4 | Handle may be stale — use `pool.get(h)` for safe validation |
 | CAS on handle to recycled slot | AH3 | Correctly fails — generation mismatch in packed word |
-| `AtomicHandle.none()` in CAS expected | AH2 | Works — `None` is a valid bit pattern for comparison |
+| `AtomicHandle.none()` in CAS expected | AH2 | Works — `none` is a valid bit pattern for comparison |
 
 ---
 
@@ -372,7 +372,7 @@ FIX 2: Use comptime if target.has_atomic128 { ... } for platform-specific paths.
 
 **AH3 (ABA protection):** Traditional lock-free algorithms need separate ABA mitigation — tagged pointers, hazard pointers, or epoch-based reclamation. Handle generation counters provide this structurally: when a pool slot is reused, the generation increments. A stale handle packed into an `AtomicHandle` has a different bit pattern than the new occupant's handle, so CAS correctly rejects it. This doesn't eliminate all concurrency hazards (safe reclamation is still needed), but it removes the most common source of subtle lock-free bugs for free.
 
-**AH4 (pool validation):** AtomicHandle guarantees you loaded a consistent handle value. It does NOT guarantee the handle is still live — another thread may have removed it between your load and your pool access. Always use `pool.get(h)` (returns `Option`) rather than `pool[h]` (panics on stale handle) after loading from an AtomicHandle.
+**AH4 (pool validation):** AtomicHandle guarantees you loaded a consistent handle value. It does NOT guarantee the handle is still live — another thread may have removed it between your load and your pool access. Always use `pool.get(h)` (returns `T?`) rather than `pool[h]` (panics on stale handle) after loading from an AtomicHandle.
 
 ### Patterns & Guidance
 
@@ -446,8 +446,8 @@ func increment_if_below(counter: AtomicU64, max: u64) -> bool {
             return false
         }
         match counter.compare_exchange_weak(current, current + 1, AcqRel, Relaxed) {
-            Ok(_) => return true,
-            Err(_) => continue,
+            u64 as _ => return true,
+            CasFailed as _ => continue,
         }
     }
 }
@@ -492,7 +492,7 @@ func spin_acquire<T>(lock: *SpinLockInner<T>) {
     unsafe {
         while (*lock).locked.compare_exchange_weak(
             false, true, Acquire, Relaxed
-        ).is_err() {
+        ) is CasFailed {
             while (*lock).locked.load(Relaxed) {
                 spin_hint()
             }
@@ -532,13 +532,13 @@ extend LockFreeStack<T> {
     }
 
     func push(mutate self, value: T) {
-        const node = self.pool.insert(Node { data: value, next: None })
+        const node = self.pool.insert(Node { data: value, next: none })
         loop {
             const current = self.head.load(Acquire)
             self.pool[node].next = current
-            match self.head.compare_exchange_weak(current, Some(node), Release, Relaxed) {
-                Ok(_) => break,
-                Err(_) => continue,
+            match self.head.compare_exchange_weak(current, node, Release, Relaxed) {
+                Handle as _ => break,
+                CasFailed as _ => continue,
             }
         }
     }

--- a/specs/memory/borrowing.md
+++ b/specs/memory/borrowing.md
@@ -229,7 +229,7 @@ with vec[i] as item {
 ```rask
 with pool[h] as entity {
     entity.health -= pool[other_h].bonus    // OK: inline read of other element
-    pool[other_h].last_attacker = Some(h)   // OK: inline write to other element
+    pool[other_h].last_attacker = h         // OK: inline write to other element
 
     // Pool-specific: insert and remove(other) are allowed
     const ally = pool.insert(new_ally)  // OK: re-resolves entity binding  [re-resolved]
@@ -516,11 +516,13 @@ FIX: Move the removal outside the with block:
 ### String Parsing
 <!-- test: parse -->
 ```rask
-func parse_header(line: string) -> Option<(string, string)> {
+type alias Header = (string, string)
+
+func parse_header(line: string) -> Header? {
     const colon = try line.find(':')
     const key = line[0..colon].trim().to_string()      // Copy out (B2)
     const value = line[colon+1..].trim().to_string()   // Copy out (B2)
-    Some((key, value))
+    return (key, value)
 }
 ```
 

--- a/specs/memory/closures.md
+++ b/specs/memory/closures.md
@@ -61,7 +61,7 @@ const double = |x| x * 2
 // Block body — explicit return required (same as functions)
 const parse = |s| {
     if s == "" { return none }
-    return Some(parse_inner(s))
+    return parse_inner(s)
 }
 ```
 
@@ -78,18 +78,20 @@ Closure parameters default to borrow mode. Mutable-borrow parameters are allowed
 
 <!-- test: parse -->
 ```rask
-func sum_values(items: Vec<Item>) -> i32 {
+func run(items: Vec<Item>) {
     // Borrow parameter (default)
     const print_name = |u: User| print(u.name)
 
     // Mutable-borrow parameter (explicit type required)
     const grow = |mutate item: Item| { item.level += 1 }
-
-    // Mutable capture (no type on parameter)
-    mut total = 0
-    items.for_each(|item, mutate total| { total += item.value })
-    return total
 }
+```
+
+<!-- test: skip -->
+```rask
+// Mutable capture (no type on parameter) — see CP3 + Mutable Capture below
+mut total = 0
+items.for_each(|item, mutate total| { total += item.value })
 ```
 
 ## Mutable Capture

--- a/specs/memory/closures.md
+++ b/specs/memory/closures.md
@@ -78,15 +78,18 @@ Closure parameters default to borrow mode. Mutable-borrow parameters are allowed
 
 <!-- test: parse -->
 ```rask
-// Borrow parameter (default)
-const print_name = |u: User| print(u.name)
+func sum_values(items: Vec<Item>) -> i32 {
+    // Borrow parameter (default)
+    const print_name = |u: User| print(u.name)
 
-// Mutable-borrow parameter (explicit type required)
-const grow = |mutate item: Item| { item.level += 1 }
+    // Mutable-borrow parameter (explicit type required)
+    const grow = |mutate item: Item| { item.level += 1 }
 
-// Mutable capture (no type on parameter)
-let total = 0
-items.for_each(|item, mutate total| { total += item.value })
+    // Mutable capture (no type on parameter)
+    mut total = 0
+    items.for_each(|item, mutate total| { total += item.value })
+    return total
+}
 ```
 
 ## Mutable Capture

--- a/specs/memory/context-clauses.md
+++ b/specs/memory/context-clauses.md
@@ -47,7 +47,7 @@ func transfer_item(
     item_h: Handle<Item>
 ) using players: Pool<Player>, items: Pool<Item> {
     player_h.inventory.push(item_h)
-    item_h.owner = Some(player_h)
+    item_h.owner = player_h
 }
 ```
 

--- a/specs/memory/linear.md
+++ b/specs/memory/linear.md
@@ -60,7 +60,7 @@ func process(path: string) -> Data or Error {
 
     const header = try file.read_header()  // try is safe after ensure
     const body = try file.read_body()
-    Ok(body)
+    return body
 }
 ```
 
@@ -82,7 +82,7 @@ func transfer(db: Database) -> () or Error {
     try tx.execute("INSERT ...")
 
     tx.commit()              // Consumes tx, cancels ensure (L6)
-    Ok(())
+    return
 }
 ```
 
@@ -97,7 +97,7 @@ Ensure the unhappy path, explicitly consume the happy path.
 | `Vec<T>` | No | Drop would need to consume each element |
 | `Map<K, V>` | No | Same as Vec |
 | `Pool<T>` | Yes | Explicit removal required; runtime panic if dropped non-empty |
-| `Option<T>` | Yes | Must pattern-match and consume the `Some` case |
+| `T?` | Yes | Must narrow (`? as v`) and consume the present case |
 
 See `mem.pools/PL9` and `mem.resources/R5` for the Pool<Linear> cleanup semantics.
 

--- a/specs/memory/owned.md
+++ b/specs/memory/owned.md
@@ -113,12 +113,12 @@ func main() {
 
 | Rule | Description |
 |------|-------------|
-| **OW7: Null optimization** | `Option<Owned<T>>` uses null-pointer optimization — same size as `Owned<T>` (8 bytes) |
+| **OW7: Null optimization** | `Owned<T>?` uses null-pointer optimization — same size as `Owned<T>` (8 bytes) |
 
 | Value | Representation |
 |-------|----------------|
-| `None` | Null pointer (0x0) |
-| `Some(ptr)` | Non-null pointer |
+| `none` | Null pointer (0x0) |
+| present | Non-null pointer |
 
 ## Recursive Types
 
@@ -268,7 +268,7 @@ FIX: Use the new binding instead:
 
 **OW6 (context allocator):** `own` uses the context allocator so arena allocation works without changing call sites. Build a tree with the system allocator, or build it in an arena — same code.
 
-**OW7 (null optimization):** `Option<Owned<T>>` is the natural way to express optional tree children. Null-pointer optimization keeps it at 8 bytes — same as a raw pointer.
+**OW7 (null optimization):** `Owned<T>?` is the natural way to express optional tree children. Null-pointer optimization keeps it at 8 bytes — same as a raw pointer.
 
 ### Patterns & Guidance
 

--- a/specs/memory/pools.md
+++ b/specs/memory/pools.md
@@ -16,8 +16,8 @@
 | **PL2: Create bounded** | `Pool.with_capacity(n)` | `Pool<T>` | Create bounded pool |
 | **PL3: Insert** | `pool.insert(v)` | `Handle<T>` | Insert, get handle (panics on failure) |
 | **PL4: Index access** | `pool[h]` | `&T` or `&mut T` | Access (panics if invalid) |
-| **PL5: Safe access** | `pool.get(h)` | `Option<T>` | Safe access (T: Copy) |
-| **PL6: Remove** | `pool.remove(h)` | `Option<T>` | Remove and return |
+| **PL5: Safe access** | `pool.get(h)` | `T?` | Safe access (T: Copy) |
+| **PL6: Remove** | `pool.remove(h)` | `T?` | Remove and return |
 | **PL7: Iterate** | `pool.handles()` | `Iterator<Handle<T>>` | Iterate all valid handles |
 
 ```rask
@@ -67,7 +67,7 @@ Every access validates the handle.
 
 **Safe access (no panic):**
 ```rask
-pool.get(h)   // Returns Option<T> (T: Copy)
+pool.get(h)   // Returns T? (T: Copy)
 ```
 
 **Generation overflow:** Saturating semantics. When a slot's generation reaches max, the slot becomes permanently unusable. Practically never happens (~4B cycles per slot with default u32). For extreme high-churn: `Pool<T, Gen=u64>`.
@@ -207,7 +207,7 @@ for entity in pool.drain() {
 | Method | Returns | Description |
 |--------|---------|-------------|
 | `weak.valid()` | `bool` | True if underlying data still exists |
-| `weak.upgrade()` | `Option<Handle<T>>` | Convert to strong handle if valid |
+| `weak.upgrade()` | `Handle<T>?` | Convert to strong handle if valid |
 
 Automatically invalidated when the element is removed, the pool is cleared, or the pool goes out of scope.
 
@@ -353,12 +353,12 @@ ensure files.take_all_with(|f| { f.close(); })
 
 | Rule | Description |
 |------|-------------|
-| **PL8: Insert panics on failure** | `insert()` returns `Handle<T>`, panics if bounded pool is full. Fallible `try_insert()` returns `Result<Handle<T>, InsertError<T>>` |
+| **PL8: Insert panics on failure** | `insert()` returns `Handle<T>`, panics if bounded pool is full. Fallible `try_insert()` returns `Handle<T> or InsertError<T>` |
 | **PL9: Handle stability** | Handles remain valid when pools grow (index-based, not pointer-based) |
 
 ```rask
 const h = pool.insert(x)           // Handle<T> — panics if full
-const h = try pool.try_insert(x)   // Result<Handle<T>, InsertError<T>>
+const h = try pool.try_insert(x)   // Handle<T> or InsertError<T>
 
 enum InsertError<T> {
     Full(T),   // Bounded pool at capacity
@@ -369,8 +369,8 @@ enum InsertError<T> {
 | Method | Returns | Semantics |
 |--------|---------|-----------|
 | `pool.len()` | `usize` | Current element count |
-| `pool.capacity()` | `Option<usize>` | `None` = unbounded |
-| `pool.remaining()` | `Option<usize>` | Slots available |
+| `pool.capacity()` | `usize?` | `none` = unbounded |
+| `pool.remaining()` | `usize?` | Slots available |
 
 | Pool type | Growth | Use case |
 |-----------|--------|----------|
@@ -385,8 +385,8 @@ Validates once at entry, then provides unchecked access inside the closure.
 
 | Method | Signature | Description |
 |--------|-----------|-------------|
-| `pool.with_valid(h, f)` | `(Handle<T>, \|T\| -> R) -> Option<R>` | One check, then read |
-| `pool.with_valid_mut(h, f)` | `(Handle<T>, \|T\| -> R) -> Option<R>` | One check, then write |
+| `pool.with_valid(h, f)` | `(Handle<T>, \|T\| -> R) -> R?` | One check, then read |
+| `pool.with_valid_mut(h, f)` | `(Handle<T>, \|T\| -> R) -> R?` | One check, then write |
 
 ### Unsafe: Unchecked Access
 
@@ -413,7 +413,7 @@ WHY: Handles are validated by generation counter. After removal, the slot's
 
 FIX: Check validity before access:
 
-  if pool.get(h) is Some(val) {
+  if pool.get(h)? as val {
       // handle is still valid
   }
 ```
@@ -456,13 +456,13 @@ FIX: Remove the frozen annotation if mutation is needed:
 
 | Case | Rule | Handling |
 |------|------|----------|
-| Stale handle access | PL4 | Panic on `pool[h]`, None on `pool.get(h)` |
-| Wrong-pool handle | PL4 | Panic on `pool[h]`, None on `pool.get(h)` |
+| Stale handle access | PL4 | Panic on `pool[h]`, `none` on `pool.get(h)` |
+| Wrong-pool handle | PL4 | Panic on `pool[h]`, `none` on `pool.get(h)` |
 | `with pool[h] as e1, pool[h] as e2` | W3 | Panic (duplicate handle) |
 | Generation overflow | PH1 | Slot becomes permanently dead |
 | Pool ID overflow | PH1 | Panic (runtime error) |
 | Panic inside `with` | — | Pool left in valid state |
-| Empty pool cursor | PF1 | `next()` returns None immediately |
+| Empty pool cursor | PF1 | `next()` returns `none` immediately |
 | Nested cursors | — | Compile error (pool already borrowed) |
 | Drop Pool<Resource> while non-empty | R5 | Runtime panic |
 | `clear()` on Pool<Resource> | — | Compile error (would abandon resources) |
@@ -506,7 +506,7 @@ func build_graph() -> Pool<Node> or Error {
     nodes[a].edges.push(c)
     nodes[b].edges.push(c)
 
-    Ok(nodes)
+    return nodes
 }
 ```
 
@@ -591,14 +591,14 @@ with pool[h1] as e1, pool[h2] as e2 {
 
 **Self-referential patterns:** Doubly-linked lists, trees with parent pointers, graphs with cycles, and arena-allocated ASTs all use the pool+handle pattern. Key guidance:
 - Use `pool.values()` or `pool.entries()` for read-only traversal
-- Follow stored handles with `pool.get(h)` (checked, returns Option)
+- Follow stored handles with `pool.get(h)` (checked, returns `T?`)
 - Use `using frozen Pool<T>` functions for analysis passes that shouldn't mutate
 
 **Shared state:** Share handles, not data. Handles are 12-byte copyable values that can be sent anywhere. The pool stays in one thread; commands flow back to it.
 
 **Emergent capabilities:**
 - **Relocatable state:** Handles are integers — no pointer fixup. Pools can be serialized to bytes (`pool.to_bytes()`), memory-mapped for flat types (`pool.to_mmap()`), and restored with handles still valid. See `mem.relocatable` for the full specification.
-- **Plugin isolation:** Dropping a pool invalidates all its handles. Stale handles fail safely (panic or `None`), never undefined behavior.
+- **Plugin isolation:** Dropping a pool invalidates all its handles. Stale handles fail safely (panic or `none`), never undefined behavior.
 
 **Handle filtering (manual partitioning):**
 
@@ -628,7 +628,7 @@ func process_by_type(mut entities: Pool<Entity>) {
 | Operation | Cost | Notes |
 |-----------|------|-------|
 | `pool[h]` | ~1 ns | Generation check + index |
-| `pool.get(h)` | ~1 ns | Same + Option wrap |
+| `pool.get(h)` | ~1 ns | Same + `?` wrap |
 | `insert()` | Amortized O(1) | May allocate (unbounded) |
 | `remove()` | O(1) | Bumps generation |
 | `cursor()` iteration | O(capacity) | Scans all slots |
@@ -648,7 +648,7 @@ extend Observable<T> {
     func set(self, value: T, pool: Pool<Observer>) {
         self.value = value
         self.observers.retain(|weak| {
-            if weak.upgrade() is Some(h) {
+            if weak.upgrade()? as h {
                 pool[h].notify(self.value);
                 true
             } else {

--- a/specs/memory/relocatable.md
+++ b/specs/memory/relocatable.md
@@ -282,9 +282,7 @@ extend UndoStack<T: Encode + Decode> {
     }
 
     func pop(self) -> Pool<T> or DecodeError {
-        const bytes = self.history.pop() is Some else {
-            return Err(DecodeError.Empty)
-        }
+        const bytes = self.history.pop() ?? return DecodeError.Empty
         return Pool.from_bytes(bytes)
     }
 }

--- a/specs/memory/resource-types.md
+++ b/specs/memory/resource-types.md
@@ -64,7 +64,7 @@ func process() -> () or Error {
     const data = try file.read_all()
     try process_data(data)
     try file.close()                          // Consumed
-    Ok(())
+    return
 }
 ```
 
@@ -78,22 +78,22 @@ struct DbConn {
 
 extend DbConn {
     func open(path: string) -> DbConn or Error {
-        return Ok(DbConn { handle: 1 })
+        return DbConn { handle: 1 }
     }
 
     func read_all(self) -> string or Error {
-        return Ok("data")
+        return "data"
     }
 
     func close(take self) -> () or Error {
-        return Ok(())
+        return
     }
 }
 
 func bad() -> () or Error {
     const conn = try DbConn.open("data.txt")
     const data = try conn.read_all()
-    Ok(())
+    return
     // ERROR: conn not consumed before scope exit
 }
 ```
@@ -108,11 +108,11 @@ struct DbConn {
 
 extend DbConn {
     func open(path: string) -> DbConn or Error {
-        return Ok(DbConn { handle: 1 })
+        return DbConn { handle: 1 }
     }
 
     func close(take self) -> () or Error {
-        return Ok(())
+        return
     }
 }
 
@@ -120,7 +120,7 @@ func also_bad() -> () or Error {
     const conn = try DbConn.open("data.txt")
     try conn.close()
     try conn.close()    // ERROR: conn already consumed
-    Ok(())
+    return
 }
 ```
 
@@ -146,12 +146,12 @@ func process() -> () or Error {
     const body = try file.read_body()
     try transform(body)
 
-    Ok(())
+    return
     // ensure runs: file.close() called
 }
 ```
 
-**Error handling in `ensure`:** If the ensured operation returns `Result`, errors are logged (debug mode), accumulated if multiple ensures fail, and returned as the scope's error if no explicit return.
+**Error handling in `ensure`:** If the ensured operation returns `T or E`, errors are logged (debug mode), accumulated if multiple ensures fail, and returned as the scope's error if no explicit return.
 
 <!-- test: parse -->
 ```rask
@@ -161,7 +161,7 @@ func risky() -> () or Error {
 
     try risky_operation()         // If this fails, ensure still runs
 
-    Ok(())
+    return
 }
 // If risky_operation() fails: file.close() runs, then try propagates
 // If file.close() fails: that error is returned
@@ -179,11 +179,11 @@ func process(path: string) -> Data or Error {
 
     const header = try file.read_header()  // Early return? ensure runs
     if !header.valid {
-        return Err(InvalidHeader)      // ensure runs, file closed
+        return InvalidHeader      // ensure runs, file closed
     }
 
     const data = try file.read_body()      // Early return? ensure runs
-    Ok(data)                           // Normal exit: ensure runs
+    return data                           // Normal exit: ensure runs
 }
 ```
 
@@ -199,14 +199,13 @@ enum FileError {
 }
 
 func read_config(file: File) -> Config or FileError {
-    const data = match file.read_all() {
-        Ok(d) => d,
-        Err(reason) => return Err(FileError.ReadFailed { file, reason }),
+    const data = if file.read_all() ? as d { d } else as reason {
+        return FileError.ReadFailed { file, reason }
     }
 
     const config = try parse(data)
     try file.close()
-    Ok(config)
+    return config
 }
 ```
 
@@ -223,7 +222,7 @@ func read_config(file: File) -> Config or FileError {
 | **RC1** | `Vec<Resource>` | No | Vec drop would need to consume each element |
 | **RC2** | `Pool<Resource>` | Yes | Explicit removal required anyway |
 | **RC3** | `Map<K, Resource>` | No | Map drop same problem as Vec |
-| **RC4** | `Option<Resource>` | Yes | Must match and consume |
+| **RC4** | `Resource?` | Yes | Must match and consume |
 
 **Pool pattern for resources:**
 <!-- test: skip -->
@@ -311,7 +310,7 @@ func conditional(file: File, keep_open: bool) -> () or Error {
         try file.close()             // Consumes by close
     }
     // Both branches consume
-    Ok(())
+    return
 }
 ```
 
@@ -327,7 +326,7 @@ func process_file(path: string) -> Data or Error {
     const header = try file.read_header()
     const data = try file.read_body()
 
-    Ok(data)
+    return data
 }
 ```
 
@@ -344,7 +343,7 @@ func update_user(db: Database, user_id: u64) -> () or Error {
 
     try txn.commit()             // Explicit commit consumes txn
                               // ensure no longer needed (already consumed)
-    Ok(())
+    return
 }
 ```
 
@@ -372,7 +371,7 @@ func handle_connections(pool: Pool<Connection>) -> () or Error {
         try conn.close()
     }
 
-    Ok(())
+    return
 }
 ```
 
@@ -422,11 +421,11 @@ extend FileError {
         match self {
             FileError.ReadFailed { file, reason } => {
                 try file.close()
-                Ok(Error.Read(reason))
+                return Error.Read(reason)
             }
             FileError.WriteFailed { file, reason } => {
                 try file.close()
-                Ok(Error.Write(reason))
+                return Error.Write(reason)
             }
         }
     }
@@ -453,7 +452,7 @@ func process_files(paths: Vec<string>) -> () or Error {
         try process(file)
     }
 
-    Ok(())
+    return
     // All ensures run in reverse order
 }
 ```

--- a/specs/memory/unsafe.md
+++ b/specs/memory/unsafe.md
@@ -438,15 +438,15 @@ extend SafeBuffer {
     public func new(size: usize) -> SafeBuffer or AllocError {
         unsafe {
             const ptr = try alloc(size)
-            return Ok(SafeBuffer { ptr, len: size })
+            return SafeBuffer { ptr, len: size }
         }
     }
 
-    public func get(self, index: usize) -> Option<u8> {
+    public func get(self, index: usize) -> u8? {
         if index >= self.len {
-            return None
+            return none
         }
-        return unsafe { Some(*self.ptr.add(index)) }
+        return unsafe { *self.ptr.add(index) }
     }
 
     func close(take self) {
@@ -475,11 +475,11 @@ extend<T> FastBuffer<T> {
         return *self.data.add(index)
     }
 
-    public func get(self, index: usize) -> Option<T> {
+    public func get(self, index: usize) -> T? {
         if index < self.len {
-            return unsafe { Some(self.get_unchecked(index)) }
+            return unsafe { self.get_unchecked(index) }
         }
-        return None
+        return none
     }
 }
 ```

--- a/specs/stdlib/README.md
+++ b/specs/stdlib/README.md
@@ -95,8 +95,8 @@ Always available without import:
 
 | Type | Description |
 |------|-------------|
-| `Option<T>` | Optional value (`some(v)` or `none`) |
-| `Result<T, E>` | Success or error |
+| `T?` | Optional value (present or `none`) |
+| `T or E` | Success value or error |
 | `Error` | Error trait |
 
 ### Collections
@@ -454,10 +454,10 @@ URL parsing (RFC 3986).
 struct Url {
     scheme: string,      // "https"
     host: string,        // "example.com"
-    port: Option<u16>,   // 443
+    port: u16?,          // 443
     path: string,        // "/api/users"
-    query: Option<string>, // "page=1&limit=10"
-    fragment: Option<string>, // "section"
+    query: string?,      // "page=1&limit=10"
+    fragment: string?,   // "section"
 }
 ```
 
@@ -470,16 +470,16 @@ const u = try url.parse("https://example.com:8080/path?query=1")
 
 u.scheme    // "https"
 u.host      // "example.com"
-u.port      // Some(8080)
+u.port      // 8080 (present)
 u.path      // "/path"
-u.query     // Some("query=1")
+u.query     // "query=1" (present)
 ```
 
 ### Query Parameters
 
 ```rask
 const params = try url.parse_query("name=Alice&age=30")
-params["name"]  // Some("Alice")
+params["name"]  // "Alice" (present)
 
 const query = url.encode_query([("name", "Alice"), ("age", "30")])
 // "name=Alice&age=30"
@@ -586,8 +586,8 @@ if terminal.is_tty() {
     print("plain")
 }
 
-terminal.width()   // -> Option<u16>
-terminal.height()  // -> Option<u16>
+terminal.width()   // -> u16?
+terminal.height()  // -> u16?
 ```
 
 **Status:** Planned — detailed specification TODO.

--- a/specs/stdlib/collections.md
+++ b/specs/stdlib/collections.md
@@ -25,24 +25,24 @@ Vec and Map with optional capacity constraints, inline element access, fallible 
 
 | Rule | Description |
 |------|-------------|
-| **CP1: Unbounded** | `capacity() == None`, grows indefinitely |
-| **CP2: Bounded** | `capacity() == Some(n)`, cannot exceed `n` elements |
+| **CP1: Unbounded** | `capacity() == none`, grows indefinitely |
+| **CP2: Bounded** | `capacity()` present with value `n`, cannot exceed `n` elements |
 | **CP3: Fixed** | Bounded + pre-allocated at creation |
 
 ## Allocation
 
-Growth operations panic on failure (C2). Fallible `try_` variants return `Result` with the rejected value for code that needs to handle allocation failure — bounded collections, embedded, or OOM-aware paths.
+Growth operations panic on failure (C2). Fallible `try_` variants return `T or E` with the rejected value for code that needs to handle allocation failure — bounded collections, embedded, or OOM-aware paths.
 
 | Operation | Returns | On failure |
 |-----------|---------|------------|
 | `vec.push(x)` | `()` | Panics |
-| `vec.try_push(x)` | `() or PushError<T>` | Returns `Err(Full(T))` or `Err(Alloc(T))` |
+| `vec.try_push(x)` | `() or PushError<T>` | Returns `PushError.Full(T)` or `PushError.Alloc(T)` |
 | `vec.extend(iter)` | `()` | Panics |
 | `vec.try_extend(iter)` | `() or ExtendError<T>` | Returns first rejected item |
 | `vec.reserve(n)` | `()` | Panics |
 | `vec.try_reserve(n)` | `() or AllocError` | Returns error |
-| `map.insert(k, v)` | `Option<V>` | Panics |
-| `map.try_insert(k, v)` | `Option<V> or InsertError<V>` | Returns `Err(Full(V))` or `Err(Alloc(V))` |
+| `map.insert(k, v)` | `V?` | Panics |
+| `map.try_insert(k, v)` | `V? or InsertError<V>` | Returns `InsertError.Full(V)` or `InsertError.Alloc(V)` |
 
 <!-- test: parse -->
 ```rask
@@ -79,18 +79,18 @@ const users = Map.from([
 |------|-------------|
 | **V1: Copy out** | `vec[i]` copies T when T: Copy. Panics on OOB |
 | **V2: Expression borrow** | `vec[i].field` borrows for expression, released at `;` |
-| **V3: Safe get** | `vec.get(i)` returns `Option<T>` (T: Copy), no panic |
+| **V3: Safe get** | `vec.get(i)` returns `T?` (T: Copy), no panic |
 
 | Method | Returns | Constraint | Panics |
 |--------|---------|------------|--------|
 | `vec[i]` | `T` | `T: Copy` | Yes (OOB) |
-| `vec[i].field` | inline access (expression-scoped) | None | Yes (OOB) |
-| `vec.get(i)` | `Option<T>` | `T: Copy` | No |
-| `vec.get_clone(i)` | `Option<T>` | `T: Cloneable` | No |
-| `with vec[i] as v { ... }` | block value (mutable) | None | Yes (OOB) |
-| `vec.insert(i, x)` | `()` | None | Yes (OOB or alloc) |
-| `vec.remove(i)` | `T` | None | Yes (OOB) |
-| `vec.pop()` | `T?` | None | No |
+| `vec[i].field` | inline access (expression-scoped) | none | Yes (OOB) |
+| `vec.get(i)` | `T?` | `T: Copy` | No |
+| `vec.get_clone(i)` | `T?` | `T: Cloneable` | No |
+| `with vec[i] as v { ... }` | block value (mutable) | none | Yes (OOB) |
+| `vec.insert(i, x)` | `()` | none | Yes (OOB or alloc) |
+| `vec.remove(i)` | `T` | none | Yes (OOB) |
+| `vec.pop()` | `T?` | none | No |
 
 ### Positional Insert/Remove
 
@@ -98,7 +98,7 @@ const users = Map.from([
 |------|-------------|
 | **V4: Insert at index** | `vec.insert(i, x)` inserts before position `i`, shifting later elements right. Panics on `i > len()` or alloc failure |
 | **V5: Remove at index** | `vec.remove(i)` removes and returns the element at `i`, shifting later elements left. Panics on `i >= len()` |
-| **V6: Pop last** | `vec.pop()` removes and returns the last element as `Option<T>`. Returns `none` on empty vec |
+| **V6: Pop last** | `vec.pop()` removes and returns the last element as `T?`. Returns `none` on empty vec |
 
 <!-- test: skip -->
 ```rask
@@ -131,10 +131,10 @@ const name = with vec[i] as v { v.name.clone() }
 |--------|---------|-----------|
 | `map[k]` | `V` | Panics if missing (V: Copy) |
 | `map[k].field` | inline access (expression-scoped) | Panics if missing |
-| `map.get(k)` | `Option<V>` | Copy out (V: Copy) |
-| `map.get_clone(k)` | `Option<V>` | Clone out (V: Cloneable) |
+| `map.get(k)` | `V?` | Copy out (V: Copy) |
+| `map.get_clone(k)` | `V?` | Clone out (V: Cloneable) |
 | `with map[k] as v { ... }` | block value (mutable) | Panics if missing |
-| `map.remove(k)` | `Option<V>` | Remove and return |
+| `map.remove(k)` | `V?` | Remove and return |
 
 ### Entry API
 
@@ -161,7 +161,7 @@ map.ensure_modify(user_id, || User.new(user_id), |u| {
 | Operation | Signature | Semantics |
 |-----------|-----------|-----------|
 | `vec.swap(i, j)` | `()` | Swap two indices (panics if equal) |
-| `vec.modify_many([i, j, k], \|[a, b, c]\| R)` | `Option<R>` | Mutate multiple (panics if duplicates) |
+| `vec.modify_many([i, j, k], \|[a, b, c]\| R)` | `R?` | Mutate multiple (panics if duplicates) |
 
 ## Iteration
 
@@ -212,17 +212,17 @@ users.sort_by(|a, b| b.score.compare(a.score))  // descending
 | Method | Signature | Trait Required | Notes |
 |--------|-----------|----------------|-------|
 | `vec.contains(item)` | `(T) -> bool` | `T: Equal` | Linear scan |
-| `vec.first()` | `() -> T?` | `T: Copy` | First element or None |
-| `vec.last()` | `() -> T?` | `T: Copy` | Last element or None |
-| `vec.reverse()` | `(mutate self)` | None | In-place reversal |
+| `vec.first()` | `() -> T?` | `T: Copy` | First element or `none` |
+| `vec.last()` | `() -> T?` | `T: Copy` | Last element or `none` |
+| `vec.reverse()` | `(mutate self)` | none | In-place reversal |
 | `vec.dedup()` | `(mutate self)` | `T: Equal` | Remove consecutive duplicates |
 
 <!-- test: skip -->
 ```rask
 mut items = [3, 1, 4, 1, 5]
 items.contains(4)             // true
-items.first()                 // Some(3)
-items.last()                  // Some(5)
+items.first()                 // 3
+items.last()                  // 5
 items.reverse()               // [5, 1, 4, 1, 3]
 
 items.sort()                  // [1, 1, 3, 4, 5]
@@ -297,9 +297,9 @@ struct SliceDescriptor<T> {
 | Method | Returns | Semantics |
 |--------|---------|-----------|
 | `vec.len()` | `usize` | Current element count |
-| `vec.capacity()` | `Option<usize>` | `None` = unbounded, `Some(n)` = max capacity |
-| `vec.is_bounded()` | `bool` | `capacity().is_some()` |
-| `vec.remaining()` | `Option<usize>` | `None` = unbounded, `Some(n)` = slots available |
+| `vec.capacity()` | `usize?` | `none` = unbounded, value = max capacity |
+| `vec.is_bounded()` | `bool` | `capacity()?` |
+| `vec.remaining()` | `usize?` | `none` = unbounded, value = slots available |
 | `vec.allocated()` | `usize` | Current allocation size (may exceed len) |
 
 ## Comptime Collections with Freeze
@@ -351,11 +351,11 @@ Vec.from_raw_parts(ptr, len, cap) -> Vec<T>  // unsafe
 ```
 ERROR [std.collections/C4]: linear resource type in Vec
    |
-3  |  let files: Vec<File> = Vec.new()
-   |             ^^^^^^^^^ File is a linear resource
+3  |  const files: Vec<File> = Vec.new()
+   |               ^^^^^^^^^ File is a linear resource
 
 WHY: Collection drop calls T.drop() for each element, but linear resource
-     drop can fail (returns Result), and collection drop can't propagate errors.
+     drop can fail (returns an error type), and collection drop can't propagate errors.
 
 FIX: Use Pool<File> with explicit consumption:
 
@@ -370,9 +370,8 @@ PANIC [std.collections/C2]: push failed — collection at capacity
 
 FIX: Use try_push to handle capacity limits:
 
-  match vec.try_push(item) {
-      Ok(()) => {},
-      Err(PushError.Full(item)) => process_overflow(item),
+  if vec.try_push(item) is PushError.Full(overflow) {
+      process_overflow(overflow)
   }
 ```
 
@@ -381,7 +380,7 @@ FIX: Use try_push to handle capacity limits:
 | Case | Rule | Handling |
 |------|------|----------|
 | `vec[usize.MAX]` | V1 | Panic (bounds check) |
-| `vec.get(usize.MAX)` | V3 | Returns `None` |
+| `vec.get(usize.MAX)` | V3 | Returns `none` |
 | `Vec.fixed(0).push(x)` | C2 | Panics (capacity 0). Use `try_push` to handle |
 | OOM on unbounded `push()` | C2 | Panics. Use `try_push` for OOM-aware code |
 | `vec.insert(n, x)` where `n > len()` | V4 | Panic (bounds check) |

--- a/specs/stdlib/encoding.md
+++ b/specs/stdlib/encoding.md
@@ -107,9 +107,7 @@ extend DateTime {
     }
 
     public func from_json(value: JsonValue) -> DateTime or JsonError {
-        const s = value.as_string() is Some else {
-            return Err(JsonError.TypeError("expected string for DateTime"))
-        }
+        const s = value.as_string() ?? return JsonError.TypeError("expected string for DateTime")
         return try DateTime.parse_iso8601(s)
     }
 }
@@ -133,7 +131,7 @@ extend DateTime {
 | `i8`–`i64`, `u8`–`u64` | `0` |
 | `f32`, `f64` | `0.0` |
 | `string` | `""` (empty) |
-| `T?` (optionals) | `None` |
+| `T?` (optionals) | `none` |
 | `Vec<T>` | empty vec |
 | `Map<K,V>` | empty map |
 | Structs, enums, other types | **No zero value** — `@skip` requires `@default(expr)` or compile error |
@@ -233,7 +231,7 @@ func encode_value<T: Encode>(value: T, w: mutate JsonWriter) -> () or JsonError 
     } else if reflect.is_float<T>() {
         return w.write_number(value)
     } else if reflect.is_optional<T>() {
-        if value is Some(v) {
+        if value? as v {
             return encode_value(v, mutate w)
         } else {
             return w.write_null()
@@ -288,9 +286,9 @@ func decode_value<T: Decode>(parser: mutate JsonParser) -> T or JsonError {
     } else if reflect.is_optional<T>() {
         if parser.peek_null() {
             parser.skip()
-            return None
+            return none
         }
-        return Some(try decode_value(parser))
+        return try decode_value(parser)
     } else if reflect.is_vec<T>() {
         mut result = Vec.new()
         try parser.begin_array()
@@ -315,15 +313,14 @@ func decode_struct<T: Decode>(parser: mutate JsonParser) -> T or JsonError {
         comptime for field in reflect.fields<T>() {
             comptime if !field.is_skipped {
                 (field.name): comptime if field.has_default {
-                    match fields.get(field.serial_name) {
-                        Some(v) => try decode_from_value(v),
-                        None => field.default_value,
+                    if fields.get(field.serial_name)? as v {
+                        try decode_from_value(v)
+                    } else {
+                        field.default_value
                     }
                 } else {
                     try decode_from_value(
-                        fields.get(field.serial_name) is Some else {
-                            return Err(JsonError.MissingField(field.serial_name))
-                        }
+                        fields.get(field.serial_name) ?? return JsonError.MissingField(field.serial_name)
                     )
                 },
             }
@@ -460,12 +457,12 @@ func encode_value<T: Encode>(value: T, w: mutate TomlWriter, key: string?) -> ()
         try w.begin_table(key)
         comptime for field in reflect.fields<T>() {
             comptime if !field.is_skipped {
-                try encode_value(value.(field.name), mutate w, Some(field.serial_name))
+                try encode_value(value.(field.name), mutate w, field.serial_name)
             }
         }
         return w.end_table()
     }
-    // TOML has no null — optionals with None are omitted
+    // TOML has no null — optionals that are `none` are omitted
     // TOML arrays, inline tables, etc.
 }
 ```

--- a/specs/stdlib/io.md
+++ b/specs/stdlib/io.md
@@ -220,7 +220,7 @@ WHY: read_text() requires valid UTF-8. Use read_all() for raw bytes.
 | `BufWriter` flush on drop fails | Error silently discarded | B2 |
 | `Stdout` not closed | Compile error | S1 |
 | `Buffer` overflow | Grows like `Vec` (fallible allocation) | B4 |
-| Zero-length read/write | Returns `Ok(0)`, no-op | R1, W1 |
+| Zero-length read/write | Returns `0`, no-op | R1, W1 |
 
 ---
 

--- a/specs/stdlib/iteration.md
+++ b/specs/stdlib/iteration.md
@@ -309,7 +309,7 @@ FIX: Use index mode for structural mutation, or collect changes first:
   }
 
   // Option 2: collect first
-  let to_add = Vec.new()
+  mut to_add = Vec.new()
   for mutate entity in entities {
       if entity.should_split {
           to_add.push(entity.split())

--- a/specs/stdlib/json.md
+++ b/specs/stdlib/json.md
@@ -67,7 +67,7 @@ json.stringify_pretty(value: JsonValue) -> string
 | **J6: Auto-encode** | Any struct satisfying `Encode` can be encoded without manual implementation. Uses `comptime for` + field access (`std.encoding/E1`–`E3`) |
 | **J7: Compatible types** | `bool`, `i32`, `i64`, `u32`, `u64`, `f32`, `f64`, `string`, `Vec<T>`, `Map<string, T>`, `T?`, nested structs |
 | **J8: Field mapping** | Struct field `serial_name` = JSON key. Defaults to field name (snake_case). Override with `@rename` (`std.encoding/E18`) |
-| **J9: Optional fields** | `T?` fields decode `null` or missing as `None`; missing required fields produce `MissingField`. `@default` fields (`std.encoding/E20`) also tolerate missing keys |
+| **J9: Optional fields** | `T?` fields decode `null` or missing as `none`; missing required fields produce `MissingField`. `@default` fields (`std.encoding/E20`) also tolerate missing keys |
 | **J10: Extra keys ignored** | JSON keys not matching any struct field are silently skipped |
 
 <!-- test: skip -->
@@ -145,7 +145,7 @@ WHY: Only primitive, collection, optional, and nested-struct types can be encode
 | Large integers (>2^53) | Precision loss in f64 | J2 |
 | Duplicate keys in object | Last value wins | J5 |
 | JSON has extra keys not in struct | Ignored | J10 |
-| Struct has extra fields not in JSON | Required fields error; optional fields get `None` | J9 |
+| Struct has extra fields not in JSON | Required fields error; optional fields get `none` | J9 |
 
 ---
 

--- a/specs/stdlib/os.md
+++ b/specs/stdlib/os.md
@@ -222,7 +222,7 @@ FIX: Remove unreachable code or move os.exit() to end of block.
 
 | Case | Rule | Handling |
 |------|------|----------|
-| `os.env("MISSING")` | E1 | Returns `None` |
+| `os.env("MISSING")` | E1 | Returns `none` |
 | `os.args()` with no args | A1 | Vec contains at least program name |
 | `os.exit(0)` in defer | P1 | Exits immediately, remaining defers skipped |
 | Process not consumed | C4 | Compile error |

--- a/specs/stdlib/path.md
+++ b/specs/stdlib/path.md
@@ -34,10 +34,10 @@ Path.from(s: string) -> Path        // alias for new
 
 <!-- test: skip -->
 ```rask
-path.parent() -> Path?              // "/home/user/file.txt" -> Some("/home/user")
-path.file_name() -> string?         // "/home/user/file.txt" -> Some("file.txt")
-path.extension() -> string?         // "/home/user/file.txt" -> Some("txt")
-path.stem() -> string?              // "/home/user/file.txt" -> Some("file")
+path.parent() -> Path?              // "/home/user/file.txt" -> "/home/user"
+path.file_name() -> string?         // "/home/user/file.txt" -> "file.txt"
+path.extension() -> string?         // "/home/user/file.txt" -> "txt"
+path.stem() -> string?              // "/home/user/file.txt" -> "file"
 path.components() -> Vec<string>    // "/home/user" -> ["home", "user"]
 ```
 
@@ -90,11 +90,11 @@ WHY: Rask paths are UTF-8. Non-UTF-8 filenames are lossy-converted at the system
 
 | Case | Rule | Handling |
 |------|------|----------|
-| `Path.new("")` | — | Empty path; `parent()` and `file_name()` return `None` |
-| `Path.new("/")` | — | Root; `parent()` and `file_name()` return `None` |
-| `Path.new("file.tar.gz")` | — | `extension()` -> `Some("gz")`, `stem()` -> `Some("file.tar")` |
-| `Path.new(".gitignore")` | — | `extension()` -> `None`, `stem()` -> `Some(".gitignore")` (dotfiles are stems) |
-| `Path.new("no_ext")` | — | `extension()` -> `None` |
+| `Path.new("")` | — | Empty path; `parent()` and `file_name()` return `none` |
+| `Path.new("/")` | — | Root; `parent()` and `file_name()` return `none` |
+| `Path.new("file.tar.gz")` | — | `extension()` -> `"gz"`, `stem()` -> `"file.tar"` |
+| `Path.new(".gitignore")` | — | `extension()` -> `none`, `stem()` -> `".gitignore"` (dotfiles are stems) |
+| `Path.new("no_ext")` | — | `extension()` -> `none` |
 | Trailing slash `"/home/user/"` | P2 | Normalized to `"/home/user"` |
 | Double separators `"/home//user"` | P2 | Normalized to `"/home/user"` |
 | Non-UTF-8 filenames on Unix | P3 | Lossy replacement (`\uFFFD`), affects <0.01% of real paths |

--- a/specs/stdlib/random.md
+++ b/specs/stdlib/random.md
@@ -20,7 +20,7 @@ One `Rng` type plus module-level convenience functions. Explicit generator for r
 |------|-------------|
 | **M1: Typed generation** | `rng.u64()`, `rng.i64()`, `rng.f64()`, `rng.f32()`, `rng.bool()` generate typed random values |
 | **M2: Range** | `rng.range(lo, hi)` returns value in `[lo, hi)` — panics if `lo >= hi` |
-| **M3: Collections** | `rng.shuffle(vec)` does in-place Fisher-Yates; `rng.choice(vec)` returns `T?` (None if empty) |
+| **M3: Collections** | `rng.shuffle(vec)` does in-place Fisher-Yates; `rng.choice(vec)` returns `T?` (`none` if empty) |
 
 <!-- test: skip -->
 ```rask
@@ -63,7 +63,7 @@ FIX: Use rng.range(5, 6) for a single value.
 | Case | Rule | Handling |
 |------|------|----------|
 | `range(5, 5)` | M2 | Panics (empty range) |
-| `choice(empty_vec)` | M3 | Returns `None` |
+| `choice(empty_vec)` | M3 | Returns `none` |
 | `shuffle(single_element)` | M3 | No-op |
 | `Rng.from_seed(0)` | R3 | Valid, deterministic (seed 0 not special) |
 

--- a/specs/stdlib/reflect.md
+++ b/specs/stdlib/reflect.md
@@ -212,7 +212,7 @@ func encode_value<T: Encode>(value: T, w: mutate Writer) -> () or Error {
             try encode_value(value.(field.name), mutate w)
         }
     } else if reflect.is_optional<T>() {
-        if value is Some(v) { try encode_value(v, mutate w) }
+        if value? as v { try encode_value(v, mutate w) }
     }
 }
 ```

--- a/specs/stdlib/strings.md
+++ b/specs/stdlib/strings.md
@@ -88,7 +88,7 @@ Plain indices for lightweight stored references — the span type for parsers, t
 |-----------|--------|-------|
 | `Span(i, j)` | `Span` | Create view (just start, end indices) |
 | `source[span]` | expression-scoped slice | Panics if out of bounds |
-| `source.get(span)` | `Option<expression-scoped slice>` | Safe bounds check |
+| `source.get(span)` | `(expression-scoped slice)?` | Safe bounds check |
 | `view.to_string(source)` | `string` | Allocates copy (panics if OOB) |
 | `view.start`, `view.end` | `usize` | Read indices |
 | `view.len()` | `usize` | `end - start` |
@@ -100,21 +100,21 @@ Validated stored references using handles (parsers, tokenizers, ASTs). Follows `
 | Operation | Return | Notes |
 |-----------|--------|-------|
 | `StringPool.new()` | `StringPool` | Empty pool |
-| `pool.insert(s)` | `Result<Handle<string>, InsertError>` | Add string, get handle |
-| `pool.slice(h, i, j)` | `Result<StringSlice, Error>` | Create validated slice |
+| `pool.insert(s)` | `Handle<string> or InsertError` | Add string, get handle |
+| `pool.slice(h, i, j)` | `StringSlice or Error` | Create validated slice |
 | `pool[slice]` | inline access (expression-scoped) | Panics if invalid |
-| `pool.get(slice)` | `Option<inline access>` | Safe access |
+| `pool.get(slice)` | `(inline access)?` | Safe access |
 | `with pool[slice] as s { ... }` | block value | Multi-statement access |
-| `pool.remove(h)` | `Option<string>` | Remove and return ownership |
+| `pool.remove(h)` | `string?` | Remove and return ownership |
 
-Handle validation: pool_id + index + generation. Wrong pool or stale handle returns `None`.
+Handle validation: pool_id + index + generation. Wrong pool or stale handle returns `none`.
 
 ## UTF-8 Validation
 
 | Operation | Return Type | Validation Cost |
 |-----------|-------------|-----------------|
 | `"literal"` | `string` | Compile-time |
-| `string.from_utf8(bytes)` | `Result<string, utf8_error>` | Runtime O(n), one-time |
+| `string.from_utf8(bytes)` | `string or utf8_error` | Runtime O(n), one-time |
 | `string.from_utf8_unchecked(bytes)` | `string` | None (unsafe block only) |
 
 ## Iteration
@@ -144,7 +144,7 @@ Iterators borrow for expression scope only. Cannot be stored.
 | Operation | Return Type | Notes |
 |-----------|-------------|-------|
 | `"literal"` | `string` | Compile-time validated. ≤ 15 bytes → SSO (inline, no allocation). > 15 bytes → static storage, sentinel refcount (never freed) |
-| `string.from_utf8(bytes)` | `Result<string, utf8_error>` | Validates bytes |
+| `string.from_utf8(bytes)` | `string or utf8_error` | Validates bytes |
 | `string.from_char(c)` | `string` | Single-char string |
 | `string.repeat(s, n)` or `s.repeat(n)` | `string` | `s` repeated `n` times, allocates |
 | `slice.to_string()` | `string` | Copy slice bytes into new independent string (allocates) |
@@ -193,8 +193,8 @@ const csv = headers.join(",")      // CSV header row
 
 | Operation | Return | Notes |
 |-----------|--------|-------|
-| `s.find(pat)` or `s.index_of(pat)` | `Option<usize>` | Byte index of first match |
-| `s.rfind(pat)` | `Option<usize>` | Byte index of last match |
+| `s.find(pat)` or `s.index_of(pat)` | `usize?` | Byte index of first match |
+| `s.rfind(pat)` | `usize?` | Byte index of last match |
 | `s.contains(pat)` | `bool` | Substring check |
 | `s.starts_with(pat)` | `bool` | Prefix check |
 | `s.ends_with(pat)` | `bool` | Suffix check |
@@ -219,8 +219,8 @@ const csv = headers.join(",")      // CSV header row
 
 | Operation | Return | Notes |
 |-----------|--------|-------|
-| `s.char_at(idx)` | `Option<char>` | Get Unicode scalar at char index (not byte index) |
-| `s.byte_at(idx)` | `Option<u8>` | Get byte at byte index |
+| `s.char_at(idx)` | `char?` | Get Unicode scalar at char index (not byte index) |
+| `s.byte_at(idx)` | `u8?` | Get byte at byte index |
 
 ## Substring Extraction
 
@@ -232,8 +232,8 @@ const csv = headers.join(",")      // CSV header row
 
 | Operation | Return | Notes |
 |-----------|--------|-------|
-| `s.parse_int()` or `s.parse()` | `Result<i64, string>` | Parse to integer, trims whitespace |
-| `s.parse_float()` | `Result<f64, string>` | Parse to floating point, trims whitespace |
+| `s.parse_int()` or `s.parse()` | `i64 or string` | Parse to integer, trims whitespace |
+| `s.parse_float()` | `f64 or string` | Parse to floating point, trims whitespace |
 
 ## String Manipulation
 
@@ -256,10 +256,10 @@ const csv = headers.join(",")      // CSV header row
 |----------------|-------------|
 | `cstring` | Owned null-terminated string |
 | `c"literal"` | Null-terminated string literal |
-| `s.to_cstring()` | `Result<cstring, null_byte_error>` (fails if `\0` present) |
+| `s.to_cstring()` | `cstring or null_byte_error` (fails if `\0` present) |
 | `cstring.as_ptr()` | `*u8` (unsafe context only) |
 | `cstring.from_ptr(ptr)` | `cstring` (unsafe, takes ownership) |
-| `cstring.to_string()` | `Result<string, utf8_error>` |
+| `cstring.to_string()` | `string or utf8_error` |
 
 <!-- test: skip -->
 ```rask
@@ -311,7 +311,7 @@ ERROR [std.strings/S7]: cannot mutate string
 WHY: Use StringBuilder for construction.
 
 FIX:
-  let b = StringBuilder.new()
+  mut b = StringBuilder.new()
   b.append(s)
   b.append("x")
   const result = b.build()
@@ -325,14 +325,14 @@ FIX:
 | Out-of-bounds slice `s[0..999]` | S5 | Panic at runtime |
 | Slice not on char boundary | S5 | Panic at runtime |
 | Embedded `\0` in string | — | Valid; `to_cstring()` returns error |
-| Allocation failure | — | Returns `Result` error |
+| Allocation failure | — | Returns `T or E` error |
 | String literal ≤ 15 bytes | S8 | SSO — inline value, no heap, no refcount |
 | String literal > 15 bytes | S6 | Sentinel refcount, never freed/decremented |
 | Short string (≤ 15 bytes) | S8 | SSO — pure value copy, no atomic ops |
 | `Span` of freed source | — | Undefined behavior (user's responsibility) |
-| `Span` out of bounds | — | Panic on `s[span]`, `None` on `s.get(span)` |
-| `StringSlice` with stale handle | — | `pool.get(slice)` returns `None` |
-| `StringSlice` wrong pool | — | `pool.get(slice)` returns `None` |
+| `Span` out of bounds | — | Panic on `s[span]`, `none` on `s.get(span)` |
+| `StringSlice` with stale handle | — | `pool.get(slice)` returns `none` |
+| `StringSlice` wrong pool | — | `pool.get(slice)` returns `none` |
 | Refcount overflow | S6 | Panic (practically unreachable — requires ~4 billion live copies) |
 | Multiple simultaneous iterators | — | Allowed (string is immutable) |
 
@@ -479,7 +479,7 @@ func tokenize(source: string) -> (StringPool, Vec<Token>) or Error {
         tokens.push(Token { text: slice, kind })
     }
 
-    return Ok((pool, tokens))
+    return (pool, tokens)
 }
 ```
 

--- a/specs/stdlib/time.md
+++ b/specs/stdlib/time.md
@@ -187,7 +187,7 @@ const tomorrow = now + time.Duration.seconds(86400)
 | Duration overflow | Wraps (u64 nanoseconds) | D4 |
 | Duration divide by zero | Panic | A4 |
 | `SystemTime` before UNIX epoch | Negative `unix_secs()` | W2 |
-| `SystemTime` NTP adjustment backward | `duration_since` returns `Err(TimeError.Backwards)` | W1 |
+| `SystemTime` NTP adjustment backward | `duration_since` returns `TimeError.Backwards` | W1 |
 | `SystemTime` serialization | Use `unix_secs()` or `unix_millis()` | W2 |
 | `SystemTime` comparison across machines | Only meaningful if clocks are synchronized | W1 |
 

--- a/specs/structure/build-design-proposal.md
+++ b/specs/structure/build-design-proposal.md
@@ -535,7 +535,7 @@ const result = try ctx.run(Command {
     args: ["--rask_out=.rk-gen/", "api.proto"],
 })
 if result.status != 0 {
-    return Err(Error.new("protoc failed: {}", result.stderr))
+    return Error.new("protoc failed: {}", result.stderr)
 }
 
 // Proposed (concise)

--- a/specs/structure/c-interop.md
+++ b/specs/structure/c-interop.md
@@ -196,10 +196,10 @@ public func open(path: string) -> Database or Error {
     unsafe {
         mut rc = sql.sqlite3_open(path.as_c_str(), &db)
         if rc != sql.SQLITE_OK {
-            return Err(Error.new("sqlite open failed"))
+            return Error.new("sqlite open failed")
         }
     }
-    Ok(Database { handle: db })
+    return Database { handle: db }
 }
 ```
 
@@ -210,8 +210,8 @@ public extern "C" func rask_process(data: *u8, len: c_size) -> c_int {
     unsafe {
         mut slice = slice_from_raw(data, len)
         match process(slice) {
-            Ok(_) => 0,
-            Err(_) => -1,
+            Success as _ => 0,
+            Error as _ => -1,
         }
     }
 }

--- a/specs/structure/modules.md
+++ b/specs/structure/modules.md
@@ -26,10 +26,10 @@ Package-visible default for items and fields, `private` keyword for extend-only 
 
 | Rule | Description |
 |------|-------------|
-| **BI1: Always available** | Primitives, `string`, `Vec`, `Map`, `Set`, `Result`, `Option`, `Error`, `Channel`, `Ok`, `Err`, `Some`, `None` |
+| **BI1: Always available** | Primitives, `string`, `Vec`, `Map`, `Set`, `Error`, `Channel`, `none`. Status types `T?` and `T or E` are builtin sugar — no nominal name |
 | **BI2: Fixed set** | Can't be extended by users or projects |
 | **BI3: No shadowing** | Defining local type with built-in name is a compile error |
-| **BI4: Qualified fallback** | `core.Result` always works regardless of local names |
+| **BI4: Qualified fallback** | `core.Error` always works regardless of local names |
 
 ## Built-in Functions
 
@@ -234,7 +234,7 @@ extend Printer with ast.Visitor {
 ```rask
 struct Node {
     value: i32
-    parent: Option<Handle<Node>>
+    parent: Handle<Node>?
     children: Vec<Handle<Node>>
 }
 ```

--- a/specs/structure/modules.md
+++ b/specs/structure/modules.md
@@ -167,8 +167,8 @@ ERROR [struct.modules/IM7]: unused import
 ```
 ERROR [struct.modules/PS3]: mutable global
    |
-5  |  let counter: i32 = 0
-   |  ^^^^^^^^^^^^^^^^^^^^^ package-level `let` not allowed; use Atomic or Shared
+5  |  mut counter: i32 = 0
+   |  ^^^^^^^^^^^^^^^^^^^^ package-level `mut` not allowed; use Atomic or Shared
 ```
 
 ## Edge Cases

--- a/specs/structure/targets.md
+++ b/specs/structure/targets.md
@@ -66,7 +66,7 @@ public func main(args: Args) {
 | Rule | Description |
 |------|-------------|
 | **EX1: Normal return** | `main` returning → status 0 |
-| **EX2: Error return** | `main` returning `Err(e)` → status 1, error to stderr |
+| **EX2: Error return** | `main` returning an error → status 1, error to stderr |
 | **EX3: Explicit exit** | `sys.exit(n)` → immediate, no cleanup |
 | **EX4: Panic** | Panic → status 101, message to stderr |
 | **EX5: Ensure runs** | `ensure` blocks run before exit (unless `sys.exit()`) |

--- a/specs/tooling/lint.md
+++ b/specs/tooling/lint.md
@@ -74,7 +74,7 @@ func validate(input: string) -> bool {
 @pure
 func parse(input: string) -> Config or ParseError {
     // P4: returning errors is fine — errors are values
-    if input.is_empty() { return Err(ParseError.Empty) }
+    if input.is_empty() { return ParseError.Empty }
     return Config { value: input }
 }
 

--- a/specs/tooling/warnings.md
+++ b/specs/tooling/warnings.md
@@ -83,7 +83,7 @@ func scratch() {
 extend Server {
     func start(take self) -> () or Error {
         try self.listener.bind(self.addr)
-        return Ok(())
+        return
     }
 }
 ```

--- a/specs/types/enums.md
+++ b/specs/types/enums.md
@@ -15,7 +15,7 @@ Tagged unions with positional or named payloads. Compiler infers binding modes. 
 enum Name { A, B }                    // Simple tag-only
 enum Name { A(T), B(U, V) }           // Positional payloads
 enum Name { A { x: T, y: U } }       // Named payloads
-enum Name<T> { Some(T), None }        // Generic enum
+enum Maybe<T> { Present(T), Missing } // Generic enum
 enum Name: u8 { A = 0, B = 1 }       // Explicit discriminants (E14-E18)
 ```
 
@@ -120,11 +120,11 @@ No mode annotations in source. IDE shows inferred mode as ghost text.
 
 **Borrow (inferred when bindings only borrowed):**
 ```rask
-match result {                      // IDE ghost: [borrows]
-    Ok(value) => println(value),    // value: borrowed (inferred read)
-    Err(error) => log(error)        // error: borrowed (inferred read)
+match msg {                         // IDE ghost: [borrows]
+    Data(value) => println(value),  // value: borrowed (inferred read)
+    Fault(error) => log(error)      // error: borrowed (inferred read)
 }
-// result still valid
+// msg still valid
 ```
 
 **Borrow + mutate (inferred when any binding mutated):**
@@ -138,11 +138,11 @@ match connection {                          // IDE ghost: [mutates]
 
 **Take (inferred when any binding passed to `take` parameter):**
 ```rask
-match result {                      // IDE ghost: [takes]
-    Ok(value) => consume(value),    // value: taken (inferred)
-    Err(error) => handle(error)     // error: taken (inferred)
+match msg {                         // IDE ghost: [takes]
+    Data(value) => consume(value),  // value: taken (inferred)
+    Fault(error) => handle(error)   // error: taken (inferred)
 }
-// result is consumed, invalid here
+// msg is consumed, invalid here
 ```
 
 ## Exhaustiveness Checking
@@ -162,9 +162,9 @@ Conditional matching requires explicit catch-all. No hidden gaps.
 
 ```rask
 match response {
-    Ok(body) if body.len() > 0: process(body),
-    Ok(body) => default(body),  // REQUIRED: catches guard failure
-    Err(e) => handle(e)
+    Loaded(body) if body.len() > 0: process(body),
+    Loaded(body) => default(body),  // REQUIRED: catches guard failure
+    Failed(e) => handle(e)
 }
 ```
 
@@ -176,8 +176,8 @@ match response {
 ```rask
 // ❌ INVALID: guard may fail with no fallback
 match response {
-    Ok(body) if body.len() > 0: process(body),
-    Err(e) => handle(e)
+    Loaded(body) if body.len() > 0: process(body),
+    Failed(e) => handle(e)
 }
 ```
 
@@ -211,9 +211,9 @@ Or-patterns can be nested and work with guards: `A(x) | B(x) if x > 0 => ...`
 
 **With payloads:**
 ```rask
-match result {
-    Ok(0) | Err(0) => println("zero"),
-    Ok(n) | Err(n) => println("value: {n}"),
+match msg {
+    Data(0) | Fault(0) => println("zero"),
+    Data(n) | Fault(n) => println("value: {n}"),
 }
 ```
 
@@ -226,24 +226,26 @@ Enums may contain linear payloads (File, Socket, etc.).
 | **PM5: Wildcards forbidden for linear** | `_` on linear payload is compile error |
 | **PM6: All arms must bind** | Each arm must name linear values; bound value must be consumed |
 
+User enum `FileOpen { Opened(File), Failed(IoError) }`:
+
 ```rask
 // ✅ VALID: linear value consumed in each arm
-match file_result {                 // IDE ghost: [consumes]
-    Ok(file) => try file.close(),    // file transferred to close()
-    Err(e) => return Err(e)
+match file_result {                      // IDE ghost: [consumes]
+    Opened(file) => try file.close(),    // file transferred to close()
+    Failed(e) => return e
 }
 
 // ❌ INVALID: wildcard discards linear File
 match file_result {
-    Ok(_) => {},
-    Err(e) => {}
+    Opened(_) => {},
+    Failed(e) => {}
 }
 // Error: "wildcard pattern discards linear resource `File`"
 
 // ❌ INVALID: read-only usage of linear resource
 match file_result {
-    Ok(file) => println(file.path),  // Only reads file
-    Err(e) => log(e)
+    Opened(file) => println(file.path),  // Only reads file
+    Failed(e) => log(e)
 }
 // Error: "linear resource `file` must be consumed, not just read"
 ```
@@ -252,8 +254,8 @@ match file_result {
 
 ```rask
 match file_result {
-    Ok(file) | Recovered(file) => file.close(),
-    Err(e) => log(e)
+    Opened(file) | Recovered(file) => file.close(),
+    Failed(e) => log(e)
 }
 ```
 
@@ -262,22 +264,22 @@ match file_result {
 ```rask
 // ✅ VALID: guard with linear resource — both arms consume
 match file_result {
-    Ok(file) if file.size() > 1000: process(file),  // Large files: process
-    Ok(file) => try file.close(),                     // Small files: still must close
-    Err(e) => log(e)
+    Opened(file) if file.size() > 1000: process(file),  // Large files: process
+    Opened(file) => try file.close(),                    // Small files: still must close
+    Failed(e) => log(e)
 }
 
 // ❌ INVALID: wildcard catch-all discards linear resource
 match file_result {
-    Ok(file) if file.size() > 1000: process(file),
-    Ok(_) => {},                                     // Error: discards linear File
-    Err(e) => log(e)
+    Opened(file) if file.size() > 1000: process(file),
+    Opened(_) => {},                                     // Error: discards linear File
+    Failed(e) => log(e)
 }
 ```
 
 ## Error Propagation and Linear Resources
 
-`try` extracts Ok or returns early with Err.
+`try` extracts the success branch or returns early with the error.
 
 **Rule:** All linear resources in scope must be resolved before `try`.
 
@@ -295,7 +297,6 @@ func process(file1: File, file2: File) -> () or Error {
     const result2 = file2.close()
     const data = try result1
     try result2
-    Ok(())
 }
 ```
 
@@ -305,7 +306,6 @@ func process(file1: File, file2: File) -> () or Error {
     ensure file1.close()  // Guaranteed at scope exit
     ensure file2.close()  // Runs on any exit
     const data = try file1.read()  // ✅ Safe: ensure registered
-    Ok(())
 }
 ```
 
@@ -313,27 +313,29 @@ func process(file1: File, file2: File) -> () or Error {
 
 Methods in `extend` blocks, separate from definition. Default to non-consuming (borrow `self`).
 
+> Note: builtin `T?` (Option) cannot be pattern-matched and isn't a user enum; use its operator surface (`?`, `!`, `??`). See [optionals.md](optionals.md). The example below defines a user enum with a similar shape.
+
 <!-- test: parse -->
 ```rask
-enum Option<T> {
-    Some(T),
-    None,
+enum Maybe<T> {
+    Present(T),
+    Missing,
 }
 
-extend Option<T> {
+extend Maybe<T> {
     // Default: borrows self (compiler infers read vs mutate)
-    func is_some(self) -> bool {
+    func has_value(self) -> bool {
         match self {               // IDE ghost: [reads] (inferred from wildcard-only usage)
-            Some(_) => true,
-            None => false
+            Present(_) => true,
+            Missing => false
         }
     }
 
-    // Explicitly consuming — prefer x! operator over calling this directly
+    // Explicitly consuming
     func force(take self) -> T {
         match self {               // IDE ghost: [consumes] (inferred from returning v)
-            Some(v) => v,
-            None => panic("force on None")
+            Present(v) => v,
+            Missing => panic("force on Missing")
         }
     }
 }
@@ -418,7 +420,7 @@ For enums with explicit backing types (E14), the return type matches the backing
 
 | Attribute | Behavior |
 |-----------|----------|
-| None | Compiler MAY reorder variants for size optimization |
+| (none) | Compiler MAY reorder variants for size optimization |
 | `@layout(ordered)` | Discriminant values locked to declaration order |
 | `@layout(C)` | C-compatible layout, no niche optimization |
 
@@ -426,8 +428,8 @@ For enums with explicit backing types (E14), the return type matches the backing
 
 | Type | Representation |
 |------|----------------|
-| `Option<Owned<T>>` | Null = None, non-null = Some |
-| `Option<Handle<T>>` | generation=0 = None, else Some |
+| `Owned<T>?` | null pointer = absent, non-null = present |
+| `Handle<T>?` | generation=0 = absent, else present |
 
 ## Explicit Discriminants
 
@@ -487,8 +489,8 @@ When a backing type is specified, variant reordering is disabled (implies `@layo
 
 <!-- test: skip -->
 ```rask
-const kind: ObjectKind? = ObjectKind.from_value(1)  // Some(ObjectKind.String)
-const bad: ObjectKind? = ObjectKind.from_value(99)   // none
+const kind: ObjectKind? = ObjectKind.from_value(1)  // ObjectKind.String
+const bad: ObjectKind? = ObjectKind.from_value(99)  // none
 ```
 
 `from_value` is auto-generated for all fieldless enums. Returns optional — invalid values produce `none`.
@@ -509,10 +511,10 @@ enum Never {}  // Cannot be constructed
 | Size | 0 bytes |
 | Construction | Impossible (no variants) |
 | Pattern match | No arms needed |
-| `Result<T, Never>` | Err arm unreachable, compiler optimizes |
+| `T or Never` | error branch uninhabited, compiler optimizes |
 
 ```rask
-func infallible() -> i32 or Never { Ok(42) }
+func infallible() -> i32 or Never { return 42 }
 
 const value = infallible()!  // Cannot panic (compiler knows)
 ```
@@ -528,10 +530,10 @@ const value = infallible()!  // Cannot panic (compiler knows)
 | Single-variant enum | E2 | Valid, discriminant may be optimized away |
 | Zero-sized payload | E1 | `enum Foo { A(()), B }` — unit optimized to `{ A, B }` |
 | >65536 variants | E3 | Compile error: "enum exceeds variant limit" |
-| Nested linear | PM6 | `Result<File, Error(File)>` — both arms bind linear, both must consume |
+| Nested linear | PM6 | `File or FileError(File)` — both arms bind linear, both must consume |
 | Enum in Vec | E5 | Allowed if non-linear |
 | Enum in Pool | E5 | Allowed; linear payloads require explicit `remove()` + consume |
-| Option\<File\> in Pool | PM5 | Error: "Pool cannot contain linear payloads" |
+| `File?` in Pool | PM5 | Error: "Pool cannot contain linear payloads" |
 | Generic constraints | E4 | `enum Foo<T: Clone>` — constraint applies to ALL variants uniformly |
 | Match on Copy type | E4 | Copies enum, mutations in arm affect copy not original |
 
@@ -551,9 +553,9 @@ extend Connection {
     func step(take self) -> Connection {
         match self {                    // IDE ghost: [consumes]
             Idle => Connecting(resolve_address()),
-            Connecting(addr) => match try_connect(addr) {
-                Ok(sock) => Connected(sock),
-                Err(e) => Failed(e)
+            Connecting(addr) => {
+                const attempt = try_connect(addr)
+                if attempt? as sock { Connected(sock) } else as e { Failed(e) }
             },
             Connected(sock) => {
                 sock.send(heartbeat())
@@ -572,11 +574,11 @@ extend Connection {
 }
 ```
 
-### Option Methods
+### Option
 ```rask
-const opt = Some(5)
-if opt.is_some() {          // ✅ opt still valid (borrows self)
-    const val = opt!  // ✅ opt consumed (force unwrap)
+const opt: i32? = 5
+if opt? {           // ✅ opt still valid, narrowed to i32 in block
+    const val = opt!   // ✅ force-extract
 }
 ```
 
@@ -600,9 +602,9 @@ Enums follow the same ownership rules as structs. Compiler infers whether bindin
 
 Use explicit `discard` to silence:
 ```rask
-match result {
-    Ok(discard) => {},  // Explicit acknowledgment
-    Err(e) => handle(e)
+match msg {
+    Data(discard) => {},  // Explicit acknowledgment
+    Fault(e) => handle(e)
 }
 ```
 

--- a/specs/types/generics.md
+++ b/specs/types/generics.md
@@ -238,7 +238,7 @@ The compiler auto-derives Default where all fields have a known default value.
 | `string` | `""` (empty string) |
 | `Vec<T>` | Empty vec |
 | `Map<K, V>` | Empty map |
-| `T?` (Option) | `None` |
+| `T?` (optional) | `none` |
 | Struct with all Default fields | Field-wise default |
 | Enum | NOT auto-derived |
 
@@ -265,14 +265,14 @@ Errors if lengths differ, inference ambiguous, or non-literal const without expl
 
 ## Must-Consume Types in Traits
 
-Must-consume resource types (`@resource`) can be generic parameters. Pattern matching on `Option<Resource>` must bind the value — wildcards are forbidden because that would silently drop the resource.
+Must-consume resource types (`@resource`) can be generic parameters. Narrowing over a `Resource?` must bind the value — wildcards are forbidden because that would silently drop the resource.
 
 | Pattern | Resource content | Valid |
 |---------|-----------------|-------|
-| `Some(f)` | Binds f | Yes, f must be consumed |
-| `Some(_)` | Wildcard | No, compile error |
-| `None` | No value | Yes, nothing to consume |
-| `Ok(f)` | Binds f | Yes, f must be consumed |
+| `if opt? as f` | Binds f | Yes, f must be consumed |
+| `if opt?` (no bind, single-payload implicit) | Wildcard | No, compile error |
+| `opt == none` branch | No value | Yes, nothing to consume |
+| `if r? as f` on `Resource or E` | Binds f | Yes, f must be consumed |
 
 ## Trait Composition
 

--- a/specs/types/integer-overflow.md
+++ b/specs/types/integer-overflow.md
@@ -67,10 +67,10 @@ const s = Saturating(255u8) + Saturating(1)     // Saturating(255)
 | `.saturating_add(b)` | `T` | Saturating add |
 | `.saturating_sub(b)` | `T` | Saturating subtract |
 | `.saturating_mul(b)` | `T` | Saturating multiply |
-| `.checked_add(b)` | `Option<T>` | `None` on overflow |
-| `.checked_sub(b)` | `Option<T>` | `None` on overflow |
-| `.checked_mul(b)` | `Option<T>` | `None` on overflow |
-| `.checked_div(b)` | `Option<T>` | `None` on zero |
+| `.checked_add(b)` | `T?` | `none` on overflow |
+| `.checked_sub(b)` | `T?` | `none` on overflow |
+| `.checked_mul(b)` | `T?` | `none` on overflow |
+| `.checked_div(b)` | `T?` | `none` on zero |
 | `.overflowing_add(b)` | `(T, bool)` | Result + overflow flag |
 | `.overflowing_sub(b)` | `(T, bool)` | Result + overflow flag |
 | `.overflowing_mul(b)` | `(T, bool)` | Result + overflow flag |

--- a/specs/types/primitives.md
+++ b/specs/types/primitives.md
@@ -53,7 +53,7 @@ const x: i8 = big_val as i8           // CV2: ERROR, narrowing
 |------|-----------|----------|
 | **CV5: Truncate** | `truncate to T` | Wrapping/bitwise truncation |
 | **CV6: Saturate** | `saturate to T` | Clamp to target range |
-| **CV7: Try convert** | `try convert to T` | `Option<T>`, `None` if out of range |
+| **CV7: Try convert** | `try convert to T` | `T?`, `none` if out of range |
 
 **Float to int:**
 
@@ -61,7 +61,7 @@ const x: i8 = big_val as i8           // CV2: ERROR, narrowing
 |------|-----------|----------|
 | **CV8: Float truncate** | `float to int T` | Truncate toward zero, panic on NaN/infinity |
 | **CV9: Float saturate** | `float to int T (saturating)` | Clamp to T.MIN/T.MAX, NaN → 0 |
-| **CV10: Float try** | `try float to int T` | `Option<T>` |
+| **CV10: Float try** | `try float to int T` | `T?` |
 
 ## `char` Type
 
@@ -71,7 +71,7 @@ const x: i8 = big_val as i8           // CV2: ERROR, narrowing
 |------|-------------|
 | **CH1: Valid range** | Code point in 0x0000–0xD7FF or 0xE000–0x10FFFF; surrogates excluded |
 | **CH2: Literal validation** | `'a'`, `'\n'`, `'\u{1F600}'` — compile-time validated |
-| **CH3: Runtime construction** | `char.from_u32(n)` returns `Option<char>` — `None` if invalid |
+| **CH3: Runtime construction** | `char.from_u32(n)` returns `char?` — `none` if invalid |
 | **CH4: Lossless to u32** | `c as u32` always succeeds |
 | **CH5: No direct cast from u32** | `n as char` is a compile error — use `char.from_u32(n)` |
 
@@ -171,7 +171,7 @@ mut port: u16 = header.port   // Native u16
 | Integer literal out of range | L1/L3 | Compile error |
 | Unsuffixed literal ambiguous | L1/L4 | Defaults to `i32` or `f64` |
 | `n as char` | CH5 | Compile error — use `char.from_u32(n)` |
-| Surrogate code point via `char.from_u32` | CH1/CH3 | Returns `None` |
+| Surrogate code point via `char.from_u32` | CH1/CH3 | Returns `none` |
 | `char.from_u32_unchecked` with invalid | CH1 | Unsafe — undefined behavior |
 | NaN in comparison | F2 | `NaN == NaN` is `false`, `NaN < x` is `false` |
 | Float-to-int with NaN | CV8 | Panics (use CV9 or CV10 for safe alternatives) |
@@ -193,7 +193,7 @@ FIX: Use an explicit conversion:
 
   const x: i8 = big_val truncate to i8    // wraps
   const x: i8 = big_val saturate to i8    // clamps
-  const x = try big_val convert to i8     // Option<i8>
+  const x = try big_val convert to i8     // i8?
 ```
 
 **Direct u32-to-char cast [CH5]:**
@@ -205,7 +205,7 @@ ERROR [type.primitives/CH5]: cannot cast u32 to char with `as`
 
 WHY: char must be a valid Unicode scalar value. Use runtime validation.
 
-FIX: const c = char.from_u32(n)   // returns Option<char>
+FIX: const c = char.from_u32(n)   // returns char?
 ```
 
 **Implicit int↔bool [BL3]:**
@@ -228,7 +228,7 @@ FIX: const flag: bool = n != 0
 
 **CV1–CV4 (as = lossless only):** `as` being lossless-only means you can read `x as i64` and know nothing was lost. Lossy conversions use named operations (`truncate`, `saturate`, `try convert`) that document intent. Consistent with the overflow philosophy in `type.integer-overflow`.
 
-**CH3 (runtime construction returns Option):** `char.from_u32(n)` returning `Option<char>` forces handling of invalid code points. The unsafe `char.from_u32_unchecked(n)` exists for performance-critical paths where validity is known.
+**CH3 (runtime construction returns `T?`):** `char.from_u32(n)` returning `char?` forces handling of invalid code points. The unsafe `char.from_u32_unchecked(n)` exists for performance-critical paths where validity is known.
 
 **E1–E3 (endian types):** Endian-explicit types make byte order visible in struct definitions without runtime overhead. The type system handles conversion at parse/build boundaries, so application code works with native types.
 

--- a/specs/types/sequence-protocol.md
+++ b/specs/types/sequence-protocol.md
@@ -111,7 +111,7 @@ func walk<T>(
     h: Handle<Node<T>>?,
     yield: |Node<T>| -> bool,
 ) -> bool {
-    if h is Some(handle) {
+    if h? as handle {
         if not walk(nodes, nodes[handle].left, yield): return false
         if not yield(nodes[handle]): return false
         if not walk(nodes, nodes[handle].right, yield): return false
@@ -135,15 +135,15 @@ struct Node<T> {
 extend Tree<T> {
     public func in_order(self) -> Sequence<Node<T>> {
         return |yield| {
-            if self.root is Some(r): walk(*r, yield)
+            if self.root? as r: walk(*r, yield)
         }
     }
 }
 
 func walk<T>(node: Node<T>, yield: |Node<T>| -> bool) -> bool {
-    if node.left is Some(l): if not walk(*l, yield): return false
+    if node.left? as l: if not walk(*l, yield): return false
     if not yield(node): return false
-    if node.right is Some(r): if not walk(*r, yield): return false
+    if node.right? as r: if not walk(*r, yield): return false
     return true
 }
 ```
@@ -158,11 +158,11 @@ extend Receiver<T> {
     public func stream(take self) -> Sequence<T> {
         return |yield| {
             loop {
-                const msg = match self.recv() {
-                    Ok(m) => m,
-                    Err(_) => break,
+                if self.recv()? as msg {
+                    if not yield(msg): break
+                } else {
+                    break
                 }
-                if not yield(msg): break
             }
         }
     }
@@ -219,7 +219,7 @@ Terminals drive the chain to completion (or short-circuit) and produce a value.
 | `collect()` | Materialize into a `Vec<T>` | `Vec<T>` |
 | `collect<C>()` | Materialize into `C: FromSequence<T>` | `C` |
 | `fold(init, f)` | Reduce with initial | `A` |
-| `reduce(f)` | Reduce without initial | `T?` (None if empty) |
+| `reduce(f)` | Reduce without initial | `T?` (`none` if empty) |
 | `sum()` | Sum items | `T where T: Numeric` |
 | `product()` | Multiply items | `T where T: Numeric` |
 | `count()` | Count items | `usize` |
@@ -251,20 +251,24 @@ const active = users.iter().filter(|u| u.active).collect()
 
 <!-- test: parse -->
 ```rask
-// Indexable (common case, zero-cost)
-for i in 0..min(a.len(), b.len()) {
-    process(a[i], b[i])
+func zip_indexable(a: Vec<i32>, b: Vec<i32>) {
+    // Indexable (common case, zero-cost)
+    for i in 0..min(a.len(), b.len()) {
+        process(a[i], b[i])
+    }
 }
 
-// Non-indexable (rare — explicit buffer shows the cost)
-const a_items = tree_a.in_order().collect()
-mut idx = 0
-tree_b.in_order()(|b_node| {
-    if idx >= a_items.len(): return false
-    process(a_items[idx], b_node)
-    idx += 1
-    return true
-})
+func zip_buffered(tree_a: Tree<Node>, tree_b: Tree<Node>) {
+    // Non-indexable (rare — explicit buffer shows the cost)
+    const a_items = tree_a.in_order().collect()
+    mut idx = 0
+    tree_b.in_order()(|b_node| {
+        if idx >= a_items.len(): return false
+        process(a_items[idx], b_node)
+        idx += 1
+        return true
+    })
+}
 ```
 
 ## Zero-Cost Contract
@@ -369,9 +373,9 @@ FIX: Use find() or capture via a local:
   const result = seq.find(|x| matches(x))
 
   // or
-  mut found: T? = None
+  mut found: T? = none
   for x in seq {
-      if matches(x) { found = Some(x); break }
+      if matches(x) { found = x; break }
   }
 ```
 
@@ -391,8 +395,8 @@ FIX: Use find() or capture via a local:
 | Sending a Sequence cross-task | SEQ-scope | Same rule as sending a closure (`mem.closures`) |
 | Infinite sequence with `.take(n)` | SEQ10 | Terminates after n yields |
 | Empty chain with `.sum()` | — | Zero value for the type |
-| Empty chain with `.reduce()` | — | None |
-| Empty chain with `.min()`/`.max()` | — | None |
+| Empty chain with `.reduce()` | — | `none` |
+| Empty chain with `.min()`/`.max()` | — | `none` |
 
 ---
 

--- a/specs/types/structs.md
+++ b/specs/types/structs.md
@@ -163,7 +163,7 @@ public struct Connection {
 extend Connection {
     public func new(addr: string) -> Connection or Error {
         const socket = try connect(addr)
-        Ok(Connection { socket, state: State.Connected })  // OK: inside extend block
+        return Connection { socket, state: State.Connected }  // OK: inside extend block
     }
 }
 ```
@@ -292,8 +292,8 @@ public struct User {
 
 extend User {
     func validate(self) -> () or Error {
-        if self.email.contains("@") { Ok(()) }
-        else { Err(Error.invalid("email")) }
+        if self.email.contains("@") { return }
+        return Error.invalid("email")
     }
 }
 ```
@@ -332,13 +332,13 @@ struct FileHandle {
 extend FileHandle {
     func open(path: string) -> FileHandle or Error {
         const fd = unsafe { libc.open(path.cstr(), O_RDONLY) }
-        if fd < 0 { return Err(Error.io()) }
-        Ok(FileHandle { fd })
+        if fd < 0 { return Error.io() }
+        return FileHandle { fd }
     }
 
     func close(take self) -> () or Error {
         unsafe { libc.close(self.fd) }
-        Ok(())
+        return
     }
 }
 ```

--- a/specs/types/traits.md
+++ b/specs/types/traits.md
@@ -173,10 +173,10 @@ extend Router {
     }
 
     func dispatch(self, req: Request) -> Response {
-        match self.routes.get(req.path) {
-            Some(handler) => handler.handle(req),
-            None => Response.not_found(),
+        if self.routes.get(req.path)? as handler {
+            return handler.handle(req)
         }
+        return Response.not_found()
     }
 }
 ```

--- a/specs/types/type-aliases.md
+++ b/specs/types/type-aliases.md
@@ -78,7 +78,7 @@ For shortening generic types and function signatures. The alias and underlying t
 ```rask
 type alias Matrix = Vec<Vec<f64>>
 type alias Callback<T> = func(T) -> bool
-type alias Result<T> = T or AppError
+type alias AppResult<T> = T or AppError
 type alias Handler = func(i32) -> string
 ```
 
@@ -206,7 +206,7 @@ type Email = string with (Equal, Hashable, Debug)
 
 extend Email {
     func parse(raw: string) -> Email or ValidationError {
-        if !raw.contains("@"): return Err(ValidationError.invalid("email", raw))
+        if !raw.contains("@"): return ValidationError.invalid("email", raw)
         return Email(raw)
     }
 }

--- a/specs/types/union-types.md
+++ b/specs/types/union-types.md
@@ -91,8 +91,8 @@ func transform<T, E>(result: T or E) -> U or (E | TransformError)
 ```
 ERROR [type.unions/U1]: union types only allowed in error position
    |
-3  |  let x: int | string = ...
-   |         ^^^^^^^^^^^^ use an explicit enum for data modeling
+3  |  const x: int | string = ...
+   |           ^^^^^^^^^^^^ use an explicit enum for data modeling
 
 WHY: General union types add subtyping complexity. Use enums instead.
 


### PR DESCRIPTION
Second pass over the spec after the Option/Result redesign. Focused on
code examples across stdlib, memory, control, concurrency, types,
tooling, structure, compiler, and analysis docs.

Type surface:
- `Option<T>` → `T?` throughout (return types, struct fields,
  signatures).
- `Result<T, E>` → `T or E`. One user-visible alias renamed
  (`type alias Result<T>` → `AppResult<T>`) since `Result` is no longer
  a builtin name.
- `compiler/name-mangling.md` picks mangle tokens for the new builtin
  sums (`Opt[T]`, `Or[T,E]`) — aspirational; compiler team can rename
  if the implementation uses different tokens.
- `memory/atomics.md` now names the error side of CAS as
  `CasFailed<T>`. The old `T or T` signature violated ER3
  (disjointness).

Construction sites:
- `return Ok(v)` → `return v`; `return Err(e)` → `return e` in every
  function returning `T or E`. Auto-wrap at return does the work.
- `return Ok(())` → bare `return` in `() or E` functions.
- `Some(v)` as a value → bare; `return None` → `return none`;
  `break Some(i)` → `break i`; `break None` → `break none`.

Matching / narrowing:
- `if x is Some(v)` → `if x? as v`; `if x is Ok(v)` → `if x? as v`;
  `if !x.is_ok()` rewrites to `else as e` branches where appropriate.
- `match r { Ok(v) => …, Err(e) => … }` → `if r? as v { … } else as e
  { … }` where it reads better; multi-error matches use type patterns
  (`T as v`, `ErrType as e`).
- Variant destructuring preserved where it's clearer
  (`JoinError.Panicked(msg) => …`).

Reference prose:
- `structure/modules.md` BI1 builtin list drops `Result`, `Option`,
  `Ok`, `Err`, `Some`, `None` and notes that `T?` and `T or E` are
  builtin sugar without a nominal name. BI4 fallback example updated.
- `tooling/lint.md`, `tooling/warnings.md`, `structure/{build,c-interop,
  targets}.md`, `analysis/complexity-stress-test.md`, `compiler/{codegen,
  effects,sequence-implementation,stdlib-audit,advanced-analyses,
  semantic-hash-caching}.md` — surface-level prose and examples updated.
- `control/comptime.md` CT45 row renamed ("Result support" → "Error-type
  support"); the safe_divide example gets a proper DivError enum since
  `i32 or string` violates ER4.

let/mut cleanup:
- Remaining `let total = 0`/`let b = StringBuilder.new()`/`let files:
  Vec<File> = …`/`let counter: i32 = 0` rewritten as `mut` or `const`
  depending on context.
- `control/control-flow.md` DS2 row renamed "Let destructuring" →
  "Mut destructuring"; the guard-pattern section title and CF13
  diagnostic text updated; the "let v = x is Ok else" cheat-sheet row
  rewritten for the `T or E` narrowing form.

Parse-test repairs:
- `memory/borrowing.md` — `(string, string)?` return type doesn't
  parse; introduced a `type alias Header = (string, string)` so the
  example uses `Header?`.
- `memory/closures.md` — the `mut total = 0` + `|item, mutate total|`
  example is split into a parse-tested function (params) and a
  skipped block (mutable capture). The parser treats `|mutate x|` as
  a parameter needing a type, not a capture — there's a pre-existing
  CP3/parser mismatch, flagged via `test: skip` until the parser
  catches up.
- `types/sequence-protocol.md` — zip example wrapped in functions so
  `mut idx = 0` isn't at top level.
- `concurrency/async.md` — restored variant-destructure form
  `JoinError.Panicked(msg) => …` per ER28.

HTTP `resp.is_ok()` kept as-is (it's the Response status-class check,
not the removed Result method). Left alone: `rejected-features.md`,
`error-model-redesign-proposal.md`, Rust-pseudocode blocks in
`concurrency/{runtime,io-context}.md` and
`compiler/test-infrastructure.md`, and the Rust-comparison column in
`canonical-patterns.md`.

Spec parse test goes from 4 pre-existing failures to 2 — the remaining
ones are a parser placeholder issue (`...` lexed as `..`) and the
`type alias` grammar gap, both implementation concerns rather than
spec drift