### PR TITLE
Fix type collision in `rask test <dir>` for standalone files

### DIFF
--- a/compiler/crates/rask-cli/src/commands/run.rs
+++ b/compiler/crates/rask-cli/src/commands/run.rs
@@ -266,25 +266,46 @@ pub fn cmd_test_native_with_opts(path: &str, filter: Option<String>, format: For
 }
 
 pub fn cmd_test_native(path: &str, filter: Option<String>, format: Format) {
-    let mut result = match std::panic::catch_unwind(|| {
-        crate::run_check_or_exit(path, format)
-    }) {
-        Ok(r) => r,
+    if !run_test_file_native(path, filter.as_deref(), format) {
+        process::exit(1);
+    }
+}
+
+/// Run tests for a single file natively. Returns true on success.
+/// Unlike `cmd_test_native`, this never calls `process::exit` — failures are
+/// reported via diagnostics and the return value, so callers can iterate over
+/// multiple files without aborting on the first failure. Panics anywhere in
+/// the pipeline are caught and reported as a per-file failure.
+pub fn run_test_file_native(path: &str, filter: Option<&str>, format: Format) -> bool {
+    let path_owned = path.to_string();
+    let filter_owned = filter.map(|s| s.to_string());
+    let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+        run_test_file_native_inner(&path_owned, filter_owned.as_deref(), format)
+    }));
+    match result {
+        Ok(success) => success,
         Err(_) => {
-            eprintln!("{}: frontend panic for {}", output::error_label(), path);
-            process::exit(1);
+            eprintln!("{}: panic while testing {}", output::error_label(), path);
+            false
         }
+    }
+}
+
+fn run_test_file_native_inner(path: &str, filter: Option<&str>, format: Format) -> bool {
+    let mut result = match crate::run_check(path, format) {
+        Ok(r) => r,
+        Err(_) => return false,
     };
 
     rask_mir::hidden_params::desugar_hidden_params_with_types(&mut result.decls, Some(&result.typed.node_types));
-    let tests = super::compile::extract_tests(&mut result.decls, filter.as_deref());
+    let tests = super::compile::extract_tests(&mut result.decls, filter);
 
     if tests.is_empty() {
         if format == Format::Human {
             println!("{} Testing {} {}\n", "===".dimmed(), output::file_path(path), "===".dimmed());
             println!("  No tests found.");
         }
-        return;
+        return true;
     }
 
     // Inject compiled stdlib functions + struct defs for mono/codegen
@@ -301,7 +322,7 @@ pub fn cmd_test_native(path: &str, filter: Option<String>, format: Format) {
         Ok(m) => m,
         Err(e) => {
             eprintln!("{}: mono: {:?}", output::error_label(), e);
-            process::exit(1);
+            return false;
         }
     };
     let cfg = rask_comptime::CfgConfig::from_host("debug", vec![]);
@@ -323,14 +344,14 @@ pub fn cmd_test_native(path: &str, filter: Option<String>, format: Format) {
             eprintln!("{}: compile: {}", output::error_label(), e);
         }
         let _ = std::fs::remove_file(&obj_path);
-        process::exit(1);
+        return false;
     }
 
     let link_opts = super::link::LinkOptions::default();
     if let Err(e) = super::link::link_executable_with(&obj_path, &bin_str, &link_opts, false, None) {
         eprintln!("{}: link: {}", output::error_label(), e);
         let _ = std::fs::remove_file(&obj_path);
-        process::exit(1);
+        return false;
     }
     let _ = std::fs::remove_file(&obj_path);
 
