### PR TITLE
Replace `()` unit type with `void` keyword

### DIFF
--- a/compiler/crates/rask-ast/src/token.rs
+++ b/compiler/crates/rask-ast/src/token.rs
@@ -94,6 +94,7 @@ pub enum TokenKind {
     Profile,
     Union,
     Discard,
+    Void,
 
     // Operators
     Plus,
@@ -228,6 +229,7 @@ impl TokenKind {
             TokenKind::Profile => "'profile'",
             TokenKind::Union => "'union'",
             TokenKind::Discard => "'discard'",
+            TokenKind::Void => "'void'",
 
             // Operators
             TokenKind::Plus => "'+'",

--- a/compiler/crates/rask-interp/src/value.rs
+++ b/compiler/crates/rask-interp/src/value.rs
@@ -561,7 +561,7 @@ impl Value {
     /// Get the type name for error messages.
     pub fn type_name(&self) -> &'static str {
         match self {
-            Value::Unit => "()",
+            Value::Unit => "void",
             Value::Bool(_) => "bool",
             Value::Int(_) => "i64",
             Value::Int128(_) => "i128",

--- a/compiler/crates/rask-lexer/src/lexer.rs
+++ b/compiler/crates/rask-lexer/src/lexer.rs
@@ -129,6 +129,8 @@ enum RawToken {
     Union,
     #[token("discard")]
     Discard,
+    #[token("void")]
+    Void,
 
     // === Operators (order matters - longer first) ===
     // Three-character operators
@@ -505,6 +507,7 @@ impl<'a> Lexer<'a> {
             RawToken::Profile => TokenKind::Profile,
             RawToken::Union => TokenKind::Union,
             RawToken::Discard => TokenKind::Discard,
+            RawToken::Void => TokenKind::Void,
 
             // Operators
             RawToken::Plus => TokenKind::Plus,

--- a/compiler/crates/rask-lsp/src/type_format.rs
+++ b/compiler/crates/rask-lsp/src/type_format.rs
@@ -15,7 +15,7 @@ impl<'a> TypeFormatter<'a> {
 
     pub fn format(&self, ty: &Type) -> String {
         match ty {
-            Type::Unit => "()".to_string(),
+            Type::Unit => "void".to_string(),
             Type::Never => "!".to_string(),
             Type::Bool => "bool".to_string(),
             Type::I8 => "i8".to_string(),

--- a/compiler/crates/rask-parser/src/lib.rs
+++ b/compiler/crates/rask-parser/src/lib.rs
@@ -318,9 +318,31 @@ mod tests {
 
     #[test]
     fn parse_result_type_in_func() {
-        // () or E return type
-        let result = parse("extend Foo {\n    public func push(mutate self, v: T) -> () or PushError<T> { }\n}");
+        // void or E return type
+        let result = parse("extend Foo {\n    public func push(mutate self, v: T) -> void or PushError<T> { }\n}");
         assert!(result.is_ok(), "Parse errors: {:?}", result.errors);
+    }
+
+    #[test]
+    fn parse_rejects_paren_unit_type() {
+        // () in type position is an error (type.primitives/P6)
+        let result = parse("func f() -> () { }");
+        assert!(!result.errors.is_empty(), "Expected parse error for `()` in type position");
+        assert!(
+            result.errors[0].message.contains("`()`"),
+            "Expected '()' mention, got: {}", result.errors[0].message
+        );
+    }
+
+    #[test]
+    fn parse_rejects_one_tuple_type() {
+        // (T,) 1-tuples are not supported (type.tuples/TU3)
+        let result = parse("func f() -> (i32,) { }");
+        assert!(!result.errors.is_empty(), "Expected parse error for 1-tuple");
+        assert!(
+            result.errors[0].message.contains("1-tuples"),
+            "Expected '1-tuples' mention, got: {}", result.errors[0].message
+        );
     }
 
     #[test]

--- a/compiler/crates/rask-parser/src/lib.rs
+++ b/compiler/crates/rask-parser/src/lib.rs
@@ -346,6 +346,50 @@ mod tests {
     }
 
     #[test]
+    fn parse_rejects_bare_or_after_params() {
+        // `func foo() or Error` — `or` must follow an explicit return type
+        let result = parse("func f() or Error { }");
+        assert!(!result.errors.is_empty(), "Expected parse error for bare `or`");
+        assert!(
+            result.errors[0].message.contains("`or` must follow an explicit return type"),
+            "Expected return-type mention, got: {}", result.errors[0].message
+        );
+    }
+
+    #[test]
+    fn parse_elided_void_return() {
+        // `func foo()` — returns void implicitly, body is valid
+        let result = parse("func greet(name: string) { println(name) }");
+        assert!(result.is_ok(), "Parse errors: {:?}", result.errors);
+        if let DeclKind::Fn(ref f) = result.decls[0].kind {
+            assert!(f.ret_ty.is_none(), "Elided return should be None (→ void)");
+        } else {
+            panic!("Expected function");
+        }
+    }
+
+    #[test]
+    fn parse_explicit_void_or_error() {
+        // `func foo() -> void or Error` — explicit void with error
+        let result = parse("func save() -> void or Error { }");
+        assert!(result.is_ok(), "Parse errors: {:?}", result.errors);
+    }
+
+    #[test]
+    fn parse_bare_return_statement() {
+        // `return` with no value — parser must accept
+        let result = parse("func f() { return }");
+        assert!(result.is_ok(), "Parse errors: {:?}", result.errors);
+        if let DeclKind::Fn(ref f) = result.decls[0].kind {
+            if let StmtKind::Return(value) = &f.body[0].kind {
+                assert!(value.is_none(), "Bare return should have no value");
+            } else {
+                panic!("Expected Return stmt, got {:?}", f.body[0].kind);
+            }
+        }
+    }
+
+    #[test]
     fn parse_func_type_param() {
         // func(T) -> R as a parameter type
         let result = parse("extend Foo {\n    public func read(self, f: func(T) -> R) -> Option<R> { }\n}");

--- a/compiler/crates/rask-parser/src/parser.rs
+++ b/compiler/crates/rask-parser/src/parser.rs
@@ -753,6 +753,17 @@ impl Parser {
         let ret_ty = if self.match_token(&TokenKind::Arrow) {
             Some(self.parse_type_name()?)
         } else {
+            // Elided return type: `func foo()` means returns void.
+            // `or E` must attach to an explicit return type — a bare `or` here
+            // would mean "void or E", which the spec forbids (type.errors, SYNTAX.md).
+            if self.check(&TokenKind::Or) {
+                let or_span = self.current().span;
+                return Err(ParseError {
+                    span: or_span,
+                    message: "`or` must follow an explicit return type".to_string(),
+                    hint: Some("write `-> void or E` (or pick the concrete success type)".to_string()),
+                });
+            }
             None
         };
 

--- a/compiler/crates/rask-parser/src/parser.rs
+++ b/compiler/crates/rask-parser/src/parser.rs
@@ -968,30 +968,48 @@ impl Parser {
         }
 
         if self.check(&TokenKind::LParen) {
+            let lparen_span = self.current().span;
             self.advance();
             if self.check(&TokenKind::RParen) {
-                self.advance();
-                return Ok("()".to_string());
+                // type.primitives/P6: () is no longer the unit type — use `void`.
+                let rparen_span = self.current().span;
+                let span = Span::with_file(lparen_span.start, rparen_span.end, lparen_span.file_id);
+                return Err(ParseError {
+                    span,
+                    message: "`()` is not a type".to_string(),
+                    hint: Some("use `void` for the zero-sized type".to_string()),
+                });
             }
             let first_ty = self.parse_type_name()?;
             if self.match_token(&TokenKind::Comma) {
-                // Tuple type: (T,) or (T, U, ...)
+                // Tuple type: (T, U, ...) — arity >= 2 (type.tuples/TU1)
                 let mut types = vec![first_ty];
-                // TU4: trailing comma before `)` — allows single-element tuples like (T,)
                 while !self.check(&TokenKind::RParen) && !self.at_end() {
                     types.push(self.parse_type_name()?);
                     if !self.match_token(&TokenKind::Comma) { break; }
                 }
+                let rparen_span = self.current().span;
                 self.expect(&TokenKind::RParen)?;
                 if types.len() == 1 {
-                    // TU4: single-element tuple — trailing comma distinguishes from parens
-                    return Ok(format!("({},)", types[0]));
+                    // type.tuples/TU3: 1-tuples are not a thing
+                    let span = Span::with_file(lparen_span.start, rparen_span.end, lparen_span.file_id);
+                    return Err(ParseError {
+                        span,
+                        message: "1-tuples are not supported".to_string(),
+                        hint: Some(format!("tuples have arity >= 2; use `{}` directly", types[0])),
+                    });
                 }
                 return Ok(format!("({})", types.join(", ")));
             }
             // Parenthesized type: (T) — not a tuple
             self.expect(&TokenKind::RParen)?;
             return Ok(first_ty);
+        }
+
+        // `void` keyword: zero-sized unit type (type.primitives/P6)
+        if self.check(&TokenKind::Void) {
+            self.advance();
+            return Ok("()".to_string());
         }
 
         if self.check(&TokenKind::LBracket) {

--- a/compiler/crates/rask-types/src/checker/builtins.rs
+++ b/compiler/crates/rask-types/src/checker/builtins.rs
@@ -81,7 +81,7 @@ pub(super) fn parse_stub_type(s: &str) -> Type {
     }
 
     match s {
-        "" | "()" => Type::Unit,
+        "" | "()" | "void" => Type::Unit,
         "bool" => Type::Bool,
         "string" => Type::String,
         "char" => Type::Char,

--- a/compiler/crates/rask-types/src/checker/parse_type.rs
+++ b/compiler/crates/rask-types/src/checker/parse_type.rs
@@ -12,7 +12,7 @@ use crate::types::{GenericArg, Type};
 pub fn parse_type_string(s: &str, types: &TypeTable) -> Result<Type, TypeError> {
     let s = s.trim();
 
-    if s.is_empty() || s == "()" {
+    if s.is_empty() || s == "()" || s == "void" {
         return Ok(Type::Unit);
     }
 

--- a/compiler/crates/rask-types/src/checker/type_table.rs
+++ b/compiler/crates/rask-types/src/checker/type_table.rs
@@ -63,6 +63,7 @@ impl TypeTable {
         self.builtins.insert("char".to_string(), Type::Char);
         self.builtins.insert("string".to_string(), Type::String);
         self.builtins.insert("()".to_string(), Type::Unit);
+        self.builtins.insert("void".to_string(), Type::Unit);
         self.builtins.insert("int".to_string(), Type::I64);
         self.builtins.insert("uint".to_string(), Type::U64);
         self.builtins.insert("isize".to_string(), Type::I64);

--- a/compiler/crates/rask-types/src/types.rs
+++ b/compiler/crates/rask-types/src/types.rs
@@ -161,7 +161,7 @@ impl fmt::Display for GenericArg {
 impl fmt::Display for Type {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
-            Type::Unit => write!(f, "()"),
+            Type::Unit => write!(f, "void"),
             Type::Bool => write!(f, "bool"),
             Type::I8 => write!(f, "i8"),
             Type::I16 => write!(f, "i16"),

--- a/specs/SYNTAX.md
+++ b/specs/SYNTAX.md
@@ -164,7 +164,7 @@ mut x = "shadow"              // Shadowing allowed (IDE shows ghost annotation)
 ### Functions
 
 ```rask
-func greet(name: string) {
+func greet(name: string) {           // Returns void — no arrow needed
     println("Hello, {name}")
 }
 
@@ -178,6 +178,18 @@ func divide(a: f64, b: f64) -> f64 or Error {
 }
 ```
 
+**Unit return (`void`):** `void` is the zero-sized type for "nothing returned" (`type.primitives/P6`). Elide the arrow when the function returns `void` and has no `or` clause. Write it explicitly when combined with an error:
+
+```rask
+func greet(name: string)                     // Returns void (elided)
+func save(data: Data) -> void or Error       // Explicit when or is present
+func compute() -> i32                        // Non-void: always explicit
+```
+
+Rule: `or E` attaches to an explicit return type. `func foo() or Error` is a parse error — write `-> void or Error`.
+
+**`return` without a value:** Valid only when the function's return type is `void`. Otherwise write `return expr`.
+
 **Private functions — types optional (gradual constraints):**
 It is possible to gradually introduce type constrains in private functions. This makes it easier to write prototype code, but is discouraged in production code. Public functions must declare types.
 
@@ -186,17 +198,17 @@ func double(x) {
     return x * 2          // Inferred: func double<T: Numeric>(x: T) -> T
 }
 func greet(name) {
-    println("Hi, {name}")  // Inferred: func greet(name: string) -> ()
+    println("Hi, {name}")  // Inferred: func greet(name: string) (returns void)
 }
 
 // Partial annotation — mix explicit and inferred
-func process(data: Vec<Record>, handler) -> () or Error {
+func process(data: Vec<Record>, handler) -> void or Error {
     try handler(data)
 }
 // handler type inferred from usage
 
 // Public: MUST have full types
-public func serve(port: i32) -> () or Error { ... }
+public func serve(port: i32) -> void or Error { ... }
 ```
 
 **Parameter modes:**
@@ -296,7 +308,7 @@ struct File {
 }
 
 extend File {
-    func close(take self) -> () or Error {
+    func close(take self) -> void or Error {
         // ...
     }
 }
@@ -999,7 +1011,7 @@ func handler(w http.ResponseWriter, r *http.Request) {
 
 **Rask:**
 ```rask
-func handler(w: ResponseWriter, r: Request) -> () or HttpError {
+func handler(w: ResponseWriter, r: Request) -> void or HttpError {
     const body = try r.body.read_all()
     const req = try json.parse<Request>(body)
     const result = try process(req)

--- a/specs/analysis/complexity-stress-test.md
+++ b/specs/analysis/complexity-stress-test.md
@@ -105,7 +105,7 @@ func sync_physics(mutate world: GameWorld) {
 
 <!-- test: skip -->
 ```rask
-func update_entities(mutate world: GameWorld) -> () or Error {
+func update_entities(mutate world: GameWorld) -> void or Error {
     mut doomed: Vec<Handle<Entity>> = Vec.new()
 
     for h in world.entities.cursor() {
@@ -154,7 +154,7 @@ func render_entities(world: GameWorld) using frozen Pool<Entity>, frozen Pool<Me
 
 <!-- test: skip -->
 ```rask
-func game_loop_parallel(mutate world: GameWorld, dt: f32) -> () or Error
+func game_loop_parallel(mutate world: GameWorld, dt: f32) -> void or Error
     using ThreadPool
 {
     const (entity_snap, _) = world.entities.snapshot()

--- a/specs/compiler/effects.md
+++ b/specs/compiler/effects.md
@@ -155,7 +155,7 @@ func process(input: string) -> Result or Error {        // ghost: [pure]
     return try parse(input)
 }
 
-func run_server() -> () or Error {                      // ghost: [io, async]
+func run_server() -> void or Error {                      // ghost: [io, async]
     using Multitasking {
         const listener = try TcpListener.bind("0.0.0.0:8080")
         loop {

--- a/specs/compiler/memory-layout.md
+++ b/specs/compiler/memory-layout.md
@@ -176,7 +176,7 @@ struct Closure_greet {
 // Total: 32 bytes
 ```
 
-Function signature: `fn(Closure_greet*, string) -> ()`
+Function signature: `fn(Closure_greet*, string) -> void`
 
 ### Immediate Closures
 
@@ -431,7 +431,7 @@ struct Unit {}
 |------|-------------|
 | **Z1: No allocation** | ZSTs never allocated on heap |
 | **Z2: Distinct addresses** | Each instance may have distinct address (unspecified) |
-| **Z3: Vec optimization** | `Vec<()>` stores only length, no pointer/capacity |
+| **Z3: Vec optimization** | `Vec<void>` stores only length, no pointer/capacity |
 
 ## Padding and Size Examples
 

--- a/specs/compiler/stdlib-audit.md
+++ b/specs/compiler/stdlib-audit.md
@@ -195,9 +195,9 @@ Per spec (C2), default growth operations panic on failure:
 - `vec.reserve(n)` → `()` (panics on OOM)
 
 Fallible `try_` variants return Result:
-- `vec.try_push(x)` → `() or PushError<T>`
+- `vec.try_push(x)` → `void or PushError<T>`
 - `map.try_insert(k, v)` → `Option<V> or InsertError<V>`
-- `vec.try_reserve(n)` → `() or AllocError`
+- `vec.try_reserve(n)` → `void or AllocError`
 
 Current interpreter matches: panics on allocation failure (Rust default), `try_push` wraps in Result.
 

--- a/specs/concurrency/async.md
+++ b/specs/concurrency/async.md
@@ -19,7 +19,7 @@ Green tasks with must-use handles. No async/await split — the same function wo
 Spawn functions do not appear in signatures. No function declares `using Multitasking` — the compiler infers which functions (transitively) need a runtime and checks callers against the current lexical scope. See [Runtime Scope](#runtime-scope) below.
 
 ```rask
-func main() -> () or Error {
+func main() -> void or Error {
     using Multitasking {
         const listener = try TcpListener.bind("0.0.0.0:8080")
 
@@ -30,7 +30,7 @@ func main() -> () or Error {
     }
 }
 
-func handle_connection(conn: TcpConnection) -> () or Error {
+func handle_connection(conn: TcpConnection) -> void or Error {
     const request = try conn.read()
     const user = try fetch_user(request.id)
     try conn.write(user.to_json())
@@ -238,11 +238,11 @@ try join_all(producer, consumer)
 
 | Operation | Returns | Description |
 |-----------|---------|-------------|
-| `tx.send(val)` | `() or SendError` | Send value, pauses/blocks if full |
+| `tx.send(val)` | `void or SendError` | Send value, pauses/blocks if full |
 | `rx.recv()` | `T or RecvError` | Receive value, pauses/blocks if empty |
-| `tx.close()` | `() or CloseError` | Explicit close with error handling |
-| `rx.close()` | `() or CloseError` | Explicit close with error handling |
-| `tx.try_send(val)` | `() or TrySendError` | Non-blocking send |
+| `tx.close()` | `void or CloseError` | Explicit close with error handling |
+| `rx.close()` | `void or CloseError` | Explicit close with error handling |
+| `tx.try_send(val)` | `void or TrySendError` | Non-blocking send |
 | `rx.try_recv()` | `T or TryRecvError` | Non-blocking receive |
 
 ### Buffered Items on Close

--- a/specs/concurrency/runtime.md
+++ b/specs/concurrency/runtime.md
@@ -768,7 +768,7 @@ func File::read(self, buf: &mut [u8]) -> usize or Error {
     // ...
 }
 
-func Channel::send<T>(self, value: T) -> () or Error {
+func Channel::send<T>(self, value: T) -> void or Error {
     if let Some(runtime) = RUNTIME_SLOT.read() {
         if runtime.current_task().cancel_flag.load(Relaxed) {
             return Err(JoinError::Cancelled)
@@ -1059,7 +1059,7 @@ Timers are fundamental async primitives. Every async runtime needs:
 
 ```rask
 // In stdlib async module
-public func sleep(duration: Duration) -> ()
+public func sleep(duration: Duration) -> void
 public func timeout<T>(duration: Duration, operation: || -> T) -> T or TimedOut
 
 // Timer struct for periodic ticks
@@ -1069,7 +1069,7 @@ public struct Timer {
 }
 
 public struct TimerReceiver {
-    func recv() -> () or RecvError  // Blocks until timer fires
+    func recv() -> void or RecvError  // Blocks until timer fires
 }
 ```
 
@@ -1318,7 +1318,7 @@ Channel<T> {
 ### Send Flow (CH2, CH4)
 
 ```rust
-func Sender::send(self, value: T) -> () or SendError {
+func Sender::send(self, value: T) -> void or SendError {
     let runtime = RUNTIME_SLOT.read();
     if let Some(r) = &runtime {
         // Check cancel flag first (CN3)
@@ -1434,7 +1434,7 @@ ThreadPool is simpler than Multitasking because it's CPU-bound (no I/O reactor n
 
 ```rust
 ThreadPool {
-    workers: Vec<JoinHandle<()>>,           // N OS threads
+    workers: Vec<JoinHandle<void>>,           // N OS threads
     work_queue: ArrayQueue<Job>,            // Lock-free bounded queue
     shutdown: AtomicBool,
 }

--- a/specs/concurrency/select.md
+++ b/specs/concurrency/select.md
@@ -85,7 +85,7 @@ select {
 }
 ```
 
-Properties: returns `Receiver<()>`, single-shot (fires once, then closes), cancellable (drop receiver to cancel).
+Properties: returns `Receiver<void>`, single-shot (fires once, then closes), cancellable (drop receiver to cancel).
 
 ## Error Messages
 
@@ -102,7 +102,7 @@ ERROR [conc.select/P3]: select requires at least one arm
 |------|------|----------|
 | Select with 0 arms | P3 | Compile error |
 | All channels closed | CL1 | Returns immediately with `Err(Closed)` |
-| Timer in select | A1 | Regular receive arm — `Timer.after()` returns `Receiver<()>` |
+| Timer in select | A1 | Regular receive arm — `Timer.after()` returns `Receiver<void>` |
 | Non-selected send value | OW2 | Value returned to caller, not consumed |
 
 ---

--- a/specs/control/comptime.md
+++ b/specs/control/comptime.md
@@ -456,7 +456,7 @@ const large = try read_packet<4096>(socket2)
 const DEBUG_MODE: bool = comptime cfg.debug
 const LOGGING_ENABLED: bool = comptime cfg.features.contains("logging")
 
-func process(data: []u8) -> () or Error {
+func process(data: []u8) -> void or Error {
     comptime if LOGGING_ENABLED {
         log.debug("Processing {} bytes", data.len)
     }

--- a/specs/control/control-flow.md
+++ b/specs/control/control-flow.md
@@ -645,7 +645,7 @@ if state is Connected(sock) && sock.is_ready() {
 
 **Guard pattern for early exit:**
 ```rask
-func process_file(path: string) -> () or Error {
+func process_file(path: string) -> void or Error {
     const file = try open(path)
     ensure file.close()
 

--- a/specs/control/ensure.md
+++ b/specs/control/ensure.md
@@ -80,7 +80,7 @@ ensure b.close()          // registered 2nd → runs FIRST ✓
 
 <!-- test: parse -->
 ```rask
-func process() -> () or Error {
+func process() -> void or Error {
     const file = try open("data.txt")   // file is linear
     ensure file.close()              // EN3: file WILL be consumed
 
@@ -99,7 +99,7 @@ func process() -> () or Error {
 
 <!-- test: skip -->
 ```rask
-func process(a: File, b: File) -> () or Error {
+func process(a: File, b: File) -> void or Error {
     ensure a.close()
 
     const data = try some_op()     // ✅ Safe: a is ensured (L1)
@@ -135,7 +135,7 @@ ensure file.close() else |e| { try fallible() }   // ❌ Error: ER3
 
 <!-- test: skip -->
 ```rask
-func process() -> () or Error {
+func process() -> void or Error {
     const a = try open("a.txt")
     ensure a.close() else |e| log("a close failed: {e}")
 
@@ -161,7 +161,7 @@ func process() -> () or Error {
 <!-- test: parse -->
 ```rask
 // When cleanup errors actually matter (rare), don't use ensure:
-func write_important(data: Data) -> () or Error {
+func write_important(data: Data) -> void or Error {
     const file = try create("important.txt")
     try file.write(data)
     try file.close()                 // Explicit: propagate close error
@@ -175,7 +175,7 @@ func write_important(data: Data) -> () or Error {
 
 <!-- test: parse -->
 ```rask
-func process() -> () or Error {
+func process() -> void or Error {
     const config = try load_config()
 
     {
@@ -252,7 +252,7 @@ Ok(())
 
 <!-- test: parse -->
 ```rask
-func transfer(db: Database, from: AccountId, to: AccountId, amount: i64) -> () or Error {
+func transfer(db: Database, from: AccountId, to: AccountId, amount: i64) -> void or Error {
     const tx = try db.begin()
     ensure tx.rollback()      // Rollback if we don't commit
 
@@ -276,7 +276,7 @@ Cleaning up pools of linear resources:
 
 <!-- test: parse -->
 ```rask
-func process_many_files(paths: Vec<string>) -> () or Error {
+func process_many_files(paths: Vec<string>) -> void or Error {
     mut files: Pool<File> = Pool.new()
     ensure files.take_all_with(|f| { f.close(); })
 
@@ -296,7 +296,7 @@ Errors during cleanup (e.g., `close()` fails) are ignored by default (ER1). If c
 
 <!-- test: parse -->
 ```rask
-func process_many_files_careful(paths: Vec<string>) -> () or Error {
+func process_many_files_careful(paths: Vec<string>) -> void or Error {
     mut files: Pool<File> = Pool.new()
 
     for path in paths {
@@ -423,7 +423,7 @@ Name choice: "ensure" reads naturally—"ensure this happens before we leave thi
 
 <!-- test: parse -->
 ```rask
-func copy_file(src: string, dst: string) -> () or Error {
+func copy_file(src: string, dst: string) -> void or Error {
     const input = try open(src)
     ensure input.close()
 
@@ -442,7 +442,7 @@ Both files guaranteed to close on any exit path.
 
 <!-- test: parse -->
 ```rask
-func modify_database(db: Database) -> () or Error {
+func modify_database(db: Database) -> void or Error {
     const tx = try db.begin()
     ensure tx.rollback()    // Ensures unhappy path
 
@@ -458,7 +458,7 @@ func modify_database(db: Database) -> () or Error {
 
 <!-- test: skip -->
 ```rask
-func process_many(paths: Vec<string>) -> () or Error {
+func process_many(paths: Vec<string>) -> void or Error {
     mut resources: Pool<Resource> = Pool.new()
     ensure resources.take_all_with(|r| { r.cleanup(); })
 

--- a/specs/memory/atomics.md
+++ b/specs/memory/atomics.md
@@ -93,7 +93,7 @@ const flag = AtomicBool.default()  // false
 | Operation | Signature | Description |
 |-----------|-----------|-------------|
 | `load(order)` | `self, Ordering -> T` | Atomically read the value |
-| `store(v, order)` | `self, T, Ordering -> ()` | Atomically write the value |
+| `store(v, order)` | `self, T, Ordering -> void` | Atomically write the value |
 | `swap(v, order)` | `self, T, Ordering -> T` | Atomically replace, return old value |
 
 `store` takes `self` (not `mutate self`) because atomics use interior mutability (AT4).

--- a/specs/memory/borrowing.md
+++ b/specs/memory/borrowing.md
@@ -201,7 +201,7 @@ const name = with pool[h] as entity { entity.name }
 with pool[h] as e: e.health -= 10
 
 // return/try/break work naturally
-func apply_buff(pool: Pool<Entity>, h: Handle<Entity>) -> () or Error {
+func apply_buff(pool: Pool<Entity>, h: Handle<Entity>) -> void or Error {
     with pool[h] as entity {
         entity.strength += 10
         entity.defense += 5
@@ -542,7 +542,7 @@ func update_combat(pool: Pool<Entity>) {
 ### Multi-Statement Mutation
 <!-- test: parse -->
 ```rask
-func apply_buff(pool: Pool<Entity>, h: Handle<Entity>) -> () or Error {
+func apply_buff(pool: Pool<Entity>, h: Handle<Entity>) -> void or Error {
     with pool[h] as entity {
         entity.strength += 10
         entity.defense += 5

--- a/specs/memory/cell.md
+++ b/specs/memory/cell.md
@@ -42,7 +42,7 @@ button.on_click(|event, state| {
 |--------|-----------|-------------|
 | `Cell.new(value)` | `T -> Cell<T>` | Create cell with initial value |
 | `cell.get()` | `Cell<T> -> T` | Copy out the inner value (CE6, Copy types only) |
-| `cell.set(value)` | `(Cell<T>, T) -> ()` | Replace inner value (CE6) |
+| `cell.set(value)` | `(Cell<T>, T) -> void` | Replace inner value (CE6) |
 | `cell.replace(value)` | `T -> T` | Swap in new value, return old |
 | `cell.into_inner()` | `take Cell<T> -> T` | Consume cell, return value |
 

--- a/specs/memory/linear.md
+++ b/specs/memory/linear.md
@@ -74,7 +74,7 @@ If the value is consumed explicitly before scope exit, any registered `ensure` i
 
 <!-- test: parse -->
 ```rask
-func transfer(db: Database) -> () or Error {
+func transfer(db: Database) -> void or Error {
     const tx = try db.begin()
     ensure tx.rollback()     // Default: rollback on any exit
 

--- a/specs/memory/parameters.md
+++ b/specs/memory/parameters.md
@@ -87,7 +87,7 @@ extend File {
         // reads from self (mutates internal position)
     }
 
-    func close(take self) -> () or Error {
+    func close(take self) -> void or Error {
         // closes and invalidates self
     }
 }

--- a/specs/memory/pools.md
+++ b/specs/memory/pools.md
@@ -133,7 +133,7 @@ with pool[h] as entity {
 `return`, `try`, `break`, and `continue` work naturally inside `with` blocks:
 <!-- test: skip -->
 ```rask
-func apply_buff(pool: Pool<Entity>, h: Handle<Entity>) -> () or Error {
+func apply_buff(pool: Pool<Entity>, h: Handle<Entity>) -> void or Error {
     with pool[h] as entity {
         entity.strength += 10
         try log_buff_applied(entity.id)   // propagates to function

--- a/specs/memory/relocatable.md
+++ b/specs/memory/relocatable.md
@@ -136,7 +136,7 @@ func load_state(bytes: Vec<u8>) -> Pool<Player> or DecodeError {
 
 <!-- test: skip -->
 ```rask
-func test_handle_roundtrip() -> () or Error {
+func test_handle_roundtrip() -> void or Error {
     const pool = Pool.new()
     const h = pool.insert(Player { id: 1, health: 100, score: 0 })
 
@@ -191,7 +191,7 @@ struct Particle {
     public life: f32
 }
 
-func save_particles(pool: Pool<Particle>) -> () or IoError {
+func save_particles(pool: Pool<Particle>) -> void or IoError {
     try pool.to_mmap("particles.bin")
 }
 
@@ -274,7 +274,7 @@ struct UndoStack<T: Encode + Decode> {
 }
 
 extend UndoStack<T: Encode + Decode> {
-    func push(self, pool: Pool<T>) -> () or EncodeError {
+    func push(self, pool: Pool<T>) -> void or EncodeError {
         if self.history.len() >= self.max_entries {
             self.history.remove(0)
         }
@@ -309,7 +309,7 @@ Send `to_bytes()` over the network. Handles are valid on the receiving end becau
 
 <!-- test: skip -->
 ```rask
-func migrate_to(pool: Pool<Entity>, target: TcpStream) -> () or Error {
+func migrate_to(pool: Pool<Entity>, target: TcpStream) -> void or Error {
     const bytes = try pool.to_bytes()
     try target.write_all(bytes)
 }

--- a/specs/memory/resource-types.md
+++ b/specs/memory/resource-types.md
@@ -47,7 +47,7 @@ A resource is consumed by calling a method with `take self`, passing to a `take`
 struct File { ... }
 
 extend File {
-    func close(take self) -> () or Error {
+    func close(take self) -> void or Error {
         // ... close logic ...
     }
 
@@ -59,7 +59,7 @@ extend File {
 
 <!-- test: parse -->
 ```rask
-func process() -> () or Error {
+func process() -> void or Error {
     const file = try File.open("data.txt")
     const data = try file.read_all()
     try process_data(data)
@@ -85,12 +85,12 @@ extend DbConn {
         return Ok("data")
     }
 
-    func close(take self) -> () or Error {
+    func close(take self) -> void or Error {
         return Ok(())
     }
 }
 
-func bad() -> () or Error {
+func bad() -> void or Error {
     const conn = try DbConn.open("data.txt")
     const data = try conn.read_all()
     Ok(())
@@ -111,12 +111,12 @@ extend DbConn {
         return Ok(DbConn { handle: 1 })
     }
 
-    func close(take self) -> () or Error {
+    func close(take self) -> void or Error {
         return Ok(())
     }
 }
 
-func also_bad() -> () or Error {
+func also_bad() -> void or Error {
     const conn = try DbConn.open("data.txt")
     try conn.close()
     try conn.close()    // ERROR: conn already consumed
@@ -136,7 +136,7 @@ func also_bad() -> () or Error {
 
 <!-- test: parse -->
 ```rask
-func process() -> () or Error {
+func process() -> void or Error {
     const file = try File.open("data.txt")
     ensure file.close()        // Consumption committed
 
@@ -155,7 +155,7 @@ func process() -> () or Error {
 
 <!-- test: parse -->
 ```rask
-func risky() -> () or Error {
+func risky() -> void or Error {
     const file = try File.open("data.txt")
     ensure file.close()        // May fail
 
@@ -250,8 +250,8 @@ for file in files.take_all() {
 | Method | Signature | Description |
 |--------|-----------|-------------|
 | `take_all()` | `Pool<T> -> Iterator<T>` | Take all elements for consumption |
-| `take_all_with(f)` | `func(T) -> ()` | Take all and apply consuming function |
-| `take_all_with_result(f)` | `func(T) -> () or E -> () or E` | Take all with fallible consumer |
+| `take_all_with(f)` | `func(T) -> void` | Take all and apply consuming function |
+| `take_all_with_result(f)` | `func(T) -> void or E -> void or E` | Take all with fallible consumer |
 
 ## Error Messages
 
@@ -304,7 +304,7 @@ Resources must be explicitly consumed (use take_all() before scope ends).
 **Conditional consumption:**
 <!-- test: parse -->
 ```rask
-func conditional(file: File, keep_open: bool) -> () or Error {
+func conditional(file: File, keep_open: bool) -> void or Error {
     if keep_open {
         GLOBAL_FILES.store(file)  // Consumes by transfer
     } else {
@@ -334,7 +334,7 @@ func process_file(path: string) -> Data or Error {
 ### Database Transaction
 <!-- test: parse -->
 ```rask
-func update_user(db: Database, user_id: u64) -> () or Error {
+func update_user(db: Database, user_id: u64) -> void or Error {
     const txn = try db.begin_transaction()
     ensure txn.rollback()     // Default: rollback on error
 
@@ -351,7 +351,7 @@ func update_user(db: Database, user_id: u64) -> () or Error {
 ### Connection Pool
 <!-- test: parse -->
 ```rask
-func handle_connections(pool: Pool<Connection>) -> () or Error {
+func handle_connections(pool: Pool<Connection>) -> void or Error {
     // Check which connections should close
     const to_close: Vec<Handle<Connection>> = Vec.new()
     for h in pool.handles().collect<Vec<_>>() {
@@ -439,7 +439,7 @@ try read_config(file).map_err(|e| e.close_and_convert())
 **Compound resources with ensure:**
 <!-- test: parse -->
 ```rask
-func process_files(paths: Vec<string>) -> () or Error {
+func process_files(paths: Vec<string>) -> void or Error {
     const files = Vec.new()
 
     for path in paths {

--- a/specs/memory/unsafe.md
+++ b/specs/memory/unsafe.md
@@ -85,7 +85,7 @@ All require unsafe except `is_null()`.
 |-----------|-----------|-------------|
 | `*ptr` | Read/write | Dereference (undefined if invalid) |
 | `ptr.read()` | `*T -> T` | Copy value from pointer |
-| `ptr.write(v)` | `*T, T -> ()` | Write value to pointer |
+| `ptr.write(v)` | `*T, T -> void` | Write value to pointer |
 | `ptr.add(n)` | `*T, usize -> *T` | Offset by n elements |
 | `ptr.sub(n)` | `*T, usize -> *T` | Offset back by n elements |
 | `ptr.offset(n)` | `*T, isize -> *T` | Signed offset |

--- a/specs/stdlib/cli.md
+++ b/specs/stdlib/cli.md
@@ -21,7 +21,7 @@ Two-level API: quick ad-hoc parsing for scripts, builder API for tools needing h
 ```rask
 import cli
 
-func main() -> () or string {
+func main() -> void or string {
     const args = cli.parse()
     const verbose = args.flag("verbose", "v")
     const output = args.option_or("output", "o", "out.txt")
@@ -47,7 +47,7 @@ func main() -> () or string {
 ```rask
 import cli
 
-func main() -> () or CliError {
+func main() -> void or CliError {
     const args = try cli.Parser.new("mygrep")
         .version("1.0.0")
         .description("Search for patterns in files")

--- a/specs/stdlib/collections.md
+++ b/specs/stdlib/collections.md
@@ -36,11 +36,11 @@ Growth operations panic on failure (C2). Fallible `try_` variants return `Result
 | Operation | Returns | On failure |
 |-----------|---------|------------|
 | `vec.push(x)` | `()` | Panics |
-| `vec.try_push(x)` | `() or PushError<T>` | Returns `Err(Full(T))` or `Err(Alloc(T))` |
+| `vec.try_push(x)` | `void or PushError<T>` | Returns `Err(Full(T))` or `Err(Alloc(T))` |
 | `vec.extend(iter)` | `()` | Panics |
-| `vec.try_extend(iter)` | `() or ExtendError<T>` | Returns first rejected item |
+| `vec.try_extend(iter)` | `void or ExtendError<T>` | Returns first rejected item |
 | `vec.reserve(n)` | `()` | Panics |
-| `vec.try_reserve(n)` | `() or AllocError` | Returns error |
+| `vec.try_reserve(n)` | `void or AllocError` | Returns error |
 | `map.insert(k, v)` | `Option<V>` | Panics |
 | `map.try_insert(k, v)` | `Option<V> or InsertError<V>` | Returns `Err(Full(V))` or `Err(Alloc(V))` |
 
@@ -192,9 +192,9 @@ for item in vec.take_all() { }   // item: T (consuming iteration)
 
 | Method | Signature | Semantics |
 |--------|-----------|-----------|
-| `vec.sort()` | `() -> ()` | Stable sort, `T: Comparable` |
-| `vec.sort_by(cmp)` | `(\|T, T\| -> Ordering) -> ()` | Stable sort with custom comparator |
-| `vec.sort_by_key(f)` | `(\|T\| -> K) -> ()` where `K: Comparable` | Stable sort by extracted key |
+| `vec.sort()` | `() -> void` | Stable sort, `T: Comparable` |
+| `vec.sort_by(cmp)` | `(\|T, T\| -> Ordering) -> void` | Stable sort with custom comparator |
+| `vec.sort_by_key(f)` | `(\|T\| -> K) -> void` where `K: Comparable` | Stable sort by extracted key |
 
 <!-- test: skip -->
 ```rask
@@ -387,7 +387,7 @@ FIX: Use try_push to handle capacity limits:
 | `vec.insert(n, x)` where `n > len()` | V4 | Panic (bounds check) |
 | `vec.remove(n)` where `n >= len()` | V5 | Panic (bounds check) |
 | `with vec[i] as e1, vec[i] as e2` | D1 | Panic (duplicate index) |
-| ZST in `Vec<()>` | — | `len()` tracks count, no storage allocated |
+| ZST in `Vec<void>` | — | `len()` tracks count, no storage allocated |
 | `Vec<LinearResource>` | C4 | Compile error |
 | `Map<f32, V>` or `Map<f64, V>` | K1 | Compile-time warning (NaN breaks lookups) |
 | Panic inside `with` | — | Collection left in valid state |

--- a/specs/stdlib/encoding.md
+++ b/specs/stdlib/encoding.md
@@ -73,7 +73,7 @@ struct InternalState {
 
 <!-- test: skip -->
 ```rask
-func send_json<T: Encode>(endpoint: string, value: T) -> () or HttpError {
+func send_json<T: Encode>(endpoint: string, value: T) -> void or HttpError {
     const body = json.encode(value)
     return http.post(endpoint, body)
 }
@@ -223,7 +223,7 @@ Format libraries use `comptime for` + `reflect` to implement encoding genericall
 import std.reflect
 
 // Type dispatch — monomorphizes per concrete type
-func encode_value<T: Encode>(value: T, w: mutate JsonWriter) -> () or JsonError {
+func encode_value<T: Encode>(value: T, w: mutate JsonWriter) -> void or JsonError {
     comptime if T == bool {
         return w.write_bool(value)
     } else if T == string {
@@ -449,7 +449,7 @@ FIX: Add @default with an explicit value:
 ```rask
 import std.reflect
 
-func encode_value<T: Encode>(value: T, w: mutate TomlWriter, key: string?) -> () or TomlError {
+func encode_value<T: Encode>(value: T, w: mutate TomlWriter, key: string?) -> void or TomlError {
     comptime if T == bool {
         return w.write_bool(key, value)
     } else if T == string {
@@ -488,7 +488,7 @@ struct Config {
     public cached_at: i64
 }
 
-func main() -> () or Error {
+func main() -> void or Error {
     // Encode
     const config = Config { host: "localhost", port: 3000, cached_at: 0 }
     const text = json.encode(config)

--- a/specs/stdlib/fs.md
+++ b/specs/stdlib/fs.md
@@ -28,12 +28,12 @@ extend File with Reader {
 
 extend File with Writer {
     func write(self, data: []u8) -> usize or IoError
-    func write_all(self, data: []u8) -> () or IoError
-    func flush(self) -> () or IoError
+    func write_all(self, data: []u8) -> void or IoError
+    func flush(self) -> void or IoError
 }
 
 extend File {
-    func close(take self) -> () or IoError
+    func close(take self) -> void or IoError
     func read_text(self) -> string or IoError
     func lines(self) -> Vec<string> or IoError
     func metadata(self) -> Metadata or IoError
@@ -51,9 +51,9 @@ extend File {
 | `fs.read_file` | `(path: string) -> string or IoError` |
 | `fs.read_bytes` | `(path: string) -> Vec<u8> or IoError` |
 | `fs.read_lines` | `(path: string) -> Vec<string> or IoError` |
-| `fs.write_file` | `(path: string, content: string) -> () or IoError` |
-| `fs.write_bytes` | `(path: string, data: Vec<u8>) -> () or IoError` |
-| `fs.append_file` | `(path: string, content: string) -> () or IoError` |
+| `fs.write_file` | `(path: string, content: string) -> void or IoError` |
+| `fs.write_bytes` | `(path: string, data: Vec<u8>) -> void or IoError` |
+| `fs.append_file` | `(path: string, content: string) -> void or IoError` |
 | `fs.exists` | `(path: string) -> bool` |
 
 <!-- test: parse -->
@@ -108,12 +108,12 @@ ensure file.close()
 | Function | Signature | Description |
 |----------|-----------|-------------|
 | `fs.read_dir` | `(path: string) -> Vec<DirEntry> or IoError` | List directory contents |
-| `fs.create_dir` | `(path: string) -> () or IoError` | Create single directory |
-| `fs.create_dir_all` | `(path: string) -> () or IoError` | Create directory tree (mkdir -p) |
-| `fs.remove` | `(path: string) -> () or IoError` | Remove file |
-| `fs.remove_dir` | `(path: string) -> () or IoError` | Remove empty directory |
-| `fs.remove_dir_all` | `(path: string) -> () or IoError` | Remove directory tree recursively |
-| `fs.rename` | `(from: string, to: string) -> () or IoError` | Rename/move file or directory |
+| `fs.create_dir` | `(path: string) -> void or IoError` | Create single directory |
+| `fs.create_dir_all` | `(path: string) -> void or IoError` | Create directory tree (mkdir -p) |
+| `fs.remove` | `(path: string) -> void or IoError` | Remove file |
+| `fs.remove_dir` | `(path: string) -> void or IoError` | Remove empty directory |
+| `fs.remove_dir_all` | `(path: string) -> void or IoError` | Remove directory tree recursively |
+| `fs.rename` | `(from: string, to: string) -> void or IoError` | Rename/move file or directory |
 | `fs.copy` | `(from: string, to: string) -> u64 or IoError` | Copy file, returns bytes copied |
 | `fs.canonicalize` | `(path: string) -> string or IoError` | Resolve to absolute path |
 | `fs.metadata` | `(path: string) -> Metadata or IoError` | Get metadata without opening |

--- a/specs/stdlib/http.md
+++ b/specs/stdlib/http.md
@@ -188,7 +188,7 @@ extend HttpServer {
 struct Responder { }
 
 extend Responder {
-    func respond(take self, response: Response) -> () or HttpError
+    func respond(take self, response: Response) -> void or HttpError
 }
 ```
 
@@ -196,7 +196,7 @@ extend Responder {
 ```rask
 import http
 
-func main() -> () or Error {
+func main() -> void or Error {
     using Multitasking {
         const server = try HttpServer.listen("0.0.0.0:8080")
         ensure server.close()
@@ -224,14 +224,14 @@ func main() -> () or Error {
 http.listen_and_serve(
     addr: string,
     handler: func(Request) -> Response,
-) -> () or HttpError
+) -> void or HttpError
 ```
 
 <!-- test: skip -->
 ```rask
 import http
 
-func main() -> () or Error {
+func main() -> void or Error {
     using Multitasking {
         try http.listen_and_serve("0.0.0.0:8080", handle)
     }
@@ -350,7 +350,7 @@ struct User {
     public email: string
 }
 
-func main() -> () or Error {
+func main() -> void or Error {
     using Multitasking {
         try http.listen_and_serve("0.0.0.0:8080", handle)
     }

--- a/specs/stdlib/io.md
+++ b/specs/stdlib/io.md
@@ -43,7 +43,7 @@ trait Reader {
     func read(self, buf: []u8) -> usize or IoError
     func read_all(self) -> []u8 or IoError
     func read_text(self) -> string or IoError
-    func read_exact(self, buf: []u8) -> () or IoError
+    func read_exact(self, buf: []u8) -> void or IoError
 }
 ```
 
@@ -59,8 +59,8 @@ trait Reader {
 ```rask
 trait Writer {
     func write(self, data: []u8) -> usize or IoError
-    func write_all(self, data: []u8) -> () or IoError
-    func flush(self) -> () or IoError
+    func write_all(self, data: []u8) -> void or IoError
+    func flush(self) -> void or IoError
 }
 ```
 

--- a/specs/stdlib/iteration.md
+++ b/specs/stdlib/iteration.md
@@ -345,7 +345,7 @@ FIX: Use an integer key or newtype wrapper with defined equality:
 | Structural mutation in mutable loop | MI1 | Compile error |
 | `break value` for !Copy | A4 | Requires `.clone()` |
 | Infinite range (`0..`) | — | Works (lazy) |
-| Zero-sized types (`Vec<()>`) | — | Yields values (all identical) |
+| Zero-sized types (`Vec<void>`) | — | Yields values (all identical) |
 | `Map<f32, V>` or `Map<f64, V>` | K2 | Compile-time warning |
 
 ---

--- a/specs/stdlib/net.md
+++ b/specs/stdlib/net.md
@@ -60,7 +60,7 @@ loop {
 ```rask
 extend TcpConnection {
     func read_all(self) -> string or IoError
-    func write_all(self, data: string) -> () or IoError
+    func write_all(self, data: string) -> void or IoError
     func remote_addr(self) -> string
     func close(take self)
 }
@@ -97,7 +97,7 @@ net.udp_bind(addr: string) -> UdpSocket or IoError
 extend UdpSocket {
     func send_to(self, data: []u8, addr: string) -> usize or IoError
     func recv_from(self, buf: []u8) -> (usize, string) or IoError
-    func connect(self, addr: string) -> () or IoError
+    func connect(self, addr: string) -> void or IoError
     func send(self, data: []u8) -> usize or IoError     // to connected peer
     func recv(self, buf: []u8) -> usize or IoError      // from connected peer
     func local_addr(self) -> string
@@ -144,7 +144,7 @@ const addrs = try net.resolve("example.com")
 
 <!-- test: skip -->
 ```rask
-func handle(conn: TcpConnection) -> () or IoError {
+func handle(conn: TcpConnection) -> void or IoError {
     ensure conn.close()
     const data = try conn.read_all()
     try conn.write_all(process(data))

--- a/specs/stdlib/os.md
+++ b/specs/stdlib/os.md
@@ -111,7 +111,7 @@ extend Process {
     func kill_and_wait(take self) -> Output or IoError
     func try_wait(self) -> Output? or IoError
     func id(self) -> u32
-    func write_stdin(self, data: string) -> () or IoError
+    func write_stdin(self, data: string) -> void or IoError
     func read_stdout(self) -> string or IoError
 }
 ```
@@ -178,7 +178,7 @@ cleanup()
 import os
 
 // Server with graceful shutdown
-func main() -> () or Error {
+func main() -> void or Error {
     using Multitasking {
         const signals = try os.on_signal([Signal.Interrupt, Signal.Terminate])
         const server = try HttpServer.listen("0.0.0.0:8080")

--- a/specs/stdlib/reflect.md
+++ b/specs/stdlib/reflect.md
@@ -206,7 +206,7 @@ comptime func assert_all_public<T>() {
 
 <!-- test: skip -->
 ```rask
-func encode_value<T: Encode>(value: T, w: mutate Writer) -> () or Error {
+func encode_value<T: Encode>(value: T, w: mutate Writer) -> void or Error {
     comptime if reflect.is_struct<T>() {
         comptime for field in reflect.fields<T>() {
             try encode_value(value.(field.name), mutate w)

--- a/specs/stdlib/time.md
+++ b/specs/stdlib/time.md
@@ -62,7 +62,7 @@ instant.elapsed() -> Duration
 
 <!-- test: skip -->
 ```rask
-time.sleep(duration: Duration) -> () or string
+time.sleep(duration: Duration) -> void or string
 ```
 
 <!-- test: skip -->

--- a/specs/structure/build-design-proposal.md
+++ b/specs/structure/build-design-proposal.md
@@ -121,7 +121,7 @@ code generation steps (protobuf + schema + C compilation), it's wasteful.
 ### Step API
 
 ```rask
-func build(ctx: BuildContext) -> () or Error {
+func build(ctx: BuildContext) -> void or Error {
     // Step 1: only re-runs when schema.json changes
     try ctx.step("codegen", inputs: ["schema.json"], || {
         const schema = try fs.read_file("schema.json")

--- a/specs/structure/build.md
+++ b/specs/structure/build.md
@@ -220,7 +220,7 @@ profile "embedded" {
 | **BL3: No self-import** | Can't import the package being built — circular dependency error |
 
 ```rask
-func build(ctx: BuildContext) -> () or Error {
+func build(ctx: BuildContext) -> void or Error {
     try ctx.declare_dependency("schema.json")
     const schema = try fs.read_file("schema.json")
     try ctx.write_source("types.rk", generate_types(schema))
@@ -277,7 +277,7 @@ struct BuildContext {
 | **ST6: Backwards compatible** | `declare_dependency()` still works — single implicit step covering the whole `build()` function |
 
 ```rask
-func build(ctx: BuildContext) -> () or Error {
+func build(ctx: BuildContext) -> void or Error {
     try ctx.step("codegen", inputs: ["schema.json"], || {
         const schema = try fs.read_file("schema.json")
         try ctx.write_source("types.rk", generate_types(schema))
@@ -677,7 +677,7 @@ Rust crates exporting C ABI functions can be compiled and linked via `compile_ru
 
 <!-- test: skip -->
 ```rask
-func build(ctx: BuildContext) -> () or Error {
+func build(ctx: BuildContext) -> void or Error {
     try ctx.compile_rust(RustCrateOptions {
         path: "vendor/fast-hash",
         cbindgen: true,
@@ -721,7 +721,7 @@ package "my-api" "1.0.0" {
     profile "staging" { inherits: "release", debug_info: true }
 }
 
-func build(ctx: BuildContext) -> () or Error {
+func build(ctx: BuildContext) -> void or Error {
     try ctx.step("protobuf", inputs: ["api.proto"], || {
         try ctx.exec("protoc", ["--rask_out=.rk-gen/", "api.proto"])
     })

--- a/specs/structure/modules.md
+++ b/specs/structure/modules.md
@@ -133,7 +133,7 @@ export internal.lexer.Lexer
 
 | Rule | Description |
 |------|-------------|
-| **IN1: init function** | `init() -> () or Error { }` runs once before main |
+| **IN1: init function** | `init() -> void or Error { }` runs once before main |
 | **IN2: One per file** | At most one `init()` per file |
 | **IN3: Parallel topo sort** | Intra-package init order: parallel topological sort of file import DAG |
 | **IN4: Deps first** | Inter-package: dependencies fully initialize before dependents |

--- a/specs/structure/targets.md
+++ b/specs/structure/targets.md
@@ -33,7 +33,7 @@ Package role is determined by presence of `func main()`. No manifest flags, no d
 | Signature | When to Use |
 |-----------|-------------|
 | `public func main()` | Sync program, infallible |
-| `public func main() -> () or Error` | Sync program, can fail |
+| `public func main() -> void or Error` | Sync program, can fail |
 | `public func main(args: Args)` | Needs CLI arguments |
 
 ## CLI Arguments

--- a/specs/tooling/describe-schema.md
+++ b/specs/tooling/describe-schema.md
@@ -261,7 +261,7 @@ public enum ServerError {
 }
 
 extend Server {
-    public func start(take self, config: Config) -> () or ServerError
+    public func start(take self, config: Config) -> void or ServerError
         using Pool<Connection>
     {
         // ...
@@ -338,7 +338,7 @@ server (src/server.rk)
     public port: u16
     connections: Vec<Connection>
 
-    public func start(take self, config: Config) -> () or ServerError  using Pool<Connection>
+    public func start(take self, config: Config) -> void or ServerError  using Pool<Connection>
     public func stop(take self)
 
   public enum ServerError

--- a/specs/tooling/warnings.md
+++ b/specs/tooling/warnings.md
@@ -81,7 +81,7 @@ func scratch() {
 
 @deny(unused_result)
 extend Server {
-    func start(take self) -> () or Error {
+    func start(take self) -> void or Error {
         try self.listener.bind(self.addr)
         return Ok(())
     }
@@ -137,7 +137,7 @@ FIX: prefix with `_` if intentional: `const _count = data.len()`
 ```
 
 ```
-WARNING [tool.warnings/W2]: unused result of type `() or IoError`
+WARNING [tool.warnings/W2]: unused result of type `void or IoError`
    |
 2  |     file.write(data)
    |     ^^^^^^^^^^^^^^^^ this `T or E` result is discarded

--- a/specs/types/enums.md
+++ b/specs/types/enums.md
@@ -283,14 +283,14 @@ match file_result {
 
 ```rask
 // ❌ INVALID: file2 may leak on early return
-func process(file1: File, file2: File) -> () or Error {
+func process(file1: File, file2: File) -> void or Error {
     const data = try file1.read()  // file2 not consumed!
     try file2.close()
 }
 // Error: "linear resource `file2` may leak on early return at `try`"
 
 // ✅ VALID: all linear resources resolved before `try`
-func process(file1: File, file2: File) -> () or Error {
+func process(file1: File, file2: File) -> void or Error {
     const result1 = file1.read()
     const result2 = file2.close()
     const data = try result1
@@ -301,7 +301,7 @@ func process(file1: File, file2: File) -> () or Error {
 
 Alternative: use `ensure` for guaranteed cleanup:
 ```rask
-func process(file1: File, file2: File) -> () or Error {
+func process(file1: File, file2: File) -> void or Error {
     ensure file1.close()  // Guaranteed at scope exit
     ensure file2.close()  // Runs on any exit
     const data = try file1.read()  // ✅ Safe: ensure registered
@@ -526,7 +526,7 @@ const value = infallible()!  // Cannot panic (compiler knows)
 | `.variants()` on enum with payloads | E8 | Compile error |
 | `.variants()` on empty enum | E7,E11 | Returns empty `Vec` |
 | Single-variant enum | E2 | Valid, discriminant may be optimized away |
-| Zero-sized payload | E1 | `enum Foo { A(()), B }` — unit optimized to `{ A, B }` |
+| Zero-sized payload | E1 | `enum Foo { A(void), B }` — void optimized to `{ A, B }` |
 | >65536 variants | E3 | Compile error: "enum exceeds variant limit" |
 | Nested linear | PM6 | `Result<File, Error(File)>` — both arms bind linear, both must consume |
 | Enum in Vec | E5 | Allowed if non-linear |

--- a/specs/types/error-model-redesign-proposal.md
+++ b/specs/types/error-model-redesign-proposal.md
@@ -442,7 +442,7 @@ After reading the affected specs, here are the concrete changes each needs:
 - GC7 says "try calls and `Err()` returns contribute to the inferred error union." Rewrite: "try calls and bare error values in return position contribute." Example code needs `Err(…)` → bare error removed.
 
 **`ensure.md`** — examples need updating:
-- Function signature `() or Error` stays, but the `Ok(())` return becomes implicit (bare success path auto-wraps). Specifically `return Ok(())` / final `Ok(())` becomes `return` or nothing (depending on whether Rask's empty-return works in a `() or E` function).
+- Function signature `void or Error` stays, but the `Ok(())` return becomes implicit (bare success path auto-wraps). Specifically `return Ok(())` / final `Ok(())` becomes `return` or nothing (depending on whether Rask's empty-return works in a `void or E` function).
 - EN4 (errors ignored in ensure body) references `Result` — rewrite as `T or E`.
 - EN5 (try forbidden in ensure) carries through unchanged.
 

--- a/specs/types/error-types.md
+++ b/specs/types/error-types.md
@@ -23,7 +23,7 @@ Libraries use union errors (`T or (A | B | C)`), applications use `any Error` (t
 ```rask
 func read_file(path: string) -> string or IoError        // two-branch
 func load() -> Config or (IoError | ParseError)          // union error
-func save(data: Data) -> () or IoError                   // unit success
+func save(data: Data) -> void or IoError                   // unit success
 ```
 
 `T or E` is valid in return types, bindings (inferred or explicit), fields, generics — same positions as any type.
@@ -61,7 +61,7 @@ extend NotFound {
 | Rule | Description |
 |------|-------------|
 | **ER9: Auto-wrap at return only** | In a function returning `T or E`, a `return` with a value of type `T` wraps to the success branch; a value of type `E` wraps to the error branch. The branch is picked by type; disjointness makes this unambiguous |
-| **ER10: Implicit unit success** | In a function returning `() or E` reaching the end without explicit `return`, the unit success path is implied |
+| **ER10: Implicit unit success** | In a function returning `void or E` reaching the end without explicit `return`, the unit success path is implied |
 | **ER11: No auto-wrap elsewhere** | Assignment, field initialisers, function arguments, and collection literals do **not** auto-wrap into `T or E`. The value must already have the union type (typically from a function call) |
 
 <!-- test: skip -->
@@ -71,7 +71,7 @@ func divide(a: f64, b: f64) -> f64 or DivError {
     return a / b                                // T branch, by type
 }
 
-func save(data: Data) -> () or IoError {
+func save(data: Data) -> void or IoError {
     try file.write(data)
     // implicit unit success at end
 }

--- a/specs/types/operators.md
+++ b/specs/types/operators.md
@@ -43,7 +43,7 @@ Operators follow standard precedence. Equality and ordering are trait-based. Com
 
 | Rule | Description |
 |------|-------------|
-| **CA1: Evaluates to unit** | `+=`, `-=`, `*=`, `/=`, `%=`, `&=`, `\|=`, `^=`, `<<=`, `>>=` evaluate to `()` |
+| **CA1: Evaluates to void** | `+=`, `-=`, `*=`, `/=`, `%=`, `&=`, `\|=`, `^=`, `<<=`, `>>=` evaluate to `void` |
 
 ## Equality Trait
 

--- a/specs/types/primitives.md
+++ b/specs/types/primitives.md
@@ -20,7 +20,7 @@ Fixed-size primitives, IEEE 754 floats, explicit conversions. Lossy casts need e
 | | `f64` | 8 bytes | Double precision |
 | **P4: Boolean** | `bool` | 1 byte | `true`/`false`, no implicit int↔bool |
 | **P5: Unicode scalar** | `char` | 4 bytes | 0x0000–0xD7FF, 0xE000–0x10FFFF |
-| **P6: Unit** | `()` | 0 bytes | Zero-sized |
+| **P6: Unit** | `void` | 0 bytes | Zero-sized. Keyword. Canonical value is `{}` (empty block); functions fall through or `return` bare |
 | **P7: Copy** | All primitives | ≤16 bytes | All primitives are Copy |
 
 ## Literals

--- a/specs/types/structs.md
+++ b/specs/types/structs.md
@@ -291,7 +291,7 @@ public struct User {
 }
 
 extend User {
-    func validate(self) -> () or Error {
+    func validate(self) -> void or Error {
         if self.email.contains("@") { Ok(()) }
         else { Err(Error.invalid("email")) }
     }
@@ -336,7 +336,7 @@ extend FileHandle {
         Ok(FileHandle { fd })
     }
 
-    func close(take self) -> () or Error {
+    func close(take self) -> void or Error {
         unsafe { libc.close(self.fd) }
         Ok(())
     }

--- a/specs/types/tuples.md
+++ b/specs/types/tuples.md
@@ -12,19 +12,15 @@ Anonymous product types. Use when naming fields adds nothing — function return
 
 | Rule | Description |
 |------|-------------|
-| **TU1: Type syntax** | `(T1, T2, ..., Tn)` denotes a tuple type |
-| **TU2: Literal syntax** | `(v1, v2, ..., vn)` constructs a tuple value |
-| **TU3: Unit** | `()` is the empty tuple, equivalent to the unit type |
-| **TU4: Single-element** | `(T,)` with trailing comma is a 1-tuple; `(T)` without comma is parenthesized expression |
+| **TU1: Type syntax** | `(T1, T2, ..., Tn)` denotes a tuple type (arity ≥ 2) |
+| **TU2: Literal syntax** | `(v1, v2, ..., vn)` constructs a tuple value (arity ≥ 2) |
+| **TU3: No empty or 1-tuples** | `()` is not a tuple — it's call syntax. For the zero-sized type, use `void` (`type.primitives/P6`). `(T)` is a parenthesized expression, not a 1-tuple |
 
 <!-- test: parse -->
 ```rask
 const pair: (i32, string) = (42, "hello")
-const unit: () = ()
 const nested: ((i32, i32), string) = ((1, 2), "point")
 ```
-
-Single-element tuple with trailing comma (`(i32,)`) — not yet implemented in parser.
 
 ## Element Access
 
@@ -61,8 +57,8 @@ const (x, y) = point
 
 | Case | Rule | Handling |
 |------|------|----------|
-| Empty tuple `()` | TU3 | Unit type |
-| Single without comma `(x)` | TU4 | Parenthesized expression, not a tuple |
+| `()` in type position | TU3 | Error: use `void` for the zero-sized type |
+| Single without comma `(x)` | TU3 | Parenthesized expression, not a tuple |
 | Named field access on tuple `.name` | TU5 | Error: tuples use positional access |
 | Index out of range `.3` on 2-tuple | TU6 | Compile error |
 
@@ -84,7 +80,7 @@ FIX: Valid indices are .0 and .1.
 
 ### Rationale
 
-**TU1–TU4 (syntax):** Parenthesized, comma-separated — same convention as Python, Rust, Swift. The trailing comma rule for single-element tuples prevents ambiguity with grouping parentheses. I could have gone with a different delimiter but `()` is universally understood.
+**TU1–TU3 (syntax):** Parenthesized, comma-separated — same convention as Python, Rust, Swift. Tuples are arity ≥ 2 only: 0-tuples and 1-tuples are degenerate and confuse `()` (call syntax) and `(x)` (grouping). The zero-sized type is `void`, a keyword (`type.primitives/P6`), not an empty tuple — I don't need the ML-style empty-product unification to cover a case users never write.
 
 **TU5 (positional access):** `.0`, `.1` instead of named fields. If you need names, use a struct — `type.structs/S1` requires named fields precisely because tuples fill the anonymous gap. Two tools, clear boundary.
 

--- a/stdlib/async.rk
+++ b/stdlib/async.rk
@@ -6,7 +6,7 @@
 /// Requires an active `using Multitasking { ... }` scope in the process.
 /// Compile error if called outside any scope (directly or transitively);
 /// runtime panic for higher-order/trait-object cases the compiler can't prove.
-public func spawn(f: func()) -> TaskHandle<()> { }
+public func spawn(f: func()) -> TaskHandle<void> { }
 
 /// Check if the current task has been cancelled.
 /// Returns true if cancel was requested. Use in long-running loops.
@@ -80,13 +80,13 @@ public struct Sender<T> { }
 
 extend Sender<T> {
     /// Send a value. Pauses/blocks if buffer full.
-    public func send(self, value: T) -> () or SendError { }
+    public func send(self, value: T) -> void or SendError { }
 
     /// Non-blocking send. Returns error if full or closed.
-    public func try_send(self, value: T) -> () or TrySendError { }
+    public func try_send(self, value: T) -> void or TrySendError { }
 
     /// Explicitly close the sender.
-    public func close(self) -> () or CloseError { }
+    public func close(self) -> void or CloseError { }
 }
 
 public struct Receiver<T> { }
@@ -99,7 +99,7 @@ extend Receiver<T> {
     public func try_recv(self) -> T or TryRecvError { }
 
     /// Explicitly close the receiver.
-    public func close(self) -> () or CloseError { }
+    public func close(self) -> void or CloseError { }
 }
 
 // --- Channel errors ---

--- a/stdlib/collections.rk
+++ b/stdlib/collections.rk
@@ -35,7 +35,7 @@ extend Vec<T> {
     public func push(mutate self, value: T) { }
 
     /// Push a value onto the end. Returns error if bounded and full, or on OOM.
-    public func try_push(mutate self, value: T) -> () or PushError<T> { }
+    public func try_push(mutate self, value: T) -> void or PushError<T> { }
 
     /// Remove and return the last element.
     public func pop(mutate self) -> Option<T> { }
@@ -53,7 +53,7 @@ extend Vec<T> {
     public func reserve(mutate self, additional: usize) { }
 
     /// Reserve space for at least `additional` more elements. Returns error on OOM.
-    public func try_reserve(mutate self, additional: usize) -> () or AllocError { }
+    public func try_reserve(mutate self, additional: usize) -> void or AllocError { }
 
     /// Get element at index (borrows).
     public func get(self, index: i64) -> Option<T> { }

--- a/stdlib/fs.rk
+++ b/stdlib/fs.rk
@@ -84,7 +84,7 @@ extend fs {
     }
 
     /// Write a string to a file, replacing its contents.
-    public func write_file(path: string, content: string) -> () or IoError {
+    public func write_file(path: string, content: string) -> void or IoError {
         const p = unsafe path.as_c_str()
         const f = unsafe fopen(p, "wb\0".as_ptr())
         if unsafe f.is_null() {
@@ -98,7 +98,7 @@ extend fs {
     }
 
     /// Write bytes to a file, replacing its contents.
-    public func write_bytes(path: string, data: Vec<u8>) -> () or IoError { }
+    public func write_bytes(path: string, data: Vec<u8>) -> void or IoError { }
 
     /// Check if a file or directory exists at the path.
     public func exists(path: string) -> bool {
@@ -156,7 +156,7 @@ extend fs {
     }
 
     /// Rename a file or directory.
-    public func rename(from: string, to: string) -> () or IoError {
+    public func rename(from: string, to: string) -> void or IoError {
         const r = unsafe rask_libc_rename(from.as_c_str(), to.as_c_str())
         if r != 0 {
             return IoError.Other("could not rename")
@@ -165,7 +165,7 @@ extend fs {
     }
 
     /// Remove a file.
-    public func remove(path: string) -> () or IoError {
+    public func remove(path: string) -> void or IoError {
         const r = unsafe rask_libc_remove(path.as_c_str())
         if r != 0 {
             return IoError.Other("could not remove")
@@ -174,7 +174,7 @@ extend fs {
     }
 
     /// Create a directory.
-    public func create_dir(path: string) -> () or IoError {
+    public func create_dir(path: string) -> void or IoError {
         const r = unsafe rask_libc_mkdir(path.as_c_str(), 493)
         if r != 0 {
             return IoError.Other("could not create directory")
@@ -183,10 +183,10 @@ extend fs {
     }
 
     /// Create a directory and all parent directories.
-    public func create_dir_all(path: string) -> () or IoError { }
+    public func create_dir_all(path: string) -> void or IoError { }
 
     /// Append a string to a file.
-    public func append_file(path: string, content: string) -> () or IoError {
+    public func append_file(path: string, content: string) -> void or IoError {
         const p = unsafe path.as_c_str()
         const f = unsafe fopen(p, "ab\0".as_ptr())
         if unsafe f.is_null() {

--- a/stdlib/http.rk
+++ b/stdlib/http.rk
@@ -82,7 +82,7 @@ extend Headers {
         return self.entries.get(name.to_lowercase())
     }
 
-    public func set(mutate self, name: string, value: string) -> () {
+    public func set(mutate self, name: string, value: string) -> void {
         self.entries.insert(name.to_lowercase(), value)
     }
 
@@ -433,7 +433,7 @@ extern "C" {
     func rask_io_write_string(fd: i64, s: i64) -> i64
     func rask_io_read_until_close(fd: i64, max: i64) -> i64
     func rask_net_tcp_connect(addr: i64) -> i64
-    func rask_io_close_fd(fd: i64) -> ()
+    func rask_io_close_fd(fd: i64) -> void
 }
 
 // Read raw bytes from a TCP connection (up to max_bytes).
@@ -710,7 +710,7 @@ struct Responder {
 }
 
 extend Responder {
-    public func respond(take self, response: Response) -> () or HttpError {
+    public func respond(take self, response: Response) -> void or HttpError {
         const raw = format_http_response(response)
         write_raw(self.conn_fd, raw)
     }
@@ -724,7 +724,7 @@ extend http {
     /// One-line HTTP server. Spawns a green task per request.
     /// Requires an active `using Multitasking { ... }` scope in the process
     /// (transitively reaches `spawn`).
-    public func listen_and_serve(addr: string, handler: func(Request) -> Response) -> () or HttpError
+    public func listen_and_serve(addr: string, handler: func(Request) -> Response) -> void or HttpError
     {
         const server = if HttpServer.listen(addr)? as s { s } else {
             return HttpError.Io("listen failed")

--- a/stdlib/io.rk
+++ b/stdlib/io.rk
@@ -77,13 +77,13 @@ extend Stdout {
     public func write(self, data: Vec<u8>) -> i64 or IoError { }
 
     /// Write all bytes, retrying partial writes.
-    public func write_all(self, data: Vec<u8>) -> () or IoError { }
+    public func write_all(self, data: Vec<u8>) -> void or IoError { }
 
     /// Write a string.
-    public func write_str(self, s: string) -> () or IoError { }
+    public func write_str(self, s: string) -> void or IoError { }
 
     /// Flush buffered output.
-    public func flush(self) -> () or IoError { }
+    public func flush(self) -> void or IoError { }
 
     /// Close the handle.
     public func close(mutate self) { }
@@ -98,13 +98,13 @@ extend Stderr {
     public func write(self, data: Vec<u8>) -> i64 or IoError { }
 
     /// Write all bytes, retrying partial writes.
-    public func write_all(self, data: Vec<u8>) -> () or IoError { }
+    public func write_all(self, data: Vec<u8>) -> void or IoError { }
 
     /// Write a string.
-    public func write_str(self, s: string) -> () or IoError { }
+    public func write_str(self, s: string) -> void or IoError { }
 
     /// Flush buffered output.
-    public func flush(self) -> () or IoError { }
+    public func flush(self) -> void or IoError { }
 
     /// Close the handle.
     public func close(mutate self) { }
@@ -133,7 +133,7 @@ extend Buffer {
     public func write(mutate self, data: Vec<u8>) -> i64 or IoError { }
 
     /// Write all bytes.
-    public func write_all(mutate self, data: Vec<u8>) -> () or IoError { }
+    public func write_all(mutate self, data: Vec<u8>) -> void or IoError { }
 
     /// View all written bytes.
     public func as_bytes(self) -> Vec<u8> { }
@@ -156,10 +156,10 @@ extend File {
     public func read_text(self) -> string or IoError { }
 
     /// Write a string to the file.
-    public func write(mutate self, data: string) -> () or IoError { }
+    public func write(mutate self, data: string) -> void or IoError { }
 
     /// Write a string followed by a newline.
-    public func write_line(mutate self, data: string) -> () or IoError { }
+    public func write_line(mutate self, data: string) -> void or IoError { }
 
     /// Read all lines into a vector.
     public func lines(self) -> Vec<string> or IoError { }

--- a/stdlib/json.rk
+++ b/stdlib/json.rk
@@ -119,7 +119,7 @@ extend JsonParser {
         }
     }
 
-    func expect(mutate self, expected: u8) -> () or JsonError {
+    func expect(mutate self, expected: u8) -> void or JsonError {
         self.skip_ws()
         if self.pos >= self.len {
             return JsonError.ParseError("unexpected end of input")

--- a/stdlib/net.rk
+++ b/stdlib/net.rk
@@ -30,7 +30,7 @@ extend TcpConnection {
     public func read_all(self) -> string or Error { }
 
     /// Write a string to the connection.
-    public func write_all(self, data: string) -> () or Error { }
+    public func write_all(self, data: string) -> void or Error { }
 
     /// Get the remote address as "ip:port".
     public func remote_addr(self) -> string { }
@@ -39,7 +39,7 @@ extend TcpConnection {
     public func read_http_request(self) -> Request or Error { }
 
     /// Write an HTTP response to the connection.
-    public func write_http_response(self, response: Response) -> () or Error { }
+    public func write_http_response(self, response: Response) -> void or Error { }
 
     /// Close the connection.
     public func close(self) { }

--- a/stdlib/os.rk
+++ b/stdlib/os.rk
@@ -110,7 +110,7 @@ extend Process {
     public func id(self) -> i64 { }
 
     /// Write data to the process stdin (requires Stdio.Piped).
-    public func write_stdin(self, data: string) -> () or IoError { }
+    public func write_stdin(self, data: string) -> void or IoError { }
 
     /// Read from the process stdout (requires Stdio.Piped).
     public func read_stdout(self) -> string or IoError { }

--- a/stdlib/time.rk
+++ b/stdlib/time.rk
@@ -5,7 +5,7 @@ struct time { }
 
 extend time {
     /// Sleep for the given duration.
-    public func sleep(duration: Duration) -> () or Error { }
+    public func sleep(duration: Duration) -> void or Error { }
 }
 
 /// A span of time.
@@ -72,9 +72,9 @@ public struct Timer { }
 extend Timer {
     /// Create a one-shot timer that fires after the given duration.
     /// Returns a Receiver that will receive () when the timer fires.
-    public func after(duration: Duration) -> Receiver<()> { }
+    public func after(duration: Duration) -> Receiver<void> { }
 
     /// Create a periodic timer that fires at the given interval.
     /// Returns a Receiver that receives () on each tick.
-    public func interval(duration: Duration) -> Receiver<()> { }
+    public func interval(duration: Duration) -> Receiver<void> { }
 }


### PR DESCRIPTION
## Summary
This PR replaces the `()` syntax for the unit type with an explicit `void` keyword throughout the language, parser, and standard library. This change improves clarity and aligns with common language conventions.

## Key Changes

### Parser & Lexer
- Added `void` as a new keyword token in the lexer
- Modified `parse_type_name()` to recognize `void` keyword and return the unit type
- Reject `()` in type position with a clear error message: "`()` is not a type — use `void`"
- Reject 1-tuples `(T,)` with error: "1-tuples are not supported"
- Added validation that `or E` must follow an explicit return type (reject bare `or` after parameter list)

### Return Type Handling
- Functions with elided return types (no `->` arrow) implicitly return `void`
- Explicit `void or Error` syntax now required when combining void with error types
- Bare `return` statements (without value) are now valid only for void-returning functions
- Added comprehensive parser tests for these scenarios

### Type System
- Updated type display/formatting to show `void` instead of `()`
- Modified type parsing to accept `void` keyword
- Updated builtin type table to recognize `void`

### Specification Updates
- Updated all spec files to use `void` instead of `()` in function signatures
- Clarified tuple rules (TU1-TU3): tuples have arity ≥ 2, `()` is not a tuple
- Documented that `void` is the zero-sized type for "nothing returned"
- Added rules for elided void returns and bare return statements

### Standard Library
- Updated all `.rk` stdlib files to use `void` in function signatures
- Updated all `.md` spec files for stdlib modules (fs, io, net, collections, async, http, etc.)

## Implementation Details
- The internal representation still uses `Type::Unit` and displays as `"()"` in some contexts, but the public-facing syntax is now `void`
- Error messages guide users to use `void` when they attempt `()` in type position
- The parser maintains backward compatibility in value contexts (tuple literals still use `()` syntax)

https://claude.ai/code/session_01CP1V1XmQuBEECDvLLQB1Sm