### PR TITLE
Implement short-circuit evaluation for && and || operators

### DIFF
--- a/compiler/crates/rask-mir/src/lower/collections.rs
+++ b/compiler/crates/rask-mir/src/lower/collections.rs
@@ -399,6 +399,50 @@ impl<'a> MirLowerer<'a> {
         8 // scalar default
     }
 
+    /// Size of a Type used as an element/key/value slot. Mirrors
+    /// `generic_type_param_size`'s rules but works on the type checker's
+    /// `Type` directly so bare `Vec.new()` / `Map.new()` can pick up an
+    /// inferred element type.
+    pub(super) fn slot_size_for_type(&self, ty: &rask_types::Type) -> Option<i64> {
+        use rask_types::Type;
+        match ty {
+            Type::String => Some(16),
+            Type::Bool
+            | Type::I8 | Type::I16 | Type::I32 | Type::I64
+            | Type::U8 | Type::U16 | Type::U32 | Type::U64
+            | Type::F32 | Type::F64 | Type::Char => Some(8),
+            Type::UnresolvedNamed(name) => match name.as_str() {
+                "string" => Some(16),
+                "bool" | "u8" | "i8" | "u16" | "i16"
+                | "u32" | "i32" | "f32"
+                | "u64" | "i64" | "f64"
+                | "usize" | "isize" | "char" => Some(8),
+                _ => self.ctx.find_struct(name).map(|(_, l)| l.size as i64).or(Some(8)),
+            },
+            Type::Var(_) => None,
+            _ => Some(8),
+        }
+    }
+
+    /// Resolve the Nth generic argument's slot size from the inferred type
+    /// at `node_id`. Falls back to `None` when the argument is missing or
+    /// still an unresolved type variable.
+    pub(super) fn inferred_generic_param_size(
+        &self,
+        node_id: rask_ast::NodeId,
+        index: usize,
+    ) -> Option<i64> {
+        use rask_types::{GenericArg, Type};
+        let ty = self.ctx.lookup_raw_type(node_id)?;
+        let args = match ty {
+            Type::Generic { args, .. } | Type::UnresolvedGeneric { args, .. } => args,
+            _ => return None,
+        };
+        let arg = args.get(index)?;
+        let GenericArg::Type(inner) = arg else { return None; };
+        self.slot_size_for_type(inner)
+    }
+
     /// Clone function name for a type, or None if the type is Copy.
     pub(super) fn clone_fn_for_type(ty: &rask_types::Type) -> Option<&'static str> {
         match ty {

--- a/compiler/crates/rask-mir/src/lower/expr.rs
+++ b/compiler/crates/rask-mir/src/lower/expr.rs
@@ -13,7 +13,7 @@ use crate::{
     MirTerminatorKind, MirType,
 };
 use rask_ast::{
-    expr::{Expr, ExprKind, UnaryOp},
+    expr::{BinOp, Expr, ExprKind, UnaryOp},
     stmt::{Stmt, StmtKind},
     token::{FloatSuffix, IntSuffix},
 };
@@ -305,6 +305,11 @@ impl<'a> MirLowerer<'a> {
             }
 
             ExprKind::Binary { op, left, right } => {
+                // Short-circuit `&&`/`||`: evaluate rhs only if lhs doesn't decide the result.
+                if matches!(op, BinOp::And | BinOp::Or) {
+                    return self.lower_short_circuit(*op, left, right);
+                }
+
                 let (left_op, left_ty) = self.lower_expr(left)?;
                 let (right_op, _) = self.lower_expr(right)?;
                 let mir_op = lower_binop(*op);
@@ -996,15 +1001,20 @@ impl<'a> MirLowerer<'a> {
 
                             // Vec.new(): inject elem_size so runtime allocates correct slots.
                             // string elements need 16 bytes; structs use layout size; default 8.
+                            // For bare `Vec.new()` (no generic args), the syntactic name
+                            // carries no `<T>`, so fall back to the inferred call type.
                             if base_name == "Vec" && method == "new" {
-                                let elem_size = self.generic_type_param_size(name, 0);
+                                let elem_size = self.inferred_generic_param_size(expr.id, 0)
+                                    .unwrap_or_else(|| self.generic_type_param_size(name, 0));
                                 let size_op = MirOperand::Constant(MirConst::Int(elem_size));
                                 arg_operands.insert(0, size_op);
                             }
                             // Map.new(): inject key_size, val_size
                             if (base_name == "Map") && method == "new" {
-                                let key_size = self.generic_type_param_size(name, 0);
-                                let val_size = self.generic_type_param_size(name, 1);
+                                let key_size = self.inferred_generic_param_size(expr.id, 0)
+                                    .unwrap_or_else(|| self.generic_type_param_size(name, 0));
+                                let val_size = self.inferred_generic_param_size(expr.id, 1)
+                                    .unwrap_or_else(|| self.generic_type_param_size(name, 1));
                                 arg_operands.insert(0, MirOperand::Constant(MirConst::Int(key_size)));
                                 arg_operands.insert(1, MirOperand::Constant(MirConst::Int(val_size)));
                             }
@@ -1453,14 +1463,25 @@ impl<'a> MirLowerer<'a> {
 
                 // Qualify method name with receiver type to avoid dispatch
                 // ambiguity (e.g. Vec.get vs Map.get vs Pool.get).
-                // Check local_meta type_prefix first (tracks actual codegen types),
-                // then fall back to type-checker info (handles both stdlib
-                // and user-defined types from extend blocks).
-                let qualified_name = if let ExprKind::Ident(var_name) = &object.kind {
+                // Priority: user-defined struct/enum from type checker first
+                // (`extend E { func get(self) }` would otherwise be shadowed by
+                // the hardcoded Map.get fallback below). Skip stdlib types
+                // (Option, Result, ...) so their methods stay on the existing
+                // dispatch path.
+                let user_type_prefix = self.ctx.lookup_raw_type(object.id)
+                    .filter(|ty| super::MirContext::stdlib_type_prefix(ty).is_none())
+                    .and_then(|ty| super::MirContext::type_prefix(ty, self.ctx.type_names))
+                    .filter(|prefix| {
+                        let base = prefix.split('<').next().unwrap_or(prefix);
+                        self.ctx.find_struct(base).is_some()
+                            || self.ctx.find_enum(base).is_some()
+                    });
+                let qualified_name = user_type_prefix
+                    .or_else(|| if let ExprKind::Ident(var_name) = &object.kind {
                         self.meta(var_name).and_then(|m| m.type_prefix.clone())
                     } else {
                         None
-                    }
+                    })
                     // Field access on struct: resolve field type from struct layout
                     .or_else(|| {
                         if let ExprKind::Field { object: inner_obj, field: field_name } = &object.kind {
@@ -3181,6 +3202,69 @@ impl<'a> MirLowerer<'a> {
         self.builder.switch_to_block(merge_block);
 
         Ok((MirOperand::Local(result_local), then_ty))
+    }
+
+    /// Lower `&&` / `||` with short-circuit semantics.
+    ///
+    /// For `lhs && rhs`: if lhs is false, skip rhs and yield false.
+    /// For `lhs || rhs`: if lhs is true, skip rhs and yield true.
+    fn lower_short_circuit(
+        &mut self,
+        op: BinOp,
+        left: &Expr,
+        right: &Expr,
+    ) -> Result<TypedOperand, LoweringError> {
+        let (left_op, _) = self.lower_expr(left)?;
+
+        let rhs_block = self.builder.create_block();
+        let short_block = self.builder.create_block();
+        let merge_block = self.builder.create_block();
+
+        // `&&`: take rhs branch when lhs is true. `||`: take rhs branch when lhs is false.
+        let (then_block, else_block) = match op {
+            BinOp::And => (rhs_block, short_block),
+            BinOp::Or => (short_block, rhs_block),
+            _ => unreachable!(),
+        };
+        self.builder.terminate(MirTerminator::dummy(MirTerminatorKind::Branch {
+            cond: left_op,
+            then_block,
+            else_block,
+        }));
+
+        let result_local = self.builder.alloc_temp(MirType::Bool);
+
+        // Short-circuit branch: yield the lhs value (false for &&, true for ||).
+        self.builder.switch_to_block(short_block);
+        let short_val = match op {
+            BinOp::And => MirOperand::Constant(MirConst::Int(0)),
+            BinOp::Or => MirOperand::Constant(MirConst::Int(1)),
+            _ => unreachable!(),
+        };
+        self.builder.push_stmt(MirStmt::dummy(MirStmtKind::Assign {
+            dst: result_local,
+            rvalue: MirRValue::Use(short_val),
+        }));
+        self.builder.terminate(MirTerminator::dummy(MirTerminatorKind::Goto {
+            target: merge_block,
+        }));
+
+        // Long branch: evaluate rhs, yield rhs.
+        self.builder.switch_to_block(rhs_block);
+        let (right_op, _) = self.lower_expr(right)?;
+        if self.builder.current_block_unterminated() {
+            self.builder.push_stmt(MirStmt::dummy(MirStmtKind::Assign {
+                dst: result_local,
+                rvalue: MirRValue::Use(right_op),
+            }));
+            self.builder.terminate(MirTerminator::dummy(MirTerminatorKind::Goto {
+                target: merge_block,
+            }));
+        }
+
+        self.builder.switch_to_block(merge_block);
+
+        Ok((MirOperand::Local(result_local), MirType::Bool))
     }
 
     /// Lower `if expr? [as v] { then } [else [as e] { else_br }]` — present-check

--- a/compiler/crates/rask-mir/src/lower/mod.rs
+++ b/compiler/crates/rask-mir/src/lower/mod.rs
@@ -2305,11 +2305,13 @@ mod tests {
 
     #[test]
     fn lower_binary_op_and_or() {
+        // Short-circuit: `&&`/`||` lower to a branch + per-arm assigns,
+        // not a single BinaryOp. Verify the branch terminator is emitted.
         let decl = make_fn("f", vec![], Some("bool"), vec![
             return_stmt(Some(binary_expr(BinOp::And, bool_expr(true), bool_expr(false)))),
         ]);
         let f = lower_one(&decl);
-        assert!(find_assign_binop(&f));
+        assert!(has_branch(&f));
     }
 
     #[test]

--- a/compiler/crates/rask-mir/src/transform/inline.rs
+++ b/compiler/crates/rask-mir/src/transform/inline.rs
@@ -309,11 +309,33 @@ fn try_inline_call(
     }
 
     // --- Create merge block ---
+    let caller_block_id = caller.blocks[block_idx].id;
     caller.blocks.push(MirBlock {
         id: merge_block_id,
         statements: post_stmts,
         terminator: original_terminator,
     });
+
+    // Successor phis previously listed `caller_block_id` as the predecessor;
+    // after the split, the merge block is the real predecessor. Without this
+    // fixup, SSA destruct emits the phi-copy in `caller_block_id` (which no
+    // longer defines the copied local), so reads in successors see undef.
+    let merge_succs = crate::analysis::cfg::successors(
+        &caller.blocks.last().unwrap().terminator,
+    );
+    for succ_id in merge_succs {
+        if let Some(succ_block) = caller.blocks.iter_mut().find(|b| b.id == succ_id) {
+            for stmt in &mut succ_block.statements {
+                if let MirStmtKind::Phi { args, .. } = &mut stmt.kind {
+                    for (pred, _) in args.iter_mut() {
+                        if *pred == caller_block_id {
+                            *pred = merge_block_id;
+                        }
+                    }
+                }
+            }
+        }
+    }
 
     // --- Fixup return values ---
     // For callee blocks that ended with Return/CleanupReturn { value: Some(op) },


### PR DESCRIPTION
## Summary
This PR implements proper short-circuit evaluation semantics for the `&&` and `||` binary operators in the MIR lowering phase. Previously, both operands were always evaluated; now the right-hand side is only evaluated when necessary.

## Key Changes

- **Short-circuit evaluation for `&&` and `||`**: Added `lower_short_circuit()` method that generates control flow with three blocks:
  - A short-circuit block that yields the deciding value without evaluating RHS
  - An RHS evaluation block that computes and yields the right operand
  - A merge block that combines both paths
  - For `&&`: skip RHS if LHS is false; for `||`: skip RHS if LHS is true

- **Improved generic type resolution for `Vec.new()` and `Map.new()`**: 
  - Added `inferred_generic_param_size()` method to resolve generic argument sizes from the type checker's inferred types
  - Falls back to syntactic generic parameters when inference data is unavailable
  - Enables bare `Vec.new()` and `Map.new()` calls (without explicit `<T>` syntax) to work correctly by using inferred element/key/value types

- **Enhanced method dispatch for user-defined types**:
  - Prioritizes user-defined struct/enum methods from `extend` blocks over stdlib type methods
  - Filters out stdlib types (Option, Result, etc.) to preserve their existing dispatch paths
  - Prevents hardcoded fallbacks from shadowing user-defined method implementations

- **Fixed SSA phi node handling in function inlining**:
  - When splitting a caller block during inlining, updates successor phi nodes to reference the merge block instead of the original caller block
  - Prevents SSA destruct from emitting phi-copies in the wrong block, which would cause reads to see undefined values

- **Updated test expectations**: Modified `lower_binary_op_and_or` test to verify branch terminator emission instead of binary operation assignment

## Implementation Details

The short-circuit implementation uses the existing MIR block builder to create proper control flow, ensuring that:
- The left operand is always evaluated first
- A conditional branch determines which path to take
- Both paths converge at a merge block with the final result
- The result is stored in a temporary local and returned as a typed operand

https://claude.ai/code/session_01MNEKcGRPifCsPrH5hWKZ8S