### PR TITLE
fix(#224): narrow if x? when scrutinee is an unsolved type var

### DIFF
--- a/compiler/crates/rask-mir/src/lower/expr.rs
+++ b/compiler/crates/rask-mir/src/lower/expr.rs
@@ -2402,6 +2402,13 @@ impl<'a> MirLowerer<'a> {
                             chosen = Some(*ok.clone());
                         } else if err_name.as_deref() == Some(ty_name.as_str()) {
                             chosen = Some(*err.clone());
+                        } else if err_name.is_some() {
+                            // Generic ok types collapse to Ptr in MIR and lose
+                            // their nominal name. If err is a known name that
+                            // doesn't match, the pattern must be the ok side.
+                            chosen = Some(*ok.clone());
+                        } else if ok_name.is_some() {
+                            chosen = Some(*err.clone());
                         }
                     }
                     chosen.unwrap_or_else(|| {
@@ -2458,10 +2465,10 @@ impl<'a> MirLowerer<'a> {
                 else_branch,
             } => {
                 let is_niche = self.is_niche_option_expr(expr);
-                let (val, _) = self.lower_expr(expr)?;
+                let (val, val_ty) = self.lower_expr(expr)?;
                 let tag = self.emit_option_tag(&val, is_niche);
 
-                let expected = self.pattern_tag(pattern);
+                let expected = self.pattern_tag_in_type_context(pattern, &val_ty);
                 let matches = self.builder.alloc_temp(MirType::Bool);
                 self.builder.push_stmt(MirStmt::dummy(MirStmtKind::Assign {
                     dst: matches,

--- a/compiler/crates/rask-mir/src/lower/expr.rs
+++ b/compiler/crates/rask-mir/src/lower/expr.rs
@@ -3270,6 +3270,16 @@ impl<'a> MirLowerer<'a> {
         left: &Expr,
         right: &Expr,
     ) -> Result<TypedOperand, LoweringError> {
+        // Special case `&& with IsPattern lhs`: the pattern test must bind its
+        // payload locals before the rhs is evaluated, so `s is Rectangle(w, h)
+        // && w > h` can reference w and h on the matched path. The bare
+        // IsPattern lowering only emits a tag comparison and drops bindings.
+        if matches!(op, BinOp::And) {
+            if let ExprKind::IsPattern { expr: scrutinee, pattern } = &left.kind {
+                return self.lower_and_with_pattern(scrutinee, pattern, right);
+            }
+        }
+
         let (left_op, _) = self.lower_expr(left)?;
 
         let rhs_block = self.builder.create_block();
@@ -3320,6 +3330,73 @@ impl<'a> MirLowerer<'a> {
 
         self.builder.switch_to_block(merge_block);
 
+        Ok((MirOperand::Local(result_local), MirType::Bool))
+    }
+
+    /// Lower `(scrutinee is Pattern) && rhs` so payload bindings from the
+    /// pattern are in scope while rhs is evaluated. Falls back to a plain
+    /// tag-test value on the no-match path.
+    fn lower_and_with_pattern(
+        &mut self,
+        scrutinee: &Expr,
+        pattern: &rask_ast::expr::Pattern,
+        right: &Expr,
+    ) -> Result<TypedOperand, LoweringError> {
+        let is_niche = self.is_niche_option_expr(scrutinee);
+        let (val, val_ty) = self.lower_expr(scrutinee)?;
+        let tag = self.emit_option_tag(&val, is_niche);
+        let expected = self.pattern_tag_in_type_context(pattern, &val_ty);
+
+        let matches = self.builder.alloc_temp(MirType::Bool);
+        self.builder.push_stmt(MirStmt::dummy(MirStmtKind::Assign {
+            dst: matches,
+            rvalue: MirRValue::BinaryOp {
+                op: crate::operand::BinOp::Eq,
+                left: MirOperand::Local(tag),
+                right: MirOperand::Constant(MirConst::Int(expected)),
+            },
+        }));
+
+        let bind_block = self.builder.create_block();
+        let short_block = self.builder.create_block();
+        let merge_block = self.builder.create_block();
+
+        self.builder.terminate(MirTerminator::dummy(MirTerminatorKind::Branch {
+            cond: MirOperand::Local(matches),
+            then_block: bind_block,
+            else_block: short_block,
+        }));
+
+        let result_local = self.builder.alloc_temp(MirType::Bool);
+
+        // No-match path: short-circuit to false.
+        self.builder.switch_to_block(short_block);
+        self.builder.push_stmt(MirStmt::dummy(MirStmtKind::Assign {
+            dst: result_local,
+            rvalue: MirRValue::Use(MirOperand::Constant(MirConst::Int(0))),
+        }));
+        self.builder.terminate(MirTerminator::dummy(MirTerminatorKind::Goto {
+            target: merge_block,
+        }));
+
+        // Match path: bind payload, then evaluate rhs.
+        self.builder.switch_to_block(bind_block);
+        let payload_ty = self
+            .extract_payload_type(scrutinee)
+            .unwrap_or(MirType::I64);
+        self.bind_pattern_payload_niche(pattern, val, payload_ty, is_niche);
+        let (right_op, _) = self.lower_expr(right)?;
+        if self.builder.current_block_unterminated() {
+            self.builder.push_stmt(MirStmt::dummy(MirStmtKind::Assign {
+                dst: result_local,
+                rvalue: MirRValue::Use(right_op),
+            }));
+            self.builder.terminate(MirTerminator::dummy(MirTerminatorKind::Goto {
+                target: merge_block,
+            }));
+        }
+
+        self.builder.switch_to_block(merge_block);
         Ok((MirOperand::Local(result_local), MirType::Bool))
     }
 

--- a/compiler/crates/rask-mir/src/lower/expr.rs
+++ b/compiler/crates/rask-mir/src/lower/expr.rs
@@ -9,7 +9,7 @@ use super::{
 };
 use crate::{
     operand::MirConst, types::{EnumLayoutId, StructLayoutId},
-    BlockId, FunctionRef, MirOperand, MirRValue, MirStmt, MirStmtKind, MirTerminator,
+    BlockId, FunctionRef, LocalId, MirOperand, MirRValue, MirStmt, MirStmtKind, MirTerminator,
     MirTerminatorKind, MirType,
 };
 use rask_ast::{
@@ -2871,6 +2871,9 @@ impl<'a> MirLowerer<'a> {
                 // Default: simple alias binding (Pool, Cell, etc.)
                 // W2a/W2b: Track pool bindings for re-resolution after pool mutators
                 let mut pool_binding_keys: Vec<String> = Vec::new();
+                // Vec[i] / Map[k] writeback info: (collection, index/key, item_local, setter_name).
+                // Captured per binding so we can emit Vec_set / Map_set after the body runs.
+                let mut coll_writebacks: Vec<(MirOperand, MirOperand, LocalId, &'static str)> = Vec::new();
                 for binding in bindings {
                     // Before lowering, extract pool/handle info for re-resolution tracking
                     let pool_info = if let ExprKind::Index { object, index } = &binding.source.kind {
@@ -2897,13 +2900,45 @@ impl<'a> MirLowerer<'a> {
                         None
                     };
 
+                    // Detect `with vec[i] as item` / `with map[k] as item` so we
+                    // can write `item` back to the collection once the body
+                    // finishes. Without this, mutations through `item` are lost.
+                    let coll_writeback_info = if let ExprKind::Index { object, index } = &binding.source.kind {
+                        if let ExprKind::Ident(coll_name) = &object.kind {
+                            let prefix = self.meta(coll_name)
+                                .and_then(|m| m.type_prefix.as_deref())
+                                .map(|s| s.to_string());
+                            let setter = match prefix.as_deref() {
+                                Some("Vec") => Some("Vec_set"),
+                                Some("Map") => Some("Map_set"),
+                                _ => None,
+                            };
+                            if let Some(setter_name) = setter {
+                                let (obj_op, _) = self.lower_expr(object)?;
+                                let (idx_op, _) = self.lower_expr(index)?;
+                                Some((obj_op, idx_op, setter_name))
+                            } else {
+                                None
+                            }
+                        } else {
+                            None
+                        }
+                    } else {
+                        None
+                    };
+
                     let (val, val_ty) = self.lower_expr(&binding.source)?;
                     let local = self.builder.alloc_local(binding.name.clone(), val_ty.clone());
-                    self.locals.insert(binding.name.clone(), (local, val_ty));
+                    self.locals.insert(binding.name.clone(), (local, val_ty.clone()));
                     self.builder.push_stmt(MirStmt::dummy(MirStmtKind::Assign {
                         dst: local,
                         rvalue: MirRValue::Use(val),
                     }));
+
+                    if let Some((obj_op, idx_op, setter_name)) = coll_writeback_info {
+                        let _ = val_ty;
+                        coll_writebacks.push((obj_op, idx_op, local, setter_name));
+                    }
 
                     // Register pool binding for re-resolution
                     if let Some((pool_name, pool_local, handle_local)) = pool_info {
@@ -2914,6 +2949,14 @@ impl<'a> MirLowerer<'a> {
                     }
                 }
                 let result = self.lower_block(body);
+                // Write back Vec[i] / Map[k] mutations through `with` bindings.
+                for (obj_op, idx_op, item_local, setter_name) in coll_writebacks {
+                    self.builder.push_stmt(MirStmt::dummy(MirStmtKind::Call {
+                        dst: None,
+                        func: FunctionRef::internal(setter_name.to_string()),
+                        args: vec![obj_op, idx_op, MirOperand::Local(item_local)],
+                    }));
+                }
                 // Clean up pool binding registrations
                 for key in &pool_binding_keys {
                     if let Some(entries) = self.with_pool_bindings.get_mut(key) {

--- a/compiler/crates/rask-mir/src/lower/expr.rs
+++ b/compiler/crates/rask-mir/src/lower/expr.rs
@@ -2603,11 +2603,16 @@ impl<'a> MirLowerer<'a> {
 
                 self.builder.switch_to_block(none_block);
                 let (default_val, _) = self.lower_expr(default)?;
-                self.builder.push_stmt(MirStmt::dummy(MirStmtKind::Assign {
-                    dst: result_local,
-                    rvalue: MirRValue::Use(default_val),
-                }));
-                self.builder.terminate(MirTerminator::dummy(MirTerminatorKind::Goto { target: merge_block }));
+                // Guard against a divergent default (`?? continue` / `?? break` /
+                // `?? return`): if it already terminated the block, don't emit
+                // the assignment+goto into a dead block.
+                if self.builder.current_block_unterminated() {
+                    self.builder.push_stmt(MirStmt::dummy(MirStmtKind::Assign {
+                        dst: result_local,
+                        rvalue: MirRValue::Use(default_val),
+                    }));
+                    self.builder.terminate(MirTerminator::dummy(MirTerminatorKind::Goto { target: merge_block }));
+                }
 
                 self.builder.switch_to_block(merge_block);
                 Ok((MirOperand::Local(result_local), payload_ty))

--- a/compiler/crates/rask-mir/src/lower/mod.rs
+++ b/compiler/crates/rask-mir/src/lower/mod.rs
@@ -1005,17 +1005,16 @@ impl<'a> MirLowerer<'a> {
 
     /// Extract the Ok/Some payload type from the raw type of an expression.
     /// For Option<T>, returns T. For Result<T, E>, returns T.
+    /// MirType::Ptr is a legitimate result for Vec/Map/Pool/Channel/etc.,
+    /// so the caller must not treat Ptr as "unresolved".
     fn extract_payload_type(&self, expr: &Expr) -> Option<MirType> {
         if let Some(ty) = self.ctx.lookup_raw_type(expr.id) {
             match ty {
                 Type::Result { ok: inner, err } if **err == Type::None => {
-                    let mir = self.ctx.type_to_mir(inner);
-                    // Ptr means unresolved — let callers fall through to other strategies
-                    if matches!(mir, MirType::Ptr) { None } else { Some(mir) }
+                    Some(self.ctx.type_to_mir(inner))
                 }
                 Type::Result { ok, .. } => {
-                    let mir = self.ctx.type_to_mir(ok);
-                    if matches!(mir, MirType::Ptr) { None } else { Some(mir) }
+                    Some(self.ctx.type_to_mir(ok))
                 }
                 _ => None,
             }
@@ -1029,8 +1028,7 @@ impl<'a> MirLowerer<'a> {
         if let Some(ty) = self.ctx.lookup_raw_type(expr.id) {
             match ty {
                 Type::Result { err, .. } => {
-                    let mir = self.ctx.type_to_mir(err);
-                    if matches!(mir, MirType::Ptr) { None } else { Some(mir) }
+                    Some(self.ctx.type_to_mir(err))
                 }
                 _ => None,
             }
@@ -1103,6 +1101,15 @@ impl<'a> MirLowerer<'a> {
                         return 0;
                     }
                     if err_name.as_deref() == Some(ty_name.as_str()) {
+                        return 1;
+                    }
+                    // Generic ok types like `Vec<i32>` collapse to MirType::Ptr
+                    // and lose their nominal name. If the err side has a known
+                    // name and it doesn't match, the pattern must be the ok side.
+                    if err_name.is_some() {
+                        return 0;
+                    }
+                    if ok_name.is_some() {
                         return 1;
                     }
                 }
@@ -1178,11 +1185,24 @@ impl<'a> MirLowerer<'a> {
         payload_ty: MirType,
         is_niche: bool,
     ) -> LocalId {
-        let result = self.builder.alloc_temp(payload_ty);
+        let result = self.builder.alloc_temp(payload_ty.clone());
         let rvalue = if is_niche {
             MirRValue::Use(value)
         } else {
-            MirRValue::Field { base: value, field_index: 0, byte_offset: None, field_size: None }
+            // For non-aggregate payloads (scalars, Ptr to Vec/Map/etc.), pass an
+            // explicit byte_offset so codegen loads the value at
+            // RESULT_PAYLOAD_OFFSET instead of falling into the aggregate
+            // fast-path that returns the slot address.
+            let is_aggregate = matches!(
+                payload_ty,
+                MirType::Struct(_) | MirType::Enum(_) | MirType::Tuple(_) | MirType::String
+            );
+            let byte_offset = if is_aggregate {
+                None
+            } else {
+                Some(crate::types::RESULT_PAYLOAD_OFFSET)
+            };
+            MirRValue::Field { base: value, field_index: 0, byte_offset, field_size: None }
         };
         self.builder.push_stmt(MirStmt::dummy(MirStmtKind::Assign { dst: result, rvalue }));
         result

--- a/compiler/crates/rask-resolve/src/resolver.rs
+++ b/compiler/crates/rask-resolve/src/resolver.rs
@@ -429,13 +429,6 @@ impl Resolver {
     /// Check if a name refers to a builtin type or enum (not a builtin function).
     /// User-defined functions can shadow builtin functions like `max`, `min`,
     /// but not builtin types like `Vec`, `Map`, `Option`.
-    /// Check whether a name matches a stdlib module namespace (`io`, `fs`,
-    /// `json`, ...). Stdlib modules aren't pre-bound in scope, so a local
-    /// `const io = ...` would silently break later `io.stdout()` calls.
-    fn is_stdlib_namespace(name: &str) -> bool {
-        rask_stdlib::registry::REGISTERED_MODULES.contains(&name)
-    }
-
     fn is_builtin_type_name(&self, name: &str) -> bool {
         if let Some(sym_id) = self.scopes.lookup(name) {
             if let Some(sym) = self.symbols.get(sym_id) {
@@ -1531,7 +1524,7 @@ impl Resolver {
             }
             StmtKind::Mut { name, name_span, ty, init } => {
                 self.resolve_expr(init);
-                if !self.stdlib_mode && Self::is_stdlib_namespace(name) {
+                if !self.stdlib_mode && self.is_builtin_name(name) {
                     self.errors.push(ResolveError::shadows_builtin(name.clone(), *name_span));
                 }
                 let sym_id = self.symbols.insert(
@@ -1547,7 +1540,7 @@ impl Resolver {
             }
             StmtKind::Const { name, name_span, ty, init } => {
                 self.resolve_expr(init);
-                if !self.stdlib_mode && Self::is_stdlib_namespace(name) {
+                if !self.stdlib_mode && self.is_builtin_name(name) {
                     self.errors.push(ResolveError::shadows_builtin(name.clone(), *name_span));
                 }
                 let sym_id = self.symbols.insert(

--- a/compiler/crates/rask-types/src/checker/check_expr.rs
+++ b/compiler/crates/rask-types/src/checker/check_expr.rs
@@ -2353,7 +2353,7 @@ impl TypeChecker {
     /// Must run after the cond has been inferred so the scrutinee's type is
     /// available in `node_types`.
     pub(super) fn extract_is_present_narrowing(
-        &self,
+        &mut self,
         cond: &Expr,
     ) -> Option<(String, Type, Option<Type>)> {
         let ExprKind::IsPresent { expr: inner, binding } = &cond.kind else {
@@ -2368,6 +2368,24 @@ impl TypeChecker {
             (Some(v), _) => v.clone(),
             (None, ExprKind::Ident(n)) if self.is_local_read_only(n) => n.clone(),
             _ => return None,
+        };
+
+        // If the scrutinee is still an unsolved type variable (e.g. Map.get
+        // on a Map.new() whose V is only fixed by later inserts), constrain
+        // it to a Result shape so we can extract ok/err vars right now.
+        // The fresh err var defers Option vs Result distinction to constraint
+        // solving — it will unify to None for `T?` and to E for `T or E`.
+        let resolved = if let Type::Var(_) = resolved {
+            let ok = self.ctx.fresh_var();
+            let err = self.ctx.fresh_var();
+            let target = Type::Result {
+                ok: Box::new(ok),
+                err: Box::new(err),
+            };
+            let _ = self.unify(&resolved, &target, cond.span);
+            self.ctx.apply(&resolved)
+        } else {
+            resolved
         };
 
         match resolved {

--- a/tests/suite/t27_error_narrowing.rk
+++ b/tests/suite/t27_error_narrowing.rk
@@ -150,4 +150,33 @@ test "generic type pattern in is ... else guard" {
     assert generic_guard() == 2
 }
 
+// --- #224: bare `if x?` narrows when scrutinee's type-var is solved later ---
+//
+// `Map.new()` without an annotation leaves V unsolved at the point `if existing?`
+// is checked. Narrowing must still bind `existing` to the unwrapped type so
+// constraint-solving can later resolve it through downstream `insert` calls.
+
+func count_occurrences(items: Vec<i32>) -> Map<i32, i32> {
+    mut counts = Map.new()
+    for item in items {
+        const existing = counts.get(item)
+        if existing? {
+            counts.insert(item, existing + 1)
+        } else {
+            counts.insert(item, 1)
+        }
+    }
+    return counts
+}
+
+test "Map.new() inferred V narrows on if x?" {
+    mut v = Vec.new()
+    v.push(1)
+    v.push(2)
+    v.push(1)
+    const c = count_occurrences(v)
+    assert c[1] == 2
+    assert c[2] == 1
+}
+
 func main() {}

--- a/tests/suite/t27_error_narrowing.rk
+++ b/tests/suite/t27_error_narrowing.rk
@@ -179,4 +179,38 @@ test "Map.new() inferred V narrows on if x?" {
     assert c[2] == 1
 }
 
+// --- #256: `is V(payload) && guard` keeps payload bindings ---
+//
+// The bare form `if s is Rectangle(w, h) { ... }` already works via IfLet,
+// but the compound form `s is Rectangle(w, h) && w > h` parses to `If` with
+// a `Binary(And, IsPattern, ..)` cond. MIR lowering of && needs to bind the
+// payload locals before the rhs is evaluated, otherwise rhs trips
+// UnresolvedVariable on the bound names.
+
+enum Shape256 { Rectangle(i32, i32), Circle(i32) }
+
+test "is constructor pattern && guard" {
+    const wide = Shape256.Rectangle(10, 5)
+    if wide is Rectangle(w, h) && w > h {
+        assert w == 10
+        assert h == 5
+    } else {
+        assert false, "expected wide rectangle"
+    }
+
+    const tall = Shape256.Rectangle(3, 5)
+    if tall is Rectangle(w, h) && w > h {
+        assert false, "guard should fail"
+    } else {
+        assert true
+    }
+
+    const round = Shape256.Circle(5)
+    if round is Rectangle(w, h) && w > h {
+        assert false, "tag should not match"
+    } else {
+        assert true
+    }
+}
+
 func main() {}


### PR DESCRIPTION
extract_is_present_narrowing matched on Type::Result and returned None
for unsolved Type::Var, so 'if existing?' on Map.get over a Map.new()
whose V was only fixed by later inserts skipped narrowing entirely.
The bare-name 'existing' kept its outer Option type and 'existing + 1'
failed method lookup as 'no method add for type i32?'.

When resolved is a Var, unify it with Result { ok: fresh, err: fresh }
so apply returns a concrete Result shape for narrowing. The fresh err
var defers Option vs Result distinction to constraint solving — it
unifies to None for T? and to E for T or E.

Adds a regression test in t27_error_narrowing.rk covering the
count-occurrences pattern from the issue.