### PR TITLE
Implement ER42/ER43: linear type checking in pattern matching

### DIFF
--- a/compiler/crates/rask-compiler/tests/pipeline.rs
+++ b/compiler/crates/rask-compiler/tests/pipeline.rs
@@ -257,3 +257,130 @@ fn missing_file_returns_error_diagnostic() {
     // Should have a single error diagnostic about the missing file.
     assert_eq!(output.diagnostics.len(), 1);
 }
+
+// ═══════════════════════════════════════════════════════════════════════
+// ER42/ER43: linear payloads in error/enum variants
+// ═══════════════════════════════════════════════════════════════════════
+
+#[test]
+fn er43_top_level_wildcard_on_linear_enum_errors() {
+    // ER43: matching a transitively-linear enum with a `_` arm silently
+    // drops the linear payload. Compile error.
+    let path = tmp_rk(r#"
+        @resource
+        struct File { path: string }
+        extend File { func close(take self) {} }
+
+        enum FileError {
+            ReadFailed(File, string),
+            Other,
+        }
+
+        func bad(take e: FileError) {
+            match e {
+                FileError.Other => {},
+                _ => {}
+            }
+        }
+
+        func main() {}
+    "#);
+    let output = check_file(path.to_str().unwrap(), &default_config());
+    assert!(!output.succeeded(), "ER43: top-level wildcard on linear scrutinee must error");
+    assert!(
+        output.diagnostics.iter().any(|d| d.code.as_ref().map_or(false, |c| c.0 == "E0816")),
+        "expected E0816 for linear-wildcard discard, got: {:?}",
+        output.diagnostics.iter().map(|d| (&d.code, &d.message)).collect::<Vec<_>>()
+    );
+    let _ = std::fs::remove_file(&path);
+}
+
+#[test]
+fn er43_field_wildcard_on_linear_payload_errors() {
+    // ER43: a `_` inside a constructor pattern at a linear field position
+    // drops that payload silently. Compile error.
+    let path = tmp_rk(r#"
+        @resource
+        struct File { path: string }
+        extend File { func close(take self) {} }
+
+        enum FileError {
+            ReadFailed(File, string),
+            Other,
+        }
+
+        func bad(take e: FileError) {
+            match e {
+                FileError.ReadFailed(_, _) => {},
+                FileError.Other => {}
+            }
+        }
+
+        func main() {}
+    "#);
+    let output = check_file(path.to_str().unwrap(), &default_config());
+    assert!(!output.succeeded(), "ER43: nested wildcard on linear field must error");
+    let has_er43 = output.diagnostics.iter().any(|d| {
+        d.code.as_ref().map_or(false, |c| c.0 == "E0816") && d.message.contains("File")
+    });
+    assert!(has_er43,
+        "expected E0816 mentioning File, got: {:?}",
+        output.diagnostics.iter().map(|d| (&d.code, &d.message)).collect::<Vec<_>>()
+    );
+    let _ = std::fs::remove_file(&path);
+}
+
+#[test]
+fn er42_linear_field_bound_and_consumed_compiles() {
+    // ER42 acceptance: when every arm consumes the linear payload it binds,
+    // the program is well-formed.
+    let path = tmp_rk(r#"
+        @resource
+        struct File { path: string }
+        extend File { func close(take self) {} }
+
+        enum FileError {
+            ReadFailed(File, string),
+            Other,
+        }
+
+        func good(take e: FileError) {
+            match e {
+                FileError.ReadFailed(file, _) => file.close(),
+                FileError.Other => {}
+            }
+        }
+
+        func main() {}
+    "#);
+    let output = check_file(path.to_str().unwrap(), &default_config());
+    assert!(output.succeeded(),
+        "ER42 good case must compile, got: {:?}",
+        output.diagnostics.iter().map(|d| (&d.code, &d.message)).collect::<Vec<_>>()
+    );
+    let _ = std::fs::remove_file(&path);
+}
+
+#[test]
+fn er42_struct_with_linear_field_is_transitively_linear() {
+    // A plain struct that wraps a @resource is itself linear: forgetting
+    // to consume it must error (resource not consumed at scope exit).
+    let path = tmp_rk(r#"
+        @resource
+        struct File { path: string }
+        extend File { func close(take self) {} }
+
+        struct Wrapper { file: File }
+
+        func leak(take w: Wrapper) {
+            // never consume w — compile error
+        }
+
+        func main() {}
+    "#);
+    let output = check_file(path.to_str().unwrap(), &default_config());
+    assert!(!output.succeeded(),
+        "transitive linearity: must error when wrapper isn't consumed"
+    );
+    let _ = std::fs::remove_file(&path);
+}

--- a/compiler/crates/rask-diagnostics/src/convert.rs
+++ b/compiler/crates/rask-diagnostics/src/convert.rs
@@ -1176,6 +1176,35 @@ impl ToDiagnostic for rask_ownership::OwnershipError {
                 .with_help(format!("clone `{}` before passing, or restructure to avoid taking ownership", item))
                 .with_why("for-mutate borrows elements in place — taking ownership would leave a hole in the collection")
             }
+
+            LinearWildcardDiscard { position, type_name } => {
+                use rask_ownership::LinearDiscardPosition;
+                let (label, help) = match position {
+                    LinearDiscardPosition::Scrutinee => (
+                        format!("`_` would silently drop linear value of type `{}`", type_name),
+                        "name the value with `name` (or `Type as name`) and consume it on every arm".to_string(),
+                    ),
+                    LinearDiscardPosition::Field { constructor, field, index } => {
+                        let where_ = match (field, index) {
+                            (Some(f), _) => format!("field `{}` of `{}`", f, constructor),
+                            (None, Some(i)) => format!("field {} of `{}`", i, constructor),
+                            (None, None) => format!("a field of `{}`", constructor),
+                        };
+                        (
+                            format!("`_` discards linear `{}` payload in {}", type_name, where_),
+                            "bind the linear field by name and consume it (e.g. `try value.close()`)".to_string(),
+                        )
+                    }
+                };
+                Diagnostic::error(format!(
+                    "wildcard would silently drop linear value of type `{}`",
+                    type_name
+                ))
+                .with_code("E0816")
+                .with_primary(self.span, label)
+                .with_help(help)
+                .with_why("linear values must be consumed exactly once — a `_` here would leak the resource [ER42/ER43]")
+            }
         }
     }
 }

--- a/compiler/crates/rask-ownership/src/error.rs
+++ b/compiler/crates/rask-ownership/src/error.rs
@@ -155,6 +155,35 @@ pub enum OwnershipErrorKind {
     ScopeLimitedClosureEscapes {
         name: String,
     },
+
+    /// ER43: a wildcard pattern would silently drop a transitively-linear value.
+    /// Either the whole scrutinee is linear and `_` discards it, or a pattern
+    /// position inside a destructure (variant payload, struct field, tuple
+    /// element) is linear and the user wrote `_` there.
+    #[error("`_` here would silently drop linear value of type `{type_name}`")]
+    LinearWildcardDiscard {
+        /// Where the discard happens (whole scrutinee vs nested field).
+        position: LinearDiscardPosition,
+        /// The transitively-linear type that would be dropped.
+        type_name: String,
+    },
+}
+
+/// Where a linear-wildcard discard occurred. Drives the ER43 diagnostic copy.
+#[derive(Debug, Clone)]
+pub enum LinearDiscardPosition {
+    /// Top-level wildcard arm: `match r { _ => ... }` where `r` is linear.
+    Scrutinee,
+    /// Field inside a destructured variant or struct pattern.
+    Field {
+        /// Constructor or struct name (e.g. `FileError.ReadFailed`, `Wrapper`).
+        constructor: String,
+        /// Field name when known (struct patterns, named variant fields).
+        /// Constructor patterns use the positional index instead.
+        field: Option<String>,
+        /// Positional index for tuple-style payloads.
+        index: Option<usize>,
+    },
 }
 
 /// User-friendly access kind for error messages.

--- a/compiler/crates/rask-ownership/src/lib.rs
+++ b/compiler/crates/rask-ownership/src/lib.rs
@@ -10,7 +10,9 @@ mod state;
 mod error;
 
 pub use state::{BindingState, BorrowMode, BorrowScope, ActiveBorrow};
-pub use error::{OwnershipError, OwnershipErrorKind, AccessKind, MoveReason};
+pub use error::{
+    AccessKind, LinearDiscardPosition, MoveReason, OwnershipError, OwnershipErrorKind,
+};
 
 use std::collections::{HashMap, HashSet};
 
@@ -479,7 +481,8 @@ impl<'a> OwnershipChecker<'a> {
             }
             StmtKind::WhileLet { pattern, expr, body } => {
                 self.check_expr(expr);
-                self.register_pattern_bindings(pattern);
+                let scrutinee_ty = self.program.node_types.get(&expr.id).cloned();
+                self.register_pattern_bindings_typed(pattern, scrutinee_ty.as_ref(), expr.span);
                 self.check_block(body);
             }
             StmtKind::For { label: _, binding, mutate, iter, body, .. } => {
@@ -991,7 +994,8 @@ impl<'a> OwnershipChecker<'a> {
             ExprKind::IfLet { expr: scrutinee, pattern, then_branch, else_branch } => {
                 self.check_expr(scrutinee);
                 let pre_branch = self.bindings.clone();
-                self.register_pattern_bindings(pattern);
+                let scrutinee_ty = self.program.node_types.get(&scrutinee.id).cloned();
+                self.register_pattern_bindings_typed(pattern, scrutinee_ty.as_ref(), scrutinee.span);
                 self.check_expr(then_branch);
                 let then_terminal = Self::is_terminal_expr(then_branch);
                 if let Some(else_branch) = else_branch {
@@ -1015,8 +1019,30 @@ impl<'a> OwnershipChecker<'a> {
             }
             ExprKind::Match { scrutinee, arms } => {
                 self.check_expr(scrutinee);
+                let scrutinee_ty = self.program.node_types.get(&scrutinee.id).cloned();
+                // L5: matching destructures the scrutinee. For a non-Copy
+                // owned binding, ownership transfers into the arms — the
+                // arm patterns receive the parts. Mark the scrutinee Moved
+                // so the function-exit check doesn't ask the caller to also
+                // consume it. Borrowed scrutinees stay borrowed.
+                if let ExprKind::Ident(name) = &scrutinee.kind {
+                    let owned = matches!(self.bindings.get(name), Some(BindingState::Owned));
+                    let needs_move = scrutinee_ty
+                        .as_ref()
+                        .map_or(false, |ty| !self.is_copy(ty));
+                    if owned && needs_move {
+                        self.bindings.insert(
+                            name.clone(),
+                            BindingState::Moved { at: scrutinee.span },
+                        );
+                    }
+                }
                 for arm in arms {
-                    self.register_pattern_bindings(&arm.pattern);
+                    self.register_pattern_bindings_typed(
+                        &arm.pattern,
+                        scrutinee_ty.as_ref(),
+                        scrutinee.span,
+                    );
                     if let Some(guard) = &arm.guard {
                         self.check_expr(guard);
                     }
@@ -1671,37 +1697,243 @@ impl<'a> OwnershipChecker<'a> {
         }
     }
 
-    /// Register pattern bindings as owned.
-    fn register_pattern_bindings(&mut self, pattern: &Pattern) {
+    /// Resolve a scrutinee `Type` to a struct's `(name, type)` field list, if
+    /// the type names a struct (or a `Generic` whose base is a struct).
+    fn struct_fields_for_type(&self, ty: &Type) -> Option<Vec<(String, Type)>> {
+        let id = match ty {
+            Type::Named(id) => *id,
+            Type::Generic { base, .. } => *base,
+            Type::UnresolvedNamed(name) | Type::UnresolvedGeneric { name, .. } => {
+                let base = name.split('<').next().unwrap_or(name);
+                self.program.types.get_type_id(base)?
+            }
+            _ => return None,
+        };
+        match self.program.types.get(id)? {
+            rask_types::TypeDef::Struct { fields, .. } => Some(fields.clone()),
+            _ => None,
+        }
+    }
+
+    /// Look up struct fields by struct name. Used when a struct pattern names
+    /// the struct directly but the scrutinee type is unresolved.
+    fn struct_fields_by_name(&self, name: &str) -> Option<Vec<(String, Type)>> {
+        let id = self.program.types.get_type_id(name)?;
+        match self.program.types.get(id)? {
+            rask_types::TypeDef::Struct { fields, .. } => Some(fields.clone()),
+            _ => None,
+        }
+    }
+
+    /// Find a variant's payload types in the enum that `scrutinee_ty` points to,
+    /// or — when scrutinee is a `Result { ok, err }` — search inside `ok` then
+    /// `err`. The constructor name may be qualified (`FileError.ReadFailed`)
+    /// or bare (`ReadFailed`); the qualified prefix is honored when present.
+    fn variant_payload_for(&self, scrutinee_ty: &Type, ctor: &str) -> Option<Vec<Type>> {
+        let (enum_name, variant_name) = match ctor.split_once('.') {
+            Some((e, v)) => (Some(e.to_string()), v.to_string()),
+            None => (None, ctor.to_string()),
+        };
+
+        // Qualified: jump straight to the named enum.
+        if let Some(name) = &enum_name {
+            return self.variant_payload_by_enum(name, &variant_name);
+        }
+
+        match scrutinee_ty {
+            Type::Named(id) => self.variant_payload_in_def(*id, &variant_name),
+            Type::Generic { base, .. } => self.variant_payload_in_def(*base, &variant_name),
+            Type::Result { ok, err } => self
+                .variant_payload_for(ok, &variant_name)
+                .or_else(|| self.variant_payload_for(err, &variant_name)),
+            Type::Union(variants) => variants
+                .iter()
+                .find_map(|v| self.variant_payload_for(v, &variant_name)),
+            Type::UnresolvedNamed(name) | Type::UnresolvedGeneric { name, .. } => {
+                let base = name.split('<').next().unwrap_or(name);
+                let id = self.program.types.get_type_id(base)?;
+                self.variant_payload_in_def(id, &variant_name)
+            }
+            _ => None,
+        }
+    }
+
+    fn variant_payload_in_def(&self, id: rask_types::TypeId, variant: &str) -> Option<Vec<Type>> {
+        match self.program.types.get(id)? {
+            rask_types::TypeDef::Enum { variants, .. } => variants
+                .iter()
+                .find(|(n, _)| n == variant)
+                .map(|(_, ts)| ts.clone()),
+            _ => None,
+        }
+    }
+
+    fn variant_payload_by_enum(&self, enum_name: &str, variant: &str) -> Option<Vec<Type>> {
+        let id = self.program.types.get_type_id(enum_name)?;
+        self.variant_payload_in_def(id, variant)
+    }
+
+    /// Search every registered enum for a variant by bare name. Used as a
+    /// fallback when the scrutinee type is unavailable.
+    fn variant_payload_by_name(&self, ctor: &str) -> Option<Vec<Type>> {
+        if let Some((e, v)) = ctor.split_once('.') {
+            return self.variant_payload_by_enum(e, v);
+        }
+        for def in self.program.types.iter() {
+            if let rask_types::TypeDef::Enum { variants, .. } = def {
+                if let Some((_, ts)) = variants.iter().find(|(n, _)| n == ctor) {
+                    return Some(ts.clone());
+                }
+            }
+        }
+        None
+    }
+
+    /// Register pattern bindings, walking with scrutinee type info so a linear
+    /// position's `_` becomes ER43 and a binding at a linear position is added
+    /// to `resource_bindings`. The `pattern_span` is the scrutinee/match-arm
+    /// span used for diagnostics. `scrutinee_ty: None` skips ER42/ER43 checks
+    /// at the top level — callers without a known type pass None.
+    fn register_pattern_bindings_typed(
+        &mut self,
+        pattern: &Pattern,
+        scrutinee_ty: Option<&Type>,
+        pattern_span: Span,
+    ) {
         match pattern {
+            Pattern::Wildcard => {
+                if let Some(ty) = scrutinee_ty {
+                    if self.type_is_resource(ty) {
+                        self.errors.push(OwnershipError {
+                            kind: OwnershipErrorKind::LinearWildcardDiscard {
+                                position: error::LinearDiscardPosition::Scrutinee,
+                                type_name: format!(
+                                    "{}",
+                                    self.program.types.resolve_type_names(ty)
+                                ),
+                            },
+                            span: pattern_span,
+                        });
+                    }
+                }
+            }
             Pattern::Ident(name) => {
+                // Qualified path "Enum.Variant" without parens is a constructor
+                // pattern with zero fields, not a binding (parser rule).
+                if name.contains('.') {
+                    return;
+                }
                 self.bindings.insert(name.clone(), BindingState::Owned);
+                if let Some(ty) = scrutinee_ty {
+                    self.binding_types.insert(name.clone(), ty.clone());
+                    if self.type_is_resource(ty) {
+                        self.resource_bindings.insert(name.clone());
+                    }
+                }
+            }
+            Pattern::Literal(_) | Pattern::Range { .. } => {
+                // Literal/range matches don't bind. Linear values are not
+                // comparable, so this position must be primitive — nothing to do.
             }
             Pattern::Tuple(pats) => {
-                for pat in pats {
-                    self.register_pattern_bindings(pat);
+                let elem_tys = scrutinee_ty.and_then(|ty| match ty {
+                    Type::Tuple(elems) => Some(elems.clone()),
+                    _ => None,
+                });
+                for (i, pat) in pats.iter().enumerate() {
+                    let pos_ty = elem_tys.as_ref().and_then(|tys| tys.get(i));
+                    self.register_pattern_bindings_typed(pat, pos_ty, pattern_span);
                 }
             }
-            Pattern::Struct { name: _, fields, rest: _ } => {
-                for (_, pat) in fields {
-                    self.register_pattern_bindings(pat);
+            Pattern::Struct { name, fields, rest } => {
+                let struct_fields = scrutinee_ty
+                    .and_then(|ty| self.struct_fields_for_type(ty))
+                    .or_else(|| self.struct_fields_by_name(name));
+                for (field_name, pat) in fields {
+                    let pos_ty = struct_fields
+                        .as_ref()
+                        .and_then(|fs| fs.iter().find(|(n, _)| n == field_name))
+                        .map(|(_, t)| t.clone());
+                    self.register_pattern_bindings_typed(pat, pos_ty.as_ref(), pattern_span);
+                }
+                // ER43: `..` rest discards every unmentioned linear field.
+                if *rest {
+                    if let Some(struct_fields) = struct_fields {
+                        let mentioned: std::collections::HashSet<&str> =
+                            fields.iter().map(|(n, _)| n.as_str()).collect();
+                        for (fname, fty) in &struct_fields {
+                            if !mentioned.contains(fname.as_str())
+                                && self.type_is_resource(fty)
+                            {
+                                self.errors.push(OwnershipError {
+                                    kind: OwnershipErrorKind::LinearWildcardDiscard {
+                                        position: error::LinearDiscardPosition::Field {
+                                            constructor: name.clone(),
+                                            field: Some(fname.clone()),
+                                            index: None,
+                                        },
+                                        type_name: format!(
+                                            "{}",
+                                            self.program.types.resolve_type_names(fty)
+                                        ),
+                                    },
+                                    span: pattern_span,
+                                });
+                            }
+                        }
+                    }
                 }
             }
-            Pattern::Constructor { name: _, fields } => {
-                for pat in fields {
-                    self.register_pattern_bindings(pat);
+            Pattern::Constructor { name, fields } => {
+                let payload_tys = scrutinee_ty
+                    .and_then(|ty| self.variant_payload_for(ty, name))
+                    .or_else(|| self.variant_payload_by_name(name));
+                for (i, pat) in fields.iter().enumerate() {
+                    let pos_ty = payload_tys.as_ref().and_then(|tys| tys.get(i));
+                    if let Pattern::Wildcard = pat {
+                        if let Some(ty) = pos_ty {
+                            if self.type_is_resource(ty) {
+                                self.errors.push(OwnershipError {
+                                    kind: OwnershipErrorKind::LinearWildcardDiscard {
+                                        position: error::LinearDiscardPosition::Field {
+                                            constructor: name.clone(),
+                                            field: None,
+                                            index: Some(i),
+                                        },
+                                        type_name: format!(
+                                            "{}",
+                                            self.program.types.resolve_type_names(ty)
+                                        ),
+                                    },
+                                    span: pattern_span,
+                                });
+                            }
+                        }
+                        continue;
+                    }
+                    self.register_pattern_bindings_typed(pat, pos_ty, pattern_span);
                 }
             }
             Pattern::Or(pats) => {
-                // For or-patterns, all branches should bind the same names
+                // Each alternative binds the same names; let the typed walk
+                // mark resources on the first, then de-dup with the rest.
                 for pat in pats {
-                    self.register_pattern_bindings(pat);
+                    self.register_pattern_bindings_typed(pat, scrutinee_ty, pattern_span);
                 }
             }
-            Pattern::Wildcard | Pattern::Literal(_) | Pattern::Range { .. } => {}
-            Pattern::TypePat { binding, .. } => {
+            Pattern::TypePat { ty_name, binding } => {
                 if let Some(name) = binding {
                     self.bindings.insert(name.clone(), BindingState::Owned);
+                    // Resolve the narrowed type to determine linearity. Strip
+                    // generic args ("FileError<T>" → "FileError") for lookup.
+                    let base = ty_name.split('<').next().unwrap_or(ty_name);
+                    if let Some(id) = self.program.types.get_type_id(base) {
+                        let narrow_ty = Type::Named(id);
+                        self.binding_types.insert(name.clone(), narrow_ty.clone());
+                        if self.type_is_resource(&narrow_ty) {
+                            self.resource_bindings.insert(name.clone());
+                        }
+                    }
                 }
             }
         }
@@ -1960,7 +2192,6 @@ impl<'a> OwnershipChecker<'a> {
 
     /// Check if a method call uses `take self`.
     fn is_take_self_method(&self, object: &Expr, method_name: &str) -> bool {
-        // Look up the type of the object expression
         if let Some(ty) = self.program.node_types.get(&object.id) {
             let type_id = match ty {
                 Type::Named(id) => Some(*id),
@@ -1984,35 +2215,23 @@ impl<'a> OwnershipChecker<'a> {
         false
     }
 
-    /// Check if a type name refers to a @resource struct.
+    /// L1/ER42: a type-name annotation refers to a transitively-linear type.
+    /// Strips generic args ("File<T>" → "File") and asks the type table.
     fn is_resource_type_name(&self, ty_name: &str) -> bool {
-        // Strip generic args: "File<T>" -> "File"
         let base = ty_name.split('<').next().unwrap_or(ty_name);
-        self.program.types.is_resource_type(base)
-    }
-
-    /// Check if a Type value refers to a @resource struct.
-    fn type_is_resource(&self, ty: &Type) -> bool {
-        match ty {
-            Type::Named(type_id) => {
-                if let Some(rask_types::TypeDef::Struct { is_resource, .. }) = self.program.types.get(*type_id) {
-                    return *is_resource;
-                }
-                false
-            }
-            Type::Generic { base, .. } => {
-                if let Some(rask_types::TypeDef::Struct { is_resource, .. }) = self.program.types.get(*base) {
-                    return *is_resource;
-                }
-                false
-            }
-            Type::UnresolvedNamed(name) => self.is_resource_type_name(name),
-            Type::UnresolvedGeneric { name, .. } => self.is_resource_type_name(name),
-            _ => false,
+        if let Some(id) = self.program.types.get_type_id(base) {
+            return self.program.types.is_transitive_resource_by_id(id);
         }
+        false
     }
 
-    /// Check if an expression's inferred type is a @resource type.
+    /// L1/ER42: a `Type` is transitively linear (carries `@resource` directly
+    /// or through nested fields/variants/tuples/etc.).
+    fn type_is_resource(&self, ty: &Type) -> bool {
+        self.program.types.type_is_transitive_resource(ty)
+    }
+
+    /// Whether an expression's inferred type is transitively linear.
     fn expr_is_resource_type(&self, expr: &Expr) -> bool {
         self.program.node_types.get(&expr.id)
             .map_or(false, |ty| self.type_is_resource(ty))

--- a/compiler/crates/rask-types/src/checker/check_pattern.rs
+++ b/compiler/crates/rask-types/src/checker/check_pattern.rs
@@ -461,12 +461,16 @@ impl TypeChecker {
             _ => {}
         }
 
+        // Qualified `Enum.Variant` patterns: the variant lookup needs the
+        // bare variant name, not the enum-qualified path.
+        let variant_lookup_name = name.rsplit('.').next().unwrap_or(name);
+
         match &resolved_scrutinee {
             Type::Named(type_id) => {
                 let variant_fields = self.types.get(*type_id).and_then(|def| {
                     if let TypeDef::Enum { variants, .. } = def {
                         variants.iter()
-                            .find(|(n, _)| n == name)
+                            .find(|(n, _)| n == variant_lookup_name)
                             .map(|(_, f)| f.clone())
                     } else {
                         None

--- a/compiler/crates/rask-types/src/checker/declarations.rs
+++ b/compiler/crates/rask-types/src/checker/declarations.rs
@@ -48,6 +48,7 @@ impl TypeChecker {
             }
         }
         self.propagate_uniqueness();
+        self.propagate_resource_linearity();
         self.auto_derive_traits();
         self.register_binary_methods();
 
@@ -202,6 +203,10 @@ impl TypeChecker {
             is_unique,
             is_binary,
             private_fields,
+            // ER42/L1: refined by `propagate_resource_linearity` after all
+            // declarations are collected. @resource is the seed; transitive
+            // linearity propagates from there.
+            is_transitive_resource: is_resource,
         });
 
         if let Some(info) = binary_info {
@@ -287,6 +292,9 @@ impl TypeChecker {
             type_params,
             variants,
             methods,
+            // ER42/L1: refined by `propagate_resource_linearity` once all
+            // declarations are visible.
+            is_transitive_resource: false,
         });
     }
 
@@ -422,6 +430,54 @@ impl TypeChecker {
                             changed = true;
                         }
                     }
+                }
+            }
+            if !changed { break; }
+        }
+    }
+
+    // ------------------------------------------------------------------------
+    // ER42/L1: Transitive linearity — a struct/enum that contains a linear
+    // field (directly or via nested struct/enum/tuple/etc.) is itself linear.
+    // Drives ownership-checker consumption obligations and the ER43 wildcard
+    // ban during pattern matching.
+    // ------------------------------------------------------------------------
+
+    fn propagate_resource_linearity(&mut self) {
+        use crate::types::TypeId;
+
+        loop {
+            let mut changed = false;
+            let type_count = self.types.types.len();
+            for idx in 0..type_count {
+                let id = TypeId(idx as u32);
+                let def = self.types.get(id).unwrap().clone();
+                match &def {
+                    TypeDef::Struct { fields, is_transitive_resource, .. } => {
+                        if *is_transitive_resource { continue; }
+                        let has_linear_field = fields.iter().any(|(_, ty)| {
+                            self.types.type_is_transitive_resource(ty)
+                        });
+                        if has_linear_field {
+                            if let Some(TypeDef::Struct { is_transitive_resource, .. }) = self.types.get_mut(id) {
+                                *is_transitive_resource = true;
+                                changed = true;
+                            }
+                        }
+                    }
+                    TypeDef::Enum { variants, is_transitive_resource, .. } => {
+                        if *is_transitive_resource { continue; }
+                        let has_linear_payload = variants.iter().any(|(_, fts)| {
+                            fts.iter().any(|ty| self.types.type_is_transitive_resource(ty))
+                        });
+                        if has_linear_payload {
+                            if let Some(TypeDef::Enum { is_transitive_resource, .. }) = self.types.get_mut(id) {
+                                *is_transitive_resource = true;
+                                changed = true;
+                            }
+                        }
+                    }
+                    _ => {}
                 }
             }
             if !changed { break; }

--- a/compiler/crates/rask-types/src/checker/type_defs.rs
+++ b/compiler/crates/rask-types/src/checker/type_defs.rs
@@ -25,12 +25,20 @@ pub enum TypeDef {
         is_binary: bool,
         /// V5: fields marked `private` — accessible only inside extend blocks
         private_fields: Vec<String>,
+        /// ER42/L1 transitive linearity: true if `is_resource` is true OR any
+        /// field type is itself transitively linear. Computed by a fixed-point
+        /// pass after declaration collection.
+        is_transitive_resource: bool,
     },
     Enum {
         name: String,
         type_params: Vec<String>,
         variants: Vec<(String, Vec<Type>)>,
         methods: Vec<MethodSig>,
+        /// ER42/L1 transitive linearity: true if any variant payload contains
+        /// a transitively-linear type. Computed by a fixed-point pass after
+        /// declaration collection.
+        is_transitive_resource: bool,
     },
     Trait {
         name: String,

--- a/compiler/crates/rask-types/src/checker/type_table.rs
+++ b/compiler/crates/rask-types/src/checker/type_table.rs
@@ -78,6 +78,7 @@ impl TypeTable {
                 ("None".to_string(), vec![]),
             ],
             methods: vec![],
+            is_transitive_resource: false,
         });
         self.option_type_id = Some(option_id);
 
@@ -89,6 +90,7 @@ impl TypeTable {
                 ("Err".to_string(), vec![Type::Var(TypeVarId(1))]),
             ],
             methods: vec![],
+            is_transitive_resource: false,
         });
         self.result_type_id = Some(result_id);
     }
@@ -248,6 +250,63 @@ impl TypeTable {
             return *is_resource;
         }
         false
+    }
+
+    /// ER42/L1: TypeId is transitively linear (carries a `@resource` directly
+    /// or through any nested field/variant). Computed by
+    /// `propagate_resource_linearity` and queried during ownership checking.
+    pub fn is_transitive_resource_by_id(&self, id: TypeId) -> bool {
+        match self.types.get(id.0 as usize) {
+            Some(TypeDef::Struct { is_transitive_resource, .. }) => *is_transitive_resource,
+            Some(TypeDef::Enum { is_transitive_resource, .. }) => *is_transitive_resource,
+            _ => false,
+        }
+    }
+
+    /// ER42/L1: A `Type` value is transitively linear. Walks through tuples,
+    /// arrays, slices, Result, and Generic args so containers of linear values
+    /// inherit the obligation. Trait objects and unresolved/error types are
+    /// conservatively non-linear.
+    pub fn type_is_transitive_resource(&self, ty: &Type) -> bool {
+        match ty {
+            Type::Named(id) => self.is_transitive_resource_by_id(*id),
+            Type::Generic { base, args } => {
+                if self.is_transitive_resource_by_id(*base) {
+                    return true;
+                }
+                args.iter().any(|a| match a {
+                    crate::types::GenericArg::Type(t) => self.type_is_transitive_resource(t),
+                    _ => false,
+                })
+            }
+            Type::Tuple(elems) => elems.iter().any(|t| self.type_is_transitive_resource(t)),
+            Type::Array { elem, .. } | Type::Slice(elem) => {
+                self.type_is_transitive_resource(elem)
+            }
+            Type::Result { ok, err } => {
+                self.type_is_transitive_resource(ok) || self.type_is_transitive_resource(err)
+            }
+            Type::Union(variants) => variants.iter().any(|v| self.type_is_transitive_resource(v)),
+            Type::UnresolvedNamed(name) => {
+                let base = name.split('<').next().unwrap_or(name);
+                self.type_names
+                    .get(base)
+                    .map_or(false, |id| self.is_transitive_resource_by_id(*id))
+            }
+            Type::UnresolvedGeneric { name, args } => {
+                let base_name = name.split('<').next().unwrap_or(name);
+                if let Some(&id) = self.type_names.get(base_name) {
+                    if self.is_transitive_resource_by_id(id) {
+                        return true;
+                    }
+                }
+                args.iter().any(|a| match a {
+                    crate::types::GenericArg::Type(t) => self.type_is_transitive_resource(t),
+                    _ => false,
+                })
+            }
+            _ => false,
+        }
     }
 
     /// Check if a TypeId refers to a `@unique` struct.


### PR DESCRIPTION
## Summary

This PR implements ER42/ER43 error checking to prevent silent resource leaks when pattern matching on linear (transitively-resource) types. The changes add comprehensive type-aware pattern binding registration, transitive linearity propagation, and wildcard discard detection.

## Key Changes

- **Transitive Linearity Propagation**: Added `propagate_resource_linearity()` in the type checker to compute which structs and enums are transitively linear (contain `@resource` fields directly or through nested types). This fixed-point algorithm marks any type containing a linear field as itself linear.

- **Type-Aware Pattern Binding**: Replaced `register_pattern_bindings()` with `register_pattern_bindings_typed()` that walks patterns with scrutinee type information. This enables:
  - Tracking which bindings are linear via `resource_bindings` set
  - Storing binding types in `binding_types` map for later consumption checks
  - Detecting linear wildcards at pattern positions

- **Linear Wildcard Detection (ER43)**: Added checks to error when:
  - A top-level `_` pattern matches a linear scrutinee
  - A `_` appears at a linear field position in destructured patterns (struct fields, enum variant payloads, tuple elements)
  - A struct pattern's `..` rest discards unmentioned linear fields

- **Match Expression Handling**: Enhanced match expression checking to:
  - Mark the scrutinee as `Moved` when it's an owned non-Copy linear binding (ownership transfers into arms)
  - Pass scrutinee type to each arm's pattern binding registration
  - Support qualified variant names (`Enum.Variant`) in pattern matching

- **Type Resolution Helpers**: Added methods to resolve type information from patterns:
  - `struct_fields_for_type()` / `struct_fields_by_name()` for struct destructuring
  - `variant_payload_for()` / `variant_payload_in_def()` / `variant_payload_by_name()` for enum variants
  - Handles unresolved types by stripping generic args and looking up base names

- **Transitive Linearity Queries**: Updated `type_is_resource()` to use new `type_is_transitive_resource()` method that recursively checks containers (tuples, arrays, Result, Union, generics).

- **Diagnostic Support**: Added `LinearDiscardPosition` enum and `LinearWildcardDiscard` error kind with detailed diagnostics distinguishing scrutinee-level vs nested field discards (E0816).

- **Test Coverage**: Added three integration tests covering ER43 rejection cases and ER42 acceptance when linear payloads are properly consumed.

## Implementation Details

- Pattern matching now requires type information to determine linearity obligations
- `if-let` and `while-let` expressions also use typed pattern binding
- Qualified patterns like `FileError.ReadFailed` are recognized as constructor patterns (zero-field bindings) rather than identifiers
- Type narrowing in `TypePat` patterns resolves the narrowed type to check linearity
- The implementation conservatively treats unresolved types as non-linear to avoid false positives

https://claude.ai/code/session_01A8BqTRxqf2BGuAhWoP7u1S