@@ -341,14 +362,58 @@ pub fn cmd_test_native(path: &str, filter: Option<String>, format: Format) {
         Ok(out) => {
             let stdout = String::from_utf8_lossy(&out.stdout);
             display_test_results(&stdout, path, format);
-            if !out.status.success() {
-                process::exit(1);
-            }
+            out.status.success()
         }
         Err(e) => {
             eprintln!("{}: executing test binary: {}", output::error_label(), e);
-            process::exit(1);
+            false
         }
+    }
+}
+
+/// Run tests for every `.rk` file in a directory independently.
+///
+/// Each file is type-checked and compiled in isolation, so identically-named
+/// types in different files don't collide. Used when the directory has no
+/// `build.rk` manifest — i.e., it's a folder of standalone test files rather
+/// than a single multi-file package. Exits 1 if any file fails.
+pub fn cmd_test_files_native(dir: &str, filter: Option<String>, format: Format) {
+    let dir_path = std::path::Path::new(dir);
+    let files = crate::collect_rk_files(dir_path);
+
+    if files.is_empty() {
+        if format == Format::Human {
+            println!("{} Testing {} {}\n", "===".dimmed(), output::file_path(dir), "===".dimmed());
+            println!("  No .rk files found.");
+        }
+        return;
+    }
+
+    if format == Format::Human {
+        println!("{} Test suite: {} ({} files) {}\n",
+            "===".dimmed(), output::file_path(dir), files.len(), "===".dimmed());
+    }
+
+    let mut failed_files = 0;
+    for file in &files {
+        if !run_test_file_native(file, filter.as_deref(), format) {
+            failed_files += 1;
+        }
+    }
+
+    if format == Format::Human && files.len() > 1 {
+        println!();
+        println!("{}", output::separator(50));
+        if failed_files == 0 {
+            println!("{} all {} files passed", output::status_pass(), files.len());
+        } else {
+            println!("{} {} of {} files failed",
+                output::status_fail(), failed_files, files.len());
+        }
+    }
+
+    if failed_files > 0 {
+        process::exit(1);
     }
 }
 

