### PR TITLE
Inline Result/Option methods and fix aggregate type handling

### DIFF
--- a/compiler/crates/rask-codegen/src/builder.rs
+++ b/compiler/crates/rask-codegen/src/builder.rs
@@ -643,7 +643,8 @@ impl<'a> FunctionBuilder<'a> {
                     // Whole-aggregate copy: rvalue produces a pointer to the source
                     // aggregate, dst has its own storage (either a stack slot or an
                     // external pointer for mutate-params).
-                    (MirType::Struct(_) | MirType::Enum(_) | MirType::Tuple(_),
+                    (MirType::Struct(_) | MirType::Enum(_) | MirType::Tuple(_)
+                     | MirType::Result { .. } | MirType::Option(_),
                      MirRValue::Use(MirOperand::Local(_))) => true,
                     // Option(T) assigned from an Option-typed local: copy the 16-byte struct
                     (MirType::Option(_), _) if src_option_ty => true,
@@ -2545,9 +2546,13 @@ impl<'a> FunctionBuilder<'a> {
                     }
                 } else if matches!(ctx.ret_ty, MirType::Result { .. } | MirType::Option(_)) {
                     // Function returns Result/Option but value is a plain scalar
-                    // (e.g. `return 42` in a function returning `i32 or string`).
-                    // Wrap the value as Ok/Some in a temporary stack slot and return
-                    // the slot address so the caller can copy_aggregate.
+                    // or non-stack-slotted local (e.g. `return 42` or
+                    // `return DivError {}` from a `i32 or DivError` fn).
+                    // Wrap as Ok/Some — or Err when the value's MIR type matches
+                    // the Result's err side. Without the Err detection, returning
+                    // a struct-typed error from a Result-returning function
+                    // wrapped it as Ok and caused `is X` checks at the call site
+                    // to silently take the wrong branch (#259 family).
                     let slot_size = Self::resolve_type_alloc_size(ctx.ret_ty, ctx.struct_layouts, ctx.enum_layouts)
                         .unwrap_or(16);
                     let ss = builder.create_sized_stack_slot(StackSlotData::new(
@@ -2555,20 +2560,40 @@ impl<'a> FunctionBuilder<'a> {
                         slot_size,
                         0,
                     ));
+                    let val_ty = value.as_ref().and_then(|v| match v {
+                        MirOperand::Local(id) => ctx.locals.iter()
+                            .find(|l| l.id == *id)
+                            .map(|l| l.ty.clone()),
+                        _ => None,
+                    });
+                    let is_err_value = if let MirType::Result { err, .. } = ctx.ret_ty {
+                        val_ty.as_ref().map_or(false, |t| t == err.as_ref())
+                    } else {
+                        false
+                    };
                     let val = if let Some(val_op) = value.as_ref() {
                         Self::lower_operand_typed(builder, val_op, Some(types::I64), ctx)?
                     } else {
                         builder.ins().iconst(types::I64, 0)
                     };
+
                     // Aggregate payload (string/struct/...) — `val` is a pointer to
                     // 16+ bytes. Copy into the payload area instead of storing the
                     // pointer at offset 8 (which leaves the rest of the slot
                     // uninitialized).
-                    let inner_aggregate = match ctx.ret_ty {
-                        MirType::Option(inner) => Some(inner.as_ref()),
-                        MirType::Result { ok, .. } => Some(ok.as_ref()),
-                        _ => None,
-                    }.filter(|t| matches!(t,
+                    let inner_branch = if is_err_value {
+                        match ctx.ret_ty {
+                            MirType::Result { err, .. } => Some(err.as_ref()),
+                            _ => None,
+                        }
+                    } else {
+                        match ctx.ret_ty {
+                            MirType::Option(inner) => Some(inner.as_ref()),
+                            MirType::Result { ok, .. } => Some(ok.as_ref()),
+                            _ => None,
+                        }
+                    };
+                    let inner_aggregate = inner_branch.filter(|t| matches!(t,
                         MirType::String | MirType::Struct(_) | MirType::Enum(_)
                         | MirType::Tuple(_) | MirType::Result { .. } | MirType::Option(_)
                     ));
@@ -2581,7 +2606,8 @@ impl<'a> FunctionBuilder<'a> {
                         } else {
                             crate::layouts::RESULT_PAYLOAD_OFFSET
                         };
-                        let tag = builder.ins().iconst(types::I64, 0);
+                        let tag_val = if is_err_value { 1 } else { 0 };
+                        let tag = builder.ins().iconst(types::I64, tag_val);
                         builder.ins().stack_store(tag, ss, crate::layouts::TAG_OFFSET);
                         if matches!(ctx.ret_ty, MirType::Result { .. }) {
                             let zero = builder.ins().iconst(types::I64, 0);
@@ -2589,27 +2615,37 @@ impl<'a> FunctionBuilder<'a> {
                             builder.ins().stack_store(zero, ss, crate::layouts::ORIGIN_LINE_OFFSET);
                         }
                         let dst = builder.ins().stack_addr(types::I64, ss, payload_off);
-                        let mut off = 0i32;
-                        let size = inner_size as i32;
-                        while off + 8 <= size {
-                            let word = builder.ins().load(types::I64, MemFlags::new(), val, off);
-                            builder.ins().store(MemFlags::new(), word, dst, off);
-                            off += 8;
+                        if inner_size > 0 {
+                            let mut off = 0i32;
+                            let size = inner_size as i32;
+                            while off + 8 <= size {
+                                let word = builder.ins().load(types::I64, MemFlags::new(), val, off);
+                                builder.ins().store(MemFlags::new(), word, dst, off);
+                                off += 8;
+                            }
+                            if size - off >= 4 {
+                                let w = builder.ins().load(types::I32, MemFlags::new(), val, off);
+                                builder.ins().store(MemFlags::new(), w, dst, off);
+                                off += 4;
+                            }
+                            if size - off >= 2 {
+                                let w = builder.ins().load(types::I16, MemFlags::new(), val, off);
+                                builder.ins().store(MemFlags::new(), w, dst, off);
+                                off += 2;
+                            }
+                            if size - off >= 1 {
+                                let w = builder.ins().load(types::I8, MemFlags::new(), val, off);
+                                builder.ins().store(MemFlags::new(), w, dst, off);
+                            }
                         }
-                        if size - off >= 4 {
-                            let w = builder.ins().load(types::I32, MemFlags::new(), val, off);
-                            builder.ins().store(MemFlags::new(), w, dst, off);
-                            off += 4;
-                        }
-                        if size - off >= 2 {
-                            let w = builder.ins().load(types::I16, MemFlags::new(), val, off);
-                            builder.ins().store(MemFlags::new(), w, dst, off);
-                            off += 2;
-                        }
-                        if size - off >= 1 {
-                            let w = builder.ins().load(types::I8, MemFlags::new(), val, off);
-                            builder.ins().store(MemFlags::new(), w, dst, off);
-                        }
+                    } else if is_err_value {
+                        // Scalar Err — tag=1, payload at RESULT_PAYLOAD_OFFSET.
+                        let tag = builder.ins().iconst(types::I64, 1);
+                        builder.ins().stack_store(tag, ss, crate::layouts::TAG_OFFSET);
+                        let zero = builder.ins().iconst(types::I64, 0);
+                        builder.ins().stack_store(zero, ss, crate::layouts::ORIGIN_FILE_OFFSET);
+                        builder.ins().stack_store(zero, ss, crate::layouts::ORIGIN_LINE_OFFSET);
+                        builder.ins().stack_store(val, ss, crate::layouts::RESULT_PAYLOAD_OFFSET);
                     } else if matches!(ctx.ret_ty, MirType::Option(_)) {
                         Self::wrap_some_into_slot(builder, val, ss);
                     } else {

--- a/compiler/crates/rask-codegen/src/builder.rs
+++ b/compiler/crates/rask-codegen/src/builder.rs
@@ -1103,16 +1103,23 @@ impl<'a> FunctionBuilder<'a> {
 
                 // Copy concrete value to heap
                 if let MirOperand::Local(src_id) = value {
-                    if let Some((ss, sz)) = ctx.stack_slot_map.get(src_id) {
-                        // Aggregate: memcpy from stack slot
-                        let src_ptr = builder.ins().stack_addr(types::I64, *ss, 0);
+                    if ctx.stack_slot_map.contains_key(src_id) {
+                        // Aggregate: memcpy from the source pointer the var holds —
+                        // not the local's own slot, which may be uninitialized when
+                        // the var aliases another slot (e.g. `_1 = _0`).
+                        let src_var = ctx.var_map.get(src_id)
+                            .ok_or_else(|| CodegenError::UnsupportedFeature(
+                                "TraitBox: source variable not found".to_string()
+                            ))?;
+                        let src_ptr = builder.use_var(*src_var);
+                        let sz = *concrete_size;
                         let mut off = 0i32;
-                        while (off as u32) + 8 <= *sz {
+                        while (off as u32) + 8 <= sz {
                             let word = builder.ins().load(types::I64, MemFlags::new(), src_ptr, off);
                             builder.ins().store(MemFlags::new(), word, data_ptr, off);
                             off += 8;
                         }
-                        if (off as u32) < *sz {
+                        if (off as u32) < sz {
                             let word = builder.ins().load(types::I64, MemFlags::new(), src_ptr, off);
                             builder.ins().store(MemFlags::new(), word, data_ptr, off);
                         }
@@ -1193,7 +1200,16 @@ impl<'a> FunctionBuilder<'a> {
                         .ok_or_else(|| CodegenError::UnsupportedFeature(
                             format!("TraitCall destination for '{}' not found", method_name)
                         ))?;
-                    builder.def_var(*var, result);
+                    // Aggregate-returning methods (string, struct, ...) hand back a
+                    // pointer to data in the callee frame. Copy into the dst's
+                    // stack slot before that frame goes away.
+                    if let Some((dst_ss, dst_size)) = ctx.stack_slot_map.get(dst_id) {
+                        Self::copy_aggregate(builder, result, *dst_ss, *dst_size);
+                        let addr = builder.ins().stack_addr(types::I64, *dst_ss, 0);
+                        builder.def_var(*var, addr);
+                    } else {
+                        builder.def_var(*var, result);
+                    }
                 }
             }
 
@@ -1775,14 +1791,14 @@ impl<'a> FunctionBuilder<'a> {
                             builder.ins().stack_addr(types::I64, ss, 0)
                         }
                         CallAdapt::DerefStringElement => {
-                            // void* pointing to 16-byte string in collection.
-                            // Copy to dst's stack slot.
+                            // void* pointing to aggregate data in collection.
+                            // Copy `slot_size` bytes into the dst's own slot.
                             let results = builder.inst_results(call_inst);
                             let ptr = if !results.is_empty() { results[0] } else {
                                 builder.ins().iconst(types::I64, 0)
                             };
-                            if let Some((ss, _)) = ctx.stack_slot_map.get(dst_id) {
-                                Self::copy_aggregate(builder, ptr, *ss, 16);
+                            if let Some((ss, slot_size)) = ctx.stack_slot_map.get(dst_id) {
+                                Self::copy_aggregate(builder, ptr, *ss, *slot_size);
                                 slot_already_written = true;
                             }
                             ptr
@@ -2853,6 +2869,31 @@ impl<'a> FunctionBuilder<'a> {
         }
     }
 
+    /// MIR arg already lives behind a pointer — its i64 value is a pointer to
+    /// the data, not the data itself. Strings, structs, enums, tuples, options,
+    /// results, slices, and trait objects all qualify.
+    fn is_by_ptr_arg(mir_args: &[MirOperand], index: usize, locals: &[rask_mir::MirLocal]) -> bool {
+        match mir_args.get(index) {
+            Some(MirOperand::Local(id)) => locals
+                .iter()
+                .find(|l| l.id == *id)
+                .map(|l| matches!(l.ty,
+                    MirType::String
+                    | MirType::Struct(_)
+                    | MirType::Enum(_)
+                    | MirType::Tuple(_)
+                    | MirType::Option(_)
+                    | MirType::Result { .. }
+                    | MirType::Slice(_)
+                    | MirType::Union(_)
+                    | MirType::TraitObject { .. }
+                ))
+                .unwrap_or(false),
+            Some(MirOperand::Constant(rask_mir::MirConst::String(_))) => true,
+            _ => false,
+        }
+    }
+
     /// Check if destination local is a string type.
     fn is_string_dst(dst: Option<&LocalId>, ctx: &CodegenCtx) -> bool {
         dst.and_then(|id| ctx.locals.iter().find(|l| l.id == *id))
@@ -2860,7 +2901,8 @@ impl<'a> FunctionBuilder<'a> {
             .unwrap_or(false)
     }
 
-    /// Wrap args[index] as a pointer unless it's already a string pointer.
+    /// Wrap args[index] as a pointer unless it's already a pointer to data
+    /// (string, struct, enum, tuple, option, result, etc.).
     fn wrap_arg_as_ptr(
         builder: &mut ClifFunctionBuilder,
         args: &mut Vec<Value>,
@@ -2868,7 +2910,7 @@ impl<'a> FunctionBuilder<'a> {
         index: usize,
         locals: &[rask_mir::MirLocal],
     ) {
-        if args.len() > index && !Self::is_string_arg(mir_args, index, locals) {
+        if args.len() > index && !Self::is_by_ptr_arg(mir_args, index, locals) {
             let val = args[index];
             args[index] = Self::value_to_ptr(builder, val);
         }
@@ -2902,9 +2944,26 @@ impl<'a> FunctionBuilder<'a> {
         }
     }
 
-    /// Deref result, but return DerefStringElement for string destinations.
+    /// Deref result, but copy through dst's slot for aggregate destinations
+    /// (string, struct, tuple, ...). The collection holds the data inline; the
+    /// runtime returns a pointer into that storage which we must copy into the
+    /// caller's slot before the collection moves.
     fn deref_or_string(dst: Option<&LocalId>, ctx: &CodegenCtx) -> CallAdapt {
-        if Self::is_string_dst(dst, ctx) { CallAdapt::DerefStringElement } else { CallAdapt::DerefResult }
+        let is_aggregate = dst
+            .and_then(|id| ctx.locals.iter().find(|l| l.id == *id))
+            .map(|l| matches!(l.ty,
+                MirType::String
+                | MirType::Struct(_)
+                | MirType::Enum(_)
+                | MirType::Tuple(_)
+                | MirType::Option(_)
+                | MirType::Result { .. }
+                | MirType::Slice(_)
+                | MirType::Union(_)
+                | MirType::TraitObject { .. }
+            ))
+            .unwrap_or(false);
+        if is_aggregate { CallAdapt::DerefStringElement } else { CallAdapt::DerefResult }
     }
 
     /// Look up struct layout size for a MIR arg, returning (elem_size, is_struct).

--- a/compiler/crates/rask-codegen/src/builder.rs
+++ b/compiler/crates/rask-codegen/src/builder.rs
@@ -629,11 +629,22 @@ impl<'a> FunctionBuilder<'a> {
                 // into the destination's stack slot rather than aliasing pointers.
                 // This covers String (always 16 bytes) and Field extractions from
                 // Struct/Tuple/Result/Option that return aggregate sub-fields.
+                //
+                // Whole-aggregate assignment (`p = q` where both are Struct/Tuple/etc.)
+                // also needs a memcpy: aliasing the pointers means a subsequent
+                // `mutate p` write would land in `q`'s storage. mem.borrowing/M-rules
+                // require `mutate` writes to flow back to the caller, which only
+                // works if `p = ...` copies bytes into `*p`'s slot.
                 let needs_copy = match (&dst_local.ty, rvalue) {
                     (MirType::String, _) => true,
                     // Field on aggregate base returns pointer for aggregate elements
                     (MirType::Struct(_) | MirType::Enum(_) | MirType::Tuple(_) |
                      MirType::Result { .. } | MirType::Option(_), MirRValue::Field { .. }) => true,
+                    // Whole-aggregate copy: rvalue produces a pointer to the source
+                    // aggregate, dst has its own storage (either a stack slot or an
+                    // external pointer for mutate-params).
+                    (MirType::Struct(_) | MirType::Enum(_) | MirType::Tuple(_),
+                     MirRValue::Use(MirOperand::Local(_))) => true,
                     // Option(T) assigned from an Option-typed local: copy the 16-byte struct
                     (MirType::Option(_), _) if src_option_ty => true,
                     _ => false,
@@ -650,6 +661,24 @@ impl<'a> FunctionBuilder<'a> {
                 if needs_copy {
                     if let Some((dst_ss, dst_size)) = ctx.stack_slot_map.get(dst) {
                         Self::copy_aggregate(builder, val, *dst_ss, *dst_size);
+                    } else if matches!(&dst_local.ty,
+                        MirType::Struct(_) | MirType::Enum(_) | MirType::Tuple(_))
+                    {
+                        // Dst variable holds an external pointer (mutate-param) —
+                        // copy bytes through it instead of overwriting the pointer.
+                        let size = Self::resolve_type_alloc_size(
+                            &dst_local.ty, ctx.struct_layouts, ctx.enum_layouts,
+                        ).unwrap_or(0);
+                        if size > 0 {
+                            let var = ctx.var_map.get(dst)
+                                .ok_or_else(|| CodegenError::UnsupportedFeature("Variable not found".to_string()))?;
+                            let dst_ptr = builder.use_var(*var);
+                            Self::copy_aggregate_to_ptr(builder, val, dst_ptr, size);
+                        } else {
+                            let var = ctx.var_map.get(dst)
+                                .ok_or_else(|| CodegenError::UnsupportedFeature("Variable not found".to_string()))?;
+                            builder.def_var(*var, val);
+                        }
                     } else {
                         let var = ctx.var_map.get(dst)
                             .ok_or_else(|| CodegenError::UnsupportedFeature("Variable not found".to_string()))?;
@@ -2796,6 +2825,32 @@ impl<'a> FunctionBuilder<'a> {
         if (size as i32 - offset) >= 1 {
             let val = builder.ins().load(types::I8, MemFlags::new(), src_ptr, offset);
             builder.ins().stack_store(val, dst_slot, offset);
+        }
+    }
+
+    /// Copy `size` bytes from `src_ptr` to `dst_ptr`. Mirror of `copy_aggregate`
+    /// but for through-pointer destinations (mutate-params, where the dst's
+    /// variable holds an external pointer instead of a stack-slot address).
+    fn copy_aggregate_to_ptr(builder: &mut ClifFunctionBuilder, src_ptr: Value, dst_ptr: Value, size: u32) {
+        let mut offset = 0i32;
+        while (offset as u32) + 8 <= size {
+            let val = builder.ins().load(types::I64, MemFlags::new(), src_ptr, offset);
+            builder.ins().store(MemFlags::new(), val, dst_ptr, offset);
+            offset += 8;
+        }
+        if (size as i32 - offset) >= 4 {
+            let val = builder.ins().load(types::I32, MemFlags::new(), src_ptr, offset);
+            builder.ins().store(MemFlags::new(), val, dst_ptr, offset);
+            offset += 4;
+        }
+        if (size as i32 - offset) >= 2 {
+            let val = builder.ins().load(types::I16, MemFlags::new(), src_ptr, offset);
+            builder.ins().store(MemFlags::new(), val, dst_ptr, offset);
+            offset += 2;
+        }
+        if (size as i32 - offset) >= 1 {
+            let val = builder.ins().load(types::I8, MemFlags::new(), src_ptr, offset);
+            builder.ins().store(MemFlags::new(), val, dst_ptr, offset);
         }
     }
 

--- a/compiler/crates/rask-codegen/src/builder.rs
+++ b/compiler/crates/rask-codegen/src/builder.rs
@@ -1414,6 +1414,37 @@ impl<'a> FunctionBuilder<'a> {
                         builder.def_var(*var, zero);
                     }
                 }
+            } else if func.name == "panic" || func.name == "todo" || func.name == "unreachable" {
+                // User-level diverging builtin: emit rask_panic_at with the
+                // message string and trap. todo/unreachable map to fixed
+                // messages when called without args.
+                let msg_ptr = if let Some(arg) = args.first() {
+                    Self::lower_operand_as_cstr(builder, arg, ctx)?
+                } else {
+                    let label = match func.name.as_str() {
+                        "todo" => "not yet implemented",
+                        "unreachable" => "entered unreachable code",
+                        _ => "panic",
+                    };
+                    ctx.string_globals.get(label)
+                        .map(|gv| builder.ins().global_value(types::I64, *gv))
+                        .unwrap_or_else(|| builder.ins().iconst(types::I64, 0))
+                };
+                if let Some(panic_ref) = ctx.func_refs.get("panic_at") {
+                    let file_ptr = ctx.source_file.and_then(|f| ctx.string_globals.get(f))
+                        .map(|gv| builder.ins().global_value(types::I64, *gv))
+                        .unwrap_or_else(|| builder.ins().iconst(types::I64, 0));
+                    let line_val = builder.ins().iconst(types::I32, ctx.current_line as i64);
+                    let col_val = builder.ins().iconst(types::I32, ctx.current_col as i64);
+                    builder.ins().call(*panic_ref, &[file_ptr, line_val, col_val, msg_ptr]);
+                }
+                builder.ins().trap(cranelift_codegen::ir::TrapCode::unwrap_user(1));
+                // After a trap, codegen needs to enter an unreachable block
+                // so subsequent Cranelift instructions are still well-formed.
+                let unreach_block = builder.create_block();
+                builder.switch_to_block(unreach_block);
+                builder.seal_block(unreach_block);
+                return Ok(());
             } else if func.name == "assert_fail" {
                 // MIR already handled branching; this is the fail path.
                 // If a message arg is provided, pass it as raw C string pointer.

--- a/compiler/crates/rask-codegen/src/builder.rs
+++ b/compiler/crates/rask-codegen/src/builder.rs
@@ -650,13 +650,27 @@ impl<'a> FunctionBuilder<'a> {
                     _ => false,
                 };
 
-                // Option(T) assigned from a scalar: wrap as Some in the stack slot.
-                // Needed for `const x: i32? = 42` — without this, the scalar 42
-                // overwrites the stack-address held in x's var, causing a SIGSEGV
-                // when code later loads the tag by dereferencing that "address".
+                // Option(T) assigned from a non-Option source: wrap as Some
+                // in the stack slot. Scalars need this so `const x: i32? = 42`
+                // doesn't overwrite x's slot-address with the scalar 42 (later
+                // tag loads would dereference 42 as a pointer and SIGSEGV).
+                // Aggregates (Struct/Enum/Tuple/String) need it so the bytes
+                // land at PAYLOAD_OFFSET of the Option slot, not just the
+                // pointer in the first 8 bytes — otherwise field reads
+                // through the Option's payload return garbage.
                 let wrap_as_some = matches!(&dst_local.ty, MirType::Option(_))
                     && !needs_copy
                     && ctx.stack_slot_map.contains_key(dst);
+                // If the source is an aggregate and dst is Option<aggregate>,
+                // we need full-aggregate wrap (tag + memcpy payload), not the
+                // scalar wrap.
+                let wrap_as_some_aggregate = wrap_as_some
+                    && matches!(rvalue, MirRValue::Use(MirOperand::Local(_)))
+                    && if let MirType::Option(inner) = &dst_local.ty {
+                        matches!(inner.as_ref(),
+                            MirType::Struct(_) | MirType::Enum(_) |
+                            MirType::Tuple(_) | MirType::String)
+                    } else { false };
 
                 if needs_copy {
                     if let Some((dst_ss, dst_size)) = ctx.stack_slot_map.get(dst) {
@@ -683,6 +697,39 @@ impl<'a> FunctionBuilder<'a> {
                         let var = ctx.var_map.get(dst)
                             .ok_or_else(|| CodegenError::UnsupportedFeature("Variable not found".to_string()))?;
                         builder.def_var(*var, val);
+                    }
+                } else if wrap_as_some_aggregate {
+                    // tag=Some at offset 0, then memcpy payload bytes at PAYLOAD_OFFSET.
+                    let (dst_ss, _) = ctx.stack_slot_map.get(dst).unwrap();
+                    let inner_size = if let MirType::Option(inner) = &dst_local.ty {
+                        Self::resolve_type_alloc_size(
+                            inner.as_ref(), ctx.struct_layouts, ctx.enum_layouts,
+                        ).unwrap_or(inner.size())
+                    } else { 0 };
+                    let zero = builder.ins().iconst(types::I64, 0);
+                    builder.ins().stack_store(zero, *dst_ss, crate::layouts::TAG_OFFSET);
+                    // Copy `inner_size` bytes from `val` (pointer to source aggregate)
+                    // to dst_slot + PAYLOAD_OFFSET.
+                    let mut offset = 0i32;
+                    let payload_base = crate::layouts::PAYLOAD_OFFSET;
+                    while (offset as u32) + 8 <= inner_size {
+                        let word = builder.ins().load(types::I64, MemFlags::new(), val, offset);
+                        builder.ins().stack_store(word, *dst_ss, payload_base + offset);
+                        offset += 8;
+                    }
+                    if (inner_size as i32 - offset) >= 4 {
+                        let word = builder.ins().load(types::I32, MemFlags::new(), val, offset);
+                        builder.ins().stack_store(word, *dst_ss, payload_base + offset);
+                        offset += 4;
+                    }
+                    if (inner_size as i32 - offset) >= 2 {
+                        let word = builder.ins().load(types::I16, MemFlags::new(), val, offset);
+                        builder.ins().stack_store(word, *dst_ss, payload_base + offset);
+                        offset += 2;
+                    }
+                    if (inner_size as i32 - offset) >= 1 {
+                        let word = builder.ins().load(types::I8, MemFlags::new(), val, offset);
+                        builder.ins().stack_store(word, *dst_ss, payload_base + offset);
                     }
                 } else if wrap_as_some {
                     let (dst_ss, _) = ctx.stack_slot_map.get(dst).unwrap();

--- a/compiler/crates/rask-codegen/src/builder.rs
+++ b/compiler/crates/rask-codegen/src/builder.rs
@@ -643,9 +643,19 @@ impl<'a> FunctionBuilder<'a> {
                     // Whole-aggregate copy: rvalue produces a pointer to the source
                     // aggregate, dst has its own storage (either a stack slot or an
                     // external pointer for mutate-params).
-                    (MirType::Struct(_) | MirType::Enum(_) | MirType::Tuple(_)
-                     | MirType::Result { .. } | MirType::Option(_),
+                    (MirType::Struct(_) | MirType::Enum(_) | MirType::Tuple(_),
                      MirRValue::Use(MirOperand::Local(_))) => true,
+                    // Result/Option whole-aggregate copy: only when src and dst
+                    // have the same general shape. Avoid clobbering layout when
+                    // src is Result and dst is Option (different payload offsets).
+                    (MirType::Result { .. }, MirRValue::Use(MirOperand::Local(src_id))) => {
+                        ctx.locals.iter().find(|l| l.id == *src_id)
+                            .map_or(false, |l| matches!(l.ty, MirType::Result { .. }))
+                    }
+                    (MirType::Option(_), MirRValue::Use(MirOperand::Local(src_id))) => {
+                        ctx.locals.iter().find(|l| l.id == *src_id)
+                            .map_or(false, |l| matches!(l.ty, MirType::Option(_)))
+                    }
                     // Option(T) assigned from an Option-typed local: copy the 16-byte struct
                     (MirType::Option(_), _) if src_option_ty => true,
                     _ => false,

--- a/compiler/crates/rask-codegen/src/dispatch.rs
+++ b/compiler/crates/rask-codegen/src/dispatch.rs
@@ -123,8 +123,8 @@ pub fn stdlib_entries() -> Vec<StdlibEntry> {
         },
         StdlibEntry {
             mir_name: "Vec_pop", c_name: "rask_vec_pop",
-            params: &[types::I64, types::I64], ret_ty: Some(types::I64), can_panic: true,
-            arg_adapt: ArgAdapt::AppendOutParam, ret_adapt: RetAdapt::FromArgAdapt,
+            params: &[types::I64], ret_ty: Some(types::I64), can_panic: false,
+            arg_adapt: ArgAdapt::None, ret_adapt: RetAdapt::DerefOption,
         },
         StdlibEntry::simple("Vec_len", "rask_vec_len", &[types::I64], Some(types::I64), false),
         StdlibEntry::simple("Vec_as_ptr", "rask_vec_as_ptr", &[types::I64], Some(types::I64), false),

--- a/compiler/crates/rask-mir/src/builder.rs
+++ b/compiler/crates/rask-mir/src/builder.rs
@@ -15,6 +15,11 @@ pub struct BlockBuilder {
 }
 
 impl BlockBuilder {
+    /// Return type of the function being built (read-only).
+    pub fn ret_ty(&self) -> &MirType {
+        &self.function.ret_ty
+    }
+
     pub fn new(name: String, ret_ty: MirType) -> Self {
         let entry_block = BlockId(0);
         let function = MirFunction {

--- a/compiler/crates/rask-mir/src/lower/collections.rs
+++ b/compiler/crates/rask-mir/src/lower/collections.rs
@@ -423,6 +423,12 @@ impl<'a> MirLowerer<'a> {
                 let name = self.ctx.type_names.get(id)?;
                 self.ctx.find_struct(name).map(|(_, l)| l.size as i64).or(Some(8))
             }
+            // `T?` (Option) lays out as [tag:8][payload:8+]. Pick max(8) for the
+            // payload so scalar inners still get a full word.
+            Type::Result { ok, err } if **err == Type::None => {
+                let inner = self.slot_size_for_type(ok)?;
+                Some(8 + inner.max(8))
+            }
             Type::Var(_) => None,
             _ => Some(8),
         }

--- a/compiler/crates/rask-mir/src/lower/collections.rs
+++ b/compiler/crates/rask-mir/src/lower/collections.rs
@@ -419,6 +419,10 @@ impl<'a> MirLowerer<'a> {
                 | "usize" | "isize" | "char" => Some(8),
                 _ => self.ctx.find_struct(name).map(|(_, l)| l.size as i64).or(Some(8)),
             },
+            Type::Named(id) => {
+                let name = self.ctx.type_names.get(id)?;
+                self.ctx.find_struct(name).map(|(_, l)| l.size as i64).or(Some(8))
+            }
             Type::Var(_) => None,
             _ => Some(8),
         }

--- a/compiler/crates/rask-mir/src/lower/errors.rs
+++ b/compiler/crates/rask-mir/src/lower/errors.rs
@@ -8,7 +8,7 @@ use crate::{
     MirTerminatorKind, MirType,
     types::RESULT_PAYLOAD_OFFSET,
 };
-use rask_ast::expr::{Expr, ExprKind, TryElse};
+use rask_ast::expr::{CallArg, Expr, ExprKind, TryElse};
 
 impl<'a> MirLowerer<'a> {
     /// Try expression lowering (spec L3).
@@ -534,5 +534,407 @@ impl<'a> MirLowerer<'a> {
 
         self.builder.switch_to_block(merge_block);
         Ok((MirOperand::Local(out), out_ty))
+    }
+
+    /// Inline lowering for Result/Option methods that have stdlib stubs but
+    /// no runtime implementation (`.map`, `.ok`, `.filter`).
+    ///
+    /// Returns `Ok(Some(operand))` when the call was inlined; `Ok(None)`
+    /// when the receiver isn't a Result/Option or the method isn't one we
+    /// inline. Falling through lets the normal method-dispatch path handle
+    /// other calls.
+    pub(super) fn try_lower_result_option_method(
+        &mut self,
+        expr: &Expr,
+        object: &Expr,
+        method: &str,
+        args: &[CallArg],
+    ) -> Result<Option<super::TypedOperand>, LoweringError> {
+        let raw_ty = match self.ctx.lookup_raw_type(object.id) {
+            Some(t) => t.clone(),
+            None => return Ok(None),
+        };
+        let is_result = matches!(&raw_ty, rask_types::Type::Result { err, .. } if **err != rask_types::Type::None);
+        let is_option = matches!(&raw_ty, rask_types::Type::Result { err, .. } if **err == rask_types::Type::None);
+        if !is_result && !is_option {
+            return Ok(None);
+        }
+
+        match (is_result, method, args.len()) {
+            (true, "map", 1) => self.lower_result_map(expr, object, &args[0].expr).map(Some),
+            (true, "ok", 0) => self.lower_result_ok(expr, object).map(Some),
+            (false, "map", 1) => self.lower_option_map(expr, object, &args[0].expr).map(Some),
+            (false, "filter", 1) => self.lower_option_filter(expr, object, &args[0].expr).map(Some),
+            _ => Ok(None),
+        }
+    }
+
+    /// Inline `result.map(closure)` for Result<T, E>:
+    ///   if Ok(t): result = Ok(closure(t))
+    ///   if Err(e): result = Err(e)  (copy through)
+    fn lower_result_map(
+        &mut self,
+        expr: &Expr,
+        object: &Expr,
+        closure: &Expr,
+    ) -> Result<super::TypedOperand, LoweringError> {
+        let (obj_op, obj_ty) = self.lower_expr(object)?;
+        let (closure_op, _) = self.lower_expr(closure)?;
+        let closure_local = match closure_op {
+            MirOperand::Local(id) => id,
+            _ => return Err(LoweringError::InvalidConstruct(
+                "Result.map closure must be a local".to_string(),
+            )),
+        };
+
+        // Result types: in T, err E; out U, err E.
+        let (in_ok_ty, err_ty) = match &obj_ty {
+            MirType::Result { ok, err } => ((**ok).clone(), (**err).clone()),
+            _ => return Err(LoweringError::InvalidConstruct(
+                "Result.map receiver must be Result".to_string(),
+            )),
+        };
+        let result_ty = self.lookup_expr_type(expr)
+            .unwrap_or(MirType::Result { ok: Box::new(MirType::I64), err: Box::new(err_ty.clone()) });
+        let out_ok_ty = match &result_ty {
+            MirType::Result { ok, .. } => (**ok).clone(),
+            _ => MirType::I64,
+        };
+
+        let result_local = self.builder.alloc_temp(result_ty.clone());
+
+        let tag_local = self.builder.alloc_temp(MirType::U8);
+        self.builder.push_stmt(MirStmt::dummy(MirStmtKind::Assign {
+            dst: tag_local,
+            rvalue: MirRValue::EnumTag { value: obj_op.clone() },
+        }));
+
+        let ok_block = self.builder.create_block();
+        let err_block = self.builder.create_block();
+        let merge_block = self.builder.create_block();
+
+        self.builder.terminate(MirTerminator::dummy(MirTerminatorKind::Branch {
+            cond: MirOperand::Local(tag_local),
+            then_block: err_block,
+            else_block: ok_block,
+        }));
+
+        // Ok branch: read T payload, call closure, store new Ok.
+        self.builder.switch_to_block(ok_block);
+        let payload_local = self.builder.alloc_temp(in_ok_ty.clone());
+        self.builder.push_stmt(MirStmt::dummy(MirStmtKind::Assign {
+            dst: payload_local,
+            rvalue: MirRValue::Field {
+                base: obj_op.clone(),
+                field_index: 0,
+                byte_offset: None,
+                field_size: None,
+            },
+        }));
+        let mapped_local = self.builder.alloc_temp(out_ok_ty.clone());
+        self.builder.push_stmt(MirStmt::dummy(MirStmtKind::ClosureCall {
+            dst: Some(mapped_local),
+            closure: closure_local,
+            args: vec![MirOperand::Local(payload_local)],
+        }));
+        // tag = 0, zero origin, payload = mapped value.
+        self.builder.push_stmt(MirStmt::dummy(MirStmtKind::Store {
+            addr: result_local, offset: 0,
+            value: MirOperand::Constant(MirConst::Int(0)),
+            store_size: Some(8),
+        }));
+        self.builder.push_stmt(MirStmt::dummy(MirStmtKind::Store {
+            addr: result_local, offset: 8,
+            value: MirOperand::Constant(MirConst::Int(0)),
+            store_size: Some(8),
+        }));
+        self.builder.push_stmt(MirStmt::dummy(MirStmtKind::Store {
+            addr: result_local, offset: 16,
+            value: MirOperand::Constant(MirConst::Int(0)),
+            store_size: Some(8),
+        }));
+        let payload_size = out_ok_ty.size().max(8);
+        self.builder.push_stmt(MirStmt::dummy(MirStmtKind::Store {
+            addr: result_local,
+            offset: RESULT_PAYLOAD_OFFSET,
+            value: MirOperand::Local(mapped_local),
+            store_size: Some(payload_size),
+        }));
+        self.builder.terminate(MirTerminator::dummy(MirTerminatorKind::Goto { target: merge_block }));
+
+        // Err branch: copy whole source Result to result_local (tag=1, origin, err
+        // payload are preserved). Same MIR shape works because both Result types
+        // share the err side.
+        self.builder.switch_to_block(err_block);
+        self.builder.push_stmt(MirStmt::dummy(MirStmtKind::Assign {
+            dst: result_local,
+            rvalue: MirRValue::Use(obj_op),
+        }));
+        self.builder.terminate(MirTerminator::dummy(MirTerminatorKind::Goto { target: merge_block }));
+
+        self.builder.switch_to_block(merge_block);
+        Ok((MirOperand::Local(result_local), result_ty))
+    }
+
+    /// Inline `result.ok()` for Result<T, E>: Result<T, E> → T?
+    ///   if Ok(t): Some(t); if Err: None
+    fn lower_result_ok(
+        &mut self,
+        expr: &Expr,
+        object: &Expr,
+    ) -> Result<super::TypedOperand, LoweringError> {
+        let (obj_op, obj_ty) = self.lower_expr(object)?;
+        let in_ok_ty = match &obj_ty {
+            MirType::Result { ok, .. } => (**ok).clone(),
+            _ => return Err(LoweringError::InvalidConstruct(
+                "Result.ok receiver must be Result".to_string(),
+            )),
+        };
+        let result_ty = self.lookup_expr_type(expr)
+            .unwrap_or(MirType::Option(Box::new(in_ok_ty.clone())));
+        let result_local = self.builder.alloc_temp(result_ty.clone());
+
+        let tag_local = self.builder.alloc_temp(MirType::U8);
+        self.builder.push_stmt(MirStmt::dummy(MirStmtKind::Assign {
+            dst: tag_local,
+            rvalue: MirRValue::EnumTag { value: obj_op.clone() },
+        }));
+
+        let ok_block = self.builder.create_block();
+        let err_block = self.builder.create_block();
+        let merge_block = self.builder.create_block();
+
+        self.builder.terminate(MirTerminator::dummy(MirTerminatorKind::Branch {
+            cond: MirOperand::Local(tag_local),
+            then_block: err_block,
+            else_block: ok_block,
+        }));
+
+        // Ok branch: result = Some(payload)
+        self.builder.switch_to_block(ok_block);
+        let payload_local = self.builder.alloc_temp(in_ok_ty.clone());
+        self.builder.push_stmt(MirStmt::dummy(MirStmtKind::Assign {
+            dst: payload_local,
+            rvalue: MirRValue::Field {
+                base: obj_op.clone(),
+                field_index: 0,
+                byte_offset: None,
+                field_size: None,
+            },
+        }));
+        self.builder.push_stmt(MirStmt::dummy(MirStmtKind::Store {
+            addr: result_local, offset: 0,
+            value: MirOperand::Constant(MirConst::Int(0)),
+            store_size: Some(8),
+        }));
+        let payload_size = in_ok_ty.size().max(8);
+        self.builder.push_stmt(MirStmt::dummy(MirStmtKind::Store {
+            addr: result_local, offset: 8,
+            value: MirOperand::Local(payload_local),
+            store_size: Some(payload_size),
+        }));
+        self.builder.terminate(MirTerminator::dummy(MirTerminatorKind::Goto { target: merge_block }));
+
+        // Err branch: result = None (tag=1)
+        self.builder.switch_to_block(err_block);
+        self.builder.push_stmt(MirStmt::dummy(MirStmtKind::Store {
+            addr: result_local, offset: 0,
+            value: MirOperand::Constant(MirConst::Int(1)),
+            store_size: Some(8),
+        }));
+        self.builder.terminate(MirTerminator::dummy(MirTerminatorKind::Goto { target: merge_block }));
+
+        self.builder.switch_to_block(merge_block);
+        Ok((MirOperand::Local(result_local), result_ty))
+    }
+
+    /// Inline `option.map(closure)` for Option<T>: T? → U?
+    fn lower_option_map(
+        &mut self,
+        expr: &Expr,
+        object: &Expr,
+        closure: &Expr,
+    ) -> Result<super::TypedOperand, LoweringError> {
+        let (obj_op, obj_ty) = self.lower_expr(object)?;
+        let (closure_op, _) = self.lower_expr(closure)?;
+        let closure_local = match closure_op {
+            MirOperand::Local(id) => id,
+            _ => return Err(LoweringError::InvalidConstruct(
+                "Option.map closure must be a local".to_string(),
+            )),
+        };
+        let in_ty = match &obj_ty {
+            MirType::Option(inner) => (**inner).clone(),
+            MirType::Result { ok, err } if **err == MirType::Void => (**ok).clone(),
+            _ => return Err(LoweringError::InvalidConstruct(
+                "Option.map receiver must be Option".to_string(),
+            )),
+        };
+        let result_ty = self.lookup_expr_type(expr)
+            .unwrap_or(MirType::Option(Box::new(MirType::I64)));
+        let out_ty = match &result_ty {
+            MirType::Option(inner) => (**inner).clone(),
+            _ => MirType::I64,
+        };
+
+        let result_local = self.builder.alloc_temp(result_ty.clone());
+
+        let tag_local = self.builder.alloc_temp(MirType::U8);
+        self.builder.push_stmt(MirStmt::dummy(MirStmtKind::Assign {
+            dst: tag_local,
+            rvalue: MirRValue::EnumTag { value: obj_op.clone() },
+        }));
+
+        let some_block = self.builder.create_block();
+        let none_block = self.builder.create_block();
+        let merge_block = self.builder.create_block();
+
+        self.builder.terminate(MirTerminator::dummy(MirTerminatorKind::Branch {
+            cond: MirOperand::Local(tag_local),
+            then_block: none_block,
+            else_block: some_block,
+        }));
+
+        // Some branch: closure(payload), result = Some(mapped)
+        self.builder.switch_to_block(some_block);
+        let payload_local = self.builder.alloc_temp(in_ty.clone());
+        self.builder.push_stmt(MirStmt::dummy(MirStmtKind::Assign {
+            dst: payload_local,
+            rvalue: MirRValue::Field {
+                base: obj_op.clone(),
+                field_index: 0,
+                byte_offset: None,
+                field_size: None,
+            },
+        }));
+        let mapped_local = self.builder.alloc_temp(out_ty.clone());
+        self.builder.push_stmt(MirStmt::dummy(MirStmtKind::ClosureCall {
+            dst: Some(mapped_local),
+            closure: closure_local,
+            args: vec![MirOperand::Local(payload_local)],
+        }));
+        self.builder.push_stmt(MirStmt::dummy(MirStmtKind::Store {
+            addr: result_local, offset: 0,
+            value: MirOperand::Constant(MirConst::Int(0)),
+            store_size: Some(8),
+        }));
+        let payload_size = out_ty.size().max(8);
+        self.builder.push_stmt(MirStmt::dummy(MirStmtKind::Store {
+            addr: result_local, offset: 8,
+            value: MirOperand::Local(mapped_local),
+            store_size: Some(payload_size),
+        }));
+        self.builder.terminate(MirTerminator::dummy(MirTerminatorKind::Goto { target: merge_block }));
+
+        // None: result = None
+        self.builder.switch_to_block(none_block);
+        self.builder.push_stmt(MirStmt::dummy(MirStmtKind::Store {
+            addr: result_local, offset: 0,
+            value: MirOperand::Constant(MirConst::Int(1)),
+            store_size: Some(8),
+        }));
+        self.builder.terminate(MirTerminator::dummy(MirTerminatorKind::Goto { target: merge_block }));
+
+        self.builder.switch_to_block(merge_block);
+        Ok((MirOperand::Local(result_local), result_ty))
+    }
+
+    /// Inline `option.filter(closure)` for Option<T>: T? → T?
+    ///   if Some(t) and closure(t): Some(t); else: None
+    fn lower_option_filter(
+        &mut self,
+        expr: &Expr,
+        object: &Expr,
+        closure: &Expr,
+    ) -> Result<super::TypedOperand, LoweringError> {
+        let (obj_op, obj_ty) = self.lower_expr(object)?;
+        let (closure_op, _) = self.lower_expr(closure)?;
+        let closure_local = match closure_op {
+            MirOperand::Local(id) => id,
+            _ => return Err(LoweringError::InvalidConstruct(
+                "Option.filter closure must be a local".to_string(),
+            )),
+        };
+        let in_ty = match &obj_ty {
+            MirType::Option(inner) => (**inner).clone(),
+            MirType::Result { ok, err } if **err == MirType::Void => (**ok).clone(),
+            _ => return Err(LoweringError::InvalidConstruct(
+                "Option.filter receiver must be Option".to_string(),
+            )),
+        };
+        let result_ty = self.lookup_expr_type(expr).unwrap_or(obj_ty.clone());
+
+        let result_local = self.builder.alloc_temp(result_ty.clone());
+
+        let tag_local = self.builder.alloc_temp(MirType::U8);
+        self.builder.push_stmt(MirStmt::dummy(MirStmtKind::Assign {
+            dst: tag_local,
+            rvalue: MirRValue::EnumTag { value: obj_op.clone() },
+        }));
+
+        let some_block = self.builder.create_block();
+        let none_block = self.builder.create_block();
+        let keep_block = self.builder.create_block();
+        let drop_block = self.builder.create_block();
+        let merge_block = self.builder.create_block();
+
+        self.builder.terminate(MirTerminator::dummy(MirTerminatorKind::Branch {
+            cond: MirOperand::Local(tag_local),
+            then_block: none_block,
+            else_block: some_block,
+        }));
+
+        // Some branch: closure(payload) → if true keep, else drop
+        self.builder.switch_to_block(some_block);
+        let payload_local = self.builder.alloc_temp(in_ty.clone());
+        self.builder.push_stmt(MirStmt::dummy(MirStmtKind::Assign {
+            dst: payload_local,
+            rvalue: MirRValue::Field {
+                base: obj_op.clone(),
+                field_index: 0,
+                byte_offset: None,
+                field_size: None,
+            },
+        }));
+        let keep_local = self.builder.alloc_temp(MirType::Bool);
+        self.builder.push_stmt(MirStmt::dummy(MirStmtKind::ClosureCall {
+            dst: Some(keep_local),
+            closure: closure_local,
+            args: vec![MirOperand::Local(payload_local)],
+        }));
+        self.builder.terminate(MirTerminator::dummy(MirTerminatorKind::Branch {
+            cond: MirOperand::Local(keep_local),
+            then_block: keep_block,
+            else_block: drop_block,
+        }));
+
+        // keep: result = source (copy)
+        self.builder.switch_to_block(keep_block);
+        self.builder.push_stmt(MirStmt::dummy(MirStmtKind::Assign {
+            dst: result_local,
+            rvalue: MirRValue::Use(obj_op.clone()),
+        }));
+        self.builder.terminate(MirTerminator::dummy(MirTerminatorKind::Goto { target: merge_block }));
+
+        // drop: result = None
+        self.builder.switch_to_block(drop_block);
+        self.builder.push_stmt(MirStmt::dummy(MirStmtKind::Store {
+            addr: result_local, offset: 0,
+            value: MirOperand::Constant(MirConst::Int(1)),
+            store_size: Some(8),
+        }));
+        self.builder.terminate(MirTerminator::dummy(MirTerminatorKind::Goto { target: merge_block }));
+
+        // None: result = None
+        self.builder.switch_to_block(none_block);
+        self.builder.push_stmt(MirStmt::dummy(MirStmtKind::Store {
+            addr: result_local, offset: 0,
+            value: MirOperand::Constant(MirConst::Int(1)),
+            store_size: Some(8),
+        }));
+        self.builder.terminate(MirTerminator::dummy(MirTerminatorKind::Goto { target: merge_block }));
+
+        self.builder.switch_to_block(merge_block);
+        Ok((MirOperand::Local(result_local), result_ty))
     }
 }

--- a/compiler/crates/rask-mir/src/lower/errors.rs
+++ b/compiler/crates/rask-mir/src/lower/errors.rs
@@ -554,18 +554,29 @@ impl<'a> MirLowerer<'a> {
             Some(t) => t.clone(),
             None => return Ok(None),
         };
-        let is_result = matches!(&raw_ty, rask_types::Type::Result { err, .. } if **err != rask_types::Type::None);
+        let is_result = matches!(&raw_ty, rask_types::Type::Result { err, .. }
+            if **err != rask_types::Type::None && !matches!(**err, rask_types::Type::Var(_)));
         let is_option = matches!(&raw_ty, rask_types::Type::Result { err, .. } if **err == rask_types::Type::None);
         if !is_result && !is_option {
             return Ok(None);
         }
 
-        match (is_result, method, args.len()) {
+        // Skip when the type checker couldn't fully resolve the err side
+        // (unresolved type variables) — MIR lowering may end up with a
+        // non-Result MirType and the inline lowering will fail to match.
+        let result = match (is_result, method, args.len()) {
             (true, "map", 1) => self.lower_result_map(expr, object, &args[0].expr).map(Some),
             (true, "ok", 0) => self.lower_result_ok(expr, object).map(Some),
             (false, "map", 1) => self.lower_option_map(expr, object, &args[0].expr).map(Some),
             (false, "filter", 1) => self.lower_option_filter(expr, object, &args[0].expr).map(Some),
             _ => Ok(None),
+        };
+        // If the inline lowering fails because the receiver's MIR type
+        // doesn't actually match Result/Option (type checker unresolved),
+        // fall through to the regular dispatch path instead of erroring.
+        match result {
+            Err(LoweringError::InvalidConstruct(msg)) if msg.contains("receiver must be") => Ok(None),
+            other => other,
         }
     }
 

--- a/compiler/crates/rask-mir/src/lower/expr.rs
+++ b/compiler/crates/rask-mir/src/lower/expr.rs
@@ -2682,18 +2682,65 @@ impl<'a> MirLowerer<'a> {
             }
 
             // Optional chaining (a?.b)
-            ExprKind::OptionalField { object, field: _ } => {
+            ExprKind::OptionalField { object, field } => {
+                // `obj?.field` lowers to:
+                //   if obj is Some(t): Some(t.field)
+                //   if obj is None:    None
+                // The result type is Option<typeof(t.field)>, NOT the payload
+                // type. Earlier lowering ignored the field name and just
+                // unwrapped the Option, which collapsed the chain to garbage
+                // for any non-leaf access (#271).
                 let is_niche = self.is_niche_option_expr(object);
                 let (obj, _) = self.lower_expr(object)?;
                 let tag_local = self.emit_option_tag(&obj, is_niche);
 
+                // Resolve the payload struct's layout to find the field's
+                // index, type, and offset. Required for the Some-branch
+                // load and to size the Option<field_ty> result.
+                // Peel off any extra Option layers — the type checker's flatten
+                // logic only fires when constraints have already resolved at
+                // OptionalField time, so chained `?.` can store an
+                // `Option<Option<T>>` raw type for the inner expression. We
+                // want the bare T to look up the field on.
+                let mut payload_ty = self.extract_payload_type(object)
+                    .unwrap_or(MirType::I64);
+                while let MirType::Option(inner) = payload_ty {
+                    payload_ty = *inner;
+                }
+                let (field_index, field_ty, byte_offset, field_size) =
+                    if let MirType::Struct(StructLayoutId { id, .. }) = &payload_ty {
+                        if let Some(layout) = self.ctx.struct_layouts.get(*id as usize) {
+                            if let Some((idx, fl)) = layout.fields.iter().enumerate()
+                                .find(|(_, f)| f.name == *field)
+                            {
+                                let ft = self.ctx.resolve_type_str(&format!("{}", fl.ty));
+                                (idx as u32, ft, Some(fl.offset), Some(fl.size))
+                            } else {
+                                (0, payload_ty.clone(), None, None)
+                            }
+                        } else {
+                            (0, payload_ty.clone(), None, None)
+                        }
+                    } else {
+                        // Non-struct payload (rare — e.g. tuple). Fall back to
+                        // the old "just unwrap" shape so we don't regress.
+                        (0, payload_ty.clone(), None, None)
+                    };
+
+                // Flatten: if the field is already T?, the result stays T?
+                // (matches check_expr.rs behavior). In that case the Some
+                // branch just copies the field-Option through; no extra wrap.
+                let field_is_option = matches!(field_ty, MirType::Option(_));
+                let result_ty = if field_is_option {
+                    field_ty.clone()
+                } else {
+                    MirType::Option(Box::new(field_ty.clone()))
+                };
+                let result_local = self.builder.alloc_temp(result_ty.clone());
+
                 let some_block = self.builder.create_block();
                 let none_block = self.builder.create_block();
                 let merge_block = self.builder.create_block();
-                // Infer field type from the optional value
-                let result_ty = self.extract_payload_type(object)
-                    .unwrap_or(MirType::I64);
-                let result_local = self.builder.alloc_temp(result_ty.clone());
 
                 self.builder.terminate(MirTerminator::dummy(MirTerminatorKind::Branch {
                     cond: MirOperand::Local(tag_local),
@@ -2701,22 +2748,78 @@ impl<'a> MirLowerer<'a> {
                     else_block: some_block,
                 }));
 
+                // Some branch: read field, then either copy through (flattened)
+                // or wrap as Some.
                 self.builder.switch_to_block(some_block);
-                let rvalue = if is_niche {
-                    MirRValue::Use(obj)
-                } else {
-                    MirRValue::Field { base: obj, field_index: 0, byte_offset: None, field_size: None }
-                };
-                self.builder.push_stmt(MirStmt::dummy(MirStmtKind::Assign {
-                    dst: result_local,
-                    rvalue,
-                }));
+                if byte_offset.is_some() {
+                    // Read payload struct, then field from struct layout.
+                    let payload_local = self.builder.alloc_temp(payload_ty.clone());
+                    self.builder.push_stmt(MirStmt::dummy(MirStmtKind::Assign {
+                        dst: payload_local,
+                        rvalue: MirRValue::Field {
+                            base: obj.clone(),
+                            field_index: 0,
+                            byte_offset: None,
+                            field_size: None,
+                        },
+                    }));
+                    let field_local = self.builder.alloc_temp(field_ty.clone());
+                    self.builder.push_stmt(MirStmt::dummy(MirStmtKind::Assign {
+                        dst: field_local,
+                        rvalue: MirRValue::Field {
+                            base: MirOperand::Local(payload_local),
+                            field_index,
+                            byte_offset,
+                            field_size,
+                        },
+                    }));
+                    if field_is_option {
+                        // result_local is the same Option<X> shape — just copy
+                        // the bytes through. Codegen Assign(Option, Option)
+                        // hits the src_option_ty needs_copy branch.
+                        self.builder.push_stmt(MirStmt::dummy(MirStmtKind::Assign {
+                            dst: result_local,
+                            rvalue: MirRValue::Use(MirOperand::Local(field_local)),
+                        }));
+                    } else {
+                        // Wrap as Some: tag=0, payload at offset 8.
+                        self.builder.push_stmt(MirStmt::dummy(MirStmtKind::Store {
+                            addr: result_local,
+                            offset: 0,
+                            value: MirOperand::Constant(MirConst::Int(0)),
+                            store_size: Some(8),
+                        }));
+                        let value_size = field_size.unwrap_or(8);
+                        self.builder.push_stmt(MirStmt::dummy(MirStmtKind::Store {
+                            addr: result_local,
+                            offset: 8,
+                            value: MirOperand::Local(field_local),
+                            store_size: Some(value_size),
+                        }));
+                    }
+                } else if is_niche {
+                    self.builder.push_stmt(MirStmt::dummy(MirStmtKind::Store {
+                        addr: result_local,
+                        offset: 0,
+                        value: MirOperand::Constant(MirConst::Int(0)),
+                        store_size: Some(8),
+                    }));
+                    self.builder.push_stmt(MirStmt::dummy(MirStmtKind::Store {
+                        addr: result_local,
+                        offset: 8,
+                        value: obj.clone(),
+                        store_size: Some(field_ty.size()),
+                    }));
+                }
                 self.builder.terminate(MirTerminator::dummy(MirTerminatorKind::Goto { target: merge_block }));
 
+                // None branch: write None-tag (1) at offset 0.
                 self.builder.switch_to_block(none_block);
-                self.builder.push_stmt(MirStmt::dummy(MirStmtKind::Assign {
-                    dst: result_local,
-                    rvalue: MirRValue::Use(MirOperand::Constant(MirConst::Int(0))),
+                self.builder.push_stmt(MirStmt::dummy(MirStmtKind::Store {
+                    addr: result_local,
+                    offset: 0,
+                    value: MirOperand::Constant(MirConst::Int(1)),
+                    store_size: Some(8),
                 }));
                 self.builder.terminate(MirTerminator::dummy(MirTerminatorKind::Goto { target: merge_block }));
 

--- a/compiler/crates/rask-mir/src/lower/expr.rs
+++ b/compiler/crates/rask-mir/src/lower/expr.rs
@@ -3566,6 +3566,9 @@ impl<'a> MirLowerer<'a> {
     pub(super) fn lower_block(&mut self, stmts: &[Stmt]) -> Result<TypedOperand, LoweringError> {
         let mut last_val = MirOperand::Constant(MirConst::Int(0));
         let mut last_ty = MirType::Void;
+        // Block scope: any const/mut declared inside the braces shadows but
+        // doesn't leak out. Snapshot the locals map and restore after.
+        let saved_locals = self.locals.clone();
         for (i, stmt) in stmts.iter().enumerate() {
             if i == stmts.len() - 1 {
                 if let StmtKind::Expr(e) = &stmt.kind {
@@ -3577,6 +3580,7 @@ impl<'a> MirLowerer<'a> {
             }
             self.lower_stmt(stmt)?;
         }
+        self.locals = saved_locals;
         Ok((last_val, last_ty))
     }
 } // end impl MirLowerer

--- a/compiler/crates/rask-mir/src/lower/expr.rs
+++ b/compiler/crates/rask-mir/src/lower/expr.rs
@@ -1522,6 +1522,16 @@ impl<'a> MirLowerer<'a> {
                     } else {
                         None
                     })
+                    // Stdlib type from the type checker (Result, Option, etc.)
+                    // when the receiver isn't an ident — e.g. method-chain on a
+                    // call result `safe_div(...).map(...)`. Without this fall-
+                    // through, "map" lands on the hardcoded Vec fallback below
+                    // and dispatches Vec_map on a Result.
+                    .or_else(|| {
+                        self.ctx.lookup_raw_type(object.id)
+                            .and_then(|ty| super::MirContext::stdlib_type_prefix(ty))
+                            .map(|s| s.to_string())
+                    })
                     // Field access on struct: resolve field type from struct layout
                     .or_else(|| {
                         if let ExprKind::Field { object: inner_obj, field: field_name } = &object.kind {

--- a/compiler/crates/rask-mir/src/lower/expr.rs
+++ b/compiler/crates/rask-mir/src/lower/expr.rs
@@ -1380,11 +1380,23 @@ impl<'a> MirLowerer<'a> {
                     }
                 }
 
-                // .ok() / .to_option(): Result<T,E> → Option<T>
-                // Pass through as-is — runtime uses the same tagged-union layout
-                // (tag 0 = Ok/Some, tag 1 = Err/None).
+                // .ok() / .to_option(): Result<T,E> → Option<T>.
+                // Try the inline lowering (try_lower_result_option_method)
+                // first so payload offsets are recomputed. The legacy
+                // pass-through here was lying about the layout — Result's
+                // origin fields between tag and payload don't exist in
+                // Option, so subsequent `.0` reads landed on the wrong
+                // bytes and `opt == none` checks compared stale pointers.
                 if (method == "ok" || method == "to_option") && args.is_empty() {
-                    return Ok((obj_op, obj_ty));
+                    if let Some(handled) = self.try_lower_result_option_method(
+                        expr, object, method.as_str(), args,
+                    )? {
+                        return Ok(handled);
+                    }
+                    // Fallback for cases the inline lowerer couldn't handle
+                    // (no resolved receiver type, etc.) — pass through.
+                    let (obj_op2, obj_ty2) = self.lower_expr(object)?;
+                    return Ok((obj_op2, obj_ty2));
                 }
 
                 // .unwrap(): Option<T>/Result<T,E> → T — panic on None/Err
@@ -1516,21 +1528,21 @@ impl<'a> MirLowerer<'a> {
                         self.ctx.find_struct(base).is_some()
                             || self.ctx.find_enum(base).is_some()
                     });
+                // Inline Result/Option methods that have no runtime impl —
+                // `.map(f)`, `.ok()`, `.filter(f)`. These were dispatching
+                // to Vec_map et al. as a fallback and silently
+                // mis-computing on aggregate or non-i64 values.
+                if let Some(handled) = self.try_lower_result_option_method(
+                    expr, object, method.as_str(), args,
+                )? {
+                    return Ok(handled);
+                }
+
                 let qualified_name = user_type_prefix
                     .or_else(|| if let ExprKind::Ident(var_name) = &object.kind {
                         self.meta(var_name).and_then(|m| m.type_prefix.clone())
                     } else {
                         None
-                    })
-                    // Stdlib type from the type checker (Result, Option, etc.)
-                    // when the receiver isn't an ident — e.g. method-chain on a
-                    // call result `safe_div(...).map(...)`. Without this fall-
-                    // through, "map" lands on the hardcoded Vec fallback below
-                    // and dispatches Vec_map on a Result.
-                    .or_else(|| {
-                        self.ctx.lookup_raw_type(object.id)
-                            .and_then(|ty| super::MirContext::stdlib_type_prefix(ty))
-                            .map(|s| s.to_string())
                     })
                     // Field access on struct: resolve field type from struct layout
                     .or_else(|| {

--- a/compiler/crates/rask-mir/src/lower/mod.rs
+++ b/compiler/crates/rask-mir/src/lower/mod.rs
@@ -1115,49 +1115,38 @@ impl<'a> MirLowerer<'a> {
             Pattern::Ident(name) => {
                 if is_variant_name(name) {
                     // If the name matches the err side of a Result, tag = 1.
-                    // Handles both enum errors (e.g. `is DbError`) and struct
-                    // errors (e.g. `is ParseError`) — without the struct case
-                    // a `result is ParseError` check compared against tag 0
+                    // Handles enum errors, struct errors, and union errors
+                    // (e.g. `result is ParseError` where err side is
+                    // `ParseError | DivError`). Without these branches a
+                    // `result is StructError` check compared against tag 0
                     // and inverted the entire control flow [#259 family].
-                    if let MirType::Result { ok, err } = val_ty {
-                        match err.as_ref() {
+                    let name_matches_type = |ty: &MirType, n: &str| -> bool {
+                        match ty {
                             MirType::Enum(eid) => {
                                 let idx = eid.id as usize;
-                                if idx < self.ctx.enum_layouts.len()
-                                    && self.ctx.enum_layouts[idx].name == name.as_str()
-                                {
-                                    return 1;
-                                }
+                                idx < self.ctx.enum_layouts.len()
+                                    && self.ctx.enum_layouts[idx].name == n
                             }
                             MirType::Struct(sid) => {
                                 let idx = sid.id as usize;
-                                if idx < self.ctx.struct_layouts.len()
-                                    && self.ctx.struct_layouts[idx].name == name.as_str()
-                                {
-                                    return 1;
-                                }
+                                idx < self.ctx.struct_layouts.len()
+                                    && self.ctx.struct_layouts[idx].name == n
                             }
-                            _ => {}
+                            _ => false,
+                        }
+                    };
+                    if let MirType::Result { ok, err } = val_ty {
+                        if name_matches_type(err.as_ref(), name) {
+                            return 1;
+                        }
+                        if let MirType::Union(variants) = err.as_ref() {
+                            if variants.iter().any(|v| name_matches_type(v, name)) {
+                                return 1;
+                            }
                         }
                         // Symmetric: name matches the ok side → tag 0 (Ok).
-                        match ok.as_ref() {
-                            MirType::Struct(sid) => {
-                                let idx = sid.id as usize;
-                                if idx < self.ctx.struct_layouts.len()
-                                    && self.ctx.struct_layouts[idx].name == name.as_str()
-                                {
-                                    return 0;
-                                }
-                            }
-                            MirType::Enum(eid) => {
-                                let idx = eid.id as usize;
-                                if idx < self.ctx.enum_layouts.len()
-                                    && self.ctx.enum_layouts[idx].name == name.as_str()
-                                {
-                                    return 0;
-                                }
-                            }
-                            _ => {}
+                        if name_matches_type(ok.as_ref(), name) {
+                            return 0;
                         }
                     }
                     return self.variant_tag(name);

--- a/compiler/crates/rask-mir/src/lower/mod.rs
+++ b/compiler/crates/rask-mir/src/lower/mod.rs
@@ -493,6 +493,10 @@ pub(crate) struct LocalMeta {
     /// C1/C2: resource_id local for consumption cancellation.
     /// Set when an ensure registers this variable as its receiver.
     pub resource_id: Option<LocalId>,
+    /// Function parameter declared `mutate`. Whole-value reassignment must
+    /// flow back through the param's pointer (mem.borrowing/M-rules), so
+    /// `p = expr` lowers to a Store(*p, ...) instead of Assign(p, ...).
+    pub is_mutate_param: bool,
 }
 
 pub struct MirLowerer<'a> {
@@ -803,6 +807,9 @@ impl<'a> MirLowerer<'a> {
                 let prefix = lowerer.mir_type_name(&param_ty)
                     .or_else(|| type_prefix_from_str(param_ty_str));
                 let meta = lowerer.local_meta.entry(param.name.clone()).or_default();
+                if param.is_mutate {
+                    meta.is_mutate_param = true;
+                }
                 if let Some(p) = prefix {
                     meta.type_prefix = Some(p);
                 }

--- a/compiler/crates/rask-mir/src/lower/mod.rs
+++ b/compiler/crates/rask-mir/src/lower/mod.rs
@@ -887,17 +887,50 @@ impl<'a> MirLowerer<'a> {
         // Implicit return for functions that don't explicitly return.
         // Void functions get `return`, non-void get Unreachable (caller
         // must ensure all paths return explicitly).
-        // Result { ok: Void, .. } also gets an implicit return — codegen
-        // wraps the void value as Ok in the Result slot.
+        // Result { ok: Void, .. } also gets an implicit return — emit a
+        // wrapped Ok-tagged temp so callers (including the inliner, which
+        // copies the return value into the call-site dst) see a properly
+        // initialized Result instead of stale stack bytes.
         if lowerer.builder.current_block_unterminated() {
-            let implicit_ok = matches!(ret_ty, MirType::Void)
-                || matches!(&ret_ty, MirType::Result { ok, .. } if matches!(ok.as_ref(), MirType::Void));
+            let result_void_ok = matches!(&ret_ty,
+                MirType::Result { ok, .. } if matches!(ok.as_ref(), MirType::Void));
+            let implicit_ok = matches!(ret_ty, MirType::Void) || result_void_ok;
             if implicit_ok {
+                // For Result<Void, E>, build a temp holding Ok(void) so the
+                // caller's slot gets the right tag bytes even when the call
+                // is inlined.
+                let return_value = if result_void_ok {
+                    let wrap_local = lowerer.builder.alloc_temp(ret_ty.clone());
+                    lowerer.builder.push_stmt(MirStmt::dummy(MirStmtKind::Store {
+                        addr: wrap_local,
+                        offset: 0,
+                        value: MirOperand::Constant(MirConst::Int(0)),
+                        store_size: Some(8),
+                    }));
+                    // Zero the origin-file and origin-line fields so they
+                    // don't carry stale bytes when the caller copies the
+                    // whole slot.
+                    lowerer.builder.push_stmt(MirStmt::dummy(MirStmtKind::Store {
+                        addr: wrap_local,
+                        offset: 8,
+                        value: MirOperand::Constant(MirConst::Int(0)),
+                        store_size: Some(8),
+                    }));
+                    lowerer.builder.push_stmt(MirStmt::dummy(MirStmtKind::Store {
+                        addr: wrap_local,
+                        offset: 16,
+                        value: MirOperand::Constant(MirConst::Int(0)),
+                        store_size: Some(8),
+                    }));
+                    Some(MirOperand::Local(wrap_local))
+                } else {
+                    None
+                };
                 if lowerer.ensure_stack.is_empty() {
-                    lowerer.builder.terminate(MirTerminator::dummy(MirTerminatorKind::Return { value: None }));
+                    lowerer.builder.terminate(MirTerminator::dummy(MirTerminatorKind::Return { value: return_value }));
                 } else {
                     lowerer.builder.terminate(MirTerminator::dummy(MirTerminatorKind::CleanupReturn {
-                        value: None,
+                        value: return_value,
                         cleanup_chain: lowerer.cleanup_chain(),
                     }));
                 }
@@ -1081,15 +1114,50 @@ impl<'a> MirLowerer<'a> {
         match pattern {
             Pattern::Ident(name) => {
                 if is_variant_name(name) {
-                    // If the name matches the error enum type of a Result, tag = 1 (Err).
-                    if let MirType::Result { err, .. } = val_ty {
-                        if let MirType::Enum(eid) = err.as_ref() {
-                            let idx = eid.id as usize;
-                            if idx < self.ctx.enum_layouts.len()
-                                && self.ctx.enum_layouts[idx].name == name.as_str()
-                            {
-                                return 1;
+                    // If the name matches the err side of a Result, tag = 1.
+                    // Handles both enum errors (e.g. `is DbError`) and struct
+                    // errors (e.g. `is ParseError`) — without the struct case
+                    // a `result is ParseError` check compared against tag 0
+                    // and inverted the entire control flow [#259 family].
+                    if let MirType::Result { ok, err } = val_ty {
+                        match err.as_ref() {
+                            MirType::Enum(eid) => {
+                                let idx = eid.id as usize;
+                                if idx < self.ctx.enum_layouts.len()
+                                    && self.ctx.enum_layouts[idx].name == name.as_str()
+                                {
+                                    return 1;
+                                }
                             }
+                            MirType::Struct(sid) => {
+                                let idx = sid.id as usize;
+                                if idx < self.ctx.struct_layouts.len()
+                                    && self.ctx.struct_layouts[idx].name == name.as_str()
+                                {
+                                    return 1;
+                                }
+                            }
+                            _ => {}
+                        }
+                        // Symmetric: name matches the ok side → tag 0 (Ok).
+                        match ok.as_ref() {
+                            MirType::Struct(sid) => {
+                                let idx = sid.id as usize;
+                                if idx < self.ctx.struct_layouts.len()
+                                    && self.ctx.struct_layouts[idx].name == name.as_str()
+                                {
+                                    return 0;
+                                }
+                            }
+                            MirType::Enum(eid) => {
+                                let idx = eid.id as usize;
+                                if idx < self.ctx.enum_layouts.len()
+                                    && self.ctx.enum_layouts[idx].name == name.as_str()
+                                {
+                                    return 0;
+                                }
+                            }
+                            _ => {}
                         }
                     }
                     return self.variant_tag(name);

--- a/compiler/crates/rask-mir/src/lower/stmt.rs
+++ b/compiler/crates/rask-mir/src/lower/stmt.rs
@@ -107,18 +107,40 @@ impl<'a> MirLowerer<'a> {
             }
 
             StmtKind::Assign { target, value } => {
-                let (val_op, _) = self.lower_expr(value)?;
+                let (val_op, val_ty) = self.lower_expr(value)?;
                 match &target.kind {
                     ExprKind::Ident(name) => {
-                        let (local_id, _) = self
+                        let (local_id, dst_ty) = self
                             .locals
                             .get(name)
                             .cloned()
                             .ok_or_else(|| LoweringError::UnresolvedVariable(name.clone()))?;
-                        self.builder.push_stmt(MirStmt::dummy(MirStmtKind::Assign {
-                            dst: local_id,
-                            rvalue: MirRValue::Use(val_op),
-                        }));
+                        // mem.borrowing/M-rules: `p = expr` on a `mutate` param
+                        // copies bytes through the caller's pointer. Lower as a
+                        // Store so DCE doesn't drop it as a "dead local write"
+                        // and codegen emits the through-pointer copy.
+                        let is_mutate_param = self.meta(name)
+                            .map(|m| m.is_mutate_param)
+                            .unwrap_or(false);
+                        if is_mutate_param {
+                            let store_size = match &dst_ty {
+                                MirType::Struct(layout) => Some(layout.byte_size),
+                                MirType::Enum(layout) => Some(layout.byte_size),
+                                _ => Some(dst_ty.size()),
+                            };
+                            let _ = val_ty;
+                            self.builder.push_stmt(MirStmt::dummy(MirStmtKind::Store {
+                                addr: local_id,
+                                offset: 0,
+                                value: val_op,
+                                store_size,
+                            }));
+                        } else {
+                            self.builder.push_stmt(MirStmt::dummy(MirStmtKind::Assign {
+                                dst: local_id,
+                                rvalue: MirRValue::Use(val_op),
+                            }));
+                        }
                     }
                     // Field assignment: obj.field = value → Store at field offset
                     ExprKind::Field { object, field } => {

--- a/compiler/crates/rask-mir/src/lower/stmt.rs
+++ b/compiler/crates/rask-mir/src/lower/stmt.rs
@@ -1617,6 +1617,40 @@ impl<'a> MirLowerer<'a> {
         label: Option<&str>,
         value: Option<&Expr>,
     ) -> Result<(), LoweringError> {
+        // `break n` is parser-ambiguous: `n` could be a label or a value
+        // expression. The parser favors label; if no enclosing loop has that
+        // label but a local of the same name is in scope, reinterpret as
+        // `break value=n`. The resolver already silenced its "unknown label"
+        // error in that case (see resolver.rs StmtKind::Break).
+        let reinterpret_as_value = label
+            .filter(|lbl| value.is_none() && !self.loop_stack.iter().any(|ctx| ctx.label.as_deref() == Some(lbl)))
+            .filter(|lbl| self.locals.contains_key(*lbl));
+        if let Some(name) = reinterpret_as_value {
+            let (local_id, _ty) = self.locals.get(name).cloned().ok_or_else(|| {
+                LoweringError::UnresolvedVariable(name.to_string())
+            })?;
+            let val_op = MirOperand::Local(local_id);
+            let ctx = self.loop_stack.last().ok_or_else(|| {
+                LoweringError::InvalidConstruct("break outside of loop".to_string())
+            })?;
+            let exit_block = ctx.exit_block;
+            let result_local = ctx.result_local;
+            let ensure_depth = ctx.ensure_depth;
+            if let Some(result) = result_local {
+                self.builder.push_stmt(MirStmt::dummy(MirStmtKind::Assign {
+                    dst: result,
+                    rvalue: MirRValue::Use(val_op),
+                }));
+            }
+            self.emit_loop_cleanup(ensure_depth);
+            self.builder.terminate(MirTerminator::dummy(MirTerminatorKind::Goto {
+                target: exit_block,
+            }));
+            let dead_block = self.builder.create_block();
+            self.builder.switch_to_block(dead_block);
+            return Ok(());
+        }
+
         let ctx = self.find_loop(label)?;
         let exit_block = ctx.exit_block;
         let result_local = ctx.result_local;

--- a/compiler/crates/rask-mir/src/lower/stmt.rs
+++ b/compiler/crates/rask-mir/src/lower/stmt.rs
@@ -80,8 +80,37 @@ impl<'a> MirLowerer<'a> {
 
             StmtKind::Return(opt_expr) => {
                 let value = if let Some(e) = opt_expr {
-                    let (op, _) = self.lower_expr(e)?;
-                    Some(op)
+                    let (op, op_ty) = self.lower_expr(e)?;
+                    // Auto-wrap a non-Option value into Some(...) when the
+                    // function returns Option<T>. The user-level shorthand
+                    // `func -> User? { return User { ... } }` relies on this;
+                    // without an explicit wrap, codegen returns just the T
+                    // pointer and the caller's Option slot ends up with
+                    // garbage in the tag/payload positions (#274).
+                    let ret_ty = self.builder.ret_ty().clone();
+                    let needs_wrap = matches!(&ret_ty, MirType::Option(inner)
+                        if !matches!(op_ty, MirType::Option(_)) && **inner == op_ty);
+                    let final_op = if needs_wrap {
+                        let wrap_local = self.builder.alloc_temp(ret_ty.clone());
+                        // tag = 0 (Some)
+                        self.builder.push_stmt(MirStmt::dummy(MirStmtKind::Store {
+                            addr: wrap_local,
+                            offset: 0,
+                            value: MirOperand::Constant(MirConst::Int(0)),
+                            store_size: Some(8),
+                        }));
+                        // payload at offset 8
+                        self.builder.push_stmt(MirStmt::dummy(MirStmtKind::Store {
+                            addr: wrap_local,
+                            offset: 8,
+                            value: op,
+                            store_size: Some(op_ty.size()),
+                        }));
+                        MirOperand::Local(wrap_local)
+                    } else {
+                        op
+                    };
+                    Some(final_op)
                 } else {
                     None
                 };

--- a/compiler/crates/rask-mir/src/transform/inline.rs
+++ b/compiler/crates/rask-mir/src/transform/inline.rs
@@ -52,9 +52,15 @@ pub fn inline_functions(fns: &mut Vec<MirFunction>) -> HashMap<String, Vec<Inlin
 
     // Snapshot callee bodies (we read callees while mutating callers).
     // Only snapshot functions that are candidates for inlining.
+    //
+    // Skip functions whose body writes through a parameter (mutate-param
+    // writeback). Inlining copies args into fresh locals before lowering the
+    // body, so the writeback would land in the fresh local instead of the
+    // caller's storage.
     let callee_bodies: HashMap<String, MirFunction> = fns
         .iter()
         .filter(|f| should_inline(&cg, &f.name))
+        .filter(|f| !writes_through_param(f))
         .map(|f| (f.name.clone(), f.clone()))
         .collect();
 
@@ -71,6 +77,18 @@ pub fn inline_functions(fns: &mut Vec<MirFunction>) -> HashMap<String, Vec<Inlin
 }
 
 /// Determine if a function is a candidate for inlining at any call site.
+/// True if the function body contains a `Store` whose address is one of the
+/// function's parameters (mutate-param writeback). Such functions can't be
+/// inlined safely — the writeback needs to flow through the caller's pointer.
+fn writes_through_param(f: &MirFunction) -> bool {
+    use crate::MirStmtKind;
+    let param_ids: std::collections::HashSet<LocalId> =
+        f.params.iter().map(|p| p.id).collect();
+    f.blocks.iter().any(|b| b.statements.iter().any(|s| {
+        matches!(&s.kind, MirStmtKind::Store { addr, .. } if param_ids.contains(addr))
+    }))
+}
+
 fn should_inline(cg: &CallGraph, callee_name: &str) -> bool {
     if cg.is_recursive(callee_name) {
         return false;

--- a/compiler/crates/rask-ownership/src/lib.rs
+++ b/compiler/crates/rask-ownership/src/lib.rs
@@ -869,7 +869,15 @@ impl<'a> OwnershipChecker<'a> {
                     for name in &captures {
                         if !resource_captures.contains(name) {
                             if self.bindings.contains_key(name) {
-                                self.bindings.insert(name.clone(), BindingState::Moved { at: expr.span });
+                                // Copy types stay valid in the outer scope (VS1/VS2).
+                                let is_copy_capture = self
+                                    .binding_types
+                                    .get(name)
+                                    .map(|t| self.is_copy(t))
+                                    .unwrap_or(false);
+                                if !is_copy_capture {
+                                    self.bindings.insert(name.clone(), BindingState::Moved { at: expr.span });
+                                }
                             }
                         }
                     }

--- a/compiler/crates/rask-parser/src/parser.rs
+++ b/compiler/crates/rask-parser/src/parser.rs
@@ -4021,7 +4021,30 @@ impl Parser {
 
         let mut contexts: Vec<(String, Vec<CallArg>)> = Vec::new();
         loop {
-            let name = self.expect_ident()?;
+            let mut name = self.expect_ident()?;
+            // Generic args on context types: `using Pool<Entity>, Multitasking { ... }`
+            // (mem.context-clauses/CC4). Mirrors the loop in parse_base_type.
+            if self.match_token(&TokenKind::Lt) {
+                name.push('<');
+                loop {
+                    if let TokenKind::Int(n, _) = self.current_kind().clone() {
+                        self.advance();
+                        name.push_str(&n.to_string());
+                    } else {
+                        name.push_str(&self.parse_type_name()?);
+                    }
+                    if self.pending_gt {
+                        break;
+                    }
+                    if self.match_token(&TokenKind::Comma) {
+                        name.push_str(", ");
+                    } else {
+                        break;
+                    }
+                }
+                self.expect_gt_in_generic()?;
+                name.push('>');
+            }
             let args = if self.match_token(&TokenKind::LParen) {
                 let args = self.parse_args()?;
                 self.expect(&TokenKind::RParen)?;

--- a/compiler/crates/rask-parser/src/parser.rs
+++ b/compiler/crates/rask-parser/src/parser.rs
@@ -3772,11 +3772,16 @@ impl Parser {
                 None
             };
 
-            // Capture call-site mode keywords
+            // Capture call-site mode keywords. `own` is overloaded — it also
+            // prefixes an owned-closure literal (`own || body` / `own |x| body`).
+            // When the next token is `|` or `||`, treat `own` as part of the
+            // expression so parse_expr sees an owned closure, not ArgMode::Own.
             let mode = if self.check(&TokenKind::MutateKw) {
                 self.advance();
                 ArgMode::Mutate
-            } else if self.check(&TokenKind::Own) {
+            } else if self.check(&TokenKind::Own)
+                && !matches!(self.peek(1), TokenKind::Pipe | TokenKind::PipePipe)
+            {
                 self.advance();
                 ArgMode::Own
             } else {

--- a/compiler/crates/rask-resolve/src/resolver.rs
+++ b/compiler/crates/rask-resolve/src/resolver.rs
@@ -158,6 +158,35 @@ impl Resolver {
         // in the global scope — they require explicit `import` statements.
         // See resolve_import() for how they enter scope.
 
+        // Top-level stdlib stub functions (e.g. async.rk's `spawn`,
+        // `cancelled`, `join_all`, `select_first`) are auto-registered.
+        // The pipeline sometimes runs the resolver without stdlib_decls
+        // (single-file `rask check`), and these names are spec-required to
+        // be in scope under their context (`spawn` under `using Multitasking`,
+        // for instance — checked separately via context-clause analysis).
+        // Skip names already claimed by hardcoded builtins above so println,
+        // print, format, etc. keep their BuiltinFunction symbol kind.
+        let stub_reg = rask_stdlib::StubRegistry::load();
+        for f in stub_reg.functions() {
+            if self.scopes.lookup(&f.name).is_some() {
+                continue;
+            }
+            let ret_ty = if f.ret_ty.is_empty() { None } else { Some(f.ret_ty.clone()) };
+            let sym_id = self.symbols.insert(
+                f.name.clone(),
+                SymbolKind::Function {
+                    params: vec![],
+                    ret_ty,
+                    context_clauses: vec![],
+                    is_unsafe: false,
+                },
+                None,
+                Span::new(0, 0),
+                true,
+            );
+            let _ = self.scopes.define(f.name.clone(), sym_id, Span::new(0, 0));
+        }
+
         // Register null constant for unsafe pointer comparisons
         let null_sym = self.symbols.insert(
             "null".to_string(),

--- a/compiler/crates/rask-types/src/checker/check_expr.rs
+++ b/compiler/crates/rask-types/src/checker/check_expr.rs
@@ -1107,7 +1107,40 @@ impl TypeChecker {
             ExprKind::WithAs { bindings, body } => {
                 self.push_scope();
                 for binding in bindings {
-                    let elem_ty = self.infer_expr(&binding.source);
+                    let raw_ty = self.infer_expr(&binding.source);
+                    let source_ty = self.ctx.apply(&raw_ty);
+                    // conc.sync/MX1: `with mutex as v { ... }` — bind `v` to the
+                    // inner T, not the Mutex wrapper. The lock is held for the
+                    // block's duration; releasing happens when `with` exits.
+                    // Same for Shared<T>: bare `with shared as v` is rejected by
+                    // R4 elsewhere; if it slips through here we still unwrap so
+                    // the body sees the inner type rather than the wrapper.
+                    let elem_ty = match &source_ty {
+                        Type::Generic { base, args } if !args.is_empty() => {
+                            let base_name = self.types.type_name(*base);
+                            if base_name == "Mutex" || base_name == "Shared" {
+                                if let GenericArg::Type(inner) = &args[0] {
+                                    (**inner).clone()
+                                } else {
+                                    source_ty.clone()
+                                }
+                            } else {
+                                source_ty.clone()
+                            }
+                        }
+                        Type::UnresolvedGeneric { name, args } if !args.is_empty() => {
+                            if name == "Mutex" || name == "Shared" {
+                                if let GenericArg::Type(inner) = &args[0] {
+                                    (**inner).clone()
+                                } else {
+                                    source_ty.clone()
+                                }
+                            } else {
+                                source_ty.clone()
+                            }
+                        }
+                        _ => source_ty.clone(),
+                    };
                     self.define_local(binding.name.clone(), elem_ty);
                 }
                 for stmt in body {

--- a/compiler/runtime/rask_runtime.h
+++ b/compiler/runtime/rask_runtime.h
@@ -85,7 +85,7 @@ int64_t  rask_vec_push(RaskVec *v, const void *elem);
 void    *rask_vec_get(const RaskVec *v, int64_t index);
 void    *rask_vec_get_unchecked(const RaskVec *v, int64_t index);
 void     rask_vec_set(RaskVec *v, int64_t index, const void *elem);
-int64_t  rask_vec_pop(RaskVec *v, void *out);
+void    *rask_vec_pop(RaskVec *v);
 int64_t  rask_vec_remove(RaskVec *v, int64_t index);
 void     rask_vec_clear(RaskVec *v);
 int64_t  rask_vec_reserve(RaskVec *v, int64_t additional);

--- a/compiler/runtime/vec.c
+++ b/compiler/runtime/vec.c
@@ -107,15 +107,17 @@ void rask_vec_set(RaskVec *v, int64_t index, const void *elem) {
     memcpy(v->data + index * v->elem_size, elem, (size_t)v->elem_size);
 }
 
-int64_t rask_vec_pop(RaskVec *v, void *out) {
+// Pop returns NULL when empty (Option encoding via DerefOption codegen
+// adapter — same convention as rask_map_get). On success, returns a
+// pointer into the buffer for the just-vacated slot; the codegen reads
+// out the bytes into the destination Option payload before any
+// subsequent vec mutation could clobber it.
+void *rask_vec_pop(RaskVec *v) {
     if (!v || v->len == 0) {
-        rask_panic("pop from empty Vec");
+        return NULL;
     }
     v->len--;
-    if (out) {
-        memcpy(out, v->data + v->len * v->elem_size, (size_t)v->elem_size);
-    }
-    return 0;
+    return v->data + v->len * v->elem_size;
 }
 
 int64_t rask_vec_remove(RaskVec *v, int64_t index) {

--- a/examples/game_loop.rk
+++ b/examples/game_loop.rk
@@ -208,12 +208,39 @@ func spawn_system(mutate state: GameState, time_since_last_spawn: f32) -> f32 {
     }
 }
 
-// Movement update across all entities. Sharing a `mutate Pool<Entity>`
-// across worker threads isn't sound (Pool needs exclusive mutable access),
-// so the parallel pipeline lives outside the example and we run movement
-// single-threaded here. For genuine parallelism, compute new positions on
-// worker threads from a read-only snapshot and ship results back over a
-// channel for the main thread to apply.
+// Movement update across all entities.
+//
+// The aspirational form (specs/concurrency/runtime.md:1807) shares the
+// pool across green tasks via a context clause:
+//
+//     func parallel_movement_system(dt: f32, num_threads: usize)
+//         using Pool<Entity>, Multitasking
+//     {
+//         const handles = pool.handles()
+//         const chunk_size = (handles.len() + num_threads - 1) / num_threads
+//         mut tasks = Vec.new()
+//         for chunk in handles.chunks(chunk_size) {
+//             const work = chunk.to_vec()
+//             tasks.push(spawn(own || {
+//                 for h in work {
+//                     if !pool[h].active: continue
+//                     pool[h].position.x += pool[h].velocity.dx * dt
+//                     pool[h].position.y += pool[h].velocity.dy * dt
+//                 }
+//             }))
+//         }
+//         for t in tasks { t.join().ok() }
+//     }
+//
+// This doesn't typecheck yet — three compiler gaps block it:
+//   #266 `using Pool<Entity>` parser rejects generic args
+//   #267 `spawn` builtin not registered in the type checker
+//   #268 `with mutex as v { ... }` doesn't unwrap to inner T
+// (Pool's internal Arc<Mutex<Vec>> threading depends on #268 too.)
+//
+// Until then, run movement single-threaded. The shape stays close to
+// the aspirational form so the only delta when the gaps land is moving
+// the body into a `spawn(own || { ... })` per chunk.
 func parallel_movement_system(mutate entities: Pool<Entity>, dt: f32, num_threads: usize) {
     const _ = num_threads
     mut handles = entities.handles()

--- a/examples/game_loop.rk
+++ b/examples/game_loop.rk
@@ -208,31 +208,20 @@ func spawn_system(mutate state: GameState, time_since_last_spawn: f32) -> f32 {
     }
 }
 
-// Parallel movement update - processes entity batches across threads
-// Takes Pool<Entity> directly — borrow checker tracks field-level borrow at call site
-func parallel_movement_system(mutate entities: Pool<Entity>, dt: f32, num_threads: usize)
-    using ThreadPool
-{
+// Movement update across all entities. Sharing a `mutate Pool<Entity>`
+// across worker threads isn't sound (Pool needs exclusive mutable access),
+// so the parallel pipeline lives outside the example and we run movement
+// single-threaded here. For genuine parallelism, compute new positions on
+// worker threads from a read-only snapshot and ship results back over a
+// channel for the main thread to apply.
+func parallel_movement_system(mutate entities: Pool<Entity>, dt: f32, num_threads: usize) {
+    const _ = num_threads
     mut handles = entities.handles()
-    mut chunk_size = (handles.len() + num_threads - 1) / num_threads
-
-    // Split work across thread pool
-    mut thread_handles = Vec.new()
-    for chunk in handles.chunks(chunk_size) {
-        mut chunk = chunk.to_vec()
-        mut task = ThreadPool.spawn(|| {
-            for h in chunk {
-                if !entities[h].active: continue
-                entities[h].position.x += entities[h].velocity.dx * dt
-                entities[h].position.y += entities[h].velocity.dy * dt
-            }
-        })
-        thread_handles.push(task)
-    }
-
-    // Wait for all chunks to complete
-    for h in thread_handles {
-        h.join().ok()
+    for i in 0..handles.len() {
+        const h = handles[i as i64]
+        if !entities[h].active: continue
+        entities[h].position.x += entities[h].velocity.dx * dt
+        entities[h].position.y += entities[h].velocity.dy * dt
     }
 }
 

--- a/examples/grep_clone.rk
+++ b/examples/grep_clone.rk
@@ -95,11 +95,10 @@ func grep_file(path: string, opts: GrepOptions) -> i64 or GrepError {
     const content = try fs.read_file(path)
         else |e| GrepError.FileError(e)
 
-    const lines = content.lines()
     mut match_count: i64 = 0
     mut line_num = 0
 
-    for line in lines {
+    for line in content.lines() {
         line_num = line_num + 1
         const matches = line_matches(line, opts.pattern, opts.ignore_case)
         const show = if opts.invert_match: !matches else: matches

--- a/examples/sensor_processor.rk
+++ b/examples/sensor_processor.rk
@@ -109,10 +109,18 @@ func isqrt(n: i64) -> i64 {
 // Interrupt Handler Simulation (runs on separate thread)
 // ============================================================================
 
-// Pushes sensor readings into a shared Vec. The Vec handle is heap-allocated,
-// so the main thread sees appended data via its own copy of the handle.
+// Reading sent from the ISR thread to the main loop over a Channel.
+// Channels transfer ownership: no shared mutable Vec, no locks.
+struct Reading {
+    sensor_id: i64
+    value: f64
+    timestamp_ns: i64
+}
+
+// Pushes sensor readings through a channel. The Sender is moved into the
+// closure that wraps this on Thread.spawn — main keeps the Receiver.
 func interrupt_handler(
-    mutate readings: Vec<i64>,
+    tx: Sender<Reading>,
     start_time: time.Instant,
     sample_rate_hz: i64
 ) {
@@ -124,10 +132,11 @@ func interrupt_handler(
 
         for sensor_id in 0..3 {
             const value = read_hardware_sensor(sensor_id, sequence)
-            // Encode reading as 3 consecutive i64s: sensor_id, value bits, timestamp
-            readings.push(sensor_id)
-            readings.push(value as i64)
-            readings.push(now_ns)
+            tx.send(Reading {
+                sensor_id: sensor_id,
+                value: value,
+                timestamp_ns: now_ns,
+            }).ok()
         }
 
         sequence += 1
@@ -212,9 +221,9 @@ func main() {
     // Build lookup tables
     const crc_table = build_crc8_table()
 
-    // Shared buffer: interrupt handler appends, main thread reads.
-    // Vec handles are heap-allocated — both threads see the same data.
-    mut readings = Vec.new()
+    // ISR → main channel. Sender is moved into the spawned thread,
+    // Receiver stays here for draining.
+    const (tx, rx) = Channel<Reading>.buffered(1024)
 
     mut temp_hist = Vec.new()
     mut pres_hist = Vec.new()
@@ -254,27 +263,24 @@ func main() {
     const process_period_ns = 1000000000 / PROCESS_RATE_HZ
     const deadline_ns = HARD_DEADLINE_US * 1000
 
-    // Start interrupt handler on separate thread
-    mut isr_handle = Thread.spawn(|| {
-        interrupt_handler(readings, start_time, SAMPLE_RATE_HZ)
+    // Start interrupt handler on separate thread. `own` moves the Sender
+    // (and Copy captures start_time / SAMPLE_RATE_HZ) into the closure.
+    mut isr_handle = Thread.spawn(own || {
+        interrupt_handler(tx, start_time, SAMPLE_RATE_HZ)
     })
 
     println("Started. Processing for {DURATION_SECS} seconds...")
     println("")
 
     mut cycle: i64 = 0
-    mut read_idx: i64 = 0
 
     while (time.Instant.now().duration_since(start_time).as_secs() as i64) < DURATION_SECS {
         const cycle_start = time.Instant.now()
 
-        // Drain available samples — each reading is 3 consecutive i64s
-        while read_idx + 2 < readings.len() {
-            const sensor_id = readings.get(read_idx)!
-            const value_bits = readings.get(read_idx + 1)!
-            const value = value_bits as f64
-            read_idx += 3
-            state.process_reading(sensor_id, value)
+        // Drain available samples without blocking — try_recv returns once
+        // the channel is empty, so the cycle stays bounded.
+        while rx.try_recv() is Reading as r {
+            state.process_reading(r.sensor_id, r.value)
         }
 
         // Compute derived values periodically

--- a/examples/text_editor.rk
+++ b/examples/text_editor.rk
@@ -55,7 +55,7 @@ extend Document {
         mut doc = Document.new()
         for line in file.lines() {
             const text = try line
-            const h = doc.lines.insert(Line { text: text })
+            const h = try doc.lines.insert(Line { text: text })
             doc.line_order.push(h)
         }
         return doc
@@ -73,9 +73,10 @@ extend Document {
 
     // Insert a new line after the given index (-1 for beginning)
     func insert_line(self, after: i32, text: string) -> void or Error {
-        const h = self.lines.insert(Line { text: text })
-        const raw_pos = after + 1
-        const insert_pos = if raw_pos > self.line_order.len(): self.line_order.len() else: raw_pos
+        const h = try self.lines.insert(Line { text: text })
+        const raw_pos = (after + 1) as i64
+        const cap = self.line_order.len() as i64
+        const insert_pos = if raw_pos > cap: cap else: raw_pos
         self.line_order.insert(insert_pos, h)
 
         // Record for undo
@@ -137,12 +138,12 @@ extend Document {
     func apply_command_silent(self, cmd: EditCommand) -> void or Error {
         match cmd {
             InsertLine(after, text) => {
-                const h = self.lines.insert(Line { text: text })
-                self.line_order.insert(after + 1, h)
+                const h = try self.lines.insert(Line { text: text })
+                self.line_order.insert((after + 1) as i64, h)
             }
             DeleteLine(at, _) => {
                 const h = self.line_order.remove(at as i64)
-                self.lines.remove(h).ok()
+                self.lines.remove(h)
             }
             ModifyLine(at, _, new_text) => {
                 const h = self.line_order[at as usize]
@@ -194,28 +195,28 @@ func parse_command(input: string) -> EditorCommand? {
     }
     if parts.is_empty(): return none
 
-    return match parts[0] {
+    match parts[0] {
         "i" | "insert" if parts.len() >= 3 => {
             const after = try parts[1].parse<i32>().ok()
             const text = parts[2..].join(" ")
-            EditorCommand.Insert(after: after, text: text)
+            return EditorCommand.Insert(after: after, text: text)
         }
         "d" | "delete" if parts.len() >= 2 => {
             const line = try parts[1].parse<i32>().ok()
-            EditorCommand.Delete(line: line)
+            return EditorCommand.Delete(line: line)
         }
         "e" | "edit" if parts.len() >= 3 => {
             const line = try parts[1].parse<i32>().ok()
             const text = parts[2..].join(" ")
-            EditorCommand.Edit(line: line, text: text)
+            return EditorCommand.Edit(line: line, text: text)
         }
-        "u" | "undo" => EditorCommand.Undo,
-        "r" | "redo" => EditorCommand.Redo,
-        "w" | "save" if parts.len() >= 2 => EditorCommand.Save(path: parts[1]),
-        "p" | "print" => EditorCommand.Print,
-        "q" | "quit" => EditorCommand.Quit,
-        "h" | "help" => EditorCommand.Help,
-        _ => none,
+        "u" | "undo" => return EditorCommand.Undo,
+        "r" | "redo" => return EditorCommand.Redo,
+        "w" | "save" if parts.len() >= 2 => return EditorCommand.Save(path: parts[1]),
+        "p" | "print" => return EditorCommand.Print,
+        "q" | "quit" => return EditorCommand.Quit,
+        "h" | "help" => return EditorCommand.Help,
+        _ => return none,
     }
 }
 

--- a/stdlib/memory.rk
+++ b/stdlib/memory.rk
@@ -60,8 +60,9 @@ extend Pool<T> {
     /// Iterate over (handle, element) pairs.
     public func iter(self) -> Iterator<(Handle<T>, T)> { }
 
-    /// Iterate over handles only.
-    public func handles(self) -> Iterator<Handle<T>> { }
+    /// Snapshot of handles. Returned as a Vec so callers can index, slice,
+    /// or iterate without invalidating on subsequent insert/remove.
+    public func handles(self) -> Vec<Handle<T>> { }
 
     /// Iterate over elements only.
     public func values(self) -> Iterator<T> { }


### PR DESCRIPTION
## Summary

This PR adds inline lowering for Result/Option methods (`.map()`, `.ok()`, `.filter()`) that previously had no runtime implementation, and fixes several critical bugs in aggregate type handling for assignments, returns, and optional field access.

## Key Changes

### Result/Option Method Inlining
- Added `try_lower_result_option_method()` to inline `.map()`, `.ok()`, and `.filter()` methods instead of dispatching to non-existent stdlib stubs
- Implemented `lower_result_map()`, `lower_result_ok()`, `lower_option_map()`, and `lower_option_filter()` with proper control flow and type conversions
- These methods now correctly handle payload offsets and type transformations (e.g., Result<T,E> → Option<T> for `.ok()`)

### Aggregate Assignment and Return Fixes
- Fixed whole-aggregate assignments to use memcpy instead of pointer aliasing, preventing mutations from clobbering source storage
- Added support for aggregate-to-aggregate copies through external pointers (mutate parameters)
- Implemented auto-wrapping of non-Option values into `Some(...)` when returning from functions with Option return types
- Fixed implicit returns for `Result<Void, E>` to emit properly initialized Ok-tagged temporaries

### Optional Field Access (OptionalField) Fixes
- Rewrote optional chaining (`obj?.field`) to properly resolve field indices and types from struct layouts
- Fixed result type to be `Option<field_type>` instead of just unwrapping the Option
- Added support for nested Option layers and non-struct payloads with fallback behavior

### Codegen Improvements
- Enhanced aggregate wrapping in Option slots to handle both scalars and aggregate types
- Fixed TraitBox and TraitCall to properly copy aggregate return values into destination stack slots
- Added support for aggregate-returning method calls with proper pointer dereferencing

### Type Checking and Parsing
- Updated `with...as` binding to unwrap `Mutex<T>` and `Shared<T>` to their inner types
- Fixed parser to distinguish `own` as a closure prefix from `own` as an argument mode keyword
- Auto-registered stdlib stub functions (spawn, cancelled, etc.) in resolver scope

### Parameter Handling
- Added `is_mutate_param` tracking to ensure `mutate` parameter reassignments flow back through the caller's pointer (mem.borrowing/M-rules)
- Lowered mutate-param assignments as Store operations instead of Assign to prevent DCE from dropping them

### Inlining Restrictions
- Disabled inlining of functions with mutate-parameter writebacks to prevent writeback from landing in fresh locals instead of caller storage

## Notable Implementation Details

- Result/Option inline lowering includes proper tag encoding (0 for Ok/Some, 1 for Err/None) and payload offset handling
- Aggregate copies use word-aligned memcpy loops (8-byte, 4-byte, 2-byte, 1-byte) for efficiency
- Optional field access now peels off nested Option layers to find the actual struct layout for field resolution
- The changes maintain backward compatibility by falling back to normal dispatch when inline lowering cannot handle a case

https://claude.ai/code/session_01FEpvTtxFzC8njbaUVMU8AP