### PR TITLE
Implement if-present expressions with payload narrowing (OPT19/OPT20)

### DIFF
--- a/compiler/crates/rask-mir/src/lower/expr.rs
+++ b/compiler/crates/rask-mir/src/lower/expr.rs
@@ -608,8 +608,8 @@ impl<'a> MirLowerer<'a> {
                 cond,
                 then_branch,
                 else_branch,
-                ..
-            } => self.lower_if(cond, then_branch, else_branch.as_deref()),
+                else_binding,
+            } => self.lower_if(cond, then_branch, else_branch.as_deref(), else_binding.as_deref()),
 
             // Match expression (spec L2)
             ExprKind::Match { scrutinee, arms } => self.lower_match(scrutinee, arms),
@@ -3057,7 +3057,29 @@ impl<'a> MirLowerer<'a> {
         cond: &Expr,
         then_branch: &Expr,
         else_branch: Option<&Expr>,
+        else_binding: Option<&str>,
     ) -> Result<TypedOperand, LoweringError> {
+        // OPT19/OPT20 + ER19/ER20/ER21/ER22: `if x?` / `if x? as v` /
+        // `... else as e` evaluate the scrutinee once and rebind the
+        // payload as a local in the matching branch.
+        if let ExprKind::IsPresent { expr: inner, binding } = &cond.kind {
+            let then_name = match (binding.as_deref(), &inner.kind) {
+                (Some(v), _) => Some(v.to_string()),
+                (None, ExprKind::Ident(n)) => Some(n.clone()),
+                _ => None,
+            };
+            let else_name = else_binding.map(|s| s.to_string()).or_else(|| then_name.clone());
+            if then_name.is_some() || else_name.is_some() {
+                return self.lower_if_present(
+                    inner,
+                    then_branch,
+                    else_branch,
+                    then_name,
+                    else_name,
+                );
+            }
+        }
+
         let (cond_op, _) = self.lower_expr(cond)?;
 
         let then_block = self.builder.create_block();
@@ -3104,6 +3126,113 @@ impl<'a> MirLowerer<'a> {
 
         self.builder.switch_to_block(merge_block);
 
+        Ok((MirOperand::Local(result_local), then_ty))
+    }
+
+    /// Lower `if expr? [as v] { then } [else [as e] { else_br }]` — present-check
+    /// with payload narrowing. Mirrors the interpreter path in
+    /// `rask-interp/src/interp/eval_expr.rs::ExprKind::If(IsPresent ..)`.
+    fn lower_if_present(
+        &mut self,
+        inner: &Expr,
+        then_branch: &Expr,
+        else_branch: Option<&Expr>,
+        then_name: Option<String>,
+        else_name: Option<String>,
+    ) -> Result<TypedOperand, LoweringError> {
+        let is_niche = self.is_niche_option_expr(inner);
+        let (val, _) = self.lower_expr(inner)?;
+        let tag = self.emit_option_tag(&val, is_niche);
+
+        // Branch on tag: 0 = present (Some/Ok), nonzero = absent (None/Err).
+        let is_present = self.builder.alloc_temp(MirType::Bool);
+        self.builder.push_stmt(MirStmt::dummy(MirStmtKind::Assign {
+            dst: is_present,
+            rvalue: MirRValue::BinaryOp {
+                op: crate::operand::BinOp::Eq,
+                left: MirOperand::Local(tag),
+                right: MirOperand::Constant(MirConst::Int(0)),
+            },
+        }));
+
+        let then_block = self.builder.create_block();
+        let else_block = self.builder.create_block();
+        let merge_block = self.builder.create_block();
+
+        self.builder.terminate(MirTerminator::dummy(MirTerminatorKind::Branch {
+            cond: MirOperand::Local(is_present),
+            then_block,
+            else_block,
+        }));
+
+        // Then: bind the present payload as the narrow name, lower body.
+        self.builder.switch_to_block(then_block);
+        let payload_ty = self.extract_payload_type(inner).unwrap_or(MirType::I64);
+        if let Some(name) = then_name.as_ref() {
+            let local = self.builder.alloc_local(name.clone(), payload_ty.clone());
+            let rvalue = if is_niche {
+                MirRValue::Use(val.clone())
+            } else {
+                MirRValue::Field {
+                    base: val.clone(),
+                    field_index: 0,
+                    byte_offset: None,
+                    field_size: None,
+                }
+            };
+            self.builder.push_stmt(MirStmt::dummy(MirStmtKind::Assign { dst: local, rvalue }));
+            self.locals.insert(name.clone(), (local, payload_ty.clone()));
+            if let Some(prefix) = self.mir_type_name(&payload_ty) {
+                self.meta_mut(name).type_prefix = Some(prefix);
+            }
+        }
+        let (then_val, then_ty) = self.lower_expr(then_branch)?;
+        let result_local = self.builder.alloc_temp(then_ty.clone());
+        if self.builder.current_block_unterminated() {
+            self.builder.push_stmt(MirStmt::dummy(MirStmtKind::Assign {
+                dst: result_local,
+                rvalue: MirRValue::Use(then_val),
+            }));
+            self.builder.terminate(MirTerminator::dummy(MirTerminatorKind::Goto {
+                target: merge_block,
+            }));
+        }
+
+        // Else: for Result, bind the err payload (field 0) as the else name.
+        // For Option, None has no payload so skip the bind.
+        self.builder.switch_to_block(else_block);
+        if let (Some(name), Some(err_ty)) = (else_name.as_ref(), self.extract_err_type(inner)) {
+            let local = self.builder.alloc_local(name.clone(), err_ty.clone());
+            self.builder.push_stmt(MirStmt::dummy(MirStmtKind::Assign {
+                dst: local,
+                rvalue: MirRValue::Field {
+                    base: val.clone(),
+                    field_index: 0,
+                    byte_offset: None,
+                    field_size: None,
+                },
+            }));
+            self.locals.insert(name.clone(), (local, err_ty.clone()));
+            if let Some(prefix) = self.mir_type_name(&err_ty) {
+                self.meta_mut(name).type_prefix = Some(prefix);
+            }
+        }
+        if let Some(else_expr) = else_branch {
+            let (else_val, _) = self.lower_expr(else_expr)?;
+            if self.builder.current_block_unterminated() {
+                self.builder.push_stmt(MirStmt::dummy(MirStmtKind::Assign {
+                    dst: result_local,
+                    rvalue: MirRValue::Use(else_val),
+                }));
+            }
+        }
+        if self.builder.current_block_unterminated() {
+            self.builder.terminate(MirTerminator::dummy(MirTerminatorKind::Goto {
+                target: merge_block,
+            }));
+        }
+
+        self.builder.switch_to_block(merge_block);
         Ok((MirOperand::Local(result_local), then_ty))
     }
 

--- a/compiler/crates/rask-types/src/checker/resolve.rs
+++ b/compiler/crates/rask-types/src/checker/resolve.rs
@@ -623,6 +623,58 @@ impl TypeChecker {
                 let err = *err.clone();
                 self.resolve_result_method(&ok, &err, &method, &args, &ret, span)
             }
+            // ER4: A method on a union (`A | B`) dispatches when every variant
+            // implements a compatible method. The result type is the unified
+            // return — repeated unification of `ret` against each variant's
+            // return type enforces compatibility.
+            Type::Union(variants) => {
+                let variants = variants.clone();
+                let any_unresolved = variants.iter().any(|v| {
+                    matches!(self.resolve_named(&self.ctx.apply(v)), Type::Var(_))
+                });
+                if any_unresolved {
+                    self.ctx.add_constraint(TypeConstraint::HasMethod {
+                        ty: Type::Union(variants),
+                        method,
+                        args,
+                        ret,
+                        span,
+                    });
+                    return Ok(false);
+                }
+
+                let mut missing: Vec<Type> = Vec::new();
+                let mut progress = false;
+                for variant in &variants {
+                    match self.resolve_method(
+                        variant.clone(),
+                        method.clone(),
+                        args.clone(),
+                        ret.clone(),
+                        span,
+                    ) {
+                        Ok(p) => {
+                            if p {
+                                progress = true;
+                            }
+                        }
+                        Err(TypeError::NoSuchMethod { .. }) => {
+                            missing.push(variant.clone());
+                        }
+                        Err(e) => return Err(e),
+                    }
+                }
+
+                if !missing.is_empty() {
+                    return Err(TypeError::NoSuchMethod {
+                        ty: Type::Union(variants),
+                        method,
+                        span,
+                    });
+                }
+
+                Ok(progress)
+            }
             _ => {
                 self.ctx.add_constraint(TypeConstraint::HasMethod {
                     ty,

--- a/tests/suite/t19_result_operators.rk
+++ b/tests/suite/t19_result_operators.rk
@@ -171,4 +171,24 @@ test "match on Result" {
     assert value == 5
 }
 
+// --- rask#211: shared methods auto-dispatch on union errors ---
+//
+// Every `E` satisfies `ErrorMessage` (ER4), so `e.message()` on a union
+// `e: A | B` resolves by dispatching to whichever variant `e` holds.
+
+func union_message(s: string, b: i32) -> string {
+    const r = combined(s, b)
+    if r? as v {
+        return "ok({v})"
+    } else as e {
+        return e.message()
+    }
+}
+
+test "union error dispatches shared message()" {
+    assert union_message("42", 2) == "ok(21)"
+    assert union_message("bad", 2) == "parse error: not a number"
+    assert union_message("42", 0) == "division by zero"
+}
+
 func main() {}


### PR DESCRIPTION
## Summary
This PR implements optimized if-present expressions that evaluate the scrutinee once and rebind the payload as a local variable in the matching branch. It also adds support for method dispatch on union types (ER4).

## Key Changes

- **If-present expression lowering**: Added `lower_if_present()` method to handle `if expr? [as v] { then } [else [as e] { else_br }]` syntax with proper payload extraction and narrowing
  - Extracts the option/result tag once and branches on presence
  - Binds the present payload to the `then_name` in the then-branch
  - For Result types, binds the error payload to `else_name` in the else-branch
  - Handles both niche-optimized and regular option/result representations

- **If expression refactoring**: Modified `lower_if()` to accept `else_binding` parameter and delegate to `lower_if_present()` when the condition is an `IsPresent` expression with a binding

- **Union type method dispatch (ER4)**: Extended `resolve_method()` in the type checker to support method calls on union types
  - Dispatches method resolution to all variants
  - Ensures all variants implement a compatible method
  - Unifies return types across variants to enforce compatibility
  - Returns error if any variant lacks the method

- **Test coverage**: Added comprehensive test for union error dispatch demonstrating the new functionality with `combined()` returning different error types

## Implementation Details

- The if-present lowering mirrors the interpreter path in `rask-interp/src/interp/eval_expr.rs`
- Payload extraction uses `extract_payload_type()` and `extract_err_type()` helpers
- Type metadata is preserved via `mir_type_name()` for proper code generation
- Union method resolution defers to constraint solving if any variant is unresolved

https://claude.ai/code/session_018dEZbwFXh4JCQRF43xEsEh