--- a/compiler/crates/rask-cli/src/main.rs
+++ b/compiler/crates/rask-cli/src/main.rs
@@ -111,13 +111,29 @@ pub(crate) fn display_pipeline_output<T>(
 
 /// Run check_file, display all diagnostics, exit on errors. Returns CheckResult on success.
 pub(crate) fn run_check_or_exit(path: &str, format: Format) -> rask_compiler::CheckResult {
+    match run_check(path, format) {
+        Ok(result) => result,
+        Err(err_count) => {
+            if format == Format::Human {
+                eprintln!("\n{}", self::output::banner_fail("Check", err_count));
+            }
+            process::exit(1);
+        }
+    }
+}
+
+/// Like `run_check_or_exit` but returns the error count instead of exiting.
+/// Diagnostics are still displayed. Use this for multi-file iteration where
+/// one file's failure shouldn't stop the rest.
+pub(crate) fn run_check(
+    path: &str,
+    format: Format,
+) -> Result<rask_compiler::CheckResult, usize> {
     let config = rask_compiler::CompilerConfig {
         cfg: rask_compiler::CfgConfig::from_host("debug", vec![]),
     };
     let output = rask_compiler::check_file(path, &config);
 
-    // Source files for display: prefer from pipeline (has all package files
-    // with correct file_id ordering), fall back to reading the target file.
     let source_files: Vec<(std::path::PathBuf, String)> = if !output.source_files.is_empty() {
         output.source_files.clone()
     } else if let Some(ref r) = output.result {
@@ -135,13 +151,10 @@ pub(crate) fn run_check_or_exit(path: &str, format: Format) -> rask_compiler::Ch
         let err_count = output.diagnostics.iter()
             .filter(|d| matches!(d.severity, rask_diagnostics::Severity::Error))
             .count();
-        if format == Format::Human {
-            eprintln!("\n{}", self::output::banner_fail("Check", err_count));
-        }
-        process::exit(1);
+        return Err(err_count);
     }
 
-    output.result.unwrap()
+    Ok(output.result.unwrap())
 }
 
 fn main() {
@@ -388,8 +401,16 @@ fn main() {
                 }
             };
             let test_opts = commands::run::TestOptions { verbose, sequential, seed };
-            if Path::new(file).is_dir() {
-                commands::run::cmd_test_project(file, filter, format);
+            let p = Path::new(file);
+            if p.is_dir() {
+                // Directory with build.rk → single project (all files share types).
+                // Directory without build.rk → folder of standalone files; run each
+                // independently so duplicate type names across files don't collide.
+                if p.join("build.rk").is_file() {
+                    commands::run::cmd_test_project(file, filter, format);
+                } else {
+                    commands::run::cmd_test_files_native(file, filter, format);
+                }
             } else {
                 commands::run::cmd_test_native_with_opts(file, filter, format, &test_opts);
             }

--- a/compiler/crates/rask-cli/tests/compile_run.rs
+++ b/compiler/crates/rask-cli/tests/compile_run.rs
@@ -880,3 +880,65 @@ fn interp_ensure_continuation() {
         "unexpected output: {:?}", stdout
     );
 }
+
+// ─── Regression: issue #236 ─────────────────────────────────
+//
+// `rask test <dir>` on a directory of standalone files (no build.rk)
+// must run each file in isolation. Without isolation, identically named
+// types in different files collide ("expected `Point`, found `Point`"
+// with different TypeIds) — type checking regresses vs single-file mode.
+
+#[test]
+fn test_dir_runs_files_independently() {
+    let rask = rask_binary();
+    let dir = std::env::temp_dir().join(format!("rask_test_dir_indep_{}", std::process::id()));
+    let _ = std::fs::remove_dir_all(&dir);
+    std::fs::create_dir_all(&dir).unwrap();
+
+    // Two files each defining their own `Point` — cannot share a TypeId.
+    std::fs::write(dir.join("a.rk"), r#"
+struct Point { x: i32, y: i32 }
+test "a uses its own Point" {
+    const p = Point { x: 1, y: 2 }
+    assert p.x == 1
+}
+"#).unwrap();
+
+    std::fs::write(dir.join("b.rk"), r#"
+struct Point { x: i32, y: i32, z: i32 }
+test "b uses its own Point" {
+    const p = Point { x: 1, y: 2, z: 3 }
+    assert p.z == 3
+}
+"#).unwrap();
+
+    let out = Command::new(&rask)
+        .arg("test")
+        .arg(&dir)
+        .env("RASK_RUNTIME_DIR", runtime_dir())
+        .output()
+        .expect("failed to run rask test");
+
+    let _ = std::fs::remove_dir_all(&dir);
+
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    let combined = format!("{}{}", stdout, stderr);
+
+    assert!(
+        out.status.success(),
+        "rask test <dir> should succeed when files have independent types\nstdout: {}\nstderr: {}",
+        stdout, stderr,
+    );
+
+    // Per-file processing prevents the spurious "expected `Point`, found `Point`"
+    // error that issue #236 was about.
+    assert!(
+        !combined.contains("expected `Point`, found `Point`"),
+        "must not produce cross-file Point/Point mismatch: {}", combined,
+    );
+    assert!(
+        combined.contains("a uses its own Point") && combined.contains("b uses its own Point"),
+        "both files' tests should run: {}", combined,
+    );
+}


### PR DESCRIPTION
## Summary
Fixes issue #236 where running `rask test <dir>` on a directory of standalone files (without a `build.rk` manifest) would cause type collisions when multiple files defined identically-named types. Each file is now compiled in isolation, preventing cross-file type ID conflicts.

## Key Changes

- **Refactored `cmd_test_native`**: Split into `run_test_file_native` (public, non-exiting) and `run_test_file_native_inner` (private implementation). This allows testing multiple files without aborting on the first failure.

- **Added `cmd_test_files_native`**: New function that iterates over all `.rk` files in a directory and runs each independently. Provides per-file test results and a summary before exiting.

- **Extracted `run_check` from `run_check_or_exit`**: Created a new `run_check` function that returns `Result<CheckResult, usize>` instead of calling `process::exit`. This enables multi-file iteration where one file's failure doesn't stop processing others.

- **Updated directory handling in `main`**: When `rask test <dir>` is invoked:
  - If `build.rk` exists → use `cmd_test_project` (all files share types, single project)
  - If no `build.rk` → use `cmd_test_files_native` (each file compiled independently)

- **Panic handling**: Both `run_test_file_native` and `run_test_file_native_inner` catch panics and report them as per-file failures rather than aborting the entire test run.

## Implementation Details

- Panic catching uses `std::panic::AssertUnwindSafe` to allow capturing owned strings across the panic boundary
- Error handling changed from `process::exit(1)` calls to `return false` statements within the inner function
- Test results summary displays pass/fail counts when testing multiple files
- Maintains backward compatibility: single-file and project-based testing unchanged

https://claude.ai/code/session_01UMFbDpo7WJMQ8FxxrqUsCw