### PR TITLE
Implement CC1-CC3: Process-global runtime slot for spawn()

### DIFF
--- a/compiler/crates/rask-compiler/src/lib.rs
+++ b/compiler/crates/rask-compiler/src/lib.rs
@@ -676,9 +676,17 @@ fn prefix_decl(decl: &Decl, pkg_name: &str) -> Decl {
 }
 
 fn effect_warning_to_diagnostic(w: &EffectWarning) -> Diagnostic {
-    Diagnostic::warning(&w.message)
-        .with_code(w.code)
-        .with_primary(w.span, format!("`{}` has IO effect", w.callee_name))
+    let diag = if w.is_error {
+        Diagnostic::error(&w.message)
+    } else {
+        Diagnostic::warning(&w.message)
+    };
+    let label = if w.is_error {
+        format!("`{}` reaches spawn here", w.callee_name)
+    } else {
+        format!("`{}` has IO effect", w.callee_name)
+    };
+    diag.with_code(w.code).with_primary(w.span, label)
 }
 
 fn frozen_to_diagnostic(d: &FrozenDiagnostic) -> Diagnostic {

--- a/compiler/crates/rask-diagnostics/src/codes.rs
+++ b/compiler/crates/rask-diagnostics/src/codes.rs
@@ -182,6 +182,9 @@ impl Default for ErrorCodeRegistry {
                 "E0352" => ("spawn outside multitasking block", Type,
                     "`spawn` requires an active `using Multitasking { ... }` block to be in scope. Without a runtime, there's nowhere to submit the task.",
                     "func main() {\n    spawn { do_work() }  // error: no `using Multitasking` block\n\n    // Fix:\n    using Multitasking {\n        spawn { do_work() }  // ok\n    }\n}"),
+                "E0353" => ("transitive spawn outside multitasking block", Type,
+                    "A function that transitively calls `spawn` is being called without an active `using Multitasking { ... }` runtime scope. The call will panic at runtime.",
+                    "func do_work() {\n    spawn(|| { task() })  // reaches spawn\n}\n\nfunc main() {\n    do_work()  // error: no runtime scope\n\n    // Fix:\n    using Multitasking {\n        do_work()  // ok\n    }\n}"),
 
                 // Trait errors (E07xx)
                 "E0700" => ("trait bound not satisfied", Trait,

--- a/compiler/crates/rask-diagnostics/src/codes.rs
+++ b/compiler/crates/rask-diagnostics/src/codes.rs
@@ -176,6 +176,12 @@ impl Default for ErrorCodeRegistry {
                 "E0342" => ("unknown context", Type,
                     "A `using` block references a context that doesn't exist. Valid contexts are `Multitasking` and `ThreadPool`.",
                     "using Foo {\n    // error: unknown context `Foo`\n}"),
+                "E0351" => ("runtime context on signature", Type,
+                    "`using Multitasking` and `using ThreadPool` install a process-global runtime slot. They cannot appear on function signatures — only on block expressions.",
+                    "// Error: signature-level using is not allowed\nfunc run_tasks() using Multitasking { }\n\n// Fix: wrap the call site instead\nfunc main() {\n    using Multitasking {\n        run_tasks()\n    }\n}"),
+                "E0352" => ("spawn outside multitasking block", Type,
+                    "`spawn` requires an active `using Multitasking { ... }` block to be in scope. Without a runtime, there's nowhere to submit the task.",
+                    "func main() {\n    spawn { do_work() }  // error: no `using Multitasking` block\n\n    // Fix:\n    using Multitasking {\n        spawn { do_work() }  // ok\n    }\n}"),
 
                 // Trait errors (E07xx)
                 "E0700" => ("trait bound not satisfied", Trait,

--- a/compiler/crates/rask-diagnostics/src/convert.rs
+++ b/compiler/crates/rask-diagnostics/src/convert.rs
@@ -555,6 +555,27 @@ impl ToDiagnostic for rask_types::TypeError {
                     .with_why("`using` blocks require a known runtime context to initialize")
             }
 
+            SignatureRuntimeContext { ctx, span } => {
+                Diagnostic::error(format!("`using {}` cannot appear on a function signature", ctx))
+                    .with_code("E0351")
+                    .with_primary(*span, "remove this clause from the signature")
+                    .with_help(format!(
+                        "`using {}` is a block, not a signature annotation — \
+                         wrap the call site in `using {} {{ ... }}` instead",
+                        ctx, ctx
+                    ))
+                    .with_why("`using Multitasking` installs a process-global runtime slot; \
+                               functions don't declare it, they just use it [conc.async/CC1]")
+            }
+
+            SpawnOutsideBlock { span } => {
+                Diagnostic::error("`spawn` must be inside a `using Multitasking { ... }` block")
+                    .with_code("E0352")
+                    .with_primary(*span, "`spawn` used here without a runtime")
+                    .with_help("wrap this code in `using Multitasking { ... }`")
+                    .with_why("spawn() requires an active runtime slot installed by `using Multitasking { }` [conc.async/CC1]")
+            }
+
             CyclicTypeAlias { cycle, span } => {
                 Diagnostic::error(format!("cyclic type alias: {}", cycle))
                     .with_code("E0343")

--- a/compiler/crates/rask-effects/src/frozen.rs
+++ b/compiler/crates/rask-effects/src/frozen.rs
@@ -195,6 +195,7 @@ mod tests {
                 async_: false,
                 grow,
                 shrink,
+                needs_runtime: false,
             },
         );
         m

--- a/compiler/crates/rask-effects/src/infer.rs
+++ b/compiler/crates/rask-effects/src/infer.rs
@@ -31,6 +31,10 @@ struct InferPass {
     effects: EffectMap,
     /// Call graph: caller → callees.
     call_graph: HashMap<FuncName, HashSet<FuncName>>,
+    /// CC2: functions that call spawn or unguarded-call something with needs_runtime.
+    direct_needs_runtime: HashSet<FuncName>,
+    /// CC2: callee names reached without an enclosing `using Multitasking {}` block.
+    unguarded_callees: HashMap<FuncName, HashSet<FuncName>>,
 }
 
 impl InferPass {
@@ -38,6 +42,8 @@ impl InferPass {
         Self {
             effects: HashMap::new(),
             call_graph: HashMap::new(),
+            direct_needs_runtime: HashSet::new(),
+            unguarded_callees: HashMap::new(),
         }
     }
 
@@ -50,6 +56,14 @@ impl InferPass {
 
         // Phase 3: Fixed-point propagation (FX2)
         self.propagate();
+
+        // Phase 4: CC2 — propagate needs_runtime via unguarded-call edges
+        let needs_runtime = self.propagate_needs_runtime();
+        for fname in needs_runtime {
+            if let Some(e) = self.effects.get_mut(&fname) {
+                e.needs_runtime = true;
+            }
+        }
     }
 
     // ── Phase 1: Collect ────────────────────────────────────────────
@@ -112,6 +126,41 @@ impl InferPass {
         if !callees.is_empty() {
             self.call_graph.insert(qname.to_string(), callees);
         }
+
+        // CC2: compute which functions call spawn (or runtime-needing callees) without a guard
+        let mut unguarded = HashSet::new();
+        let direct_needs_rt = rt_scan_stmts(&f.body, 0, &mut unguarded);
+        if direct_needs_rt {
+            self.direct_needs_runtime.insert(qname.to_string());
+        }
+        if !unguarded.is_empty() {
+            self.unguarded_callees.insert(qname.to_string(), unguarded);
+        }
+    }
+
+    // ── Phase 4: CC2 needs_runtime propagation ──────────────────────
+
+    fn propagate_needs_runtime(&self) -> HashSet<FuncName> {
+        let mut needs_runtime = self.direct_needs_runtime.clone();
+        loop {
+            let mut changed = false;
+            for (caller, callees) in &self.unguarded_callees {
+                if needs_runtime.contains(caller) {
+                    continue;
+                }
+                for callee in callees {
+                    if needs_runtime.contains(callee) {
+                        needs_runtime.insert(caller.clone());
+                        changed = true;
+                        break;
+                    }
+                }
+            }
+            if !changed {
+                break;
+            }
+        }
+        needs_runtime
     }
 
     // ── Phase 2: Extern declarations ────────────────────────────────
@@ -126,7 +175,7 @@ impl InferPass {
                 }
                 self.effects.insert(
                     e.name.clone(),
-                    Effects { io: true, async_: false, grow: false, shrink: false },
+                    Effects { io: true, async_: false, grow: false, shrink: false, needs_runtime: false },
                 );
             }
         }
@@ -422,6 +471,192 @@ fn extract_callee_name(func: &Expr) -> Option<String> {
             }
         }
         _ => None,
+    }
+}
+
+// ── CC2: runtime-needs scanning ────────────────────────────────────────
+//
+// These functions walk the AST tracking `using Multitasking {}` nesting depth.
+// At depth 0, a direct `spawn()` call sets `needs_runtime = true`.
+// Function calls at depth 0 are collected into `unguarded` for transitive propagation.
+
+fn is_multitasking_block(name: &str) -> bool {
+    matches!(name, "Multitasking" | "MultiTasking" | "multitasking")
+}
+
+fn rt_scan_stmts(stmts: &[Stmt], depth: u32, unguarded: &mut HashSet<String>) -> bool {
+    stmts.iter().fold(false, |acc, s| acc | rt_scan_stmt(s, depth, unguarded))
+}
+
+fn rt_scan_stmt(stmt: &Stmt, depth: u32, unguarded: &mut HashSet<String>) -> bool {
+    match &stmt.kind {
+        StmtKind::Expr(e) => rt_scan_expr(e, depth, unguarded),
+        StmtKind::Mut { init, .. } | StmtKind::Const { init, .. } => rt_scan_expr(init, depth, unguarded),
+        StmtKind::MutTuple { init, .. } | StmtKind::ConstTuple { init, .. } => rt_scan_expr(init, depth, unguarded),
+        StmtKind::Assign { target, value } => {
+            rt_scan_expr(target, depth, unguarded) | rt_scan_expr(value, depth, unguarded)
+        }
+        StmtKind::Return(Some(e)) => rt_scan_expr(e, depth, unguarded),
+        StmtKind::Return(None) | StmtKind::Break { value: None, .. }
+        | StmtKind::Continue(_) | StmtKind::Discard { .. } => false,
+        StmtKind::Break { value: Some(v), .. } => rt_scan_expr(v, depth, unguarded),
+        StmtKind::While { cond, body } => {
+            rt_scan_expr(cond, depth, unguarded) | rt_scan_stmts(body, depth, unguarded)
+        }
+        StmtKind::WhileLet { expr, body, .. } => {
+            rt_scan_expr(expr, depth, unguarded) | rt_scan_stmts(body, depth, unguarded)
+        }
+        StmtKind::Loop { body, .. } | StmtKind::Comptime(body) | StmtKind::ComptimeFor { body, .. } => {
+            rt_scan_stmts(body, depth, unguarded)
+        }
+        StmtKind::For { iter, body, .. } => {
+            rt_scan_expr(iter, depth, unguarded) | rt_scan_stmts(body, depth, unguarded)
+        }
+        StmtKind::Ensure { body, else_handler } => {
+            let mut r = rt_scan_stmts(body, depth, unguarded);
+            if let Some((_, handler)) = else_handler {
+                r |= rt_scan_stmts(handler, depth, unguarded);
+            }
+            r
+        }
+    }
+}
+
+fn rt_scan_expr(expr: &Expr, depth: u32, unguarded: &mut HashSet<String>) -> bool {
+    match &expr.kind {
+        ExprKind::Call { func, args } => {
+            let mut direct = false;
+            if let Some(name) = extract_callee_name(func) {
+                if name == "spawn" && depth == 0 {
+                    direct = true;
+                } else if depth == 0 {
+                    unguarded.insert(name);
+                }
+            }
+            direct |= rt_scan_expr(func, depth, unguarded);
+            for arg in args {
+                direct |= rt_scan_expr(&arg.expr, depth, unguarded);
+            }
+            direct
+        }
+
+        // `using Multitasking { }` guards the body — increase depth
+        ExprKind::UsingBlock { name, args, body } if is_multitasking_block(name) => {
+            for arg in args {
+                rt_scan_expr(&arg.expr, depth, unguarded);
+            }
+            rt_scan_stmts(body, depth + 1, unguarded);
+            false
+        }
+
+        // All other expressions: recurse with same depth
+        ExprKind::MethodCall { object, args, .. } => {
+            let mut r = rt_scan_expr(object, depth, unguarded);
+            for arg in args { r |= rt_scan_expr(&arg.expr, depth, unguarded); }
+            r
+        }
+        ExprKind::UsingBlock { args, body, .. } => {
+            let mut r = false;
+            for arg in args { r |= rt_scan_expr(&arg.expr, depth, unguarded); }
+            r |= rt_scan_stmts(body, depth, unguarded);
+            r
+        }
+        ExprKind::Binary { left, right, .. } => {
+            rt_scan_expr(left, depth, unguarded) | rt_scan_expr(right, depth, unguarded)
+        }
+        ExprKind::Unary { operand, .. } => rt_scan_expr(operand, depth, unguarded),
+        ExprKind::Field { object, .. } | ExprKind::OptionalField { object, .. } => rt_scan_expr(object, depth, unguarded),
+        ExprKind::DynamicField { object, field_expr } => {
+            rt_scan_expr(object, depth, unguarded) | rt_scan_expr(field_expr, depth, unguarded)
+        }
+        ExprKind::Index { object, index } => {
+            rt_scan_expr(object, depth, unguarded) | rt_scan_expr(index, depth, unguarded)
+        }
+        ExprKind::Block(stmts) => rt_scan_stmts(stmts, depth, unguarded),
+        ExprKind::If { cond, then_branch, else_branch, .. } => {
+            let mut r = rt_scan_expr(cond, depth, unguarded);
+            r |= rt_scan_expr(then_branch, depth, unguarded);
+            if let Some(e) = else_branch { r |= rt_scan_expr(e, depth, unguarded); }
+            r
+        }
+        ExprKind::IfLet { expr, then_branch, else_branch, .. } => {
+            let mut r = rt_scan_expr(expr, depth, unguarded);
+            r |= rt_scan_expr(then_branch, depth, unguarded);
+            if let Some(e) = else_branch { r |= rt_scan_expr(e, depth, unguarded); }
+            r
+        }
+        ExprKind::GuardPattern { expr, else_branch, .. } => {
+            rt_scan_expr(expr, depth, unguarded) | rt_scan_expr(else_branch, depth, unguarded)
+        }
+        ExprKind::IsPattern { expr, .. } | ExprKind::IsPresent { expr, .. }
+        | ExprKind::Unwrap { expr, .. } | ExprKind::Cast { expr, .. } => rt_scan_expr(expr, depth, unguarded),
+        ExprKind::Match { scrutinee, arms } => {
+            let mut r = rt_scan_expr(scrutinee, depth, unguarded);
+            for arm in arms {
+                if let Some(g) = &arm.guard { r |= rt_scan_expr(g, depth, unguarded); }
+                r |= rt_scan_expr(&arm.body, depth, unguarded);
+            }
+            r
+        }
+        ExprKind::Try { expr: e, else_clause } => {
+            let mut r = rt_scan_expr(e, depth, unguarded);
+            if let Some(ec) = else_clause { r |= rt_scan_expr(&ec.body, depth, unguarded); }
+            r
+        }
+        ExprKind::NullCoalesce { value, default } => {
+            rt_scan_expr(value, depth, unguarded) | rt_scan_expr(default, depth, unguarded)
+        }
+        ExprKind::Range { start, end, .. } => {
+            let mut r = false;
+            if let Some(s) = start { r |= rt_scan_expr(s, depth, unguarded); }
+            if let Some(e) = end { r |= rt_scan_expr(e, depth, unguarded); }
+            r
+        }
+        ExprKind::StructLit { fields, spread, .. } => {
+            let mut r = false;
+            for f in fields { r |= rt_scan_expr(&f.value, depth, unguarded); }
+            if let Some(s) = spread { r |= rt_scan_expr(s, depth, unguarded); }
+            r
+        }
+        ExprKind::Array(elems) | ExprKind::Tuple(elems) => {
+            elems.iter().fold(false, |acc, e| acc | rt_scan_expr(e, depth, unguarded))
+        }
+        ExprKind::ArrayRepeat { value, count } => {
+            rt_scan_expr(value, depth, unguarded) | rt_scan_expr(count, depth, unguarded)
+        }
+        ExprKind::WithAs { bindings, body } => {
+            let mut r = false;
+            for b in bindings { r |= rt_scan_expr(&b.source, depth, unguarded); }
+            r |= rt_scan_stmts(body, depth, unguarded);
+            r
+        }
+        ExprKind::Closure { body, .. } => rt_scan_expr(body, depth, unguarded),
+        ExprKind::Spawn { body } | ExprKind::Comptime { body }
+        | ExprKind::BlockCall { body, .. } | ExprKind::Loop { body, .. }
+        | ExprKind::Unsafe { body } => rt_scan_stmts(body, depth, unguarded),
+        ExprKind::Assert { condition, message } | ExprKind::Check { condition, message } => {
+            let mut r = rt_scan_expr(condition, depth, unguarded);
+            if let Some(m) = message { r |= rt_scan_expr(m, depth, unguarded); }
+            r
+        }
+        ExprKind::Select { arms, .. } => {
+            let mut r = false;
+            for arm in arms {
+                match &arm.kind {
+                    rask_ast::expr::SelectArmKind::Recv { channel, .. } => { r |= rt_scan_expr(channel, depth, unguarded); }
+                    rask_ast::expr::SelectArmKind::Send { channel, value } => {
+                        r |= rt_scan_expr(channel, depth, unguarded);
+                        r |= rt_scan_expr(value, depth, unguarded);
+                    }
+                    rask_ast::expr::SelectArmKind::Default => {}
+                }
+                r |= rt_scan_expr(&arm.body, depth, unguarded);
+            }
+            r
+        }
+        ExprKind::Int(_, _) | ExprKind::Float(_, _) | ExprKind::String(_)
+        | ExprKind::StringInterp(_) | ExprKind::Char(_) | ExprKind::Bool(_)
+        | ExprKind::Null | ExprKind::None | ExprKind::Ident(_) => false,
     }
 }
 

--- a/compiler/crates/rask-effects/src/lib.rs
+++ b/compiler/crates/rask-effects/src/lib.rs
@@ -35,6 +35,10 @@ pub struct Effects {
     pub grow: bool,
     /// Shrink effect: pool.remove, pool.clear, pool.drain (EF1).
     pub shrink: bool,
+    /// CC2: this function needs an active `using Multitasking` runtime at the call site.
+    /// Set when the function (or something it calls without an internal block) reaches `spawn`.
+    /// NOT propagated via the regular call graph — uses unguarded-call edges only.
+    pub needs_runtime: bool,
 }
 
 impl Effects {
@@ -76,16 +80,18 @@ impl Effects {
 /// Per-function effect results keyed by qualified function name.
 pub type EffectMap = HashMap<String, Effects>;
 
-/// A warning from effect analysis (CW1, CW2).
+/// A warning or error from effect analysis (CW1, CW2, CC2).
 #[derive(Debug, Clone)]
 pub struct EffectWarning {
-    /// Spec rule: "comp.effects/CW1" or "comp.effects/CW2".
+    /// Spec rule: "comp.effects/CW1", "comp.effects/CW2", "conc.async/CC2".
     pub code: &'static str,
     pub message: String,
     /// Location of the problematic call site.
     pub span: Span,
     /// Name of the function that introduces the effect.
     pub callee_name: String,
+    /// True if this should be reported as an error (CC2), false for warnings (CW1, CW2).
+    pub is_error: bool,
 }
 
 /// Run effect inference on a set of declarations.
@@ -104,8 +110,8 @@ mod tests {
 
     #[test]
     fn effects_union() {
-        let mut a = Effects { io: true, async_: false, grow: false, shrink: false };
-        let b = Effects { io: false, async_: true, grow: true, shrink: true };
+        let mut a = Effects { io: true, async_: false, grow: false, shrink: false, needs_runtime: false };
+        let b = Effects { io: false, async_: true, grow: true, shrink: true, needs_runtime: false };
         a.union(b);
         assert!(a.io);
         assert!(a.async_);

--- a/compiler/crates/rask-effects/src/sources.rs
+++ b/compiler/crates/rask-effects/src/sources.rs
@@ -17,22 +17,22 @@ pub fn classify_call(callee: &str) -> Effects {
     if is_io_source(callee) {
         // Some IO sources are also Async (AS3: Async implies IO)
         if is_async_source(callee) {
-            return Effects { io: true, async_: true, grow: false, shrink: false };
+            return Effects { io: true, async_: true, grow: false, shrink: false, needs_runtime: false };
         }
-        return Effects { io: true, async_: false, grow: false, shrink: false };
+        return Effects { io: true, async_: false, grow: false, shrink: false, needs_runtime: false };
     }
 
     // Async-only sources (also get IO via AS3)
     if is_async_source(callee) {
-        return Effects { io: true, async_: true, grow: false, shrink: false };
+        return Effects { io: true, async_: true, grow: false, shrink: false, needs_runtime: false };
     }
 
     // Pool structural mutation sources (EF1: split into Grow/Shrink)
     if is_grow_source(callee) {
-        return Effects { io: false, async_: false, grow: true, shrink: false };
+        return Effects { io: false, async_: false, grow: true, shrink: false, needs_runtime: false };
     }
     if is_shrink_source(callee) {
-        return Effects { io: false, async_: false, grow: false, shrink: true };
+        return Effects { io: false, async_: false, grow: false, shrink: true, needs_runtime: false };
     }
 
     Effects::default()

--- a/compiler/crates/rask-effects/src/warnings.rs
+++ b/compiler/crates/rask-effects/src/warnings.rs
@@ -134,6 +134,23 @@ impl<'a> WarnContext<'a> {
                 let callee_name = extract_callee_name(func);
                 if let Some(ref name) = callee_name {
                     self.maybe_warn_io_call(name, expr.span, warnings);
+                    // CC2: calling a needs_runtime function outside any using Multitasking block
+                    if !self.in_multitasking {
+                        if let Some(callee_effects) = self.effects.get(name.as_str()) {
+                            if callee_effects.needs_runtime {
+                                warnings.push(EffectWarning {
+                                    code: "E0353",
+                                    message: format!(
+                                        "`{}` reaches `spawn` — wrap the call in `using Multitasking {{ }}`",
+                                        name
+                                    ),
+                                    span: expr.span,
+                                    callee_name: name.clone(),
+                                    is_error: true,
+                                });
+                            }
+                        }
+                    }
                 }
                 self.check_expr(func, warnings);
                 for arg in args {
@@ -325,6 +342,7 @@ impl<'a> WarnContext<'a> {
                 ),
                 span,
                 callee_name: callee.to_string(),
+                is_error: false,
             });
         }
 
@@ -338,6 +356,7 @@ impl<'a> WarnContext<'a> {
                 ),
                 span,
                 callee_name: callee.to_string(),
+                is_error: false,
             });
         }
     }
@@ -438,16 +457,16 @@ mod tests {
 
     fn effects_with_io(name: &str) -> EffectMap {
         let mut m = HashMap::new();
-        m.insert(name.into(), crate::Effects { io: true, async_: false, grow: false, shrink: false });
+        m.insert(name.into(), crate::Effects { io: true, async_: false, grow: false, shrink: false, needs_runtime: false });
         m
     }
 
     /// Effect map that marks a function as IO AND marks the program as concurrent.
     fn effects_with_io_concurrent(name: &str) -> EffectMap {
         let mut m = HashMap::new();
-        m.insert(name.into(), crate::Effects { io: true, async_: false, grow: false, shrink: false });
+        m.insert(name.into(), crate::Effects { io: true, async_: false, grow: false, shrink: false, needs_runtime: false });
         // Some other function uses concurrency, making the program concurrent.
-        m.insert("_concurrent_marker".into(), crate::Effects { io: false, async_: true, grow: false, shrink: false });
+        m.insert("_concurrent_marker".into(), crate::Effects { io: false, async_: true, grow: false, shrink: false, needs_runtime: false });
         m
     }
 

--- a/compiler/crates/rask-hidden-params/src/collect.rs
+++ b/compiler/crates/rask-hidden-params/src/collect.rs
@@ -68,10 +68,13 @@ impl<'a> HiddenParamPass<'a> {
             Vec::new()
         };
 
-        // Collect explicit context requirements
+        // Collect explicit context requirements.
+        // Runtime contexts (Multitasking, ThreadPool) are no longer threaded as
+        // hidden params — they use a process-global slot instead (conc.async/CC1-CC3).
         let reqs: Vec<ContextReq> = f
             .context_clauses
             .iter()
+            .filter(|cc| !is_runtime_context(&cc.ty))
             .map(|cc| context_clause_to_req(cc))
             .collect();
 
@@ -162,6 +165,11 @@ fn infer_pool_type_from_expr(expr: &rask_ast::expr::Expr) -> Option<String> {
         }
         _ => None,
     }
+}
+
+/// True for runtime contexts that use the process-global slot, not hidden params.
+pub(crate) fn is_runtime_context(ty: &str) -> bool {
+    matches!(ty, "Multitasking" | "MultiTasking" | "multitasking" | "ThreadPool" | "threadpool")
 }
 
 /// Check if any parameter in a function is a Handle<T> type.

