### PR TITLE
Add Iterator methods, Char type support, and generic type instantiation

### DIFF
--- a/compiler/Cargo.lock
+++ b/compiler/Cargo.lock
@@ -1586,6 +1586,7 @@ dependencies = [
  "rask-c-parse",
  "rask-lexer",
  "rask-parser",
+ "rask-stdlib",
  "reqwest",
  "serde",
  "serde_json",

--- a/compiler/crates/rask-cli/src/commands/compile.rs
+++ b/compiler/crates/rask-cli/src/commands/compile.rs
@@ -523,6 +523,14 @@ pub fn compile_tests_to_object(
         codegen.set_debug_context(src_file, lm.clone());
     }
 
+    // Build and register vtables for trait objects used by test bodies.
+    let test_trait_methods = build_trait_methods(typed);
+    let vtables = collect_vtables(&mir_functions, &test_trait_methods, mono);
+    if !vtables.is_empty() {
+        codegen.register_vtables(&vtables)
+            .map_err(|e| vec![e.to_string()])?;
+    }
+
     gen_functions(&mut codegen, &mir_functions)?;
 
     // Generate the test runner entry point

--- a/compiler/crates/rask-cli/src/commands/run.rs
+++ b/compiler/crates/rask-cli/src/commands/run.rs
@@ -256,6 +256,55 @@ pub fn cmd_test_project(path: &str, filter: Option<String>, format: Format) {
 
 /// Compile a .rk file's tests natively and run them.
 /// Compile and run tests with options (verbose, sequential, seed).
+/// Run tests through the tree-walking interpreter (no codegen).
+/// Useful for cross-checking codegen-side regressions and for tests that
+/// don't yet compile natively.
+pub fn cmd_test_interp(path: &str, filter: Option<String>, format: Format) {
+    let result = crate::run_check_or_exit(path, format);
+
+    let mut interp = rask_interp::Interpreter::new();
+    let cfg = rask_comptime::CfgConfig::from_host("debug", vec![]);
+    interp.inject_cfg(&cfg);
+    if let Some((_, source)) = result.source_files.first() {
+        interp.set_source_info(path, source);
+    }
+    if !result.package_names.is_empty() {
+        interp.register_packages(&result.package_names);
+    }
+
+    let test_results = interp.run_tests(&result.decls, filter.as_deref());
+
+    // Render in the same format as native (JSON-per-line, then summarize).
+    let mut json_lines = String::new();
+    for r in &test_results {
+        let escaped_name = r.name.replace('\\', "\\\\").replace('"', "\\\"");
+        let dur_ns = r.duration.as_nanos() as u64;
+        if let Some(reason) = &r.skipped {
+            let escaped = reason.replace('\\', "\\\\").replace('"', "\\\"");
+            json_lines.push_str(&format!(
+                "{{\"name\":\"{}\",\"passed\":true,\"duration_ns\":{},\"skipped\":\"{}\"}}\n",
+                escaped_name, dur_ns, escaped,
+            ));
+        } else if r.passed {
+            json_lines.push_str(&format!(
+                "{{\"name\":\"{}\",\"passed\":true,\"duration_ns\":{}}}\n",
+                escaped_name, dur_ns,
+            ));
+        } else {
+            let err = r.errors.join("; ").replace('\\', "\\\\").replace('"', "\\\"");
+            json_lines.push_str(&format!(
+                "{{\"name\":\"{}\",\"passed\":false,\"duration_ns\":{},\"error\":\"{}\"}}\n",
+                escaped_name, dur_ns, err,
+            ));
+        }
+    }
+    display_test_results(&json_lines, path, format);
+
+    if test_results.iter().any(|r| !r.passed && r.skipped.is_none()) {
+        process::exit(1);
+    }
+}
+
 pub fn cmd_test_native_with_opts(path: &str, filter: Option<String>, format: Format, opts: &TestOptions) {
     // --seed is accepted for forward-compatibility (T8) but not yet functional
     if opts.seed.is_some() && format == Format::Human {

--- a/compiler/crates/rask-cli/src/main.rs
+++ b/compiler/crates/rask-cli/src/main.rs
@@ -401,8 +401,15 @@ fn main() {
                 }
             };
             let test_opts = commands::run::TestOptions { verbose, sequential, seed };
+            let interp = cmd_args.contains(&"--interp");
             let p = Path::new(file);
-            if p.is_dir() {
+            if interp {
+                if p.is_dir() {
+                    eprintln!("{}: --interp does not yet support directory mode", output::error_label());
+                    process::exit(1);
+                }
+                commands::run::cmd_test_interp(file, filter, format);
+            } else if p.is_dir() {
                 // Directory with build.rk → single project (all files share types).
                 // Directory without build.rk → folder of standalone files; run each
                 // independently so duplicate type names across files don't collide.

--- a/compiler/crates/rask-cli/tests/compile_run.rs
+++ b/compiler/crates/rask-cli/tests/compile_run.rs
@@ -6,6 +6,18 @@
 
 use std::path::{Path, PathBuf};
 use std::process::Command;
+use std::sync::atomic::{AtomicU64, Ordering};
+
+/// Global counter for temp file names. Local per-function counters collide
+/// across helper functions (each starts at 0), producing identical paths
+/// like `rask_ctest_<pid>_1.rk` from different threads — one thread deletes
+/// the file before another's rask subprocess can read it. Sharing one counter
+/// guarantees unique IDs across the test binary.
+static NEXT_TMP_ID: AtomicU64 = AtomicU64::new(0);
+
+fn next_tmp_id() -> u64 {
+    NEXT_TMP_ID.fetch_add(1, Ordering::Relaxed)
+}
 
 fn rask_binary() -> PathBuf {
     // cargo test builds into target/debug or target/release
@@ -318,10 +330,8 @@ fn error_missing_return() {
 
 /// Run `rask check` and return combined stdout+stderr.
 fn check_output(source: &str) -> String {
-    use std::sync::atomic::{AtomicU64, Ordering};
-    static COUNTER: AtomicU64 = AtomicU64::new(0);
     let rask = rask_binary();
-    let id = COUNTER.fetch_add(1, Ordering::Relaxed);
+    let id = next_tmp_id();
     let tmp = std::env::temp_dir().join(format!("rask_errtest_{}_{}.rk", std::process::id(), id));
     std::fs::write(&tmp, source).unwrap();
 
@@ -389,10 +399,8 @@ fn fmt_normalizes_spacing() {
 // ─── rask lint integration ──────────────────────────────────
 
 fn lint_output(source: &str) -> String {
-    use std::sync::atomic::{AtomicU64, Ordering};
-    static COUNTER: AtomicU64 = AtomicU64::new(0);
     let rask = rask_binary();
-    let id = COUNTER.fetch_add(1, Ordering::Relaxed);
+    let id = next_tmp_id();
     let tmp = std::env::temp_dir().join(format!("rask_linttest_{}_{}.rk", std::process::id(), id));
     std::fs::write(&tmp, source).unwrap();
 
@@ -475,10 +483,8 @@ fn api_shows_map_methods() {
 // This catches stubs that exist but aren't wired into the resolver.
 
 fn check_succeeds(source: &str) -> bool {
-    use std::sync::atomic::{AtomicU64, Ordering};
-    static COUNTER: AtomicU64 = AtomicU64::new(0);
     let rask = rask_binary();
-    let id = COUNTER.fetch_add(1, Ordering::Relaxed);
+    let id = next_tmp_id();
     let tmp = std::env::temp_dir().join(format!("rask_disctest_{}_{}.rk", std::process::id(), id));
     std::fs::write(&tmp, source).unwrap();
 
@@ -562,10 +568,8 @@ fn c_header_fixture(name: &str) -> PathBuf {
 
 /// Write a temp .rk file that imports the given header and check it.
 fn check_c_import(header: &str, rask_body: &str) -> bool {
-    use std::sync::atomic::{AtomicU64, Ordering};
-    static COUNTER: AtomicU64 = AtomicU64::new(0);
     let rask = rask_binary();
-    let id = COUNTER.fetch_add(1, Ordering::Relaxed);
+    let id = next_tmp_id();
     let header_path = c_header_fixture(header);
     let tmp = std::env::temp_dir().join(format!("rask_ctest_{}_{}.rk", std::process::id(), id));
     let source = format!(
@@ -587,10 +591,8 @@ fn check_c_import(header: &str, rask_body: &str) -> bool {
 
 /// Run `rask check` and return stderr+stdout for assertion.
 fn check_c_import_output(header: &str, rask_body: &str) -> (bool, String) {
-    use std::sync::atomic::{AtomicU64, Ordering};
-    static COUNTER: AtomicU64 = AtomicU64::new(0);
     let rask = rask_binary();
-    let id = COUNTER.fetch_add(1, Ordering::Relaxed);
+    let id = next_tmp_id();
     let header_path = c_header_fixture(header);
     let tmp = std::env::temp_dir().join(format!("rask_ctest_{}_{}.rk", std::process::id(), id));
     let source = format!(
@@ -617,10 +619,8 @@ fn check_c_import_output(header: &str, rask_body: &str) -> (bool, String) {
 
 /// Run `rask resolve` and return stdout for symbol inspection.
 fn resolve_c_import(header: &str, rask_body: &str) -> String {
-    use std::sync::atomic::{AtomicU64, Ordering};
-    static COUNTER: AtomicU64 = AtomicU64::new(0);
     let rask = rask_binary();
-    let id = COUNTER.fetch_add(1, Ordering::Relaxed);
+    let id = next_tmp_id();
     let header_path = c_header_fixture(header);
     let tmp = std::env::temp_dir().join(format!("rask_crestest_{}_{}.rk", std::process::id(), id));
     let source = format!(
@@ -720,10 +720,8 @@ fn c_import_call_with_args_typechecks() {
 // CI5: import c "header.h" hiding { symbol }
 #[test]
 fn c_import_hiding() {
-    use std::sync::atomic::{AtomicU64, Ordering};
-    static COUNTER: AtomicU64 = AtomicU64::new(0);
     let rask = rask_binary();
-    let id = COUNTER.fetch_add(1, Ordering::Relaxed);
+    let id = next_tmp_id();
     let header_path = c_header_fixture("mylib.h");
     let tmp = std::env::temp_dir().join(format!("rask_chidetest_{}_{}.rk", std::process::id(), id));
     let source = format!(
@@ -755,10 +753,8 @@ fn c_import_hiding() {
 // CI1: Aliased import: import c "header.h" as mylib
 #[test]
 fn c_import_alias() {
-    use std::sync::atomic::{AtomicU64, Ordering};
-    static COUNTER: AtomicU64 = AtomicU64::new(0);
     let rask = rask_binary();
-    let id = COUNTER.fetch_add(1, Ordering::Relaxed);
+    let id = next_tmp_id();
     let header_path = c_header_fixture("mylib.h");
     let tmp = std::env::temp_dir().join(format!("rask_caliastest_{}_{}.rk", std::process::id(), id));
     let source = format!(

--- a/compiler/crates/rask-codegen/src/builder.rs
+++ b/compiler/crates/rask-codegen/src/builder.rs
@@ -2792,10 +2792,15 @@ impl<'a> FunctionBuilder<'a> {
 
     /// Check if MIR arg at `index` is a string type.
     fn is_string_arg(mir_args: &[MirOperand], index: usize, locals: &[rask_mir::MirLocal]) -> bool {
-        mir_args.get(index)
-            .and_then(|a| Self::operand_mir_type(a, locals))
-            .map(|t| t == MirType::String)
-            .unwrap_or(false)
+        match mir_args.get(index) {
+            Some(MirOperand::Local(id)) => locals
+                .iter()
+                .find(|l| l.id == *id)
+                .map(|l| l.ty == MirType::String)
+                .unwrap_or(false),
+            Some(MirOperand::Constant(rask_mir::MirConst::String(_))) => true,
+            _ => false,
+        }
     }
 
     /// Check if destination local is a string type.

--- a/compiler/crates/rask-codegen/src/builder.rs
+++ b/compiler/crates/rask-codegen/src/builder.rs
@@ -2468,7 +2468,57 @@ impl<'a> FunctionBuilder<'a> {
                     } else {
                         builder.ins().iconst(types::I64, 0)
                     };
-                    if matches!(ctx.ret_ty, MirType::Option(_)) {
+                    // Aggregate payload (string/struct/...) — `val` is a pointer to
+                    // 16+ bytes. Copy into the payload area instead of storing the
+                    // pointer at offset 8 (which leaves the rest of the slot
+                    // uninitialized).
+                    let inner_aggregate = match ctx.ret_ty {
+                        MirType::Option(inner) => Some(inner.as_ref()),
+                        MirType::Result { ok, .. } => Some(ok.as_ref()),
+                        _ => None,
+                    }.filter(|t| matches!(t,
+                        MirType::String | MirType::Struct(_) | MirType::Enum(_)
+                        | MirType::Tuple(_) | MirType::Result { .. } | MirType::Option(_)
+                    ));
+                    if let Some(inner) = inner_aggregate {
+                        let inner_size = Self::resolve_type_alloc_size(
+                            inner, ctx.struct_layouts, ctx.enum_layouts,
+                        ).unwrap_or(inner.size());
+                        let payload_off = if matches!(ctx.ret_ty, MirType::Option(_)) {
+                            crate::layouts::PAYLOAD_OFFSET
+                        } else {
+                            crate::layouts::RESULT_PAYLOAD_OFFSET
+                        };
+                        let tag = builder.ins().iconst(types::I64, 0);
+                        builder.ins().stack_store(tag, ss, crate::layouts::TAG_OFFSET);
+                        if matches!(ctx.ret_ty, MirType::Result { .. }) {
+                            let zero = builder.ins().iconst(types::I64, 0);
+                            builder.ins().stack_store(zero, ss, crate::layouts::ORIGIN_FILE_OFFSET);
+                            builder.ins().stack_store(zero, ss, crate::layouts::ORIGIN_LINE_OFFSET);
+                        }
+                        let dst = builder.ins().stack_addr(types::I64, ss, payload_off);
+                        let mut off = 0i32;
+                        let size = inner_size as i32;
+                        while off + 8 <= size {
+                            let word = builder.ins().load(types::I64, MemFlags::new(), val, off);
+                            builder.ins().store(MemFlags::new(), word, dst, off);
+                            off += 8;
+                        }
+                        if size - off >= 4 {
+                            let w = builder.ins().load(types::I32, MemFlags::new(), val, off);
+                            builder.ins().store(MemFlags::new(), w, dst, off);
+                            off += 4;
+                        }
+                        if size - off >= 2 {
+                            let w = builder.ins().load(types::I16, MemFlags::new(), val, off);
+                            builder.ins().store(MemFlags::new(), w, dst, off);
+                            off += 2;
+                        }
+                        if size - off >= 1 {
+                            let w = builder.ins().load(types::I8, MemFlags::new(), val, off);
+                            builder.ins().store(MemFlags::new(), w, dst, off);
+                        }
+                    } else if matches!(ctx.ret_ty, MirType::Option(_)) {
                         Self::wrap_some_into_slot(builder, val, ss);
                     } else {
                         Self::wrap_ok_into_slot(builder, val, ss);

--- a/compiler/crates/rask-interp/src/builtins/primitives.rs
+++ b/compiler/crates/rask-interp/src/builtins/primitives.rs
@@ -191,7 +191,21 @@ impl Interpreter {
             "max" => { let b = self.expect_float(args, 0)?; Ok(Value::Float(a.max(b))) }
             "to_string" | "debug_string" => Ok(Value::String(Arc::new(Mutex::new(a.to_string())))),
             "to_int" => Ok(Value::Int(a as i64)),
-            "pow" => { let b = self.expect_float(args, 0)?; Ok(Value::Float(a.powf(b))) }
+            "pow" | "powf" => { let b = self.expect_float(args, 0)?; Ok(Value::Float(a.powf(b))) }
+            "powi" => { let b = self.expect_int(args, 0)?; Ok(Value::Float(a.powi(b as i32))) }
+            "rem" => { let b = self.expect_float(args, 0)?; Ok(Value::Float(a.rem_euclid(b))) }
+            "sin" => Ok(Value::Float(a.sin())),
+            "cos" => Ok(Value::Float(a.cos())),
+            "tan" => Ok(Value::Float(a.tan())),
+            "asin" => Ok(Value::Float(a.asin())),
+            "acos" => Ok(Value::Float(a.acos())),
+            "atan" => Ok(Value::Float(a.atan())),
+            "ln" => Ok(Value::Float(a.ln())),
+            "log10" => Ok(Value::Float(a.log10())),
+            "log2" => Ok(Value::Float(a.log2())),
+            "exp" => Ok(Value::Float(a.exp())),
+            "trunc" => Ok(Value::Float(a.trunc())),
+            "fract" => Ok(Value::Float(a.fract())),
             _ => Err(RuntimeError::NoSuchMethod {
                 ty: "f64".to_string(),
                 method: method.to_string(),

--- a/compiler/crates/rask-interp/src/drift.rs
+++ b/compiler/crates/rask-interp/src/drift.rs
@@ -16,7 +16,7 @@ use crate::value::{ModuleKind, PoolData, ThreadHandleInner, Value};
 /// Only needs to route to the right dispatch — doesn't need valid data.
 fn dummy_value(type_name: &str) -> Value {
     match type_name {
-        "i64" => Value::Int(0),
+        "i8" | "i16" | "i32" | "i64" | "u8" | "u16" | "u32" | "u64" => Value::Int(0),
         "i128" => Value::Int128(0),
         "u128" => Value::Uint128(0),
         "f64" => Value::Float(0.0),

--- a/compiler/crates/rask-mir/src/lower/expr.rs
+++ b/compiler/crates/rask-mir/src/lower/expr.rs
@@ -251,6 +251,37 @@ impl<'a> MirLowerer<'a> {
             // Variable reference (or bare enum variant like None)
             ExprKind::Ident(name) => {
                 if let Some((id, ty)) = self.locals.get(name).cloned() {
+                    // ER24/CF22: ER24 narrowing redefines the binding's type in
+                    // the type checker's scope, but the MIR local keeps its
+                    // declared type. When the use-site has a more specific
+                    // narrowed type recorded, extract the payload from the
+                    // wider Result/Option so downstream Field / method lookup
+                    // operates on the narrowed type, not the wrapper.
+                    let narrow_ty = self
+                        .ctx
+                        .lookup_node_type(expr.id)
+                        .filter(|t| !matches!(t, MirType::Ptr));
+                    let needs_narrow = matches!(
+                        (&ty, &narrow_ty),
+                        (MirType::Result { .. }, Some(n)) if !matches!(n, MirType::Result { .. })
+                    ) || matches!(
+                        (&ty, &narrow_ty),
+                        (MirType::Option(_), Some(n)) if !matches!(n, MirType::Option(_))
+                    );
+                    if needs_narrow {
+                        let inner_ty = narrow_ty.unwrap();
+                        let inner_local = self.builder.alloc_temp(inner_ty.clone());
+                        self.builder.push_stmt(MirStmt::dummy(MirStmtKind::Assign {
+                            dst: inner_local,
+                            rvalue: MirRValue::Field {
+                                base: MirOperand::Local(id),
+                                field_index: 0,
+                                byte_offset: None,
+                                field_size: None,
+                            },
+                        }));
+                        return Ok((MirOperand::Local(inner_local), inner_ty));
+                    }
                     Ok((MirOperand::Local(id), ty))
                 } else if name == "None" {
                     // Niche: Option<Handle<T>> uses sentinel instead of tag
@@ -2358,13 +2389,29 @@ impl<'a> MirLowerer<'a> {
                 // Then block: bind payload, evaluate body
                 self.builder.switch_to_block(then_block);
                 // ER23: `Type as v` on the err side needs the err type, not ok.
+                // Match `ty_name` against the actual ok/err names first; fall back
+                // to the case heuristic only when neither side has a discoverable
+                // name (string, primitives, generics).
                 let bind_ty = if let rask_ast::expr::Pattern::TypePat { ty_name, .. } = pattern {
-                    let is_ok_side = ty_name.chars().next().map_or(false, |c| c.is_lowercase());
-                    if is_ok_side {
-                        self.extract_payload_type(expr).unwrap_or(MirType::I64)
-                    } else {
-                        self.extract_err_type(expr).unwrap_or(MirType::I64)
+                    let val_ty = &val_ty;
+                    let mut chosen: Option<MirType> = None;
+                    if let MirType::Result { ok, err } = val_ty {
+                        let ok_name = self.mir_type_name(ok);
+                        let err_name = self.mir_type_name(err);
+                        if ok_name.as_deref() == Some(ty_name.as_str()) {
+                            chosen = Some(*ok.clone());
+                        } else if err_name.as_deref() == Some(ty_name.as_str()) {
+                            chosen = Some(*err.clone());
+                        }
                     }
+                    chosen.unwrap_or_else(|| {
+                        let is_ok_side = ty_name.chars().next().map_or(false, |c| c.is_lowercase());
+                        if is_ok_side {
+                            self.extract_payload_type(expr).unwrap_or(MirType::I64)
+                        } else {
+                            self.extract_err_type(expr).unwrap_or(MirType::I64)
+                        }
+                    })
                 } else {
                     self.extract_payload_type(expr).unwrap_or(MirType::I64)
                 };

--- a/compiler/crates/rask-mir/src/lower/expr.rs
+++ b/compiler/crates/rask-mir/src/lower/expr.rs
@@ -187,16 +187,25 @@ impl<'a> MirLowerer<'a> {
         match &expr.kind {
             // Literals
             ExprKind::Int(val, suffix) => {
+                // Suffixed literals carry their type explicitly. Unsuffixed
+                // literals follow the type checker's inference (default i32).
                 let ty = match suffix {
                     Some(IntSuffix::I8) => MirType::I8,
                     Some(IntSuffix::I16) => MirType::I16,
                     Some(IntSuffix::I32) => MirType::I32,
-                    Some(IntSuffix::I64) | None => MirType::I64,
+                    Some(IntSuffix::I64) => MirType::I64,
                     Some(IntSuffix::U8) => MirType::U8,
                     Some(IntSuffix::U16) => MirType::U16,
                     Some(IntSuffix::U32) => MirType::U32,
                     Some(IntSuffix::U64) => MirType::U64,
                     Some(IntSuffix::I128 | IntSuffix::U128 | IntSuffix::Isize | IntSuffix::Usize) => MirType::I64,
+                    None => self
+                        .ctx
+                        .lookup_node_type(expr.id)
+                        .filter(|t| matches!(t,
+                            MirType::I8 | MirType::I16 | MirType::I32 | MirType::I64
+                            | MirType::U8 | MirType::U16 | MirType::U32 | MirType::U64))
+                        .unwrap_or(MirType::I64),
                 };
                 Ok((MirOperand::Constant(MirConst::Int(*val)), ty))
             }

--- a/compiler/crates/rask-mir/src/lower/mod.rs
+++ b/compiler/crates/rask-mir/src/lower/mod.rs
@@ -1091,9 +1091,21 @@ impl<'a> MirLowerer<'a> {
                 }
                 0
             }
-            // ER23: `Type as v` — lowercase first char ⇒ ok side, uppercase
-            // user enum ⇒ err side (when scrutinee is `T or E`).
+            // ER23: `Type as v` — for Result<T, E>, prefer matching `ty_name` against
+            // the actual ok / err names. Without this, a user struct on the ok side
+            // (uppercase, e.g. `Cfg or CfgError`) wrongly maps to tag=1 because of
+            // the case heuristic.
             Pattern::TypePat { ty_name, .. } => {
+                if let MirType::Result { ok, err } = val_ty {
+                    let ok_name = self.mir_type_name(ok);
+                    let err_name = self.mir_type_name(err);
+                    if ok_name.as_deref() == Some(ty_name.as_str()) {
+                        return 0;
+                    }
+                    if err_name.as_deref() == Some(ty_name.as_str()) {
+                        return 1;
+                    }
+                }
                 if ty_name.chars().next().map_or(false, |c| c.is_lowercase()) {
                     0
                 } else {

--- a/compiler/crates/rask-mono/src/layout.rs
+++ b/compiler/crates/rask-mono/src/layout.rs
@@ -139,10 +139,18 @@ pub fn type_size_align(ty: &Type, cache: &LayoutCache) -> (u32, u32) {
                 "i32" | "u32" | "f32" => (4, 4),
                 "i64" | "u64" | "f64" => (8, 8),
                 "char" => (4, 4),
+                // Stdlib types backed by opaque runtime pointers
+                "TcpListener" | "TcpConnection" | "File" | "ThreadHandle"
+                | "TaskHandle" | "Sender" | "Receiver" | "ThreadPool"
+                | "MultitaskingRuntime" | "Rng" | "Iterator" | "StringBuilder" => (8, 8),
                 _ => {
                     // Look up user-defined types from the layout cache
                     if let Some(&cached) = cache.get(name.as_str()) {
                         cached
+                    } else if is_typevar_name(name) {
+                        // Unsubstituted type parameter — pointer-sized fallback,
+                        // silent because mono always picks a concrete size on real call sites.
+                        (8, 8)
                     } else {
                         // Treat as opaque pointer-sized. If this is a user type,
                         // it should have been caught by the type checker.
@@ -188,6 +196,18 @@ pub fn type_size_align(ty: &Type, cache: &LayoutCache) -> (u32, u32) {
 /// Align a value up to the given alignment
 fn align_up(val: u32, align: u32) -> u32 {
     (val + align - 1) & !(align - 1)
+}
+
+/// Heuristic: single uppercase letter (or letter + digit) is a type parameter
+/// like `T`, `K`, `V`, `T1`. These should never reach layout in monomorphized
+/// code; the warning is noise on every compile.
+fn is_typevar_name(name: &str) -> bool {
+    let bytes = name.as_bytes();
+    match bytes.len() {
+        1 => bytes[0].is_ascii_uppercase(),
+        2 => bytes[0].is_ascii_uppercase() && bytes[1].is_ascii_digit(),
+        _ => false,
+    }
 }
 
 /// Parse a field type string (from AST) to a Type for layout computation.

--- a/compiler/crates/rask-parser/src/parser.rs
+++ b/compiler/crates/rask-parser/src/parser.rs
@@ -920,6 +920,25 @@ impl Parser {
         Ok(params)
     }
 
+    /// Parse one parameter inside a function type: `T`, `name: T`, or `mutate name: T`.
+    /// In type position, names and modifiers are noise — only the type part is kept.
+    fn parse_func_type_param(&mut self) -> Result<String, ParseError> {
+        // Skip optional `mutate` modifier
+        if matches!(self.current_kind(), TokenKind::MutateKw) {
+            self.advance();
+        }
+
+        // If `name :` precedes the type, skip the name and colon
+        if let TokenKind::Ident(_) = self.current_kind() {
+            if matches!(self.peek(1), TokenKind::Colon) {
+                self.advance(); // name
+                self.advance(); // :
+            }
+        }
+
+        self.parse_type_name()
+    }
+
     fn parse_type_name(&mut self) -> Result<String, ParseError> {
         let base = self.parse_base_type()?;
 
@@ -1077,13 +1096,14 @@ impl Parser {
             return Ok(n.to_string());
         }
 
-        // Closure type: |T1, T2| -> R
+        // Closure type: |T1, T2| -> R, or with named/modified params:
+        //   |name: T|, |mutate name: T| (names are noise in type position)
         if self.check(&TokenKind::Pipe) {
             self.advance();
             let mut params = Vec::new();
             if !self.check(&TokenKind::Pipe) {
                 loop {
-                    params.push(self.parse_type_name()?);
+                    params.push(self.parse_func_type_param()?);
                     if !self.match_token(&TokenKind::Comma) { break; }
                 }
             }
@@ -1105,7 +1125,7 @@ impl Parser {
             let mut params = Vec::new();
             if !self.check(&TokenKind::RParen) {
                 loop {
-                    params.push(self.parse_type_name()?);
+                    params.push(self.parse_func_type_param()?);
                     if !self.match_token(&TokenKind::Comma) { break; }
                 }
             }

--- a/compiler/crates/rask-resolve/Cargo.toml
+++ b/compiler/crates/rask-resolve/Cargo.toml
@@ -8,6 +8,7 @@ edition.workspace = true
 rask-ast = { path = "../rask-ast" }
 rask-lexer = { path = "../rask-lexer" }
 rask-parser = { path = "../rask-parser" }
+rask-stdlib = { path = "../rask-stdlib" }
 rask-c-parse = { path = "../rask-c-parse" }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"

--- a/compiler/crates/rask-resolve/src/resolver.rs
+++ b/compiler/crates/rask-resolve/src/resolver.rs
@@ -429,6 +429,13 @@ impl Resolver {
     /// Check if a name refers to a builtin type or enum (not a builtin function).
     /// User-defined functions can shadow builtin functions like `max`, `min`,
     /// but not builtin types like `Vec`, `Map`, `Option`.
+    /// Check whether a name matches a stdlib module namespace (`io`, `fs`,
+    /// `json`, ...). Stdlib modules aren't pre-bound in scope, so a local
+    /// `const io = ...` would silently break later `io.stdout()` calls.
+    fn is_stdlib_namespace(name: &str) -> bool {
+        rask_stdlib::registry::REGISTERED_MODULES.contains(&name)
+    }
+
     fn is_builtin_type_name(&self, name: &str) -> bool {
         if let Some(sym_id) = self.scopes.lookup(name) {
             if let Some(sym) = self.symbols.get(sym_id) {
@@ -1524,6 +1531,9 @@ impl Resolver {
             }
             StmtKind::Mut { name, name_span, ty, init } => {
                 self.resolve_expr(init);
+                if !self.stdlib_mode && Self::is_stdlib_namespace(name) {
+                    self.errors.push(ResolveError::shadows_builtin(name.clone(), *name_span));
+                }
                 let sym_id = self.symbols.insert(
                     name.clone(),
                     SymbolKind::Variable { mutable: true },
@@ -1537,6 +1547,9 @@ impl Resolver {
             }
             StmtKind::Const { name, name_span, ty, init } => {
                 self.resolve_expr(init);
+                if !self.stdlib_mode && Self::is_stdlib_namespace(name) {
+                    self.errors.push(ResolveError::shadows_builtin(name.clone(), *name_span));
+                }
                 let sym_id = self.symbols.insert(
                     name.clone(),
                     SymbolKind::Variable { mutable: false },

--- a/compiler/crates/rask-stdlib/src/registry.rs
+++ b/compiler/crates/rask-stdlib/src/registry.rs
@@ -91,10 +91,13 @@ const U128_METHODS: &[&str] = &[
 ];
 
 const F64_METHODS: &[&str] = &[
-    "add", "sub", "mul", "div", "neg",
-    "eq", "lt", "le", "gt", "ge",
-    "abs", "floor", "ceil", "round", "sqrt",
-    "min", "max", "to_string", "to_int", "pow",
+    "add", "sub", "mul", "div", "rem", "neg",
+    "eq", "lt", "le", "gt", "ge", "compare",
+    "abs", "floor", "ceil", "round", "sqrt", "trunc", "fract",
+    "min", "max", "to_string", "to_int",
+    "pow", "powf", "powi",
+    "sin", "cos", "tan", "asin", "acos", "atan",
+    "ln", "log10", "log2", "exp",
 ];
 
 const BOOL_METHODS: &[&str] = &["eq"];

--- a/compiler/crates/rask-stdlib/src/stubs.rs
+++ b/compiler/crates/rask-stdlib/src/stubs.rs
@@ -382,10 +382,12 @@ fn fn_to_method_stub(f: &FnDecl, filename: &str, source: &str, parent_span: Span
         .map(|p| (p.name.clone(), p.ty.clone()))
         .collect();
 
-    let span = find_func_name_span(source, &f.name, parent_span);
+    // Parser appends `<T: Bound>` to generic function names; strip for lookup.
+    let bare_name = strip_type_params(&f.name);
+    let span = find_func_name_span(source, &bare_name, parent_span);
 
     MethodStub {
-        name: f.name.clone(),
+        name: bare_name,
         takes_self,
         mutate_self,
         take_self,
@@ -491,6 +493,7 @@ mod tests {
         assert!(reg.has_method("Option", "map"));
         assert!(reg.has_method("Option", "or"));
     }
+
 
     #[test]
     fn string_methods_present() {

--- a/compiler/crates/rask-types/src/checker/builtins.rs
+++ b/compiler/crates/rask-types/src/checker/builtins.rs
@@ -80,6 +80,38 @@ pub(super) fn parse_stub_type(s: &str) -> Type {
         return Type::option(parse_stub_type(inner));
     }
 
+    // Handle other generics: `Name<T1, T2, ...>` (Vec, Map, Pool, Handle, ...)
+    // Without this, `Vec<string>` returns as `UnresolvedNamed("Vec<string>")`,
+    // which the method-lookup path doesn't unify against `Generic { Vec, [string] }`.
+    if let Some(open) = s.find('<') {
+        if s.ends_with('>') {
+            let name = s[..open].trim();
+            let inner = &s[open + 1..s.len() - 1];
+            let mut args = Vec::new();
+            let mut start = 0usize;
+            let mut depth: i32 = 0;
+            let bytes = inner.as_bytes();
+            for (i, b) in bytes.iter().enumerate() {
+                match b {
+                    b'<' => depth += 1,
+                    b'>' => depth -= 1,
+                    b',' if depth == 0 => {
+                        args.push(parse_stub_type(inner[start..i].trim()));
+                        start = i + 1;
+                    }
+                    _ => {}
+                }
+            }
+            if !inner.is_empty() {
+                args.push(parse_stub_type(inner[start..].trim()));
+            }
+            return Type::UnresolvedGeneric {
+                name: name.to_string(),
+                args: args.into_iter().map(|t| crate::types::GenericArg::Type(Box::new(t))).collect(),
+            };
+        }
+    }
+
     match s {
         "" | "()" | "void" => Type::Unit,
         "none" => Type::None,
@@ -229,10 +261,14 @@ mod tests {
 
     #[test]
     fn cli_args_returns_vec_string() {
+        use crate::types::GenericArg;
         let bm = BuiltinModules::new();
         let sig = bm.get_method("cli", "args").unwrap();
         assert!(sig.params.is_empty());
-        assert_eq!(sig.ret, Type::UnresolvedNamed("Vec<string>".to_string()));
+        assert_eq!(sig.ret, Type::UnresolvedGeneric {
+            name: "Vec".to_string(),
+            args: vec![GenericArg::Type(Box::new(Type::String))],
+        });
     }
 
     #[test]
@@ -269,8 +305,12 @@ mod tests {
 
     #[test]
     fn parse_generic_type() {
+        use crate::types::GenericArg;
         let ty = parse_stub_type("Vec<string>");
-        assert_eq!(ty, Type::UnresolvedNamed("Vec<string>".to_string()));
+        assert_eq!(ty, Type::UnresolvedGeneric {
+            name: "Vec".to_string(),
+            args: vec![GenericArg::Type(Box::new(Type::String))],
+        });
     }
 
     #[test]

--- a/compiler/crates/rask-types/src/checker/check_expr.rs
+++ b/compiler/crates/rask-types/src/checker/check_expr.rs
@@ -219,9 +219,19 @@ impl TypeChecker {
                             Type::Char
                         }
                     }
-                    // Vec<T>, Map<K,V>, Pool<T> — extract element type from first type arg
+                    // Vec<T>, Pool<T>, Handle<T> → element from first type arg.
+                    // Map<K,V> indexed by K → value type from second arg.
                     Type::Generic { args, .. } | Type::UnresolvedGeneric { args, .. } => {
-                        if let Some(GenericArg::Type(elem)) = args.first() {
+                        let is_map = match &obj_ty {
+                            Type::UnresolvedGeneric { name, .. } => name == "Map",
+                            Type::Generic { base, .. } => self
+                                .types
+                                .get_type_id("Map")
+                                .map_or(false, |id| id == *base),
+                            _ => false,
+                        };
+                        let elem_arg = if is_map { args.get(1) } else { args.first() };
+                        if let Some(GenericArg::Type(elem)) = elem_arg {
                             if is_range {
                                 Type::Slice(elem.clone())
                             } else {

--- a/compiler/crates/rask-types/src/checker/check_expr.rs
+++ b/compiler/crates/rask-types/src/checker/check_expr.rs
@@ -55,7 +55,29 @@ fn parse_type_arg(s: &str) -> Type {
             args,
         }
     } else {
-        Type::UnresolvedNamed(s.to_string())
+        // Map primitive names directly; otherwise they leak as UnresolvedNamed
+        // and method resolution can't dispatch (e.g. `Vec<i32>.new()` followed
+        // by `v[0] + 5` looking up `i32.add`).
+        match s {
+            "i8" => Type::I8,
+            "i16" => Type::I16,
+            "i32" => Type::I32,
+            "i64" | "isize" | "int" => Type::I64,
+            "i128" => Type::I128,
+            "u8" => Type::U8,
+            "u16" => Type::U16,
+            "u32" => Type::U32,
+            "u64" | "usize" | "uint" => Type::U64,
+            "u128" => Type::U128,
+            "f32" => Type::F32,
+            "f64" => Type::F64,
+            "bool" => Type::Bool,
+            "char" => Type::Char,
+            "string" => Type::String,
+            "void" | "()" => Type::Unit,
+            "none" => Type::None,
+            _ => Type::UnresolvedNamed(s.to_string()),
+        }
     }
 }
 

--- a/compiler/crates/rask-types/src/checker/resolve.rs
+++ b/compiler/crates/rask-types/src/checker/resolve.rs
@@ -239,9 +239,13 @@ impl TypeChecker {
                 Ok(false)
             }
             Type::Named(type_id) => {
-                let methods = match self.types.get(*type_id) {
-                    Some(TypeDef::Struct { methods, .. }) => methods.clone(),
-                    Some(TypeDef::Enum { methods, .. }) => methods.clone(),
+                let (methods, type_params) = match self.types.get(*type_id) {
+                    Some(TypeDef::Struct { methods, type_params, .. }) => {
+                        (methods.clone(), type_params.clone())
+                    }
+                    Some(TypeDef::Enum { methods, type_params, .. }) => {
+                        (methods.clone(), type_params.clone())
+                    }
                     _ => {
                         return Err(TypeError::NoSuchMethod {
                             ty,
@@ -260,14 +264,26 @@ impl TypeChecker {
                         });
                     }
 
+                    // Instantiate generic type params with fresh vars so a
+                    // bare `Vec.new()` produces a Vec carrying a fresh element
+                    // var instead of the literal "T" placeholder. Without this
+                    // the placeholder leaks into node_types and downstream
+                    // unifications (push, get, ...) silently no-op.
+                    let subst: std::collections::HashMap<&str, Type> = type_params
+                        .iter()
+                        .map(|p| (p.as_str(), self.ctx.fresh_var()))
+                        .collect();
+
                     let mut progress = false;
                     for ((param_ty, _mode), arg) in method_sig.params.iter().zip(args.iter()) {
-                        if self.unify(param_ty, arg, span)? {
+                        let substituted = Self::substitute_type_params(param_ty, &subst);
+                        if self.unify(&substituted, arg, span)? {
                             progress = true;
                         }
                     }
 
-                    if self.unify(&method_sig.ret, &ret, span)? {
+                    let substituted_ret = Self::substitute_type_params(&method_sig.ret, &subst);
+                    if self.unify(&substituted_ret, &ret, span)? {
                         progress = true;
                     }
 

--- a/compiler/crates/rask-types/src/checker/resolve.rs
+++ b/compiler/crates/rask-types/src/checker/resolve.rs
@@ -373,6 +373,7 @@ impl TypeChecker {
                 }
             }
             Type::String => self.resolve_string_method(&method, &args, &ret, span),
+            Type::Char => self.resolve_char_method(&method, &args, &ret, span),
             Type::Array { .. } | Type::Slice(_) => {
                 self.resolve_array_method(&ty, &method, &args, &ret, span)
             }
@@ -470,6 +471,10 @@ impl TypeChecker {
             // SIMD vector types (f32x4, f32x8, i32x4, i32x8, f64x2, f64x4)
             Type::UnresolvedNamed(name) if Self::is_simd_type(name) => {
                 self.resolve_simd_method(name, &method, &args, &ret, span)
+            }
+            // Iterator<T> — adapter chain methods, terminator methods.
+            Type::UnresolvedGeneric { name, args: type_args } if name == "Iterator" => {
+                self.resolve_iterator_method(&type_args, &method, &args, &ret, span)
             }
             // Shared<T>, Sender<T>, Receiver<T>, Channel<T>
             Type::UnresolvedGeneric { name, args: type_args } if matches!(name.as_str(), "Cell" | "Shared" | "Mutex" | "Sender" | "Receiver" | "Channel") => {
@@ -723,6 +728,138 @@ impl TypeChecker {
             .iter()
             .map(|ty| self.apply_type_var_substitution(ty, &substitution))
             .collect()
+    }
+
+    /// Resolve methods on `Iterator<T>` (lazy iterator type returned by
+    /// `string.split`, `Vec.iter`, etc.). The runtime is implemented in
+    /// the interpreter; the type checker only needs to ascribe types.
+    pub(super) fn resolve_iterator_method(
+        &mut self,
+        type_args: &[GenericArg],
+        method: &str,
+        args: &[Type],
+        ret: &Type,
+        span: Span,
+    ) -> Result<bool, TypeError> {
+        let elem = type_args.first().and_then(|a| {
+            if let GenericArg::Type(t) = a { Some(*t.clone()) } else { None }
+        }).unwrap_or_else(|| self.ctx.fresh_var());
+        let self_ty = Type::UnresolvedGeneric {
+            name: "Iterator".to_string(),
+            args: vec![GenericArg::Type(Box::new(elem.clone()))],
+        };
+        match method {
+            "next" if args.is_empty() => {
+                self.unify(ret, &Type::option(elem), span)
+            }
+            "iter" if args.is_empty() => self.unify(ret, &self_ty, span),
+            "collect" if args.is_empty() => {
+                let vec_ty = Type::UnresolvedGeneric {
+                    name: "Vec".to_string(),
+                    args: vec![GenericArg::Type(Box::new(elem))],
+                };
+                self.unify(ret, &vec_ty, span)
+            }
+            "count" if args.is_empty() => self.unify(ret, &Type::U64, span),
+            "sum" if args.is_empty() => self.unify(ret, &elem, span),
+            "min" | "max" if args.is_empty() => self.unify(ret, &Type::option(elem), span),
+            "map" if args.len() == 1 => {
+                let out = self.ctx.fresh_var();
+                let expected_fn = Type::Fn {
+                    params: vec![elem],
+                    ret: Box::new(out.clone()),
+                };
+                self.unify(&args[0], &expected_fn, span)?;
+                let iter_out = Type::UnresolvedGeneric {
+                    name: "Iterator".to_string(),
+                    args: vec![GenericArg::Type(Box::new(out))],
+                };
+                self.unify(ret, &iter_out, span)
+            }
+            "filter" if args.len() == 1 => {
+                let expected_fn = Type::Fn {
+                    params: vec![elem],
+                    ret: Box::new(Type::Bool),
+                };
+                self.unify(&args[0], &expected_fn, span)?;
+                self.unify(ret, &self_ty, span)
+            }
+            "fold" if args.len() == 2 => {
+                let acc = args[0].clone();
+                let expected_fn = Type::Fn {
+                    params: vec![acc.clone(), elem],
+                    ret: Box::new(acc.clone()),
+                };
+                self.unify(&args[1], &expected_fn, span)?;
+                self.unify(ret, &acc, span)
+            }
+            "take" | "skip" if args.len() == 1 => {
+                self.unify(&args[0], &Type::U64, span)?;
+                self.unify(ret, &self_ty, span)
+            }
+            "enumerate" if args.is_empty() => {
+                let pair = Type::Tuple(vec![Type::U64, elem]);
+                let iter_pairs = Type::UnresolvedGeneric {
+                    name: "Iterator".to_string(),
+                    args: vec![GenericArg::Type(Box::new(pair))],
+                };
+                self.unify(ret, &iter_pairs, span)
+            }
+            "any" | "all" if args.len() == 1 => {
+                let expected_fn = Type::Fn {
+                    params: vec![elem],
+                    ret: Box::new(Type::Bool),
+                };
+                self.unify(&args[0], &expected_fn, span)?;
+                self.unify(ret, &Type::Bool, span)
+            }
+            "find" if args.len() == 1 => {
+                let expected_fn = Type::Fn {
+                    params: vec![elem.clone()],
+                    ret: Box::new(Type::Bool),
+                };
+                self.unify(&args[0], &expected_fn, span)?;
+                self.unify(ret, &Type::option(elem), span)
+            }
+            _ => Err(TypeError::NoSuchMethod {
+                ty: self_ty,
+                method: method.to_string(),
+                span,
+            }),
+        }
+    }
+
+    pub(super) fn resolve_char_method(
+        &mut self,
+        method: &str,
+        args: &[Type],
+        ret: &Type,
+        span: Span,
+    ) -> Result<bool, TypeError> {
+        if let Some(method_def) = rask_stdlib::lookup_method("char", method) {
+            let expected_params = method_def.params.len();
+            if args.len() != expected_params {
+                return Err(TypeError::ArityMismatch {
+                    expected: expected_params,
+                    found: args.len(),
+                    span,
+                });
+            }
+            let ret_ty = super::builtins::parse_stub_type(&method_def.ret_ty);
+            return self.unify(ret, &ret_ty, span);
+        }
+
+        match method {
+            "eq" | "ne" if args.len() == 1 => {
+                self.unify(&args[0], &Type::Char, span)?;
+                self.unify(ret, &Type::Bool, span)
+            }
+            _ => Err(TypeError::NoSuchMethod {
+                ty: Type::Char,
+                method: method.to_string(),
+                span,
+            }),
+        }
     }
 
     pub(super) fn resolve_string_method(
@@ -2432,12 +2569,20 @@ impl TypeChecker {
         span: Span,
     ) -> Result<bool, TypeError> {
         match method {
-            "add" | "sub" | "mul" | "div"
-            | "min" | "max" | "pow" if args.len() == 1 => {
+            "add" | "sub" | "mul" | "div" | "rem"
+            | "min" | "max" | "pow" | "powf" if args.len() == 1 => {
                 let _ = self.unify(&args[0], ty, span);
                 self.unify(ret, ty, span)
             }
-            "neg" | "abs" | "floor" | "ceil" | "round" | "sqrt" if args.is_empty() => {
+            "powi" if args.len() == 1 => {
+                let _ = self.unify(&args[0], &Type::I32, span);
+                self.unify(ret, ty, span)
+            }
+            "neg" | "abs" | "floor" | "ceil" | "round" | "sqrt"
+            | "sin" | "cos" | "tan" | "asin" | "acos" | "atan"
+            | "ln" | "log10" | "log2" | "exp" | "trunc" | "fract"
+                if args.is_empty() =>
+            {
                 self.unify(ret, ty, span)
             }
             "eq" | "ne" | "lt" | "le" | "gt" | "ge" if args.len() == 1 => {

--- a/specs/concurrency/async.md
+++ b/specs/concurrency/async.md
@@ -129,7 +129,7 @@ const results = try group.join_all()
 func main() {
     using Multitasking(workers: 4) {
         // all spawn() calls below, on any thread, use this runtime
-        ...
+        // body
     }
     // block exit: all spawned tasks drained, runtime shut down
 }

--- a/stdlib/bits.rk
+++ b/stdlib/bits.rk
@@ -35,16 +35,16 @@ extend bits {
 
 // ── Binary parsing (P1-P4) ──────────────────────────────────────────
 
-enum ParseError {
+enum BinaryParseError {
     UnexpectedEnd { expected: usize, actual: usize }
     InvalidData { message: string }
 }
 
-extend ParseError {
+extend BinaryParseError {
     public func message(self) -> string {
         match self {
-            ParseError.UnexpectedEnd { expected, actual } => return "unexpected end: expected {expected} bytes, got {actual}",
-            ParseError.InvalidData { message } => return "invalid data: {message}",
+            BinaryParseError.UnexpectedEnd { expected, actual } => return "unexpected end: expected {expected} bytes, got {actual}",
+            BinaryParseError.InvalidData { message } => return "invalid data: {message}",
         }
     }
 }

--- a/stdlib/option.rk
+++ b/stdlib/option.rk
@@ -9,6 +9,21 @@
 public enum Option<T> { }
 
 extend Option<T> {
+    /// True if the value is present.
+    public func is_some(self) -> bool { }
+
+    /// True if the value is absent.
+    public func is_none(self) -> bool { }
+
+    /// Extract the contained value, panicking if absent.
+    public func unwrap(self) -> T { }
+
+    /// Return the contained value or `default` if absent.
+    public func unwrap_or(self, default: T) -> T { }
+
+    /// Return self if present, otherwise `other`.
+    public func or(self, other: T?) -> T? { }
+
     /// Transform the contained value if present.
     public func map(self, f: func(T) -> U) -> U? { }
 

--- a/stdlib/result.rk
+++ b/stdlib/result.rk
@@ -12,6 +12,21 @@
 public enum Result<T, E> { }
 
 extend Result<T, E> {
+    /// True if the result is a success.
+    public func is_ok(self) -> bool { }
+
+    /// True if the result is an error.
+    public func is_err(self) -> bool { }
+
+    /// Extract the success value, panicking on error.
+    public func unwrap(self) -> T { }
+
+    /// Extract the error, panicking on success.
+    public func unwrap_err(self) -> E { }
+
+    /// Return the success value or `default` on error.
+    public func unwrap_or(self, default: T) -> T { }
+
     /// Transform the success value; error propagates unchanged.
     public func map(self, f: func(T) -> U) -> U or E { }
 


### PR DESCRIPTION
## Summary
This PR adds comprehensive support for Iterator methods, implements the Char type with methods, fixes generic type parameter instantiation in method resolution, and improves type narrowing in the MIR lowering phase. It also adds interpreter-based test execution and enhances numeric method coverage.

## Key Changes

### Iterator Support
- Implemented `resolve_iterator_method()` to handle lazy iterator chains (map, filter, fold, take, skip, enumerate, etc.)
- Iterator methods properly track element types through transformations
- Supports both adapter methods (returning Iterator) and terminator methods (returning concrete types like Vec, Option, Bool)

### Char Type Implementation
- Added `resolve_char_method()` for char-specific operations (eq, ne)
- Integrated char method resolution into the type checker's dispatch path
- Added char to generic type argument parsing

### Generic Type Parameter Instantiation
- Fixed critical bug where bare generic calls (e.g., `Vec.new()`) leaked placeholder type parameters into downstream unifications
- Now instantiates generic type parameters with fresh type variables at method call sites
- Substitutes type parameters in both method parameters and return types before unification

### Type Narrowing Improvements
- Enhanced ER23 pattern matching to prefer exact type name matching over case heuristics
- Prevents uppercase user structs on ok-side from being misclassified as error types
- Added narrowing logic in MIR lowering to extract payloads from Result/Option when type checker has narrowed the type

### Numeric Methods Expansion
- Added `rem`, `powf`, `powi` for floating-point operations
- Added trigonometric functions: sin, cos, tan, asin, acos, atan
- Added logarithmic functions: ln, log10, log2, exp
- Added utility functions: trunc, fract

### Parser Enhancements
- Improved function type parameter parsing to handle named and modified parameters (e.g., `|name: T|`, `|mutate x: T|`)
- Names and modifiers in type position are now properly skipped

### Type Stub Parsing
- Fixed generic type parsing in stub types (e.g., `Vec<string>` now correctly parses as `UnresolvedGeneric` instead of `UnresolvedNamed`)
- Improved primitive type mapping in generic arguments to prevent method resolution failures

### Interpreter Testing
- Added `cmd_test_interp()` for running tests through the tree-walking interpreter
- Useful for cross-checking codegen regressions and testing code that doesn't yet compile natively
- Supports same test filtering and output formats as native test runner

### Code Generation Improvements
- Enhanced aggregate payload handling in Option/Result wrapping
- Properly copies large payloads (strings, structs) instead of storing pointers
- Fixed string argument detection in function calls

### Test Infrastructure
- Unified temporary file ID generation across test helpers using global atomic counter
- Prevents file collision issues in parallel test execution

### Standard Library Updates
- Added Option methods: `is_some()`, `is_none()`, `unwrap()`, `unwrap_or()`, `or()`
- Added Result methods: `is_ok()`, `is_err()`, `unwrap()`, `unwrap_err()`, `unwrap_or()`
- Renamed `ParseError` to `BinaryParseError` in bits module for clarity
- Updated F64 method registry with new numeric operations

### Resolver Improvements
- Added stdlib namespace checking to prevent local variables from shadowing module names
- Prevents silent breakage of calls like `io.stdout()` when `io` is redefined locally

## Notable Implementation Details

- Generic type parameter substitution uses a HashMap for efficient lookup during unification
- Iterator element type extraction handles both explicit type arguments and fresh variable generation
- Type narrowing in MIR uses field extraction (offset 0) for Result/Option payloads
- Aggregate payload copying in codegen uses word-aligned loads/stores with fallback for remainder bytes

https://claude.ai/code/session_011xCeZUkVjh16en1sjs8hdw