### PR TITLE
Fix Option/Result handling in codegen and ownership checking

### DIFF
--- a/compiler/crates/rask-codegen/src/builder.rs
+++ b/compiler/crates/rask-codegen/src/builder.rs
@@ -610,6 +610,20 @@ impl<'a> FunctionBuilder<'a> {
                     val = Self::convert_value(builder, val, val_ty, dst_ty);
                 }
 
+                // When dest is Option(T) and the source is already Option-typed,
+                // copy the struct. When the source is a scalar, wrap as Some.
+                let src_option_ty = if let MirType::Option(_) = &dst_local.ty {
+                    if let MirRValue::Use(MirOperand::Local(src_id)) = rvalue {
+                        ctx.locals.iter().find(|l| l.id == *src_id)
+                            .map(|l| matches!(l.ty, MirType::Option(_)))
+                            .unwrap_or(false)
+                    } else {
+                        false
+                    }
+                } else {
+                    false
+                };
+
                 // Aggregate assignment: when the destination has a stack slot and
                 // the rvalue produces a pointer to aggregate data, copy the data
                 // into the destination's stack slot rather than aliasing pointers.
@@ -620,8 +634,19 @@ impl<'a> FunctionBuilder<'a> {
                     // Field on aggregate base returns pointer for aggregate elements
                     (MirType::Struct(_) | MirType::Enum(_) | MirType::Tuple(_) |
                      MirType::Result { .. } | MirType::Option(_), MirRValue::Field { .. }) => true,
+                    // Option(T) assigned from an Option-typed local: copy the 16-byte struct
+                    (MirType::Option(_), _) if src_option_ty => true,
                     _ => false,
                 };