--- a/compiler/crates/rask-hidden-params/src/lib.rs
+++ b/compiler/crates/rask-hidden-params/src/lib.rs
@@ -28,7 +28,7 @@ use rask_ast::{NodeId, Span};
 /// A context requirement derived from a `using` clause.
 #[derive(Debug, Clone)]
 pub(crate) struct ContextReq {
-    /// Hidden parameter name: `__ctx_pool_Player`, `__ctx_runtime`, etc.
+    /// Hidden parameter name: `__ctx_pool_Player`, etc.
     pub param_name: String,
     /// Type string for the parameter: `&Pool<Player>`, `RuntimeContext`
     pub param_type: String,
@@ -189,28 +189,24 @@ impl<'a> HiddenParamPass<'a> {
 // ── Helpers ─────────────────────────────────────────────────────────────
 
 /// Convert a ContextClause into a ContextReq.
+///
+/// Only called for pool contexts — runtime types (Multitasking, ThreadPool)
+/// are filtered out before this point (see `collect::is_runtime_context`).
 pub(crate) fn context_clause_to_req(cc: &ContextClause) -> ContextReq {
-    let is_runtime = cc.ty == "Multitasking" || cc.ty == "multitasking";
-
-    let (param_name, param_type) = if is_runtime {
-        ("__ctx_runtime".to_string(), "RuntimeContext".to_string())
+    // Pool<T> → __ctx_pool_T with type &Pool<T>
+    let inner = extract_generic_arg(&cc.ty).unwrap_or_default();
+    let param_name = if let Some(alias) = &cc.name {
+        format!("__ctx_{}", alias)
     } else {
-        // Pool<T> → __ctx_pool_T with type &Pool<T>
-        let inner = extract_generic_arg(&cc.ty).unwrap_or_default();
-        let name = if let Some(alias) = &cc.name {
-            format!("__ctx_{}", alias)
-        } else {
-            format!("__ctx_pool_{}", inner)
-        };
-        let ty = format!("&{}", cc.ty);
-        (name, ty)
+        format!("__ctx_pool_{}", inner)
     };
+    let param_type = format!("&{}", cc.ty);
 
     ContextReq {
         param_name,
         param_type,
         clause_type: cc.ty.clone(),
-        is_runtime,
+        is_runtime: false,
         alias: cc.name.clone(),
     }
 }
@@ -299,16 +295,14 @@ mod tests {
     }
 
     #[test]
-    fn test_context_clause_to_req_runtime() {
-        let cc = ContextClause {
-            name: None,
-            ty: "Multitasking".to_string(),
-            is_frozen: false,
-        };
-        let req = context_clause_to_req(&cc);
-        assert_eq!(req.param_name, "__ctx_runtime");
-        assert_eq!(req.param_type, "RuntimeContext");
-        assert!(req.is_runtime);
+    fn test_runtime_context_filtered() {
+        // Runtime contexts must be filtered before reaching context_clause_to_req.
+        use crate::collect::is_runtime_context;
+        assert!(is_runtime_context("Multitasking"));
+        assert!(is_runtime_context("multitasking"));
+        assert!(is_runtime_context("ThreadPool"));
+        assert!(is_runtime_context("threadpool"));
+        assert!(!is_runtime_context("Pool<Player>"));
     }
 
     #[test]

--- a/compiler/crates/rask-interp/src/interp/eval_expr.rs
+++ b/compiler/crates/rask-interp/src/interp/eval_expr.rs
@@ -10,6 +10,17 @@ use crate::value::{ModuleKind, PoolTask, ThreadHandleInner, ThreadPoolInner, Typ
 
 use super::{Interpreter, RuntimeDiagnostic, RuntimeError};
 
+/// CC3 runtime panic message for spawn() without an active `using Multitasking` block.
+const SPAWN_NO_RUNTIME_MSG: &str =
+    "RUNTIME PANIC: spawn() called with no active `using Multitasking` scope\n\
+     \n\
+     This can happen when:\n\
+     - A closure containing spawn is stored and called outside a block\n\
+     - A trait object dispatches to an impl that spawns\n\
+     - FFI calls back into Rask outside any scope\n\
+     \n\
+     Install a `using Multitasking { ... }` block that encloses the call.";
+
 /// Set origin on an error value (the inner payload of Err). Only sets if not already set (ER15).
 fn set_error_origin(val: Value, origin: &Arc<str>) -> Value {
     match val {
@@ -1609,7 +1620,7 @@ impl Interpreter {
             ExprKind::UsingBlock { name, args, body }
                 if name == "Multitasking" || name == "multitasking" =>
             {
-                use crate::value::MultitaskingRuntime;
+                use crate::value::{MultitaskingRuntime, ACTIVE_RUNTIME};
 
                 let num_workers = if args.is_empty() {
                     std::thread::available_parallelism()
@@ -1622,9 +1633,23 @@ impl Interpreter {
 
                 let runtime = Arc::new(MultitaskingRuntime::new(num_workers));
 
+                // C1: exactly one active block per process — nested blocks panic at runtime
+                {
+                    let mut slot = ACTIVE_RUNTIME.write().unwrap();
+                    if slot.is_some() {
+                        return Err(RuntimeDiagnostic::new(
+                            RuntimeError::Panic(
+                                "nested `using Multitasking` blocks are not allowed\n\
+                                 only one block may be active per process at a time".to_string(),
+                            ),
+                            expr.span,
+                        ));
+                    }
+                    *slot = Some(runtime.clone());
+                }
+
                 self.env.push_scope();
                 let scope_depth = self.env.scope_depth();
-                self.env.define("__multitasking_ctx".to_string(), Value::MultitaskingRuntime(runtime.clone()));
 
                 let mut result = Value::Unit;
                 for stmt in body {
@@ -1632,6 +1657,7 @@ impl Interpreter {
                         Ok(val) => result = val,
                         Err(e) => {
                             runtime.shutdown();
+                            *ACTIVE_RUNTIME.write().unwrap() = None;
                             self.env.pop_scope();
                             return Err(e);
                         }
@@ -1641,6 +1667,7 @@ impl Interpreter {
                 // Check for unconsumed handles (conc.async/H1)
                 if let Err(msg) = self.resource_tracker.check_scope_exit(scope_depth) {
                     runtime.shutdown();
+                    *ACTIVE_RUNTIME.write().unwrap() = None;
                     self.env.pop_scope();
                     return Err(RuntimeDiagnostic::new(
                         RuntimeError::Panic(msg),
@@ -1649,77 +1676,66 @@ impl Interpreter {
                 }
 
                 runtime.shutdown();
+                *ACTIVE_RUNTIME.write().unwrap() = None;
                 self.env.pop_scope();
                 Ok(result)
             }
 
             ExprKind::Spawn { body } => {
+                use crate::value::ACTIVE_RUNTIME;
+
                 let body = body.clone();
                 let captured = self.env.capture();
                 let child = self.spawn_child(captured);
-                let in_multitasking = self.env.get("__multitasking_ctx").is_some();
 
-                let handle_inner = if in_multitasking {
-                    // Submit to the multitasking thread pool
-                    let (result_tx, result_rx) = std::sync::mpsc::channel();
-                    let task = PoolTask {
-                        work: Box::new(move || {
-                            let mut interp = child;
-                            let mut result = Value::Unit;
-                            for stmt in &body {
-                                match interp.exec_stmt(stmt) {
-                                    Ok(val) => result = val,
-                                    Err(e) => {
-                                        let _ = result_tx.send(Err(format!("{}", e)));
-                                        return;
-                                    }
-                                }
-                            }
-                            let _ = result_tx.send(Ok(result));
-                        }),
-                    };
-
-                    if let Some(Value::MultitaskingRuntime(rt)) = self.env.get("__multitasking_ctx") {
-                        let sender = rt.sender.lock().unwrap();
-                        if let Some(tx) = sender.as_ref() {
-                            let _ = tx.send(task);
-                        }
+                // Read the active runtime from the process-global slot (CC3 fallback if None)
+                let runtime = ACTIVE_RUNTIME.read().unwrap().clone();
+                let rt = match runtime {
+                    Some(rt) => rt,
+                    None => {
+                        return Err(RuntimeDiagnostic::new(
+                            RuntimeError::Panic(SPAWN_NO_RUNTIME_MSG.to_string()),
+                            expr.span,
+                        ));
                     }
+                };
 
-                    Arc::new(ThreadHandleInner {
-                        handle: Mutex::new(None),
-                        receiver: Mutex::new(Some(result_rx)),
-                    })
-                } else {
-                    // Outside multitasking: spawn OS thread directly
-                    let join_handle = std::thread::spawn(move || {
+                // Submit to the multitasking thread pool
+                let (result_tx, result_rx) = std::sync::mpsc::channel();
+                let task = PoolTask {
+                    work: Box::new(move || {
                         let mut interp = child;
                         let mut result = Value::Unit;
                         for stmt in &body {
                             match interp.exec_stmt(stmt) {
                                 Ok(val) => result = val,
-                                Err(e) => return Err(format!("{}", e)),
+                                Err(e) => {
+                                    let _ = result_tx.send(Err(format!("{}", e)));
+                                    return;
+                                }
                             }
                         }
-                        Ok(result)
-                    });
-
-                    Arc::new(ThreadHandleInner {
-                        handle: Mutex::new(Some(join_handle)),
-                        receiver: Mutex::new(None),
-                    })
+                        let _ = result_tx.send(Ok(result));
+                    }),
                 };
+
+                {
+                    let sender = rt.sender.lock().unwrap();
+                    if let Some(tx) = sender.as_ref() {
+                        let _ = tx.send(task);
+                    }
+                }
+
+                let handle_inner = Arc::new(ThreadHandleInner {
+                    handle: Mutex::new(None),
+                    receiver: Mutex::new(Some(result_rx)),
+                });
 
                 // Register handle for affine tracking (conc.async/H1)
                 let ptr = Arc::as_ptr(&handle_inner) as usize;
-                let type_name = if in_multitasking { "TaskHandle" } else { "ThreadHandle" };
-                self.resource_tracker.register_handle(ptr, type_name, self.env.scope_depth());
+                self.resource_tracker.register_handle(ptr, "TaskHandle", self.env.scope_depth());
 
-                if in_multitasking {
-                    Ok(Value::TaskHandle(handle_inner))
-                } else {
-                    Ok(Value::ThreadHandle(handle_inner))
-                }
+                Ok(Value::TaskHandle(handle_inner))
             }
 
             ExprKind::Assert { condition, message } => {

--- a/compiler/crates/rask-interp/src/interp/mod.rs
+++ b/compiler/crates/rask-interp/src/interp/mod.rs
@@ -261,10 +261,11 @@ impl Interpreter {
             ));
         }
 
-        // Check for Multitasking context
-        if self.env.get("__multitasking_ctx").is_none() {
-            return Err(RuntimeError::TypeError(
-                "spawn() requires 'using Multitasking' context".to_string(),
+        // Check for active runtime slot (CC3 fallback)
+        if crate::value::ACTIVE_RUNTIME.read().unwrap().is_none() {
+            return Err(RuntimeError::Panic(
+                "RUNTIME PANIC: spawn() called with no active `using Multitasking` scope\n\
+                 Install a `using Multitasking { ... }` block that encloses the call.".to_string(),
             ));
         }
 

--- a/compiler/crates/rask-interp/src/stdlib/async_mod.rs
+++ b/compiler/crates/rask-interp/src/stdlib/async_mod.rs
@@ -2,7 +2,7 @@
 //! Async module - green task spawning.
 
 use crate::interp::{Interpreter, RuntimeError};
-use crate::value::{ThreadHandleInner, Value};
+use crate::value::{ThreadHandleInner, Value, ACTIVE_RUNTIME};
 use std::sync::{Arc, Mutex};
 
 impl Interpreter {
@@ -29,9 +29,10 @@ impl Interpreter {
                         body,
                         captured_env,
                     } => {
-                        if self.env.get("__multitasking_ctx").is_none() {
-                            return Err(RuntimeError::TypeError(
-                                "spawn() requires 'using Multitasking' context".to_string(),
+                        if ACTIVE_RUNTIME.read().unwrap().is_none() {
+                            return Err(RuntimeError::Panic(
+                                "RUNTIME PANIC: spawn() called with no active `using Multitasking` scope\n\
+                                 Install a `using Multitasking { ... }` block that encloses the call.".to_string(),
                             ));
                         }
 

--- a/compiler/crates/rask-interp/src/value.rs
+++ b/compiler/crates/rask-interp/src/value.rs
@@ -7,11 +7,17 @@ use std::fmt;
 use std::fs::File as StdFile;
 use std::sync::atomic::{AtomicU32, Ordering};
 use std::sync::{mpsc, Arc, Mutex, RwLock};
+use std::sync::LazyLock;
 
 use rask_ast::expr::Expr;
 
 /// Global pool ID counter. Each Pool gets a unique ID.
 static NEXT_POOL_ID: AtomicU32 = AtomicU32::new(1);
+
+/// Process-global active Multitasking runtime slot (conc.async/C1).
+/// At most one `using Multitasking { }` block may be active per process.
+pub static ACTIVE_RUNTIME: LazyLock<RwLock<Option<Arc<MultitaskingRuntime>>>> =
+    LazyLock::new(|| RwLock::new(None));
 
 /// Allocate the next unique pool ID.
 pub fn next_pool_id() -> u32 {

--- a/compiler/crates/rask-mir/src/hidden_params/collect.rs
+++ b/compiler/crates/rask-mir/src/hidden_params/collect.rs
@@ -68,10 +68,12 @@ impl<'a> HiddenParamPass<'a> {
             Vec::new()
         };
 
-        // Collect explicit context requirements
+        // Collect explicit context requirements.
+        // Runtime contexts (Multitasking, ThreadPool) use the process-global slot.
         let reqs: Vec<ContextReq> = f
             .context_clauses
             .iter()
+            .filter(|cc| !is_runtime_context(&cc.ty))
             .map(|cc| context_clause_to_req(cc))
             .collect();
 
@@ -162,6 +164,11 @@ fn infer_pool_type_from_expr(expr: &rask_ast::expr::Expr) -> Option<String> {
         }
         _ => None,
     }
+}
+
+/// True for runtime contexts that use the process-global slot, not hidden params.
+pub(crate) fn is_runtime_context(ty: &str) -> bool {
+    matches!(ty, "Multitasking" | "MultiTasking" | "multitasking" | "ThreadPool" | "threadpool")
 }
 
 /// Check if any parameter in a function is a Handle<T> type.

--- a/compiler/crates/rask-mir/src/hidden_params/mod.rs
+++ b/compiler/crates/rask-mir/src/hidden_params/mod.rs
@@ -28,7 +28,7 @@ use rask_ast::{NodeId, Span};
 /// A context requirement derived from a `using` clause.
 #[derive(Debug, Clone)]
 pub(crate) struct ContextReq {
-    /// Hidden parameter name: `__ctx_pool_Player`, `__ctx_runtime`, etc.
+    /// Hidden parameter name: `__ctx_pool_Player`, etc.
     pub param_name: String,
     /// Type string for the parameter: `&Pool<Player>`, `RuntimeContext`
     pub param_type: String,
@@ -189,28 +189,24 @@ impl<'a> HiddenParamPass<'a> {
 // ── Helpers ─────────────────────────────────────────────────────────────
 
 /// Convert a ContextClause into a ContextReq.
+///
+/// Only called for pool contexts — runtime types (Multitasking, ThreadPool)
+/// are filtered out before this point (see `collect::is_runtime_context`).
 pub(crate) fn context_clause_to_req(cc: &ContextClause) -> ContextReq {
-    let is_runtime = cc.ty == "Multitasking" || cc.ty == "multitasking";
-
-    let (param_name, param_type) = if is_runtime {
-        ("__ctx_runtime".to_string(), "RuntimeContext".to_string())
+    // Pool<T> → __ctx_pool_T with type &Pool<T>
+    let inner = extract_generic_arg(&cc.ty).unwrap_or_default();
+    let param_name = if let Some(alias) = &cc.name {
+        format!("__ctx_{}", alias)
     } else {
-        // Pool<T> → __ctx_pool_T with type &Pool<T>
-        let inner = extract_generic_arg(&cc.ty).unwrap_or_default();
-        let name = if let Some(alias) = &cc.name {
-            format!("__ctx_{}", alias)
-        } else {
-            format!("__ctx_pool_{}", inner)
-        };
-        let ty = format!("&{}", cc.ty);
-        (name, ty)
+        format!("__ctx_pool_{}", inner)
     };
+    let param_type = format!("&{}", cc.ty);
 
     ContextReq {
         param_name,
         param_type,
         clause_type: cc.ty.clone(),
-        is_runtime,
+        is_runtime: false,
         alias: cc.name.clone(),
     }
 }
@@ -299,16 +295,13 @@ mod tests {
     }
 
     #[test]
-    fn test_context_clause_to_req_runtime() {
-        let cc = ContextClause {
-            name: None,
-            ty: "Multitasking".to_string(),
-            is_frozen: false,
-        };
-        let req = context_clause_to_req(&cc);
-        assert_eq!(req.param_name, "__ctx_runtime");
-        assert_eq!(req.param_type, "RuntimeContext");
-        assert!(req.is_runtime);
+    fn test_runtime_context_filtered() {
+        use crate::hidden_params::collect::is_runtime_context;
+        assert!(is_runtime_context("Multitasking"));
+        assert!(is_runtime_context("multitasking"));
+        assert!(is_runtime_context("ThreadPool"));
+        assert!(is_runtime_context("threadpool"));
+        assert!(!is_runtime_context("Pool<Player>"));
     }
 
     #[test]

--- a/compiler/crates/rask-resolve/src/lib.rs
+++ b/compiler/crates/rask-resolve/src/lib.rs
@@ -27,7 +27,7 @@ pub mod signing;
 
 pub use error::{ResolveError, ResolveErrorKind};
 pub use scope::{Scope, ScopeId, ScopeKind};
-pub use symbol::{Symbol, SymbolId, SymbolKind, SymbolTable};
+pub use symbol::{Symbol, SymbolId, SymbolKind, SymbolTable, BuiltinFunctionKind};
 pub use resolver::Resolver;
 pub use package::{Package, PackageId, PackageRegistry, PackageError, SourceFile};
 #[cfg(not(target_arch = "wasm32"))]

--- a/compiler/crates/rask-types/src/checker/check_expr.rs
+++ b/compiler/crates/rask-types/src/checker/check_expr.rs
@@ -957,6 +957,11 @@ impl TypeChecker {
             }
 
             ExprKind::Spawn { body } => {
+                // CC1: direct spawn must be lexically inside a `using Multitasking { }` block
+                if self.multitasking_depth == 0 {
+                    self.errors.push(TypeError::SpawnOutsideBlock { span: expr.span });
+                }
+
                 // Spawn blocks are like anonymous functions - they have their own return type
                 let outer_return_type = self.current_return_type.take();
                 let outer_accumulate = self.accumulate_errors;
@@ -1021,8 +1026,19 @@ impl TypeChecker {
                 for arg in args {
                     self.infer_expr(&arg.expr);
                 }
+                // CC1: track nesting depth so spawn() inside this block is allowed
+                let is_multitasking = matches!(
+                    name.as_str(),
+                    "Multitasking" | "MultiTasking" | "multitasking"
+                );
+                if is_multitasking {
+                    self.multitasking_depth += 1;
+                }
                 for stmt in body {
                     self.check_stmt(stmt);
+                }
+                if is_multitasking {
+                    self.multitasking_depth -= 1;
                 }
                 // Check if the block ends with a diverging statement (return/break/continue)
                 if let Some(last) = body.last() {
@@ -1282,9 +1298,19 @@ impl TypeChecker {
         }
 
         // Extern and unsafe function calls require unsafe context
+        // Also: CC1 — spawn() must be inside a `using Multitasking { }` block
         if let ExprKind::Ident(_) = &func.kind {
             if let Some(&sym_id) = self.resolved.resolutions.get(&func.id) {
                 if let Some(sym) = self.resolved.symbols.get(sym_id) {
+                    // CC1: spawn() outside any using Multitasking block
+                    if matches!(&sym.kind, SymbolKind::BuiltinFunction { builtin }
+                        if *builtin == rask_resolve::BuiltinFunctionKind::Spawn)
+                    {
+                        if self.multitasking_depth == 0 {
+                            self.errors.push(TypeError::SpawnOutsideBlock { span });
+                        }
+                    }
+
                     let unsafe_category = match &sym.kind {
                         SymbolKind::ExternFunction { .. } => Some(super::UnsafeCategory::ExternCall),
                         SymbolKind::Function { is_unsafe: true, .. } => Some(super::UnsafeCategory::UnsafeFuncCall),

--- a/compiler/crates/rask-types/src/checker/check_fn.rs
+++ b/compiler/crates/rask-types/src/checker/check_fn.rs
@@ -78,6 +78,16 @@ impl TypeChecker {
             _ => false,
         };
 
+        // CC1: reject `using Multitasking` / `using ThreadPool` on function signatures
+        for cc in &f.context_clauses {
+            if is_runtime_context(&cc.ty) {
+                self.errors.push(TypeError::SignatureRuntimeContext {
+                    ctx: cc.ty.clone(),
+                    span: f.span,
+                });
+            }
+        }
+
         // UF1: unsafe func body is implicitly unsafe
         let was_unsafe = self.in_unsafe;
         if f.is_unsafe {
@@ -107,6 +117,9 @@ impl TypeChecker {
                 });
             }
         }
+
+        // Reset multitasking depth for each function body
+        self.multitasking_depth = 0;
 
         self.push_scope();
         for param in &f.params {
@@ -448,4 +461,8 @@ impl TypeChecker {
             _ => false,
         }
     }
+}
+
+fn is_runtime_context(ty: &str) -> bool {
+    matches!(ty, "Multitasking" | "MultiTasking" | "multitasking" | "ThreadPool" | "threadpool")
 }

--- a/compiler/crates/rask-types/src/checker/errors.rs
+++ b/compiler/crates/rask-types/src/checker/errors.rs
@@ -179,6 +179,19 @@ pub enum TypeError {
         span: Span,
     },
 
+    /// CC1: `using Multitasking`/`ThreadPool` may not appear on a function signature
+    #[error("`using {ctx}` cannot appear on a function signature")]
+    SignatureRuntimeContext {
+        ctx: String,
+        span: Span,
+    },
+
+    /// CC1: `spawn` used outside any `using Multitasking` block
+    #[error("`spawn` must be inside a `using Multitasking {{ ... }}` block")]
+    SpawnOutsideBlock {
+        span: Span,
+    },
+
     /// T6: cyclic type alias
     #[error("cyclic type alias: {cycle}")]
     CyclicTypeAlias {

--- a/compiler/crates/rask-types/src/checker/mod.rs
+++ b/compiler/crates/rask-types/src/checker/mod.rs
@@ -119,6 +119,8 @@ pub struct TypeChecker {
     pub(super) span_types: HashMap<(usize, usize, u16), Type>,
     /// D1: Bindings invalidated by `discard`. Maps name → discard span.
     pub(super) discarded_bindings: HashMap<String, rask_ast::Span>,
+    /// CC1: nesting depth of `using Multitasking { }` blocks in current function.
+    pub(super) multitasking_depth: u32,
 }
 
 impl TypeChecker {
@@ -148,6 +150,7 @@ impl TypeChecker {
             span_types: HashMap::new(),
             accumulate_errors: false,
             discarded_bindings: HashMap::new(),
+            multitasking_depth: 0,
         }
     }
 


### PR DESCRIPTION
## Summary

This PR implements the CC1-CC3 specification for managing the Multitasking runtime as a process-global slot rather than threading it through function signatures. The changes ensure that `spawn()` can only be called within a `using Multitasking { }` block, with compile-time and runtime enforcement.

## Key Changes

### Type Checking & Compilation (CC1)
- **Reject runtime contexts on signatures**: Functions cannot declare `using Multitasking` or `using ThreadPool` in their signature (error E0351)
- **Enforce spawn lexical scoping**: `spawn()` expressions must be syntactically inside a `using Multitasking { }` block (error E0352)
- Track `multitasking_depth` in TypeChecker to validate spawn placement
- Add `is_runtime_context()` helper to identify Multitasking/ThreadPool contexts

### Effect Analysis (CC2)
- Add `needs_runtime` field to `Effects` struct to track functions that reach `spawn`
- Implement Phase 4 propagation: compute `direct_needs_runtime` (functions calling spawn directly) and `unguarded_callees` (functions called without a guard)
- Propagate `needs_runtime` transitively via unguarded-call edges (not the regular call graph)
- Add warning E0353 when calling a `needs_runtime` function outside a `using Multitasking` block

### Runtime Implementation (CC3)
- Replace environment-based `__multitasking_ctx` with process-global `ACTIVE_RUNTIME` slot (LazyLock<RwLock<Option<Arc<MultitaskingRuntime>>>>)
- Enforce single active block per process: nested `using Multitasking` blocks panic at runtime
- Simplify `spawn()` implementation: always submit to the active runtime (no fallback to OS threads)
- Return `TaskHandle` exclusively; remove `ThreadHandle` variant
- Properly manage runtime lifecycle: set slot on entry, clear on exit/error

### Hidden Parameters
- Filter out runtime contexts before generating hidden parameters
- Only pool contexts (e.g., `Pool<T>`) generate `__ctx_pool_T` parameters
- Remove `__ctx_runtime` parameter generation entirely

### Diagnostics
- Add error codes E0351 (runtime context on signature) and E0352 (spawn outside block)
- Update effect warning conversion to distinguish errors (CC2 violations) from warnings (IO effects)
- Improve error messages with spec references (conc.async/CC1-CC3)

## Implementation Details

- The `rt_scan_stmts`/`rt_scan_expr` functions walk the AST tracking nesting depth within `using Multitasking` blocks
- At depth 0, direct `spawn()` calls set `needs_runtime = true`; function calls are collected for transitive analysis
- The fixed-point propagation in Phase 4 computes which functions transitively reach spawn without an internal guard
- Runtime panics with detailed message if `spawn()` is called without an active runtime slot (e.g., from closures or FFI callbacks)

https://claude.ai/code/session_01Erp67FYQxcZzKCZLU3gnn6