+
+                // Option(T) assigned from a scalar: wrap as Some in the stack slot.
+                // Needed for `const x: i32? = 42` — without this, the scalar 42
+                // overwrites the stack-address held in x's var, causing a SIGSEGV
+                // when code later loads the tag by dereferencing that "address".
+                let wrap_as_some = matches!(&dst_local.ty, MirType::Option(_))
+                    && !needs_copy
+                    && ctx.stack_slot_map.contains_key(dst);
+
                 if needs_copy {
                     if let Some((dst_ss, dst_size)) = ctx.stack_slot_map.get(dst) {
                         Self::copy_aggregate(builder, val, *dst_ss, *dst_size);
@@ -630,6 +655,9 @@ impl<'a> FunctionBuilder<'a> {
                             .ok_or_else(|| CodegenError::UnsupportedFeature("Variable not found".to_string()))?;
                         builder.def_var(*var, val);
                     }
+                } else if wrap_as_some {
+                    let (dst_ss, _) = ctx.stack_slot_map.get(dst).unwrap();
+                    Self::wrap_some_into_slot(builder, val, *dst_ss);
                 } else {
                     let var = ctx.var_map.get(dst)
                         .ok_or_else(|| CodegenError::UnsupportedFeature("Variable not found".to_string()))?;
@@ -1551,8 +1579,15 @@ impl<'a> FunctionBuilder<'a> {
                             builder.ins().iconst(types::I64, 0)
                         };
                         if let Some((ss, _size)) = ctx.stack_slot_map.get(dst_id) {
-                            // Extern C functions return plain values; wrap in Ok for Result destinations
-                            Self::wrap_ok_into_slot(builder, val, *ss);
+                            let dst_is_option = ctx.locals.iter()
+                                .find(|l| l.id == *dst_id)
+                                .map(|l| matches!(l.ty, MirType::Option(_)))
+                                .unwrap_or(false);
+                            if dst_is_option {
+                                Self::wrap_some_into_slot(builder, val, *ss);
+                            } else {
+                                Self::wrap_ok_into_slot(builder, val, *ss);
+                            }
                         } else {
                             builder.def_var(*var, val);
                         }
@@ -1776,8 +1811,16 @@ impl<'a> FunctionBuilder<'a> {
                             Self::wrap_result_into_slot(builder, final_val, *ss);
                         } else {
                             // C stdlib function returns a plain value (not a pointer to an aggregate).
-                            // Wrap it as Ok(value) in the destination Result slot.
-                            Self::wrap_ok_into_slot(builder, final_val, *ss);
+                            // Wrap as Some/Ok depending on destination type.
+                            let dst_is_option = ctx.locals.iter()
+                                .find(|l| l.id == *dst_id)
+                                .map(|l| matches!(l.ty, MirType::Option(_)))
+                                .unwrap_or(false);
+                            if dst_is_option {
+                                Self::wrap_some_into_slot(builder, final_val, *ss);
+                            } else {
+                                Self::wrap_ok_into_slot(builder, final_val, *ss);
+                            }
                         }
                     } else {
                         builder.def_var(*var, final_val);
@@ -2076,6 +2119,43 @@ impl<'a> FunctionBuilder<'a> {
             }
 
             MirRValue::Cast { value, target_ty } => {
+                if target_ty == &MirType::String {
+                    // Casting to string requires a runtime call that writes 16-byte
+                    // RaskStr into an out-param. A plain type-cast (convert_value)
+                    // would return a scalar, which copy_aggregate would dereference
+                    // as a pointer — causing a segfault.
+                    let src_mir_ty = Self::operand_mir_type(value, ctx.locals);
+                    let (fn_name, arg_ty) = match src_mir_ty.as_ref() {
+                        Some(MirType::Bool) => ("rask_bool_to_string", types::I64),
+                        Some(MirType::F64) => ("rask_f64_to_string", types::F64),
+                        Some(MirType::F32) => ("rask_f64_to_string", types::F64),
+                        Some(MirType::Char) => ("rask_char_to_string", types::I32),
+                        _ => match value {
+                            MirOperand::Constant(MirConst::Bool(_)) => ("rask_bool_to_string", types::I64),
+                            MirOperand::Constant(MirConst::Float(_)) => ("rask_f64_to_string", types::F64),
+                            MirOperand::Constant(MirConst::Char(_)) => ("rask_char_to_string", types::I32),
+                            _ => ("rask_i64_to_string", types::I64),
+                        }
+                    };
+
+                    let fr = ctx.func_refs.get(fn_name)
+                        .ok_or_else(|| CodegenError::FunctionNotFound(fn_name.to_string()))?;
+
+                    let out_ss = builder.create_sized_stack_slot(StackSlotData::new(
+                        StackSlotKind::ExplicitSlot, 16, 0,
+                    ));
+                    let out_ptr = builder.ins().stack_addr(types::I64, out_ss, 0);
+
+                    let mut val = Self::lower_operand_typed(builder, value, Some(arg_ty), ctx)?;
+                    let val_ty = builder.func.dfg.value_type(val);
+                    if val_ty != arg_ty {
+                        val = Self::convert_value(builder, val, val_ty, arg_ty);
+                    }
+
+                    builder.ins().call(*fr, &[out_ptr, val]);
+                    return Ok(out_ptr);
+                }
+
                 let val = Self::lower_operand(builder, value, ctx)?;
                 let target = mir_to_cranelift_type(target_ty)?;
                 let val_ty = builder.func.dfg.value_type(val);
@@ -2167,6 +2247,16 @@ impl<'a> FunctionBuilder<'a> {
                             let is_aggregate = |t: &MirType| matches!(t, MirType::Struct(_) | MirType::Enum(_) | MirType::Tuple(_) | MirType::String);
                             if *field_index == 0 && (is_aggregate(ok.as_ref()) || is_aggregate(err.as_ref())) {
                                 let payload_addr = builder.ins().iadd_imm(base_val, crate::layouts::RESULT_PAYLOAD_OFFSET as i64);
+                                // If the caller expects a scalar (non-I64), this is a scalar
+                                // payload extraction (e.g., Ok value from Result<I32, SomeEnum>).
+                                // Load from the payload address instead of returning the address.
+                                // Without this, convert_value would truncate the address to I32.
+                                if let Some(exp) = expected_ty {
+                                    if exp != types::I64 {
+                                        let loaded = builder.ins().load(exp, MemFlags::new(), payload_addr, 0);
+                                        return Ok(loaded);
+                                    }
+                                }
                                 return Ok(payload_addr);
                             }
                             crate::layouts::RESULT_PAYLOAD_OFFSET + (*field_index * 8) as i32
@@ -2295,15 +2385,50 @@ impl<'a> FunctionBuilder<'a> {
                 if ctx.is_main {
                     builder.ins().return_(&[]);
                 } else if let Some(stack_info) = Self::return_stack_info(value.as_ref(), ctx.stack_slot_map) {
-                    // For small aggregate return values (≤8 bytes) in stack slots,
-                    // load the data and return it directly.
+                    // For small aggregate return values (≤8 bytes) in stack slots:
+                    //   - If the function return type is Result/Option, the small value
+                    //     is a component (ok or err), not a Result — must be wrapped.
+                    //   - Otherwise load the scalar and return it directly.
                     // For larger aggregates, return the stack slot address. The caller
                     // copies from it immediately via copy_aggregate (the callee stack
                     // is still accessible at that point on x86-64).
-                    let (_local_id, ss, size) = stack_info;
+                    let (local_id, ss, size) = stack_info;
                     if size <= 8 {
                         let loaded = builder.ins().stack_load(types::I64, ss, 0);
-                        builder.ins().return_(&[loaded]);
+                        if matches!(ctx.ret_ty, MirType::Result { .. } | MirType::Option(_)) {
+                            // Small component in a Result/Option-returning function.
+                            // Wrap it as Ok or Err by checking the local's type.
+                            let slot_size = Self::resolve_type_alloc_size(
+                                ctx.ret_ty, ctx.struct_layouts, ctx.enum_layouts
+                            ).unwrap_or(16);
+                            let ret_ss = builder.create_sized_stack_slot(StackSlotData::new(
+                                StackSlotKind::ExplicitSlot, slot_size, 0,
+                            ));
+                            let is_err = if let MirType::Result { err, .. } = ctx.ret_ty {
+                                ctx.locals.iter()
+                                    .find(|l| l.id == local_id)
+                                    .map(|l| &l.ty == err.as_ref())
+                                    .unwrap_or(false)
+                            } else {
+                                false
+                            };
+                            if is_err {
+                                let tag = builder.ins().iconst(types::I64, 1);
+                                builder.ins().stack_store(tag, ret_ss, crate::layouts::TAG_OFFSET);
+                                let zero = builder.ins().iconst(types::I64, 0);
+                                builder.ins().stack_store(zero, ret_ss, crate::layouts::ORIGIN_FILE_OFFSET);
+                                builder.ins().stack_store(zero, ret_ss, crate::layouts::ORIGIN_LINE_OFFSET);
+                                builder.ins().stack_store(loaded, ret_ss, crate::layouts::RESULT_PAYLOAD_OFFSET);
+                            } else if matches!(ctx.ret_ty, MirType::Option(_)) {
+                                Self::wrap_some_into_slot(builder, loaded, ret_ss);
+                            } else {
+                                Self::wrap_ok_into_slot(builder, loaded, ret_ss);
+                            }
+                            let addr = builder.ins().stack_addr(types::I64, ret_ss, 0);
+                            builder.ins().return_(&[addr]);
+                        } else {
+                            builder.ins().return_(&[loaded]);
+                        }
                     } else {
                         // Return pointer to stack slot data for copy_aggregate
                         Self::emit_return(builder, value.as_ref(), ctx)?;
@@ -2325,7 +2450,11 @@ impl<'a> FunctionBuilder<'a> {
                     } else {
                         builder.ins().iconst(types::I64, 0)
                     };
-                    Self::wrap_ok_into_slot(builder, val, ss);
+                    if matches!(ctx.ret_ty, MirType::Option(_)) {
+                        Self::wrap_some_into_slot(builder, val, ss);
+                    } else {
+                        Self::wrap_ok_into_slot(builder, val, ss);
+                    }
                     let addr = builder.ins().stack_addr(types::I64, ss, 0);
                     builder.ins().return_(&[addr]);
                 } else {
@@ -2522,13 +2651,15 @@ impl<'a> FunctionBuilder<'a> {
                     .unwrap_or(ok.size());
                 let err_size = Self::resolve_type_alloc_size(err, struct_layouts, enum_layouts)
                     .unwrap_or(err.size());
-                // tag (8) + origin_file (8) + origin_line (8) + payload
-                Some(crate::layouts::RESULT_PAYLOAD_OFFSET as u32 + ok_size.max(err_size))
+                // tag (8) + origin_file (8) + origin_line (8) + payload.
+                // Scalars are stored as 8-byte values in codegen; .max(8) prevents OOB writes.
+                Some(crate::layouts::RESULT_PAYLOAD_OFFSET as u32 + ok_size.max(8).max(err_size.max(8)))
             }
             MirType::Option(inner) => {
                 let inner_size = Self::resolve_type_alloc_size(inner, struct_layouts, enum_layouts)
                     .unwrap_or(inner.size());
-                Some(8 + inner_size)
+                // Scalars are stored as 8-byte values in codegen; .max(8) prevents OOB writes.
+                Some(8 + inner_size.max(8))
             }
             MirType::Tuple(fields) => {
                 let mut offset = 0u32;
@@ -2593,6 +2724,16 @@ impl<'a> FunctionBuilder<'a> {
         builder.ins().stack_store(zero, dst_slot, crate::layouts::ORIGIN_FILE_OFFSET);
         builder.ins().stack_store(zero, dst_slot, crate::layouts::ORIGIN_LINE_OFFSET);
         builder.ins().stack_store(value, dst_slot, crate::layouts::RESULT_PAYLOAD_OFFSET);
+    }
+
+    /// Wrap a scalar value as Some(value) into an Option stack slot.
+    ///
+    /// Option layout: [tag:8][payload:8]. Much smaller than Result — no origin fields.
+    /// Using `wrap_ok_into_slot` for Options writes past the end of the slot (UB/crash).
+    fn wrap_some_into_slot(builder: &mut ClifFunctionBuilder, value: Value, dst_slot: StackSlot) {
+        let tag = builder.ins().iconst(types::I64, 0); // 0 = Some
+        builder.ins().stack_store(tag, dst_slot, crate::layouts::TAG_OFFSET);
+        builder.ins().stack_store(value, dst_slot, crate::layouts::PAYLOAD_OFFSET);
     }
 
     /// C functions that use "negative return = error" convention.

--- a/compiler/crates/rask-codegen/src/module.rs
+++ b/compiler/crates/rask-codegen/src/module.rs
@@ -519,6 +519,50 @@ impl CodeGenerator {
             self.func_ids.insert("rask_check_fail".to_string(), id);
         }
 
+        // rask_i64_to_string(out: *RaskStr, val: i64) -> void
+        {
+            let mut sig = self.module.make_signature();
+            sig.params.push(AbiParam::new(types::I64)); // out ptr
+            sig.params.push(AbiParam::new(types::I64)); // val
+            let id = self.module
+                .declare_function("rask_i64_to_string", Linkage::Import, &sig)
+                .map_err(|e| CodegenError::CraneliftError(e.to_string()))?;
+            self.func_ids.insert("rask_i64_to_string".to_string(), id);
+        }
+
+        // rask_bool_to_string(out: *RaskStr, val: i64) -> void
+        {
+            let mut sig = self.module.make_signature();
+            sig.params.push(AbiParam::new(types::I64)); // out ptr
+            sig.params.push(AbiParam::new(types::I64)); // val
+            let id = self.module
+                .declare_function("rask_bool_to_string", Linkage::Import, &sig)
+                .map_err(|e| CodegenError::CraneliftError(e.to_string()))?;
+            self.func_ids.insert("rask_bool_to_string".to_string(), id);
+        }
+
+        // rask_f64_to_string(out: *RaskStr, val: f64) -> void
+        {
+            let mut sig = self.module.make_signature();
+            sig.params.push(AbiParam::new(types::I64)); // out ptr
+            sig.params.push(AbiParam::new(types::F64)); // val
+            let id = self.module
+                .declare_function("rask_f64_to_string", Linkage::Import, &sig)
+                .map_err(|e| CodegenError::CraneliftError(e.to_string()))?;
+            self.func_ids.insert("rask_f64_to_string".to_string(), id);
+        }
+
+        // rask_char_to_string(out: *RaskStr, codepoint: i32) -> void
+        {
+            let mut sig = self.module.make_signature();
+            sig.params.push(AbiParam::new(types::I64)); // out ptr
+            sig.params.push(AbiParam::new(types::I32)); // codepoint
+            let id = self.module
+                .declare_function("rask_char_to_string", Linkage::Import, &sig)
+                .map_err(|e| CodegenError::CraneliftError(e.to_string()))?;
+            self.func_ids.insert("rask_char_to_string".to_string(), id);
+        }
+
         Ok(())
     }
 

--- a/compiler/crates/rask-diagnostics/src/convert.rs
+++ b/compiler/crates/rask-diagnostics/src/convert.rs
@@ -907,30 +907,28 @@ impl ToDiagnostic for rask_ownership::OwnershipError {
                 let (note, help) = match reason {
                     MoveReason::SizeExceedsThreshold { type_name, size } => (
                         format!(
-                            "`{}` is {} bytes (copy threshold is 16) — `let` moves instead of copying",
+                            "`{}` is {} bytes (copy threshold is 16) — assignment moves instead of copying",
                             type_name, size
                         ),
                         format!(
-                            "use `const` instead of `let` if you don't need to mutate, \
-                             or `{}.clone()` if you need an independent copy",
+                            "add `{}.clone()` if you need an independent copy",
                             name
                         ),
                     ),
                     MoveReason::OwnsHeapMemory { type_name } => (
                         format!(
-                            "`{}` owns heap memory — `let` moves instead of copying",
+                            "`{}` owns heap memory — assignment moves instead of copying",
                             type_name
                         ),
                         format!(
-                            "use `const` instead of `let` to borrow, \
-                             or `{}.clone()` for a deep copy",
+                            "add `{}.clone()` if you need an independent copy",
                             name
                         ),
                     ),
                     MoveReason::Unique { type_name } => (
                         format!("`{}` is @unique — implicit copy is disabled", type_name),
                         format!(
-                            "use `const` to borrow, or `{}.clone()` for an explicit copy",
+                            "add `{}.clone()` if the type supports it",
                             name
                         ),
                     ),
@@ -939,10 +937,9 @@ impl ToDiagnostic for rask_ownership::OwnershipError {
                         "restructure so the resource is only used once".to_string(),
                     ),
                     MoveReason::Unknown => (
-                        format!("`{}` was moved — `let` transfers ownership", name),
+                        format!("`{}` was moved — assignment transfers ownership", name),
                         format!(
-                            "use `const` instead of `let` to borrow, \
-                             or `{}.clone()` if you need a separate copy",
+                            "add `{}.clone()` if you need a separate copy",
                             name
                         ),
                     ),

--- a/compiler/crates/rask-mir/src/lower/expr.rs
+++ b/compiler/crates/rask-mir/src/lower/expr.rs
@@ -2387,9 +2387,9 @@ impl<'a> MirLowerer<'a> {
             // Pattern test (expr is Pattern) — evaluates to bool
             ExprKind::IsPattern { expr: inner, pattern } => {
                 let is_niche = self.is_niche_option_expr(inner);
-                let (val, _ty) = self.lower_expr(inner)?;
+                let (val, val_ty) = self.lower_expr(inner)?;
                 let tag = self.emit_option_tag(&val, is_niche);
-                let expected = self.pattern_tag(pattern);
+                let expected = self.pattern_tag_in_type_context(pattern, &val_ty);
                 let result = self.builder.alloc_temp(MirType::Bool);
                 self.builder.push_stmt(MirStmt::dummy(MirStmtKind::Assign {
                     dst: result,

--- a/compiler/crates/rask-mir/src/lower/match_lower.rs
+++ b/compiler/crates/rask-mir/src/lower/match_lower.rs
@@ -123,6 +123,13 @@ impl<'a> MirLowerer<'a> {
                 Pattern::Ident(name) => {
                     if let Some(tag) = self.resolve_pattern_tag(name) {
                         cases.push((tag, arm_blocks[i]));
+                    } else if has_tag && is_result_or_option {
+                        // Result match: ok arm = tag 0, err arm = tag 1.
+                        // Determine which by comparing name to the ok payload type.
+                        let ok_name = self.mir_type_name(&ok_payload_ty);
+                        let is_ok_arm = ok_name.as_deref() == Some(name.as_str())
+                            || name.chars().next().map_or(false, |c| c.is_lowercase());
+                        cases.push((if is_ok_arm { 0 } else { 1 }, arm_blocks[i]));
                     } else if has_tag && is_variant_name(name) {
                         cases.push((self.variant_tag(name) as u64, arm_blocks[i]));
                     } else {
@@ -150,6 +157,17 @@ impl<'a> MirLowerer<'a> {
                 Pattern::Struct { name, .. } => {
                     if let Some(tag) = self.resolve_pattern_tag(name) {
                         cases.push((tag, arm_blocks[i]));
+                    } else {
+                        cases.push((i as u64, arm_blocks[i]));
+                    }
+                }
+                Pattern::TypePat { ty_name, .. } => {
+                    if is_result_or_option {
+                        // Result/Option match: ok arm = tag 0, err arm = tag 1.
+                        let ok_name = self.mir_type_name(&ok_payload_ty);
+                        let is_ok_arm = ok_name.as_deref() == Some(ty_name.as_str())
+                            || ty_name.chars().next().map_or(false, |c| c.is_lowercase());
+                        cases.push((if is_ok_arm { 0 } else { 1 }, arm_blocks[i]));
                     } else {
                         cases.push((i as u64, arm_blocks[i]));
                     }

--- a/compiler/crates/rask-mir/src/lower/mod.rs
+++ b/compiler/crates/rask-mir/src/lower/mod.rs
@@ -247,6 +247,10 @@ impl<'a> MirContext<'a> {
                 if let Some(inner) = name.strip_prefix("Option<").and_then(|s| s.strip_suffix('>')) {
                     return MirType::Option(Box::new(self.resolve_type_str(inner)));
                 }
+                // "T?" → MirType::Option (shorthand syntax from type annotations)
+                if let Some(inner) = name.strip_suffix('?') {
+                    return MirType::Option(Box::new(self.resolve_type_str(inner)));
+                }
                 // Generic collection types: Vec<T>, Map<K,V>, etc. are heap pointers
                 if name.starts_with("Vec<") || name == "Vec" {
                     return MirType::Ptr; // Vec handle (opaque pointer)
@@ -1050,6 +1054,37 @@ impl<'a> MirLowerer<'a> {
             }
             _ => 0,
         }
+    }
+
+    /// Like `pattern_tag` but uses the matched value's type to resolve ambiguity.
+    ///
+    /// When matching `r is DivError` where `r: T or DivError`, "DivError" is the
+    /// error enum type name, not a variant — it should map to tag 1 (Err).
+    /// `pattern_tag` can't detect this without type context.
+    pub(crate) fn pattern_tag_in_type_context(
+        &self,
+        pattern: &rask_ast::expr::Pattern,
+        val_ty: &MirType,
+    ) -> i64 {
+        use rask_ast::expr::Pattern;
+        if let Pattern::Ident(name) = pattern {
+            if is_variant_name(name) {
+                // If the name matches the error enum type of a Result, tag = 1 (Err).
+                if let MirType::Result { err, .. } = val_ty {
+                    if let MirType::Enum(eid) = err.as_ref() {
+                        let idx = eid.id as usize;
+                        if idx < self.ctx.enum_layouts.len()
+                            && self.ctx.enum_layouts[idx].name == name.as_str()
+                        {
+                            return 1;
+                        }
+                    }
+                }
+                return self.variant_tag(name);
+            }
+            return 0;
+        }
+        self.pattern_tag(pattern)
     }
 
     /// Look up the tag value for a variant name.

--- a/compiler/crates/rask-mir/src/transform/inline.rs
+++ b/compiler/crates/rask-mir/src/transform/inline.rs
@@ -172,6 +172,15 @@ fn try_inline_call(
         return false;
     }
 
+    // Don't inline Result/Option-returning functions where some return paths carry
+    // a non-Result/Option value. The codegen wraps these in lower_terminator, but
+    // the inline pass can't emit that wrapping logic, so the inlined code would
+    // assign a raw scalar to a Result-typed variable and crash when the caller
+    // later dereferences it as a struct pointer.
+    if is_result_or_option(&callee.ret_ty) && has_unwrapped_return(callee) {
+        return false;
+    }
+
     // --- Renumbering ---
 
     // Find the next available LocalId and BlockId in the caller
@@ -762,6 +771,39 @@ fn fixup_cleanup_exits(
             }
         }
     }
+}
+
+fn is_result_or_option(ty: &MirType) -> bool {
+    matches!(ty, MirType::Result { .. } | MirType::Option(_))
+}
+
+/// True if the callee has any Return/CleanupReturn that carries a value whose
+/// type is NOT a Result or Option. These returns need codegen-level wrapping
+/// that the inline pass can't reproduce.
+fn has_unwrapped_return(callee: &MirFunction) -> bool {
+    for block in &callee.blocks {
+        let ret_val = match &block.terminator.kind {
+            MirTerminatorKind::Return { value: Some(op) } => Some(op),
+            MirTerminatorKind::CleanupReturn { value: Some(op), .. } => Some(op),
+            _ => None,
+        };
+        if let Some(MirOperand::Local(id)) = ret_val {
+            if let Some(local) = callee.locals.iter().find(|l| l.id == *id) {
+                if !is_result_or_option(&local.ty) {
+                    return true;
+                }
+            } else if let Some(param) = callee.params.iter().find(|p| p.id == *id) {
+                if !is_result_or_option(&param.ty) {
+                    return true;
+                }
+            }
+        }
+        // Constant returns (e.g. return 0) are scalars and would also need wrapping
+        if let Some(MirOperand::Constant(_)) = ret_val {
+            return true;
+        }
+    }
+    false
 }
 
 #[cfg(test)]

--- a/compiler/crates/rask-ownership/src/lib.rs
+++ b/compiler/crates/rask-ownership/src/lib.rs
@@ -346,16 +346,16 @@ impl<'a> OwnershipChecker<'a> {
             }
             StmtKind::Const { name, name_span: _, ty, init } => {
                 self.check_expr(init);
-                // const: Copy types are copied, non-Copy types create
-                // a block-scoped borrow (source stays valid but frozen)
+                // non-Copy types are moved (O3); field/index projections create borrows.
                 self.handle_assignment(init, stmt.span, false);
                 self.bindings.insert(name.clone(), BindingState::Owned);
                 self.binding_decl_blocks.insert(name.clone(), self.current_block);
                 if let Some(t) = self.program.node_types.get(&init.id).cloned() {
                     self.binding_types.insert(name.clone(), t.clone());
-                    // SL1: If this is a non-copy type, this const is a borrow view.
-                    // Track it so closures capturing it are scope-limited.
-                    if !self.is_copy(&t) {
+                    // SL1: Only a projection (field/index) borrow creates a borrow view.
+                    // Whole-variable moves create owned bindings; closures can capture freely.
+                    let (_, projection) = Self::extract_root_and_fields(init);
+                    if !self.is_copy(&t) && projection.is_some() {
                         self.borrow_bindings.insert(name.clone(), self.current_block);
                     }
                 }
@@ -1259,12 +1259,17 @@ impl<'a> OwnershipChecker<'a> {
                 return;
             }
 
-            // Non-Copy types: move or borrow depending on binding mutability
+            // Non-Copy types: whole-variable access moves the source (O3);
+            // field/index projections create a borrow (mode depends on is_mutable).
             // F1: Extract root binding and optional field projection
             let (root, projection) = Self::extract_root_and_fields(expr);
             if let Some(source_name) = root {
-                if is_mutable {
-                    // Mutable binding (let): check not borrowed, then move
+                if projection.is_some() {
+                    // F1: Field-projected — borrow the source
+                    let mode = if is_mutable { BorrowMode::Exclusive } else { BorrowMode::Shared };
+                    self.create_borrow_with_projection(source_name, mode, span, projection);
+                } else {
+                    // Whole-variable assignment: move source regardless of const/mut
                     if let Some(state) = self.bindings.get(&source_name) {
                         match state {
                             BindingState::Borrowed { .. } => {
@@ -1302,15 +1307,7 @@ impl<'a> OwnershipChecker<'a> {
                             BindingState::Owned => {}
                         }
                     }
-                    if projection.is_some() {
-                        // F1: Field-projected borrow — disjoint fields don't conflict
-                        self.create_borrow_with_projection(source_name, BorrowMode::Exclusive, span, projection);
-                    } else {
-                        self.bindings.insert(source_name, BindingState::Moved { at: span });
-                    }
-                } else {
-                    // Immutable binding (const): create block-scoped borrow
-                    self.create_borrow_with_projection(source_name, BorrowMode::Shared, span, projection);
+                    self.bindings.insert(source_name, BindingState::Moved { at: span });
                 }
             }
         }

--- a/compiler/crates/rask-parser/src/parser.rs
+++ b/compiler/crates/rask-parser/src/parser.rs
@@ -4481,9 +4481,9 @@ impl Parser {
                     self.advance();
                     let binding = self.expect_ident()?;
                     Ok(Pattern::TypePat { ty_name: name, binding: Some(binding) })
-                } else if self.check(&TokenKind::LBrace) && name.contains('.') {
+                } else if self.check(&TokenKind::LBrace) && name.contains('.') && self.allow_brace_expr {
                     // Struct variant pattern: Enum.Variant { field1, field2 }
-                    // Only for qualified names to avoid ambiguity with blocks
+                    // Only for qualified names, and only when braces are allowed (not in while/if conditions)
                     self.advance();
                     self.skip_newlines();
                     let mut fields = Vec::new();

--- a/tests/suite/t14_ownership.rk
+++ b/tests/suite/t14_ownership.rk
@@ -60,7 +60,6 @@ test "small struct survives function pass" {
 }
 
 // --- Vec is never Copy (VS3), moves on assignment (O2) ---
-// NOTE: Use-after-move (O3) is not yet enforced by the ownership checker.
 
 test "vec move to new binding" {
     mut v = Vec<i32>.new()


### PR DESCRIPTION
## Summary
This PR fixes critical bugs in code generation and ownership checking related to Option and Result types, particularly around wrapping scalars into Option/Result stack slots and improving pattern matching for Result types.

## Key Changes

### Code Generation (builder.rs)
- **Option wrapping for scalar assignments**: Added `wrap_some_into_slot()` function to properly wrap scalar values as `Some(value)` into Option stack slots. This fixes crashes when assigning scalars to Option-typed variables (e.g., `const x: i32? = 42`).
- **String casting support**: Implemented proper string casting via runtime calls (`rask_i64_to_string`, `rask_bool_to_string`, `rask_f64_to_string`, `rask_char_to_string`) that write to out-parameters, preventing segfaults from incorrect pointer dereferencing.
- **Result/Option return wrapping**: Fixed return value handling to properly wrap small scalar components as Ok/Some when returning from Result/Option-returning functions.
- **Scalar payload extraction**: Added logic to load scalar payloads from Result fields instead of returning addresses when the caller expects a non-I64 type.
- **Stack slot size calculation**: Updated `resolve_type_alloc_size()` to ensure scalars are allocated as 8-byte values, preventing out-of-bounds writes.

### Module Setup (module.rs)
- Declared four new runtime functions for string conversion with proper signatures and linkage.

### Inlining (inline.rs)
- **Prevent inlining of Result/Option-returning functions with unwrapped returns**: Added `has_unwrapped_return()` check to prevent inlining functions that return raw scalars when the return type is Result/Option, since the inline pass cannot emit the necessary wrapping logic.

### Type Resolution (lower/mod.rs)
- **Option shorthand syntax**: Added support for `T?` syntax as shorthand for `Option<T>` in type annotations.
- **Pattern tag resolution with type context**: Added `pattern_tag_in_type_context()` to disambiguate pattern matching when matching error enum types in Result patterns.

### Pattern Matching (match_lower.rs)
- **Result/Option pattern matching**: Improved handling of identifier and type patterns in Result/Option matches by determining ok/err arms based on type context and naming conventions.

### Ownership Checking (ownership/lib.rs)
- **Const binding semantics**: Changed const bindings to move whole variables (O3) instead of creating block-scoped borrows. Only field/index projections create borrow views.
- **Assignment move semantics**: Simplified assignment handling so non-Copy types are moved regardless of const/mut distinction, with borrows only created for projections.

### Parser (parser.rs)
- **Struct variant pattern parsing**: Added check for `allow_brace_expr` flag to prevent incorrect parsing of struct variant patterns when brace expressions are not allowed.

### Diagnostics (diagnostics/convert.rs)
- Updated error messages to reflect that assignment (not just `let`) causes moves for non-Copy types, and removed suggestions to use `const` as a workaround.

### Tests (t14_ownership.rk)
- Removed outdated comment about use-after-move enforcement not being implemented.

## Notable Implementation Details
- Option layout is smaller than Result (8 bytes tag + 8 bytes payload vs. 24+ bytes), requiring a separate `wrap_some_into_slot()` function.
- String casting requires runtime calls that write to stack-allocated out-parameters, fundamentally different from type conversions.
- The inline pass cannot reproduce codegen-level wrapping logic, necessitating the inlining restriction for Result/Option-returning functions.
- Pattern matching for Results now uses type context to disambiguate between ok and err arms when patterns are simple identifiers.

https://claude.ai/code/session_019jcprwSWyhfzSPkT3Wzig9